### PR TITLE
feat: plotting layer — SVG/DOT Rust renderers + Python backend dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,63 @@ df = ak.grad(f)          # symbolic gradient
 df_fast = ak.jit(df)     # compiled gradient
 ```
 
+### Plotting
+
+Alkahest never bundles a plotting library — it detects what is installed and calls into it. The default backend is **Matplotlib** (static PNG/SVG); **Plotly** is also supported for interactive figures (and renders natively in the demo-playground notebook). A dependency-free **SVG renderer** is built into the Rust kernel and works without any plotting library installed.
+
+```python
+import alkahest as ak
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+
+# Curve (matplotlib by default, or backend="plotly")
+ax = ak.plot(ak.sin(x), x, (-3 * 3.14159, 3 * 3.14159))
+
+# 3-D surface
+y = pool.symbol("y")
+fig = ak.plot3d(ak.sin(x) * ak.cos(y), x, y, (-5, 5), (-5, 5))
+
+# Parametric curve
+t = pool.symbol("t")
+ax2 = ak.plot_parametric(ak.cos(t), ak.sin(t), t, (0, 6.28318))
+
+# Implicit curve: x² + y² = 1
+ax3 = ak.plot_implicit(x**2 + y**2 - pool.integer(1), x, y, (-2, 2), (-2, 2))
+
+# Real roots of a polynomial on the x-axis
+p = ak.UniPoly.from_symbolic(x**3 - x, x)
+ax4 = ak.plot_roots(p, x)
+
+# Series truncation vs exact function
+s = ak.series(ak.cos(x), x, pool.integer(0), 6)
+ax5 = ak.plot_series(s, ak.cos(x), x, (-4, 4))
+
+# Expression DAG (requires graphviz package, falls back to DOT string)
+dot = ak.plot_dag(ak.sin(x**2 + pool.integer(1)))
+
+# Dependency-free SVG (no matplotlib/plotly needed)
+svg_str = ak.plot_svg(ak.sin(x), x, (-6, 6))
+```
+
+Install a backend once — alkahest uses whichever is available:
+
+```bash
+pip install matplotlib   # default; static PNG/SVG
+pip install plotly       # interactive; also renders in demo-playground
+```
+
+For GPU-accelerated plots on dense grids (pairs well with the `+full` JIT wheel):
+
+```bash
+pip install fastplotlib
+```
+
+```python
+from alkahest.experimental._fastplotlib import fplot, fplot3d
+fplot(ak.sin(x), x, (-10, 10), n=100_000)
+```
+
 ---
 
 ## Directory layout
@@ -474,15 +531,18 @@ alkahest/
 │   │   ├── diffalg/       # Rosenfeld–Gröbner / differential elimination (groebner)
 │   │   ├── solver/        # polynomial solving: Gröbner triangular, regular chains, homotopy
 │   │   ├── lean/          # Lean 4 proof certificate export
+│   │   ├── plot/          # SVG polyline + Graphviz DOT renderers (dependency-free)
 │   │   └── primitive/     # primitive registration system
 │   └── benches/           # criterion benchmarks
 ├── alkahest-mlir/         # MLIR dialect and lowering passes
 ├── alkahest-py/           # PyO3 bindings (Rust side)
 ├── python/alkahest/       # Python package
+│   ├── _plot.py           # plotting: plot, plot3d, plot_parametric, plot_implicit, …
 │   ├── _transform.py      # trace, grad, jit decorators
 │   ├── _pytree.py         # JAX-style pytree flattening
 │   ├── _context.py        # context manager and defaults
 │   └── experimental/      # unstable API surface
+│       └── _fastplotlib.py# GPU-accelerated plotting adapter
 ├── examples/              # runnable end-to-end examples
 │   └── rust_quickstart/   # self-contained Cargo project for alkahest-cas
 ├── tests/                 # Python test suite (pytest + hypothesis)

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -41,6 +41,8 @@ pub mod diffalg;
 // V2-10 — Gosper / creative telescoping (WZ certificates)
 pub mod stablehlo;
 pub mod sum;
+// Plot — dependency-free SVG / DOT renderers
+pub mod plot;
 
 pub use acausal::{capacitor, resistor, voltage_source, Component, Port, System};
 pub use calculus::{limit, series, LimitDirection, LimitError, Series, SeriesError};
@@ -109,6 +111,9 @@ pub use jit::{
     select_compile_tier, CompileCache, CompileConfig, CompileTier, CompiledFn, JitError,
     INTERP_MAX_EXPECTED_EVALS, INTERP_MAX_NODES, LLVM_MIN_EXPECTED_EVALS,
 };
+
+// Plot — SVG polyline and Graphviz DOT renderers (dependency-free)
+pub use plot::{render_dot, render_svg, render_svg_opts};
 
 // V5-2 — StableHLO/XLA bridge
 pub use stablehlo::emit_stablehlo;
@@ -271,6 +276,7 @@ pub mod experimental {
     pub use crate::ode::sensitivity::{
         adjoint_system, sensitivity_system, AdjointSystem, SensitivitySystem,
     };
+    pub use crate::plot::{render_dot, render_svg, render_svg_opts};
     pub use crate::poly::{
         gcd_sparse_modular, sparse_interpolate, sparse_interpolate_univariate, SparseGcdError,
         SparseInterpError,

--- a/alkahest-core/src/plot/dot.rs
+++ b/alkahest-core/src/plot/dot.rs
@@ -1,0 +1,75 @@
+/// Graphviz DOT emitter for symbolic expression DAGs.
+///
+/// Walks the expression tree rooted at `expr` and emits a `digraph` in DOT
+/// format.  Shared sub-expressions (same `ExprId`) are rendered as a single
+/// node with multiple incoming edges, faithfully representing the DAG
+/// structure.
+///
+/// Pipe the output through `dot -Tpng -o graph.png` or `dot -Tsvg` to render.
+use crate::kernel::expr::ExprData;
+use crate::kernel::{ExprId, ExprPool};
+use std::collections::HashSet;
+
+/// Emit a Graphviz DOT string for the expression DAG rooted at `expr`.
+pub fn render_dot(pool: &ExprPool, expr: ExprId) -> String {
+    let mut out =
+        String::from("digraph expr {\n  node [shape=box fontname=\"Courier\" fontsize=10];\n");
+    let mut visited = HashSet::new();
+    emit_node(pool, expr, &mut out, &mut visited);
+    out.push_str("}\n");
+    out
+}
+
+fn node_id(id: ExprId) -> String {
+    format!("n{}", id.0)
+}
+
+fn node_label(pool: &ExprPool, id: ExprId) -> String {
+    match pool.get(id) {
+        ExprData::Symbol { name, .. } => format!("sym\\n{}", escape_dot(&name)),
+        ExprData::Integer(n) => format!("int\\n{}", n),
+        ExprData::Rational(r) => format!("rat\\n{}", r),
+        ExprData::Float(f) => format!("float\\n{}", f),
+        ExprData::Add(_) => "Add".to_string(),
+        ExprData::Mul(_) => "Mul".to_string(),
+        ExprData::Pow { .. } => "Pow".to_string(),
+        ExprData::Func { name, .. } => format!("fn\\n{}", escape_dot(&name)),
+        ExprData::Piecewise { .. } => "Piecewise".to_string(),
+        ExprData::Predicate { kind, .. } => format!("pred\\n{}", kind),
+        ExprData::Forall { .. } => "Forall".to_string(),
+        ExprData::Exists { .. } => "Exists".to_string(),
+        ExprData::BigO(_) => "BigO".to_string(),
+    }
+}
+
+fn escape_dot(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn emit_node(pool: &ExprPool, id: ExprId, out: &mut String, visited: &mut HashSet<u32>) {
+    if !visited.insert(id.0) {
+        return;
+    }
+    let label = node_label(pool, id);
+    out.push_str(&format!("  {} [label=\"{}\"];\n", node_id(id), label));
+
+    let children: Vec<ExprId> = match pool.get(id) {
+        ExprData::Add(kids) | ExprData::Mul(kids) => kids,
+        ExprData::Pow { base, exp } => vec![base, exp],
+        ExprData::Func { args, .. } => args,
+        ExprData::Piecewise { branches, default } => {
+            let mut v: Vec<ExprId> = branches.iter().flat_map(|(c, v)| [*c, *v]).collect();
+            v.push(default);
+            v
+        }
+        ExprData::Predicate { args, .. } => args,
+        ExprData::Forall { var, body } | ExprData::Exists { var, body } => vec![var, body],
+        ExprData::BigO(inner) => vec![inner],
+        _ => vec![],
+    };
+
+    for child in &children {
+        emit_node(pool, *child, out, visited);
+        out.push_str(&format!("  {} -> {};\n", node_id(id), node_id(*child)));
+    }
+}

--- a/alkahest-core/src/plot/mod.rs
+++ b/alkahest-core/src/plot/mod.rs
@@ -1,0 +1,5 @@
+pub mod dot;
+pub mod svg;
+
+pub use dot::render_dot;
+pub use svg::{render_svg, render_svg_opts};

--- a/alkahest-core/src/plot/svg.rs
+++ b/alkahest-core/src/plot/svg.rs
@@ -1,0 +1,113 @@
+/// Dependency-free SVG polyline renderer for symbolic expressions.
+///
+/// Evaluates `expr` in `var` over `[lo, hi]` using the tree-walking interpreter
+/// (no JIT required) and emits a standalone `<svg>` element containing a
+/// `<polyline>`. NaN / infinite samples are silently skipped so that
+/// asymptotes don't corrupt the path.
+use crate::jit::eval_interp;
+use crate::kernel::{ExprId, ExprPool};
+use std::collections::HashMap;
+
+/// Default number of sample points along the x axis.
+const DEFAULT_N: usize = 300;
+
+/// Render `expr(var)` over `[lo, hi]` as a standalone SVG string.
+///
+/// * `width` / `height` — output dimensions in pixels.
+/// * `n_pts`   — number of evenly-spaced sample points (default: `300`).
+/// * `padding` — pixel margin inside the SVG viewport (default: `10`).
+///
+/// Returns a UTF-8 SVG string suitable for embedding in HTML, saving as
+/// a `.svg` file, or encoding as `data:image/svg+xml;base64,...`.
+pub fn render_svg(
+    pool: &ExprPool,
+    expr: ExprId,
+    var: ExprId,
+    lo: f64,
+    hi: f64,
+    width: u32,
+    height: u32,
+) -> String {
+    render_svg_opts(pool, expr, var, lo, hi, width, height, DEFAULT_N, 10)
+}
+
+/// Like [`render_svg`] but exposes sampling density and padding.
+pub fn render_svg_opts(
+    pool: &ExprPool,
+    expr: ExprId,
+    var: ExprId,
+    lo: f64,
+    hi: f64,
+    width: u32,
+    height: u32,
+    n_pts: usize,
+    padding: u32,
+) -> String {
+    let n = n_pts.max(2);
+    let mut xs = Vec::with_capacity(n);
+    let mut ys = Vec::with_capacity(n);
+
+    let mut env = HashMap::with_capacity(1);
+    for i in 0..n {
+        let t = lo + (hi - lo) * (i as f64) / ((n - 1) as f64);
+        env.insert(var, t);
+        if let Some(y) = eval_interp(expr, &env, pool) {
+            if y.is_finite() {
+                xs.push(t);
+                ys.push(y);
+            }
+        }
+    }
+
+    if xs.is_empty() {
+        return empty_svg(width, height);
+    }
+
+    let y_min = ys.iter().cloned().fold(f64::INFINITY, f64::min);
+    let y_max = ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let y_range = if (y_max - y_min).abs() < 1e-14 {
+        1.0
+    } else {
+        y_max - y_min
+    };
+
+    let pad = padding as f64;
+    let inner_w = (width as f64) - 2.0 * pad;
+    let inner_h = (height as f64) - 2.0 * pad;
+    let x_range = hi - lo;
+
+    let points: String = xs
+        .iter()
+        .zip(ys.iter())
+        .map(|(x, y)| {
+            let px = pad + (x - lo) / x_range * inner_w;
+            // SVG y-axis is inverted: y_max maps to top (pad), y_min to bottom.
+            let py = pad + (y_max - y) / y_range * inner_h;
+            format!("{:.2},{:.2}", px, py)
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" viewBox="0 0 {w} {h}">
+  <rect width="{w}" height="{h}" fill="#ffffff"/>
+  <polyline points="{pts}" fill="none" stroke="#1f77b4" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>"##,
+        w = width,
+        h = height,
+        pts = points,
+    )
+}
+
+fn empty_svg(width: u32, height: u32) -> String {
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" viewBox="0 0 {w} {h}">
+  <rect width="{w}" height="{h}" fill="#ffffff"/>
+  <text x="{cx}" y="{cy}" font-size="12" fill="#888888" text-anchor="middle">no finite values</text>
+</svg>"##,
+        w = width,
+        h = height,
+        cx = width / 2,
+        cy = height / 2,
+    )
+}

--- a/alkahest-core/src/plot/svg.rs
+++ b/alkahest-core/src/plot/svg.rs
@@ -32,6 +32,7 @@ pub fn render_svg(
 }
 
 /// Like [`render_svg`] but exposes sampling density and padding.
+#[allow(clippy::too_many_arguments)]
 pub fn render_svg_opts(
     pool: &ExprPool,
     expr: ExprId,

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -5876,6 +5876,7 @@ fn py_guess_relation(
 
 #[pyfunction]
 #[pyo3(name = "plot_svg", signature = (expr, var, lo, hi, width=640, height=400, n_pts=300, padding=10))]
+#[allow(clippy::too_many_arguments)]
 fn py_plot_svg(
     py: Python<'_>,
     expr: PyRef<PyExpr>,

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -5870,6 +5870,44 @@ fn py_guess_relation(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Plot — SVG polyline and Graphviz DOT renderers
+// ---------------------------------------------------------------------------
+
+#[pyfunction]
+#[pyo3(name = "plot_svg", signature = (expr, var, lo, hi, width=640, height=400, n_pts=300, padding=10))]
+fn py_plot_svg(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    var: PyRef<PyExpr>,
+    lo: f64,
+    hi: f64,
+    width: u32,
+    height: u32,
+    n_pts: usize,
+    padding: u32,
+) -> String {
+    let pool_ref = expr.pool.borrow(py);
+    alkahest_core::render_svg_opts(
+        &pool_ref.inner,
+        expr.id,
+        var.id,
+        lo,
+        hi,
+        width,
+        height,
+        n_pts,
+        padding,
+    )
+}
+
+#[pyfunction]
+#[pyo3(name = "plot_dot")]
+fn py_plot_dot(py: Python<'_>, expr: PyRef<PyExpr>) -> String {
+    let pool_ref = expr.pool.borrow(py);
+    alkahest_core::render_dot(&pool_ref.inner, expr.id)
+}
+
 #[pymodule]
 fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
@@ -6048,6 +6086,9 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_nt_jacobi, m)?)?;
     m.add_function(wrap_pyfunction!(py_nt_nthroot_mod, m)?)?;
     m.add_function(wrap_pyfunction!(py_nt_discrete_log, m)?)?;
+    // Plot — SVG and DOT renderers
+    m.add_function(wrap_pyfunction!(py_plot_svg, m)?)?;
+    m.add_function(wrap_pyfunction!(py_plot_dot, m)?)?;
     // V1-3 — Structured exception hierarchy
     m.add("AlkahestError", m.py().get_type_bound::<PyAlkahestError>())?;
     m.add(

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -450,6 +450,58 @@ unicode_str(e)
 
 ---
 
+## Plotting
+
+Alkahest never bundles a plotting library. All plot functions detect what is installed and call into it. The default backend is **Matplotlib**; **Plotly** is the interactive alternative (`backend="plotly"`).
+
+```python
+import alkahest as ak
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+y = pool.symbol("y")
+
+# 1-D curve — uses matplotlib by default, or plotly if specified
+ax  = ak.plot(ak.sin(x), x, (-6.28, 6.28))
+fig = ak.plot(ak.sin(x), x, (-6.28, 6.28), backend="plotly")
+
+# 2-D surface
+ak.plot3d(ak.sin(x) * ak.cos(y), x, y, (-5, 5), (-5, 5))
+
+# Parametric curve
+t = pool.symbol("t")
+ak.plot_parametric(ak.cos(t), ak.sin(t), t, (0, 6.28318))
+
+# Implicit curve f(x, y) = 0
+ak.plot_implicit(x**2 + y**2 - pool.integer(1), x, y, (-2, 2), (-2, 2))
+
+# Root markers on x-axis
+p = ak.UniPoly.from_symbolic(x**3 - x, x)
+ak.plot_roots(p, x)
+
+# Series truncation vs exact
+s = ak.series(ak.cos(x), x, pool.integer(0), 6)
+ak.plot_series(s, ak.cos(x), x, (-4, 4))
+
+# Expression DAG (graphviz package → rendered figure; else DOT string)
+dot_or_src = ak.plot_dag(ak.sin(x**2))
+
+# Dependency-free SVG — no matplotlib/plotly needed
+svg_str = ak.plot_svg(ak.sin(x), x, (-6, 6))
+# Use in Jupyter: from IPython.display import SVG; SVG(svg_str)
+```
+
+All `plot*` functions accept `**kw` forwarded to the backend. `plot` / `plot_parametric` also accept `ax=` (matplotlib) or `fig=` (plotly) to draw onto an existing figure.
+
+GPU-accelerated plotting for dense grids (experimental; requires `pip install fastplotlib`):
+
+```python
+from alkahest.experimental._fastplotlib import fplot, fplot3d
+fplot(ak.sin(x), x, (-10, 10), n=100_000)   # 100k-point GPU line
+```
+
+---
+
 ## Stable vs experimental API
 
 Semantics-stable symbols are those in `alkahest.__all__` (and Rust `alkahest_core::stable`). New or unstable Python APIs live under `alkahest.experimental` and may change in minor releases—prefer top-level exports for agent-written code unless the user asks for experimental features.
@@ -479,3 +531,5 @@ reg = PrimitiveRegistry()
 8. **`grad` expects a `TracedFn`.** `jit` accepts a `TracedFn` or `GradTracedFn`; both raise `TypeError` on undecorated callables.
 9. **`numpy_eval` expects a `CompiledFn`** (from `compile_expr`), not a `TracedFn`.
 10. **Symbols from different pools are incompatible.** Keep one pool per computation graph.
+11. **`plot*` functions detect the backend automatically.** Never import matplotlib/plotly in user code just to call `ak.plot` — let alkahest dispatch. Use `backend="plotly"` or `backend="matplotlib"` to force one. Use `plot_svg` when no plotting library is available.
+12. **`plot_dag` returns a `graphviz.Source` if the `graphviz` package is installed, otherwise a raw DOT string.** Call `.render()` or `.view()` on the returned object, or pipe the string to `dot -Tpng`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -126,6 +126,19 @@ Current stable feature surface.
 - Hybrid systems with events (`HybridODE`, `Event`)
 - Piecewise expressions and predicates
 
+## Plotting
+
+- **No bundled dependency** — detects and uses whatever the user has installed (Matplotlib or Plotly).
+- `plot(expr, var, range_)` — 1-D curve (Matplotlib or Plotly backend).
+- `plot3d(expr, var_x, var_y, x_range, y_range)` — 3-D surface.
+- `plot_parametric(expr_x, expr_y, param, range_)` — parametric curve.
+- `plot_implicit(expr, var_x, var_y, x_range, y_range)` — zero-set of a 2-variable expression (contour at 0).
+- `plot_roots(unipoly, var)` — real root markers on the x-axis (rug plot via `real_roots`).
+- `plot_series(series_result, original_expr, var, range_)` — Taylor/Laurent truncation vs exact.
+- `plot_dag(expr)` — expression DAG via Graphviz Python package (falls back to raw DOT string).
+- `plot_svg(expr, var, range_)` — standalone SVG polyline rendered entirely in Rust; no Python plotting dep required; suitable for embedding in HTML or Jupyter.
+- `alkahest.experimental._fastplotlib` — GPU-accelerated `fplot` / `fplot3d` via fastplotlib (WGPU); recommended for dense grids with the `+full` JIT wheel.
+
 ## Output and parsing
 
 - LaTeX pretty-printing (`latex(expr)`)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,6 +28,7 @@ Chapters:
 - ODE and DAE modeling
 - Polynomial system solving
 - Interoperability (NumPy, JAX, PyTorch, StableHLO)
+- Plotting (backend dispatch, Matplotlib/Plotly/fastplotlib, SVG renderer)
 - Derivation logs
 - Lean certificates
 - Error handling
@@ -42,7 +43,7 @@ sphinx-build -b html docs/sphinx/ docs/sphinx/_build/
 ```
 
 Covers: core types, simplification, calculus, polynomials, numerics,
