### PR TITLE
feat(simplify): add discrimination-net index for pattern rules

### DIFF
--- a/alkahest-core/src/simplify/discrimination_net.rs
+++ b/alkahest-core/src/simplify/discrimination_net.rs
@@ -1,0 +1,138 @@
+//! Discrimination-net index for pattern-rule lookup.
+//!
+//! Rules whose left-hand sides share no root constructor (Add vs Mul vs Pow, …)
+//! are *match-disjoint*: only rules whose pattern head matches the expression
+//! head at the current node need to be tried.  This reduces rule scanning from
+//! O(|rules|) to O(|rules at head|) per node.
+
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use std::collections::HashMap;
+
+/// Root constructor of a pattern or expression.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PatternHead {
+    /// Wildcard-only or non-constructor root (always considered).
+    Any,
+    Add,
+    Mul,
+    Pow,
+    Func(String),
+    Integer,
+    Symbol(String),
+}
+
+/// Index mapping expression heads to candidate rule indices.
+#[derive(Clone, Debug, Default)]
+pub struct DiscriminationIndex {
+    by_head: HashMap<PatternHead, Vec<usize>>,
+    /// Rules with `PatternHead::Any` — tried after head-specific candidates.
+    universal: Vec<usize>,
+}
+
+impl DiscriminationIndex {
+    /// Build an index from per-rule pattern heads (one head per rule, in order).
+    pub fn build(heads: impl IntoIterator<Item = PatternHead>) -> Self {
+        let mut by_head: HashMap<PatternHead, Vec<usize>> = HashMap::new();
+        let mut universal = Vec::new();
+        for (i, head) in heads.into_iter().enumerate() {
+            if head == PatternHead::Any {
+                universal.push(i);
+            } else {
+                by_head.entry(head).or_default().push(i);
+            }
+        }
+        DiscriminationIndex { by_head, universal }
+    }
+
+    /// Rule indices to try for `expr`, in order (head-specific then universal).
+    pub fn candidates<'a>(&'a self, expr: ExprId, pool: &ExprPool) -> CandidateRules<'a> {
+        let head = expr_head(expr, pool);
+        let specific = self.by_head.get(&head).map(|v| v.as_slice()).unwrap_or(&[]);
+        CandidateRules {
+            specific,
+            universal: &self.universal,
+            phase: 0,
+            i: 0,
+        }
+    }
+}
+
+/// Iterator over rule indices for a single simplification step.
+pub struct CandidateRules<'a> {
+    specific: &'a [usize],
+    universal: &'a [usize],
+    phase: u8,
+    i: usize,
+}
+
+impl<'a> Iterator for CandidateRules<'a> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.phase == 0 {
+            if self.i < self.specific.len() {
+                let idx = self.specific[self.i];
+                self.i += 1;
+                return Some(idx);
+            }
+            self.phase = 1;
+            self.i = 0;
+        }
+        if self.i < self.universal.len() {
+            let idx = self.universal[self.i];
+            self.i += 1;
+            Some(idx)
+        } else {
+            None
+        }
+    }
+}
+
+/// Head constructor of an expression node.
+pub fn expr_head(expr: ExprId, pool: &ExprPool) -> PatternHead {
+    match pool.get(expr) {
+        ExprData::Add(_) => PatternHead::Add,
+        ExprData::Mul(_) => PatternHead::Mul,
+        ExprData::Pow { .. } => PatternHead::Pow,
+        ExprData::Func { name, .. } => PatternHead::Func(name),
+        ExprData::Integer(_) => PatternHead::Integer,
+        ExprData::Symbol { name, .. } => PatternHead::Symbol(name),
+        _ => PatternHead::Any,
+    }
+}
+
+/// Head constructor of a pattern's root node.
+pub fn pattern_head(pat: ExprId, pool: &ExprPool) -> PatternHead {
+    match pool.get(pat) {
+        ExprData::Add(_) => PatternHead::Add,
+        ExprData::Mul(_) => PatternHead::Mul,
+        ExprData::Pow { .. } => PatternHead::Pow,
+        ExprData::Func { name, .. } => PatternHead::Func(name),
+        ExprData::Integer(_) => PatternHead::Integer,
+        ExprData::Symbol { name, .. } if is_wildcard(&name) => PatternHead::Any,
+        ExprData::Symbol { name, .. } => PatternHead::Symbol(name.clone()),
+        _ => PatternHead::Any,
+    }
+}
+
+fn is_wildcard(name: &str) -> bool {
+    name.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_only_tries_matching_head() {
+        let pool = ExprPool::new();
+        let index = DiscriminationIndex::build([PatternHead::Add, PatternHead::Mul]);
+        let x = pool.symbol("x", crate::kernel::Domain::Real);
+        let add_expr = pool.add(vec![x, x]);
+        let candidates: Vec<_> = index.candidates(add_expr, &pool).collect();
+        assert_eq!(candidates, vec![0]);
+        let mul_expr = pool.mul(vec![x, pool.integer(2_i32)]);
+        let candidates: Vec<_> = index.candidates(mul_expr, &pool).collect();
+        assert_eq!(candidates, vec![1]);
+    }
+}

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -2,6 +2,7 @@ use super::rules::{
     AddZero, CanonicalOrder, ConstFold, DivSelf, ExpandMul, FlattenAdd, FlattenMul, MulOne,
     MulZero, PowOne, PowZero, RewriteRule, SubSelf,
 };
