### PR TITLE
feat(horner): add SIMD batch f64 Horner evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "proptest",
  "rayon",
  "rug",
+ "wide",
 ]
 
 [[package]]
@@ -204,6 +205,12 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cast"
@@ -1786,6 +1793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2245,16 @@ checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/alkahest-core/Cargo.toml
+++ b/alkahest-core/Cargo.toml
@@ -66,6 +66,7 @@ dashmap = { version = "6",   optional = true }
 cudarc  = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "fallback-dynamic-loading", "cuda-12060"], optional = true }
 bitflags = "2.11.1"
 boxcar = "0.2.14"
+wide = "0.7"
 
 [dev-dependencies]
 proptest = "1"

--- a/alkahest-core/src/horner.rs
+++ b/alkahest-core/src/horner.rs
@@ -91,6 +91,53 @@ pub fn emit_horner_c(
 }
 
 /// Build a C expression string for the Horner evaluation.
+// ---------------------------------------------------------------------------
+// f64 Horner evaluation (scalar + SIMD batch)
+// ---------------------------------------------------------------------------
+
+/// Evaluate `a₀ + x·(a₁ + x·(a₂ + …))` for coefficients `[a₀, a₁, …, aₙ]`.
+#[inline]
+pub fn eval_horner_f64(coeffs: &[f64], x: f64) -> f64 {
+    if coeffs.is_empty() {
+        return 0.0;
+    }
+    let mut acc = coeffs[coeffs.len() - 1];
+    for &c in coeffs[..coeffs.len() - 1].iter().rev() {
+        acc = c + x * acc;
+    }
+    acc
+}
+
+/// Evaluate the same polynomial at many points, writing into `out`.
+///
+/// Uses 4-wide SIMD via the `wide` crate when `xs.len() == out.len()`; falls
+/// back to scalar [`eval_horner_f64`] for tail elements.
+pub fn eval_horner_f64_batch(coeffs: &[f64], xs: &[f64], out: &mut [f64]) {
+    assert_eq!(xs.len(), out.len());
+    let mut i = 0;
+    while i + 4 <= xs.len() {
+        let chunk = wide::f64x4::new([xs[i], xs[i + 1], xs[i + 2], xs[i + 3]]);
+        let vals = eval_horner_f64x4(coeffs, chunk).to_array();
+        out[i..i + 4].copy_from_slice(&vals);
+        i += 4;
+    }
+    for (x, o) in xs[i..].iter().zip(out[i..].iter_mut()) {
+        *o = eval_horner_f64(coeffs, *x);
+    }
+}
+
+#[inline]
+fn eval_horner_f64x4(coeffs: &[f64], x: wide::f64x4) -> wide::f64x4 {
+    if coeffs.is_empty() {
+        return wide::f64x4::splat(0.0);
+    }
+    let mut acc = wide::f64x4::splat(coeffs[coeffs.len() - 1]);
+    for &c in coeffs[..coeffs.len() - 1].iter().rev() {
+        acc = wide::f64x4::splat(c) + x * acc;
+    }
+    acc
+}
+
 fn build_c_horner(coeffs: &[i64], var: &str) -> String {
     if coeffs.is_empty() {
         return "0.0".to_string();
@@ -211,5 +258,27 @@ mod tests {
         let env = HashMap::new();
         let val = eval_interp(h, &env, &pool).unwrap();
         assert!((val - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn eval_horner_f64_matches_interp() {
+        let coeffs = [1.0, 2.0, 3.0]; // 1 + 2x + 3x²
+        let xs = [-1.0, 0.0, 0.5, 2.0, 10.0];
+        for &x in &xs {
+            let scalar = eval_horner_f64(&coeffs, x);
+            let expected = 1.0 + x * (2.0 + x * 3.0);
+            assert!((scalar - expected).abs() < 1e-12, "x={x}");
+        }
+    }
+
+    #[test]
+    fn eval_horner_f64_batch_matches_scalar() {
+        let coeffs = [1.0, 2.0, 3.0];
+        let xs = [-1.0, 0.0, 0.5, 2.0, 10.0, 3.0, 7.0];
+        let mut out = vec![0.0; xs.len()];
+        eval_horner_f64_batch(&coeffs, &xs, &mut out);
+        for (i, &x) in xs.iter().enumerate() {
+            assert!((out[i] - eval_horner_f64(&coeffs, x)).abs() < 1e-12);
+        }
     }
 }

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -88,7 +88,7 @@ pub use poly::{
 };
 
 // Phase 24 — Horner form
-pub use horner::{emit_horner_c, horner};
+pub use horner::{emit_horner_c, eval_horner_f64, eval_horner_f64_batch, horner};
 pub use simplify::rulesets::{log_exp_rules, log_exp_rules_safe, trig_rules};
 pub use simplify::{
     assumptions_satisfy, rules_for_config, simplify, simplify_colored, simplify_egraph,


### PR DESCRIPTION
Add eval_horner_f64 and eval_horner_f64_batch using 4-wide f64x4 SIMD via the wide crate for interpreter-path polynomial evaluation at many points.