-transformations, matrices, ODE/DAE, solver, code generation, errors.
+transformations, matrices, ODE/DAE, solver, code generation, plotting, errors.
 
 ## Other reference
 

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -17,6 +17,16 @@ from ._context import (
 )
 from ._dlpack import _to_numpy
 from ._parse import parse
+from ._plot import (
+    plot,
+    plot3d,
+    plot_dag,
+    plot_implicit,
+    plot_parametric,
+    plot_roots,
+    plot_series,
+    plot_svg,
+)
 from ._pretty import latex, unicode_str
 from ._product import Product
 from ._pytree import (
@@ -920,6 +930,14 @@ __all__ = [
     "parse",
     # PA-9
     "piecewise",
+    "plot",
+    "plot3d",
+    "plot_dag",
+    "plot_implicit",
+    "plot_parametric",
+    "plot_roots",
+    "plot_series",
+    "plot_svg",
     # Phase 27
     "poly_normal",
     "product_definite",

--- a/python/alkahest/_plot.py
+++ b/python/alkahest/_plot.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import numpy as np
-
 # ---------------------------------------------------------------------------
 # Backend selection
 # ---------------------------------------------------------------------------
@@ -64,6 +62,7 @@ def _require_backend(name: str | None) -> str:
 
 def _eval_1d(expr, var, lo: float, hi: float, n: int = 300):
     """Return (xs, ys) as float64 arrays, skipping non-finite samples."""
+    import numpy as np
     from .alkahest import compile_expr  # type: ignore[import]
     from ._dlpack import numpy_eval_dlpack
 
@@ -76,6 +75,7 @@ def _eval_1d(expr, var, lo: float, hi: float, n: int = 300):
 
 def _eval_2d(expr, var_x, var_y, x_range, y_range, n: int = 80):
     """Return (X, Y, Z) meshgrid arrays."""
+    import numpy as np
     from .alkahest import compile_expr  # type: ignore[import]
     from ._dlpack import numpy_eval_dlpack
 
@@ -236,6 +236,7 @@ def plot_parametric(
     _, xs_vals = _eval_1d(expr_x, param, lo, hi, n)
     _, ys_vals = _eval_1d(expr_y, param, lo, hi, n)
     # Re-evaluate on a common grid (no filtering) for a connected curve.
+    import numpy as np
     from .alkahest import compile_expr  # type: ignore[import]
     from ._dlpack import numpy_eval_dlpack
     ts = np.linspace(lo, hi, n)

--- a/python/alkahest/_plot.py
+++ b/python/alkahest/_plot.py
@@ -1,0 +1,507 @@
+"""Plotting helpers for Alkahest symbolic expressions.
+
+Backend dispatch
+----------------
+alkahest never lists a plotting library in its own dependencies.  Instead,
+``plot()`` and friends detect what the user has installed and call into it.
+The active backend can be forced with the ``backend`` keyword argument:
+
+    ak.plot(expr, x, (-3, 3), backend="plotly")
+
+Supported backends:
+- ``"matplotlib"`` — default when importable; static PNG/SVG, Jupyter inline.
+- ``"plotly"``     — interactive browser figures; also renders in the
+                     demo-playground notebook (HTML output blob).
+
+``plot_dag`` additionally accepts ``"graphviz"`` (renders via the Graphviz
+Python package) and falls back to a text DOT string when it is absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+_KNOWN_BACKENDS = {"matplotlib", "plotly"}
+
+
+def _default_backend() -> str:
+    try:
+        import matplotlib  # noqa: F401
+        return "matplotlib"
+    except ImportError:
+        pass
+    try:
+        import plotly  # noqa: F401
+        return "plotly"
+    except ImportError:
+        pass
+    raise ImportError(
+        "No plotting backend found.\n"
+        "Install one with:  pip install matplotlib\n"
+        "Or:               pip install plotly"
+    )
+
+
+def _require_backend(name: str | None) -> str:
+    if name is None:
+        return _default_backend()
+    if name not in _KNOWN_BACKENDS:
+        raise ValueError(
+            f"Unknown backend {name!r}. Choose from: {sorted(_KNOWN_BACKENDS)}"
+        )
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Internal: evaluate expr numerically over a 1-D grid
+# ---------------------------------------------------------------------------
+
+def _eval_1d(expr, var, lo: float, hi: float, n: int = 300):
+    """Return (xs, ys) as float64 arrays, skipping non-finite samples."""
+    from .alkahest import compile_expr  # type: ignore[import]
+    from ._dlpack import numpy_eval_dlpack
+
+    xs = np.linspace(lo, hi, n)
+    fn = compile_expr(expr, [var])
+    ys = numpy_eval_dlpack(fn, xs)
+    finite = np.isfinite(ys)
+    return xs[finite], ys[finite]
+
+
+def _eval_2d(expr, var_x, var_y, x_range, y_range, n: int = 80):
+    """Return (X, Y, Z) meshgrid arrays."""
+    from .alkahest import compile_expr  # type: ignore[import]
+    from ._dlpack import numpy_eval_dlpack
+
+    xs = np.linspace(x_range[0], x_range[1], n)
+    ys = np.linspace(y_range[0], y_range[1], n)
+    X, Y = np.meshgrid(xs, ys)
+    fn = compile_expr(expr, [var_x, var_y])
+    Z = numpy_eval_dlpack(fn, X, Y)
+    return X, Y, Z
+
+
+# ---------------------------------------------------------------------------
+# plot — 1-D curve
+# ---------------------------------------------------------------------------
+
+def plot(
+    expr,
+    var,
+    range_: tuple[float, float] = (-5.0, 5.0),
+    *,
+    n: int = 300,
+    label: str | None = None,
+    title: str | None = None,
+    backend: str | None = None,
+    **kw: Any,
+):
+    """Plot a single-variable symbolic expression.
+
+    Parameters
+    ----------
+    expr    : Expr  — symbolic expression in *var*.
+    var     : Expr  — the free variable.
+    range_  : (lo, hi) — plotting interval (default: ``(-5, 5)``).
+    n       : number of sample points (default: ``300``).
+    label   : legend label.
+    title   : axis title.
+    backend : ``"matplotlib"`` (default) or ``"plotly"``.
+    **kw    : forwarded to the backend's line-plot call.
+
+    Returns
+    -------
+    Axes (matplotlib) or Figure (plotly).
+    """
+    b = _require_backend(backend)
+    lo, hi = float(range_[0]), float(range_[1])
+    xs, ys = _eval_1d(expr, var, lo, hi, n)
+
+    if b == "matplotlib":
+        import matplotlib.pyplot as plt
+        ax = kw.pop("ax", None)
+        if ax is None:
+            _, ax = plt.subplots()
+        ax.plot(xs, ys, label=label, **kw)
+        if label:
+            ax.legend()
+        if title:
+            ax.set_title(title)
+        ax.set_xlabel(str(var))
+        return ax
+
+    if b == "plotly":
+        import plotly.graph_objects as go
+        fig = kw.pop("fig", None) or go.Figure()
+        fig.add_trace(go.Scatter(x=xs, y=ys, mode="lines", name=label or str(expr)))
+        if title:
+            fig.update_layout(title=title)
+        fig.update_layout(xaxis_title=str(var))
+        return fig
+
+    raise RuntimeError(f"Unreachable backend: {b!r}")
+
+
+# ---------------------------------------------------------------------------
+# plot3d — 2-D surface
+# ---------------------------------------------------------------------------
+
+def plot3d(
+    expr,
+    var_x,
+    var_y,
+    x_range: tuple[float, float] = (-5.0, 5.0),
+    y_range: tuple[float, float] = (-5.0, 5.0),
+    *,
+    n: int = 80,
+    title: str | None = None,
+    backend: str | None = None,
+    **kw: Any,
+):
+    """Plot a two-variable symbolic expression as a 3-D surface.
+
+    Parameters
+    ----------
+    expr    : Expr  — symbolic expression in *var_x* and *var_y*.
+    var_x, var_y : Expr — the two free variables.
+    x_range, y_range : (lo, hi) — plotting intervals.
+    n       : grid resolution per axis (default: ``80``).
+    title   : figure title.
+    backend : ``"matplotlib"`` (default) or ``"plotly"``.
+    **kw    : forwarded to the backend surface call.
+
+    Returns
+    -------
+    Axes3D (matplotlib) or Figure (plotly).
+    """
+    b = _require_backend(backend)
+    X, Y, Z = _eval_2d(expr, var_x, var_y, x_range, y_range, n)
+
+    if b == "matplotlib":
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+        fig = kw.pop("fig", None) or plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        ax.plot_surface(X, Y, Z, **kw)
+        ax.set_xlabel(str(var_x))
+        ax.set_ylabel(str(var_y))
+        if title:
+            ax.set_title(title)
+        return ax
+
+    if b == "plotly":
+        import plotly.graph_objects as go
+        fig = kw.pop("fig", None) or go.Figure()
+        fig.add_trace(go.Surface(x=X, y=Y, z=Z, **kw))
+        if title:
+            fig.update_layout(title=title)
+        return fig
+
+    raise RuntimeError(f"Unreachable backend: {b!r}")
+
+
+# ---------------------------------------------------------------------------
+# plot_parametric — parametric curve (x(t), y(t))
+# ---------------------------------------------------------------------------
+
+def plot_parametric(
+    expr_x,
+    expr_y,
+    param,
+    range_: tuple[float, float] = (0.0, 6.283185307179586),
+    *,
+    n: int = 500,
+    label: str | None = None,
+    title: str | None = None,
+    backend: str | None = None,
+    **kw: Any,
+):
+    """Plot a parametric curve (x(t), y(t)).
+
+    Parameters
+    ----------
+    expr_x, expr_y : Expr — x- and y-components in *param*.
+    param  : Expr  — the parameter variable.
+    range_ : (lo, hi) — parameter interval (default: ``(0, 2π)``).
+    n      : number of sample points.
+    """
+    b = _require_backend(backend)
+    lo, hi = float(range_[0]), float(range_[1])
+    _, xs_vals = _eval_1d(expr_x, param, lo, hi, n)
+    _, ys_vals = _eval_1d(expr_y, param, lo, hi, n)
+    # Re-evaluate on a common grid (no filtering) for a connected curve.
+    from .alkahest import compile_expr  # type: ignore[import]
+    from ._dlpack import numpy_eval_dlpack
+    ts = np.linspace(lo, hi, n)
+    fn_x = compile_expr(expr_x, [param])
+    fn_y = compile_expr(expr_y, [param])
+    xs_vals = numpy_eval_dlpack(fn_x, ts)
+    ys_vals = numpy_eval_dlpack(fn_y, ts)
+
+    if b == "matplotlib":
+        import matplotlib.pyplot as plt
+        ax = kw.pop("ax", None)
+        if ax is None:
+            _, ax = plt.subplots()
+        ax.plot(xs_vals, ys_vals, label=label, **kw)
+        if label:
+            ax.legend()
+        if title:
+            ax.set_title(title)
+        return ax
+
+    if b == "plotly":
+        import plotly.graph_objects as go
+        fig = kw.pop("fig", None) or go.Figure()
+        fig.add_trace(go.Scatter(x=xs_vals, y=ys_vals, mode="lines", name=label or ""))
+        if title:
+            fig.update_layout(title=title)
+        return fig
+
+    raise RuntimeError(f"Unreachable backend: {b!r}")
+
+
+# ---------------------------------------------------------------------------
+# plot_implicit — implicit curve f(x,y) = 0
+# ---------------------------------------------------------------------------
+
+def plot_implicit(
+    expr,
+    var_x,
+    var_y,
+    x_range: tuple[float, float] = (-5.0, 5.0),
+    y_range: tuple[float, float] = (-5.0, 5.0),
+    *,
+    n: int = 200,
+    title: str | None = None,
+    backend: str | None = None,
+    **kw: Any,
+):
+    """Plot the zero-set of a two-variable expression via matplotlib contour.
+
+    Evaluates ``expr`` on an ``n×n`` grid and draws the zero contour.
+    Only supports the ``"matplotlib"`` backend (Plotly contour lines are
+    available as a ``"plotly"`` fallback using ``Contour``).
+    """
+    b = _require_backend(backend)
+    X, Y, Z = _eval_2d(expr, var_x, var_y, x_range, y_range, n)
+
+    if b == "matplotlib":
+        import matplotlib.pyplot as plt
+        ax = kw.pop("ax", None)
+        if ax is None:
+            _, ax = plt.subplots()
+        ax.contour(X, Y, Z, levels=[0], **kw)
+        ax.set_xlabel(str(var_x))
+        ax.set_ylabel(str(var_y))
+        if title:
+            ax.set_title(title)
+        return ax
+
+    if b == "plotly":
+        import plotly.graph_objects as go
+        fig = kw.pop("fig", None) or go.Figure()
+        fig.add_trace(
+            go.Contour(x=X[0], y=Y[:, 0], z=Z, contours=dict(value=0, type="constraint"), **kw)
+        )
+        if title:
+            fig.update_layout(title=title)
+        return fig
+
+    raise RuntimeError(f"Unreachable backend: {b!r}")
+
+
+# ---------------------------------------------------------------------------
+# plot_roots — real root markers
+# ---------------------------------------------------------------------------
+
+def plot_roots(
+    unipoly,
+    var,
+    *,
+    title: str | None = None,
+    backend: str | None = None,
+    **kw: Any,
+):
+    """Mark real roots of a ``UniPoly`` on the x-axis (rug plot).
+
+    Uses :func:`alkahest.real_roots` to isolate roots, then places a vertical
+    line at the midpoint of each isolating interval.
+
+    Parameters
+    ----------
+    unipoly : UniPoly — polynomial whose real roots are to be marked.
+    var     : Expr    — the variable (used for axis labelling only).
+    """
+    from .alkahest import real_roots  # type: ignore[import]
+
+    b = _require_backend(backend)
+    result = real_roots(unipoly, var)
+    intervals = result.value if hasattr(result, "value") else result
+
+    mids = []
+    for interval in intervals:
+        lo_r = float(str(interval.lo)) if hasattr(interval, "lo") else float(interval[0])
+        hi_r = float(str(interval.hi)) if hasattr(interval, "hi") else float(interval[1])
+        mids.append((lo_r + hi_r) / 2.0)
+
+    if b == "matplotlib":
+        import matplotlib.pyplot as plt
+        ax = kw.pop("ax", None)
+        if ax is None:
+            _, ax = plt.subplots()
+        for m in mids:
+            ax.axvline(m, color="red", linestyle="--", alpha=0.7)
+        ax.set_xlabel(str(var))
+        ax.set_yticks([])
+        if title:
+            ax.set_title(title)
+        return ax
+
+    if b == "plotly":
+        import plotly.graph_objects as go
+        fig = kw.pop("fig", None) or go.Figure()
+        for m in mids:
+            fig.add_vline(x=m, line_color="red", line_dash="dash")
+        if title:
+            fig.update_layout(title=title)
+        return fig
+
+    raise RuntimeError(f"Unreachable backend: {b!r}")
+
+
+# ---------------------------------------------------------------------------
+# plot_series — series truncation vs original
+# ---------------------------------------------------------------------------
+
+def plot_series(
+    series_result,
+    original_expr,
+    var,
+    range_: tuple[float, float] = (-3.0, 3.0),
+    *,
+    n: int = 300,
+    title: str | None = None,
+    backend: str | None = None,
+    **kw: Any,
+):
+    """Overlay a Taylor/Laurent series truncation against the original function.
+
+    Parameters
+    ----------
+    series_result : Series or DerivedResult — output of :func:`alkahest.series`.
+    original_expr : Expr — the exact expression (plotted as a reference).
+    var           : Expr — the variable.
+    range_        : (lo, hi) — plotting interval.
+    """
+    b = _require_backend(backend)
+    lo, hi = float(range_[0]), float(range_[1])
+
+    series_expr = (
+        series_result.expr if hasattr(series_result, "expr") else series_result.value
+    )
+    xs_o, ys_o = _eval_1d(original_expr, var, lo, hi, n)
+    xs_s, ys_s = _eval_1d(series_expr, var, lo, hi, n)
+
+    if b == "matplotlib":
+        import matplotlib.pyplot as plt
+        ax = kw.pop("ax", None)
+        if ax is None:
+            _, ax = plt.subplots()
+        ax.plot(xs_o, ys_o, label="exact", **kw)
+        ax.plot(xs_s, ys_s, label="series", linestyle="--")
+        ax.legend()
+        if title:
+            ax.set_title(title)
+        ax.set_xlabel(str(var))
+        return ax
+
+    if b == "plotly":
+        import plotly.graph_objects as go
+        fig = kw.pop("fig", None) or go.Figure()
+        fig.add_trace(go.Scatter(x=xs_o, y=ys_o, mode="lines", name="exact"))
+        fig.add_trace(go.Scatter(x=xs_s, y=ys_s, mode="lines", name="series", line=dict(dash="dash")))
+        if title:
+            fig.update_layout(title=title)
+        return fig
+
+    raise RuntimeError(f"Unreachable backend: {b!r}")
+
+
+# ---------------------------------------------------------------------------
+# plot_dag — expression tree / DAG
+# ---------------------------------------------------------------------------
+
+def plot_dag(expr, *, title: str | None = None, **kw: Any):
+    """Visualise the expression DAG.
+
+    Tries the ``graphviz`` Python package first (renders a nice PNG/SVG via
+    system Graphviz).  Falls back to returning the raw DOT string so the
+    caller can pipe it to ``dot`` manually.
+
+    Parameters
+    ----------
+    expr : Expr — the expression to visualise.
+
+    Returns
+    -------
+    graphviz.Source  — if the ``graphviz`` package is installed.
+    str              — raw DOT string otherwise.
+    """
+    from .alkahest import plot_dot as _plot_dot  # type: ignore[import]
+    dot_src = _plot_dot(expr)
+
+    try:
+        import graphviz
+        src = graphviz.Source(dot_src)
+        if title:
+            src.comment = title
+        return src
+    except ImportError:
+        pass
+
+    return dot_src
+
+
+# ---------------------------------------------------------------------------
+# plot_svg — Rust SVG renderer (no Python plotting dep required)
+# ---------------------------------------------------------------------------
+
+def plot_svg(
+    expr,
+    var,
+    range_: tuple[float, float] = (-5.0, 5.0),
+    *,
+    width: int = 640,
+    height: int = 400,
+    n: int = 300,
+) -> str:
+    """Return a standalone SVG string for the expression (no Python dep needed).
+
+    This calls the Rust ``render_svg`` function directly and requires no
+    matplotlib / plotly installation.  The result can be:
+    - Written to a ``.svg`` file.
+    - Embedded in HTML as ``<img src="data:image/svg+xml;base64,...">``.
+    - Displayed in Jupyter: ``IPython.display.SVG(alkahest.plot_svg(...))``.
+    """
+    from .alkahest import plot_svg as _rust_plot_svg  # type: ignore[import]
+    lo, hi = float(range_[0]), float(range_[1])
+    return _rust_plot_svg(expr, var, lo, hi, width, height, n)
+
+
+__all__ = [
+    "plot",
+    "plot3d",
+    "plot_dag",
+    "plot_implicit",
+    "plot_parametric",
+    "plot_roots",
+    "plot_series",
+    "plot_svg",
+]

--- a/python/alkahest/_plot.py
+++ b/python/alkahest/_plot.py
@@ -31,11 +31,13 @@ _KNOWN_BACKENDS = {"matplotlib", "plotly"}
 def _default_backend() -> str:
     try:
         import matplotlib  # noqa: F401
+
         return "matplotlib"
     except ImportError:
         pass
     try:
         import plotly  # noqa: F401
+
         return "plotly"
     except ImportError:
         pass
@@ -50,9 +52,7 @@ def _require_backend(name: str | None) -> str:
     if name is None:
         return _default_backend()
     if name not in _KNOWN_BACKENDS:
-        raise ValueError(
-            f"Unknown backend {name!r}. Choose from: {sorted(_KNOWN_BACKENDS)}"
-        )
+        raise ValueError(f"Unknown backend {name!r}. Choose from: {sorted(_KNOWN_BACKENDS)}")
     return name
 
 
@@ -60,11 +60,13 @@ def _require_backend(name: str | None) -> str:
 # Internal: evaluate expr numerically over a 1-D grid
 # ---------------------------------------------------------------------------
 
+
 def _eval_1d(expr, var, lo: float, hi: float, n: int = 300):
     """Return (xs, ys) as float64 arrays, skipping non-finite samples."""
     import numpy as np
-    from .alkahest import compile_expr  # type: ignore[import]
+
     from ._dlpack import numpy_eval_dlpack
+    from .alkahest import compile_expr  # type: ignore[import]
 
     xs = np.linspace(lo, hi, n)
     fn = compile_expr(expr, [var])
@@ -76,8 +78,9 @@ def _eval_1d(expr, var, lo: float, hi: float, n: int = 300):
 def _eval_2d(expr, var_x, var_y, x_range, y_range, n: int = 80):
     """Return (X, Y, Z) meshgrid arrays."""
     import numpy as np
-    from .alkahest import compile_expr  # type: ignore[import]
+
     from ._dlpack import numpy_eval_dlpack
+    from .alkahest import compile_expr  # type: ignore[import]
 
     xs = np.linspace(x_range[0], x_range[1], n)
     ys = np.linspace(y_range[0], y_range[1], n)
@@ -90,6 +93,7 @@ def _eval_2d(expr, var_x, var_y, x_range, y_range, n: int = 80):
 # ---------------------------------------------------------------------------
 # plot — 1-D curve
 # ---------------------------------------------------------------------------
+
 
 def plot(
     expr,
@@ -125,6 +129,7 @@ def plot(
 
     if b == "matplotlib":
         import matplotlib.pyplot as plt
+
         ax = kw.pop("ax", None)
         if ax is None:
             _, ax = plt.subplots()
@@ -138,6 +143,7 @@ def plot(
 
     if b == "plotly":
         import plotly.graph_objects as go
+
         fig = kw.pop("fig", None) or go.Figure()
         fig.add_trace(go.Scatter(x=xs, y=ys, mode="lines", name=label or str(expr)))
         if title:
@@ -151,6 +157,7 @@ def plot(
 # ---------------------------------------------------------------------------
 # plot3d — 2-D surface
 # ---------------------------------------------------------------------------
+
 
 def plot3d(
     expr,
@@ -186,6 +193,7 @@ def plot3d(
     if b == "matplotlib":
         import matplotlib.pyplot as plt
         from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
         fig = kw.pop("fig", None) or plt.figure()
         ax = fig.add_subplot(111, projection="3d")
         ax.plot_surface(X, Y, Z, **kw)
@@ -197,6 +205,7 @@ def plot3d(
 
     if b == "plotly":
         import plotly.graph_objects as go
+
         fig = kw.pop("fig", None) or go.Figure()
         fig.add_trace(go.Surface(x=X, y=Y, z=Z, **kw))
         if title:
@@ -209,6 +218,7 @@ def plot3d(
 # ---------------------------------------------------------------------------
 # plot_parametric — parametric curve (x(t), y(t))
 # ---------------------------------------------------------------------------
+
 
 def plot_parametric(
     expr_x,
@@ -237,8 +247,10 @@ def plot_parametric(
     _, ys_vals = _eval_1d(expr_y, param, lo, hi, n)
     # Re-evaluate on a common grid (no filtering) for a connected curve.
     import numpy as np
-    from .alkahest import compile_expr  # type: ignore[import]
+
     from ._dlpack import numpy_eval_dlpack
+    from .alkahest import compile_expr  # type: ignore[import]
+
     ts = np.linspace(lo, hi, n)
     fn_x = compile_expr(expr_x, [param])
     fn_y = compile_expr(expr_y, [param])
@@ -247,6 +259,7 @@ def plot_parametric(
 
     if b == "matplotlib":
         import matplotlib.pyplot as plt
+
         ax = kw.pop("ax", None)
         if ax is None:
             _, ax = plt.subplots()
@@ -259,6 +272,7 @@ def plot_parametric(
 
     if b == "plotly":
         import plotly.graph_objects as go
+
         fig = kw.pop("fig", None) or go.Figure()
         fig.add_trace(go.Scatter(x=xs_vals, y=ys_vals, mode="lines", name=label or ""))
         if title:
@@ -271,6 +285,7 @@ def plot_parametric(
 # ---------------------------------------------------------------------------
 # plot_implicit — implicit curve f(x,y) = 0
 # ---------------------------------------------------------------------------
+
 
 def plot_implicit(
     expr,
@@ -295,6 +310,7 @@ def plot_implicit(
 
     if b == "matplotlib":
         import matplotlib.pyplot as plt
+
         ax = kw.pop("ax", None)
         if ax is None:
             _, ax = plt.subplots()
@@ -307,9 +323,10 @@ def plot_implicit(
 
     if b == "plotly":
         import plotly.graph_objects as go
+
         fig = kw.pop("fig", None) or go.Figure()
         fig.add_trace(
-            go.Contour(x=X[0], y=Y[:, 0], z=Z, contours=dict(value=0, type="constraint"), **kw)
+            go.Contour(x=X[0], y=Y[:, 0], z=Z, contours={"value": 0, "type": "constraint"}, **kw)
         )
         if title:
             fig.update_layout(title=title)
@@ -321,6 +338,7 @@ def plot_implicit(
 # ---------------------------------------------------------------------------
 # plot_roots — real root markers
 # ---------------------------------------------------------------------------
+
 
 def plot_roots(
     unipoly,
@@ -354,6 +372,7 @@ def plot_roots(
 
     if b == "matplotlib":
         import matplotlib.pyplot as plt
+
         ax = kw.pop("ax", None)
         if ax is None:
             _, ax = plt.subplots()
@@ -367,6 +386,7 @@ def plot_roots(
 
     if b == "plotly":
         import plotly.graph_objects as go
+
         fig = kw.pop("fig", None) or go.Figure()
         for m in mids:
             fig.add_vline(x=m, line_color="red", line_dash="dash")
@@ -380,6 +400,7 @@ def plot_roots(
 # ---------------------------------------------------------------------------
 # plot_series — series truncation vs original
 # ---------------------------------------------------------------------------
+
 
 def plot_series(
     series_result,
@@ -404,14 +425,13 @@ def plot_series(
     b = _require_backend(backend)
     lo, hi = float(range_[0]), float(range_[1])
 
-    series_expr = (
-        series_result.expr if hasattr(series_result, "expr") else series_result.value
-    )
+    series_expr = series_result.expr if hasattr(series_result, "expr") else series_result.value
     xs_o, ys_o = _eval_1d(original_expr, var, lo, hi, n)
     xs_s, ys_s = _eval_1d(series_expr, var, lo, hi, n)
 
     if b == "matplotlib":
         import matplotlib.pyplot as plt
+
         ax = kw.pop("ax", None)
         if ax is None:
             _, ax = plt.subplots()
@@ -425,9 +445,12 @@ def plot_series(
 
     if b == "plotly":
         import plotly.graph_objects as go
+
         fig = kw.pop("fig", None) or go.Figure()
         fig.add_trace(go.Scatter(x=xs_o, y=ys_o, mode="lines", name="exact"))
-        fig.add_trace(go.Scatter(x=xs_s, y=ys_s, mode="lines", name="series", line=dict(dash="dash")))
+        fig.add_trace(
+            go.Scatter(x=xs_s, y=ys_s, mode="lines", name="series", line={"dash": "dash"})
+        )
         if title:
             fig.update_layout(title=title)
         return fig
@@ -438,6 +461,7 @@ def plot_series(
 # ---------------------------------------------------------------------------
 # plot_dag — expression tree / DAG
 # ---------------------------------------------------------------------------
+
 
 def plot_dag(expr, *, title: str | None = None, **kw: Any):
     """Visualise the expression DAG.
@@ -456,10 +480,12 @@ def plot_dag(expr, *, title: str | None = None, **kw: Any):
     str              — raw DOT string otherwise.
     """
     from .alkahest import plot_dot as _plot_dot  # type: ignore[import]
+
     dot_src = _plot_dot(expr)
 
     try:
         import graphviz
+
         src = graphviz.Source(dot_src)
         if title:
             src.comment = title
@@ -473,6 +499,7 @@ def plot_dag(expr, *, title: str | None = None, **kw: Any):
 # ---------------------------------------------------------------------------
 # plot_svg — Rust SVG renderer (no Python plotting dep required)
 # ---------------------------------------------------------------------------
+
 
 def plot_svg(
     expr,
@@ -492,6 +519,7 @@ def plot_svg(
     - Displayed in Jupyter: ``IPython.display.SVG(alkahest.plot_svg(...))``.
     """
     from .alkahest import plot_svg as _rust_plot_svg  # type: ignore[import]
+
     lo, hi = float(range_[0]), float(range_[1])
     return _rust_plot_svg(expr, var, lo, hi, width, height, n)
 

--- a/python/alkahest/experimental/_fastplotlib.py
+++ b/python/alkahest/experimental/_fastplotlib.py
@@ -1,0 +1,137 @@
+"""GPU-accelerated plotting via fastplotlib (experimental).
+
+fastplotlib (https://github.com/fastplotlib/fastplotlib) is built on WGPU /
+pygfx and handles millions of points at interactive frame rates.  It is the
+recommended backend for users evaluating expressions on dense grids with the
+``+full`` JIT wheel (JIT + parallel evaluation).
+
+Install
+-------
+    pip install fastplotlib
+
+Usage
+-----
+    import alkahest as ak
+    from alkahest.experimental._fastplotlib import fplot, fplot3d
+
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    fplot(ak.sin(x), x, (-10, 10))
+
+Stability
+---------
+This module is **experimental**: the fastplotlib API is still evolving, and
+this adapter may change in minor Alkahest releases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def _require_fpl():
+    try:
+        import fastplotlib as fpl  # noqa: F401
+        return fpl
+    except ImportError:
+        raise ImportError(
+            "fastplotlib is not installed.\n"
+            "Install it with:  pip install fastplotlib\n"
+            "Note: fastplotlib requires a GPU context (WGPU / WebGPU)."
+        )
+
+
+def _eval_1d(expr, var, lo: float, hi: float, n: int):
+    from alkahest.alkahest import compile_expr  # type: ignore[import]
+    from alkahest._dlpack import numpy_eval_dlpack
+    xs = np.linspace(lo, hi, n, dtype=np.float32)
+    fn = compile_expr(expr, [var])
+    ys = numpy_eval_dlpack(fn, xs.astype(np.float64)).astype(np.float32)
+    return xs, ys
+
+
+def _eval_2d(expr, var_x, var_y, x_range, y_range, n: int):
+    from alkahest.alkahest import compile_expr  # type: ignore[import]
+    from alkahest._dlpack import numpy_eval_dlpack
+    xs = np.linspace(x_range[0], x_range[1], n, dtype=np.float64)
+    ys = np.linspace(y_range[0], y_range[1], n, dtype=np.float64)
+    X, Y = np.meshgrid(xs, ys)
+    fn = compile_expr(expr, [var_x, var_y])
+    Z = numpy_eval_dlpack(fn, X, Y).astype(np.float32)
+    return X.astype(np.float32), Y.astype(np.float32), Z
+
+
+def fplot(
+    expr,
+    var,
+    range_: tuple[float, float] = (-5.0, 5.0),
+    *,
+    n: int = 100_000,
+    title: str | None = None,
+    **kw: Any,
+):
+    """GPU-accelerated 1-D curve plot via fastplotlib.
+
+    Evaluates ``expr`` at ``n`` points (default 100 000) and renders a line
+    graphic in a fastplotlib Figure.
+
+    Parameters
+    ----------
+    expr   : Expr  — symbolic expression in *var*.
+    var    : Expr  — the free variable.
+    range_ : (lo, hi) — plotting interval.
+    n      : number of sample points (default: ``100_000``).
+    **kw   : forwarded to ``fpl.Figure()[0, 0].add_line()``.
+
+    Returns
+    -------
+    fastplotlib.Figure
+    """
+    fpl = _require_fpl()
+    lo, hi = float(range_[0]), float(range_[1])
+    xs, ys = _eval_1d(expr, var, lo, hi, n)
+    data = np.column_stack([xs, ys])
+
+    fig = fpl.Figure(size=(800, 400))
+    fig[0, 0].add_line(data=data, **kw)
+    if title:
+        fig[0, 0].set_title(title)
+    fig.show()
+    return fig
+
+
+def fplot3d(
+    expr,
+    var_x,
+    var_y,
+    x_range: tuple[float, float] = (-5.0, 5.0),
+    y_range: tuple[float, float] = (-5.0, 5.0),
+    *,
+    n: int = 512,
+    title: str | None = None,
+    **kw: Any,
+):
+    """GPU-accelerated 2-D surface plot via fastplotlib ImageGraphic.
+
+    Renders ``expr(var_x, var_y)`` as a heatmap/image on an ``n×n`` grid.
+    Use ``n=512`` or higher for dense evaluation — the JIT + parallel wheel
+    handles this efficiently with :func:`alkahest.numpy_eval_par`.
+
+    Returns
+    -------
+    fastplotlib.Figure
+    """
+    fpl = _require_fpl()
+    _, _, Z = _eval_2d(expr, var_x, var_y, x_range, y_range, n)
+
+    fig = fpl.Figure(size=(600, 600))
+    fig[0, 0].add_image(data=Z, **kw)
+    if title:
+        fig[0, 0].set_title(title)
+    fig.show()
+    return fig
+
+
+__all__ = ["fplot", "fplot3d"]

--- a/python/alkahest/experimental/_fastplotlib.py
+++ b/python/alkahest/experimental/_fastplotlib.py
@@ -28,24 +28,26 @@ from __future__ import annotations
 
 from typing import Any
 
-import numpy as np
-
 
 def _require_fpl():
     try:
-        import fastplotlib as fpl  # noqa: F401
+        import fastplotlib as fpl
+
         return fpl
     except ImportError:
         raise ImportError(
             "fastplotlib is not installed.\n"
             "Install it with:  pip install fastplotlib\n"
             "Note: fastplotlib requires a GPU context (WGPU / WebGPU)."
-        )
+        ) from None
 
 
 def _eval_1d(expr, var, lo: float, hi: float, n: int):
-    from alkahest.alkahest import compile_expr  # type: ignore[import]
+    import numpy as np
+
     from alkahest._dlpack import numpy_eval_dlpack
+    from alkahest.alkahest import compile_expr  # type: ignore[import]
+
     xs = np.linspace(lo, hi, n, dtype=np.float32)
     fn = compile_expr(expr, [var])
     ys = numpy_eval_dlpack(fn, xs.astype(np.float64)).astype(np.float32)
@@ -53,8 +55,11 @@ def _eval_1d(expr, var, lo: float, hi: float, n: int):
 
 
 def _eval_2d(expr, var_x, var_y, x_range, y_range, n: int):
-    from alkahest.alkahest import compile_expr  # type: ignore[import]
+    import numpy as np
+
     from alkahest._dlpack import numpy_eval_dlpack
+    from alkahest.alkahest import compile_expr  # type: ignore[import]
+
     xs = np.linspace(x_range[0], x_range[1], n, dtype=np.float64)
     ys = np.linspace(y_range[0], y_range[1], n, dtype=np.float64)
     X, Y = np.meshgrid(xs, ys)
@@ -89,6 +94,8 @@ def fplot(
     -------
     fastplotlib.Figure
     """
+    import numpy as np
+
     fpl = _require_fpl()
     lo, hi = float(range_[0]), float(range_[1])
     xs, ys = _eval_1d(expr, var, lo, hi, n)

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -129,6 +129,30 @@ print(p // q)     # x^2 + x + 1</code></pre>
         </article>
 
         <article class="example">
+          <h3 class="example-title">Plotting — no bundled dependency</h3>
+          <p class="example-desc">
+            alkahest detects what you have installed (Matplotlib or Plotly) and
+            calls into it. A dependency-free SVG renderer is built into the
+            Rust kernel for zero-install use.
+          </p>
+          <pre class="code-block" tabindex="0"><code>import alkahest as ak
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+
+# Curve — uses matplotlib by default, or plotly if specified
+ak.plot(ak.sin(x), x, (-6.28, 6.28))
+ak.plot(ak.sin(x), x, (-6.28, 6.28), backend="plotly")
+
+# 2-D surface
+y = pool.symbol("y")
+ak.plot3d(ak.sin(x) * ak.cos(y), x, y, (-5, 5), (-5, 5))
+
+# Standalone SVG — no plotting library needed
+svg = ak.plot_svg(ak.sin(x), x, (-6, 6))</code></pre>
+        </article>
+
+        <article class="example">
           <h3 class="example-title">Use the Rust kernel directly</h3>
           <p class="example-desc">
             <code>alkahest-cas</code> is a native Rust crate — embed the CAS in


### PR DESCRIPTION
## Summary

- **Rust `alkahest-core/src/plot/`** — dependency-free SVG polyline renderer (`render_svg` / `render_svg_opts`) and Graphviz DOT emitter (`render_dot`) using the existing tree-walking interpreter. No new Cargo dependencies. Both exposed as `plot_svg` / `plot_dot` PyO3 pyfunctions.
- **Python `_plot.py`** — `plot`, `plot3d`, `plot_parametric`, `plot_implicit`, `plot_roots`, `plot_series`, `plot_dag`, `plot_svg`. Auto-detects Matplotlib (default) or Plotly; raises a clear `ImportError` if neither is installed. alkahest itself lists no plotting library as a dependency.
- **Python `experimental/_fastplotlib.py`** — GPU-accelerated `fplot` / `fplot3d` via fastplotlib (WGPU), for users evaluating on large grids with the `+full` JIT wheel.
- **Docs** — README (new Plotting section + directory layout), `docs/features.md`, `docs/overview.md`, `alkahest-skill/alkahest.md` (examples + 2 new agent rules), `website/src/index.html` (new example card).

## Design decisions

- No plotting library is added to alkahest's dependencies — backend detection happens inside each function body via `try: import matplotlib`.
- `plot_svg` calls the Rust renderer and requires zero Python plotting deps; suitable for WASM / notebook embed.
- `plot_dag` returns a `graphviz.Source` when the `graphviz` package is available, otherwise a raw DOT string.
- fastplotlib lives in `experimental/` because its API is still evolving.

## Test plan

- [ ] `cargo check` passes for both `alkahest-core` and `alkahest-py` (verified locally).
- [ ] `cargo fmt` applied (verified locally).
- [ ] Python syntax check passes for `_plot.py` and `_fastplotlib.py`.
- [ ] CI (Rust tests, Python tests, ruff, ty) green on this PR.
- [ ] Manual smoke: `ak.plot(ak.sin(x), x, (-6, 6))` renders a curve; `ak.plot_svg(...)` returns a valid SVG string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)