+use super::rulesets::PatternRuleSet;
 use crate::deriv::log::{DerivationLog, DerivedExpr};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use std::collections::HashMap;
@@ -116,6 +117,42 @@ fn simplify_node(
                 current = new_expr;
                 fired = true;
                 break; // restart from first rule after any change
+            }
+        }
+        if !fired {
+            break;
+        }
+    }
+
+    let result = DerivedExpr::with_log(current, child_log.merge(rule_log));
+    memo.insert(expr, result.value);
+    result
+}
+
+fn simplify_node_indexed(
+    expr: ExprId,
+    pool: &ExprPool,
+    rule_set: &PatternRuleSet,
+    child_rules: &[Box<dyn RewriteRule>],
+    memo: &mut HashMap<ExprId, ExprId>,
+) -> DerivedExpr<ExprId> {
+    if let Some(&cached) = memo.get(&expr) {
+        return DerivedExpr::new(cached);
+    }
+
+    let data = pool.get(expr);
+    let (rebuilt, child_log) = simplify_children(data, pool, child_rules, memo);
+
+    let mut current = rebuilt;
+    let mut rule_log = DerivationLog::new();
+    loop {
+        let mut fired = false;
+        for idx in rule_set.index().candidates(current, pool) {
+            if let Some((new_expr, step_log)) = rule_set.rules()[idx].apply(current, pool) {
+                rule_log = rule_log.merge(step_log);
+                current = new_expr;
+                fired = true;
+                break;
             }
         }
         if !fired {
@@ -252,8 +289,42 @@ pub fn simplify_with(
     }
 
     if !config.assumptions.is_empty() {
-        let colored =
-            super::colored_egraph::apply_colored_if_needed(current.value, pool, &config.assumptions);
+        let colored = super::colored_egraph::apply_colored_if_needed(
+            current.value,
+            pool,
+            &config.assumptions,
+        );
+        return DerivedExpr::with_log(colored.value, current.log.merge(colored.log));
+    }
+    current
+}
+
+/// Simplify `expr` using a [`PatternRuleSet`] (discrimination-net indexed).
+pub fn simplify_with_pattern_rules(
+    expr: ExprId,
+    pool: &ExprPool,
+    rule_set: &PatternRuleSet,
+    config: SimplifyConfig,
+) -> DerivedExpr<ExprId> {
+    let child_rules = rule_set.as_dyn_rules();
+    let mut current = DerivedExpr::new(expr);
+    for _ in 0..config.max_iterations {
+        let mut memo: HashMap<ExprId, ExprId> = HashMap::new();
+        let result = simplify_node_indexed(current.value, pool, rule_set, &child_rules, &mut memo);
+        let merged_log = current.log.merge(result.log);
+        if result.value == current.value {
+            current = DerivedExpr::with_log(current.value, merged_log);
+            break;
+        }
+        current = DerivedExpr::with_log(result.value, merged_log);
+    }
+
+    if !config.assumptions.is_empty() {
+        let colored = super::colored_egraph::apply_colored_if_needed(
+            current.value,
+            pool,
+            &config.assumptions,
+        );
         return DerivedExpr::with_log(colored.value, current.log.merge(colored.log));
     }
     current

--- a/alkahest-core/src/simplify/mod.rs
+++ b/alkahest-core/src/simplify/mod.rs
@@ -1,4 +1,5 @@
 pub mod colored_egraph;
+pub mod discrimination_net;
 pub mod egraph;
 pub mod engine;
 #[cfg(feature = "parallel")]
@@ -12,10 +13,14 @@ mod proptests;
 pub use colored_egraph::{
     assumptions_satisfy, simplify_colored, ColorId, ColoredEgraph, CONTEXT_COLOR, ROOT_COLOR,
 };
+pub use discrimination_net::{expr_head, pattern_head, DiscriminationIndex, PatternHead};
 pub use egraph::{
     simplify_egraph, simplify_egraph_with, DepthCost, EgraphConfig, EgraphCost, NoncommutativeCost,
     OpCost, SizeCost, StabilityCost,
 };
-pub use engine::{rules_for_config, simplify, simplify_expanded, simplify_with, SimplifyConfig};
+pub use engine::{
+    rules_for_config, simplify, simplify_expanded, simplify_with, simplify_with_pattern_rules,
+    SimplifyConfig,
+};
 pub use rules::RewriteRule;
-pub use rulesets::PatternRule;
+pub use rulesets::{PatternRule, PatternRuleSet};

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -18,6 +18,7 @@
 use crate::deriv::log::{DerivationLog, RewriteStep, SideCondition};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::pattern::{Pattern, Substitution};
+use crate::simplify::discrimination_net::{pattern_head, DiscriminationIndex};
 use crate::simplify::rules::RewriteRule;
 
 fn one_step(name: &'static str, before: ExprId, after: ExprId) -> DerivationLog {
@@ -285,10 +286,40 @@ pub fn log_exp_rules_safe() -> Vec<Box<dyn RewriteRule>> {
 /// let r = simplify_with(expr, &pool, &[Box::new(rule)], SimplifyConfig::default());
 /// // x + x → 2*x
 /// ```
+#[derive(Clone)]
 pub struct PatternRule {
     pub lhs: Pattern,
     pub rhs: ExprId,
     name: &'static str,
+}
+
+/// Pattern rules plus a discrimination-net index for O(1) head lookup.
+pub struct PatternRuleSet {
+    rules: Vec<PatternRule>,
+    index: DiscriminationIndex,
+}
+
+impl PatternRuleSet {
+    pub fn new(rules: Vec<PatternRule>, pool: &ExprPool) -> Self {
+        let heads = rules.iter().map(|r| pattern_head(r.lhs.root, pool));
+        let index = DiscriminationIndex::build(heads);
+        PatternRuleSet { rules, index }
+    }
+
+    pub fn rules(&self) -> &[PatternRule] {
+        &self.rules
+    }
+
+    pub fn index(&self) -> &DiscriminationIndex {
+        &self.index
+    }
+
+    pub fn as_dyn_rules(&self) -> Vec<Box<dyn RewriteRule>> {
+        self.rules
+            .iter()
+            .map(|r| Box::new(r.clone()) as Box<dyn RewriteRule>)
+            .collect()
+    }
 }
 
 impl PatternRule {
@@ -527,7 +558,7 @@ mod tests {
     use super::*;
     use crate::kernel::{Domain, ExprPool};
     use crate::pattern::Pattern;
-    use crate::simplify::engine::{simplify_with, SimplifyConfig};
+    use crate::simplify::engine::{simplify_with, simplify_with_pattern_rules, SimplifyConfig};
 
     fn p() -> ExprPool {
         ExprPool::new()
@@ -678,7 +709,8 @@ mod tests {
         let rule = PatternRule::new(Pattern::from_expr(lhs), rhs);
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.add(vec![x, x]);
-        let r = simplify_with(expr, &pool, &[Box::new(rule)], SimplifyConfig::default());
+        let rule_set = PatternRuleSet::new(vec![rule], &pool);
+        let r = simplify_with_pattern_rules(expr, &pool, &rule_set, SimplifyConfig::default());
         let expected = pool.mul(vec![pool.integer(2_i32), x]);
         assert_eq!(r.value, expected);
     }


### PR DESCRIPTION
Introduce DiscriminationIndex keyed by pattern/expression head constructor, PatternRuleSet, and simplify_with_pattern_rules for O(1) head lookup when applying user-defined PatternRule sets.