### PR TITLE
Risch integration: fill Gaps 6, 1, and 3 (rational-function integration)

### DIFF
--- a/alkahest-core/src/diff/forward.rs
+++ b/alkahest-core/src/diff/forward.rs
@@ -154,6 +154,20 @@ impl DualValue {
         let tangent = pool.mul(vec![self.tangent, pool.pow(two_sqrt, pool.integer(-1_i32))]);
         DualValue::new(value, tangent)
     }
+
+    fn atan(self, pool: &ExprPool) -> Self {
+        // d/dx atan(f) = f' / (1 + f²)
+        let value = pool.func("atan", vec![self.value]);
+        let one_plus_f2 = pool.add(vec![
+            pool.integer(1_i32),
+            pool.pow(self.value, pool.integer(2_i32)),
+        ]);
+        let tangent = pool.mul(vec![
+            self.tangent,
+            pool.pow(one_plus_f2, pool.integer(-1_i32)),
+        ]);
+        DualValue::new(value, tangent)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +265,7 @@ fn eval_dual(
                 "exp" => Ok(inner.exp(pool)),
                 "log" => Ok(inner.log(pool)),
                 "sqrt" => Ok(inner.sqrt(pool)),
+                "atan" => Ok(inner.atan(pool)),
                 other => Err(DiffError::ForwardUnknownFunction(other.to_string())),
             }
         }

--- a/alkahest-core/src/diff/reverse.rs
+++ b/alkahest-core/src/diff/reverse.rs
@@ -206,6 +206,14 @@ fn func_local_deriv(name: &str, arg: ExprId, pool: &ExprPool) -> Option<ExprId> 
             let cos_x = pool.func("cos", vec![arg]);
             Some(pool.pow(cos_x, pool.integer(-2_i32)))
         }
+        "atan" => {
+            // d/dx atan(x) = 1/(1 + x²)
+            let one_plus_x2 = pool.add(vec![
+                pool.integer(1_i32),
+                pool.pow(arg, pool.integer(2_i32)),
+            ]);
+            Some(pool.pow(one_plus_x2, pool.integer(-1_i32)))
+        }
         _ => None,
     }
 }
@@ -353,6 +361,18 @@ mod tests {
         let exp_x = pool.func("exp", vec![x]);
         let gs = grad(exp_x, &[x], &pool);
         assert_eq!(gs[0], exp_x);
+    }
+
+    #[test]
+    fn grad_atan() {
+        // ∂atan(x)/∂x = 1/(1+x²)
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let atan_x = pool.func("atan", vec![x]);
+        let gs = grad(atan_x, &[x], &pool);
+        let one_plus_x2 = pool.add(vec![pool.integer(1_i32), pool.pow(x, pool.integer(2_i32))]);
+        let expected = pool.pow(one_plus_x2, pool.integer(-1_i32));
+        assert_eq!(gs[0], expected, "d/dx atan(x) should be 1/(1+x²)");
     }
 
     #[test]

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -266,6 +266,163 @@ fn try_x_times_func(
 }
 
 // ---------------------------------------------------------------------------
+// Known non-elementary pre-check (Risch Gap 6)
+// ---------------------------------------------------------------------------
+
+/// Transcendental functions `f` for which `∫ f(linear)/poly dx` is a classic
+/// non-elementary special function (Liouville's theorem):
+///   - `exp` → exponential integral `Ei`
+///   - `sin` → sine integral `Si`
+///   - `cos` → cosine integral `Ci`
+///   - `sinh` → hyperbolic sine integral `Shi`
+///   - `cosh` → hyperbolic cosine integral `Chi`
+fn special_integral_name(func: &str) -> Option<&'static str> {
+    match func {
+        "exp" => Some("Ei"),
+        "sin" => Some("Si"),
+        "cos" => Some("Ci"),
+        "sinh" => Some("Shi"),
+        "cosh" => Some("Chi"),
+        _ => None,
+    }
+}
+
+/// Return `true` if `exp` is a negative integer literal.
+fn is_negative_integer(exp: ExprId, pool: &ExprPool) -> bool {
+    as_integer(exp, pool).is_some_and(|n| n < 0)
+}
+
+/// Return `true` if `expr` is a polynomial in `var` (integer powers only).
+fn is_polynomial_in(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    if expr == var || is_free_of(expr, var, pool) {
+        return true;
+    }
+    match pool.get(expr) {
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            args.iter().all(|&a| is_polynomial_in(a, var, pool))
+        }
+        ExprData::Pow { base, exp } => {
+            is_polynomial_in(base, var, pool) && as_integer(exp, pool).is_some_and(|n| n >= 0)
+        }
+        _ => false,
+    }
+}
+
+/// Return `true` if `base` is a non-constant polynomial in `var` that can appear
+/// as a denominator in a known non-elementary form.  Dividing a special
+/// transcendental `f(linear)` by *any* non-constant polynomial yields an
+/// Ei/Si/Ci/Shi/Chi-family integral, so this is a sound `NonElementary`
+/// certificate (Liouville's theorem), not a guess.
+fn is_simple_denominator_base(base: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    !is_free_of(base, var, pool) && is_polynomial_in(base, var, pool)
+}
+
+/// Structural pre-check certifying that `expr` is a provably non-elementary
+/// integrand of one of the classic special-function families.  Returns a
+/// human-readable description (used in the `NonElementary` message) on a match.
+///
+/// Recognised forms (with `g`, `D` linear and non-constant in `var`, and every
+/// other factor free of `var`):
+///   - `c · f(g) · D^(-n)` with `f ∈ {exp, sin, cos, sinh, cosh}` → `Ei/Si/Ci/Shi/Chi`
+///   - `c · log(g)^(-n)` → logarithmic integral `li`
+///
+/// These are non-elementary by Liouville's theorem (Bronstein 2005, §1.2).  The
+/// matcher is intentionally narrow: the *only* `var`-dependent factors allowed
+/// are the transcendental numerator and the polynomial denominator, so it never
+/// fires on cancelling cases such as `x²·sin(x)/x = x·sin(x)` (elementary).
+fn known_nonelementary(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<String> {
+    // A single `log(g)^(-n)` factor (not wrapped in a Mul) is the bare `li` case.
+    if let Some(msg) = match_log_denominator(expr, var, pool) {
+        return Some(msg);
+    }
+
+    let args = match pool.get(expr) {
+        ExprData::Mul(args) => args,
+        _ => return None,
+    };
+
+    let mut special: Option<String> = None; // f(g) with f a special transcendental
+    let mut has_poly_denom = false; // a D^(-n) factor
+    let mut log_denom: Option<String> = None; // a log(g)^(-n) factor (li)
+
+    for &a in &args {
+        // Constant factor — always allowed.
+        if is_free_of(a, var, pool) {
+            continue;
+        }
+
+        // Transcendental numerator f(g), f special, g linear non-constant.
+        if let ExprData::Func { ref name, ref args } = pool.get(a) {
+            if args.len() == 1
+                && special_integral_name(name).is_some()
+                && is_linear_in(args[0], var, pool).is_some()
+            {
+                if special.is_some() {
+                    return None; // two interacting specials — out of scope
+                }
+                special = Some(pool.display(a).to_string());
+                continue;
+            }
+        }
+
+        // Denominator factor D^(-n).
+        if let ExprData::Pow { base, exp } = pool.get(a) {
+            if is_negative_integer(exp, pool) {
+                if let Some(msg) = match_log_denominator(a, var, pool) {
+                    if log_denom.is_some() {
+                        return None;
+                    }
+                    log_denom = Some(msg);
+                    continue;
+                }
+                if is_simple_denominator_base(base, var, pool) {
+                    has_poly_denom = true;
+                    continue;
+                }
+            }
+        }
+
+        // Any other factor involving `var` breaks the recognised shape.
+        return None;
+    }
+
+    if let (Some(f), true) = (&special, has_poly_denom) {
+        return Some(format!(
+            "{f} divided by a polynomial gives a special-function integral \
+             (Ei/Si/Ci/Shi/Chi), which is not elementary (Liouville's theorem)"
+        ));
+    }
+
+    if let Some(msg) = log_denom {
+        return Some(msg);
+    }
+
+    None
+}
+
+/// Match a `log(linear)^(-n)` factor (`1/log` family → logarithmic integral `li`).
+fn match_log_denominator(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<String> {
+    let ExprData::Pow { base, exp } = pool.get(expr) else {
+        return None;
+    };
+    if !is_negative_integer(exp, pool) {
+        return None;
+    }
+    let ExprData::Func { ref name, ref args } = pool.get(base) else {
+        return None;
+    };
+    if name == "log" && args.len() == 1 && is_linear_in(args[0], var, pool).is_some() {
+        Some(format!(
+            "1/{} is the logarithmic integral li, which is not elementary \
+             (Liouville's theorem)",
+            pool.display(base)
+        ))
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Core integration (no simplification yet)
 // ---------------------------------------------------------------------------
 
@@ -366,6 +523,17 @@ pub(crate) fn integrate_raw(
                 1 => Some(consts[0]),
                 _ => Some(pool.mul(consts.clone())),
             };
+
+            // Guard against self-recursion: if no constant factor was split off,
+            // `inner` is the same product we started with, and recursing would loop
+            // forever (this previously crashed the process with a stack overflow on
+            // inputs like `sin(x)/x` or `exp(x)/x`).  Bail out cleanly instead.
+            if inner == expr {
+                return Err(IntegrationError::NotImplemented(format!(
+                    "∫ {} — irreducible product of var-dependent factors",
+                    pool.display(expr)
+                )));
+            }
 
             // Integrate the non-constant part
             let int_inner = integrate_raw(inner, var, pool, log)?;
@@ -556,6 +724,13 @@ pub fn integrate(
     // V2+: Route transcendental Risch cases (exp polynomial, log powers, etc.)
     if super::risch::contains_risch_form(expr, var, pool) {
         return super::risch::integrate_risch(expr, var, pool);
+    }
+
+    // Risch Gap 6: certify classic non-elementary special-function integrands
+    // (Ei/Si/Ci/Shi/Chi/li) before the rule-based engine, which would otherwise
+    // return the weaker `NotImplemented` verdict.
+    if let Some(reason) = known_nonelementary(expr, var, pool) {
+        return Err(IntegrationError::NonElementary(reason));
     }
 
     let mut log = DerivationLog::new();
@@ -874,5 +1049,125 @@ mod tests {
             Err(e) => println!("ERROR: {e}"),
         }
         assert!(result.is_ok(), "∫ sqrt(x²+1) dx failed: {:?}", result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Risch Gap 6: crash fix + known-non-elementary certification
+    // -----------------------------------------------------------------------
+
+    /// Build `f(arg) / denom` as `Mul([f(arg), denom^(-1)])`.
+    fn over(pool: &ExprPool, num: ExprId, denom: ExprId) -> ExprId {
+        let inv = pool.pow(denom, pool.integer(-1_i32));
+        pool.mul(vec![num, inv])
+    }
+
+    #[test]
+    fn sin_over_x_is_nonelementary_not_crash() {
+        // ∫ sin(x)/x dx = Si(x): previously stack-overflowed; must now certify NE.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = over(&pool, pool.func("sin", vec![x]), x);
+        let r = integrate(f, x, &pool);
+        assert!(
+            matches!(r, Err(IntegrationError::NonElementary(_))),
+            "∫ sin(x)/x dx should be NonElementary; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn exp_over_x_is_nonelementary() {
+        // ∫ exp(x)/x dx = Ei(x).
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = over(&pool, pool.func("exp", vec![x]), x);
+        let r = integrate(f, x, &pool);
+        assert!(
+            matches!(r, Err(IntegrationError::NonElementary(_))),
+            "∫ exp(x)/x dx should be NonElementary; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn cos_over_linear_is_nonelementary() {
+        // ∫ cos(x)/(2x+1) dx is a shifted Ci — non-elementary.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let denom = pool.add(vec![
+            pool.mul(vec![pool.integer(2_i32), x]),
+            pool.integer(1_i32),
+        ]);
+        let f = over(&pool, pool.func("cos", vec![x]), denom);
+        let r = integrate(f, x, &pool);
+        assert!(
+            matches!(r, Err(IntegrationError::NonElementary(_))),
+            "∫ cos(x)/(2x+1) dx should be NonElementary; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn one_over_log_is_nonelementary() {
+        // ∫ 1/log(x) dx = li(x).
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.pow(pool.func("log", vec![x]), pool.integer(-1_i32));
+        let r = integrate(f, x, &pool);
+        assert!(
+            matches!(r, Err(IntegrationError::NonElementary(_))),
+            "∫ 1/log(x) dx should be NonElementary; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn exp_over_x_squared_is_nonelementary() {
+        // ∫ exp(x)/x² dx — still an Ei-family non-elementary integral.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let f = over(&pool, pool.func("exp", vec![x]), x2);
+        let r = integrate(f, x, &pool);
+        assert!(
+            matches!(r, Err(IntegrationError::NonElementary(_))),
+            "∫ exp(x)/x² dx should be NonElementary; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn log_over_x_is_elementary_not_misclassified() {
+        // ∫ log(x)/x dx = log(x)²/2 is ELEMENTARY — the pre-check must NOT fire
+        // (log is not in the special set; only 1/log triggers the li case).
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = over(&pool, pool.func("log", vec![x]), x);
+        let r = integrate(f, x, &pool);
+        assert!(
+            !matches!(r, Err(IntegrationError::NonElementary(_))),
+            "∫ log(x)/x dx must not be flagged NonElementary; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn x_times_sin_over_x_not_flagged() {
+        // x·sin(x)/x = sin(x) is elementary; the extra `var` factor must block
+        // the (otherwise tempting) Si pattern match.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let num = pool.mul(vec![x, pool.func("sin", vec![x])]);
+        let f = over(&pool, num, x);
+        // After construction this may auto-simplify, but the matcher itself must
+        // not certify NonElementary on the raw structural form.
+        assert!(
+            known_nonelementary(f, x, &pool).is_none(),
+            "x·sin(x)/x must not be certified NonElementary"
+        );
+    }
+
+    #[test]
+    fn plain_sin_not_flagged() {
+        // ∫ sin(x) dx = -cos(x): a bare special function (no denominator) is fine.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.func("sin", vec![x]);
+        assert!(integrate(f, x, &pool).is_ok());
+        assert!(known_nonelementary(f, x, &pool).is_none());
     }
 }

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -1222,16 +1222,15 @@ mod tests {
     }
 
     #[test]
-    fn arctan_case_still_declines() {
-        // ∫ 1/(x²+1) dx needs arctan — unsupported; must surface NotImplemented.
+    fn arctan_case_via_fallback() {
+        // ∫ 1/(x²+1) dx = atan(x), via the Rothstein–Trager / arctan fallback.
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
         let f = pool.pow(den, pool.integer(-1_i32));
-        assert!(matches!(
-            integrate(f, x, &pool),
-            Err(IntegrationError::NotImplemented(_))
-        ));
+        let r = integrate(f, x, &pool);
+        assert!(r.is_ok(), "∫ 1/(x²+1) dx should integrate; got {r:?}");
+        assert!(pool.display(r.unwrap().value).to_string().contains("atan"));
     }
 
     fn eval_simple(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -734,10 +734,32 @@ pub fn integrate(
     }
 
     let mut log = DerivationLog::new();
-    let raw = integrate_raw(expr, var, pool, &mut log)?;
-    let simplified = simplify(raw, pool);
-    let final_log = log.merge(simplified.log);
-    Ok(DerivedExpr::with_log(simplified.value, final_log))
+    match integrate_raw(expr, var, pool, &mut log) {
+        Ok(raw) => {
+            let simplified = simplify(raw, pool);
+            let final_log = log.merge(simplified.log);
+            Ok(DerivedExpr::with_log(simplified.value, final_log))
+        }
+        Err(IntegrationError::NotImplemented(msg)) => {
+            // Risch Gap 3: rational-function integration via Rothstein–Trager.
+            // Tried as a fallback so simple cases keep their existing rules.
+            if let Some(result) =
+                super::risch::rational_integrate::try_integrate_rational(expr, var, pool)
+            {
+                let simplified = simplify(result, pool);
+                let mut rlog = DerivationLog::new();
+                rlog.push(RewriteStep::simple(
+                    "rothstein_trager",
+                    expr,
+                    simplified.value,
+                ));
+                let final_log = rlog.merge(simplified.log);
+                return Ok(DerivedExpr::with_log(simplified.value, final_log));
+            }
+            Err(IntegrationError::NotImplemented(msg))
+        }
+        Err(other) => Err(other),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1159,6 +1181,73 @@ mod tests {
             known_nonelementary(f, x, &pool).is_none(),
             "x·sin(x)/x must not be certified NonElementary"
         );
+    }
+
+    #[test]
+    fn rational_integration_via_fallback() {
+        // ∫ 1/(x²−1) dx is solved by the Rothstein–Trager fallback (rule engine
+        // returns NotImplemented first).
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-1_i32)]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        let r = integrate(f, x, &pool);
+        assert!(
+            r.is_ok(),
+            "∫ 1/(x²−1) dx should integrate via fallback; got {r:?}"
+        );
+        // Result should contain logarithms.
+        assert!(
+            pool.display(r.unwrap().value).to_string().contains("log"),
+            "expected log terms in the antiderivative"
+        );
+    }
+
+    #[test]
+    fn power_rule_not_regressed_by_fallback() {
+        // ∫ x⁻² dx = −x⁻¹ must still come from the power rule, not the fallback.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.pow(x, pool.integer(-2_i32));
+        let r = integrate(f, x, &pool).unwrap();
+        // d/dx result == x⁻².
+        let d = diff(r.value, x, &pool).unwrap();
+        for &xv in &[1.5_f64, 2.5] {
+            let lhs = eval_simple(d.value, x, xv, &pool);
+            assert!(
+                (lhs - xv.powi(-2)).abs() < 1e-9,
+                "power rule regressed at {xv}"
+            );
+        }
+    }
+
+    #[test]
+    fn arctan_case_still_declines() {
+        // ∫ 1/(x²+1) dx needs arctan — unsupported; must surface NotImplemented.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        assert!(matches!(
+            integrate(f, x, &pool),
+            Err(IntegrationError::NotImplemented(_))
+        ));
+    }
+
+    fn eval_simple(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        if expr == x {
+            return xv;
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => n.0.to_f64(),
+            ExprData::Rational(r) => r.0.to_f64(),
+            ExprData::Add(args) => args.iter().map(|&a| eval_simple(a, x, xv, pool)).sum(),
+            ExprData::Mul(args) => args.iter().map(|&a| eval_simple(a, x, xv, pool)).product(),
+            ExprData::Pow { base, exp } => {
+                eval_simple(base, x, xv, pool).powf(eval_simple(exp, x, xv, pool))
+            }
+            other => panic!("eval_simple: unsupported {other:?}"),
+        }
     }
 
     #[test]

--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -31,7 +31,8 @@ use crate::integrate::engine::IntegrationError;
 use crate::kernel::{ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
-use super::poly_rde::{expr_to_qpoly, is_free_of_var, qpoly_to_expr, solve_poly_rde};
+use super::poly_rde::{expr_to_qpoly, is_free_of_var, poly_scale, qpoly_to_expr, solve_poly_rde};
+use super::rational_rde::{expr_to_qrational, solve_rational_rde};
 use super::tower::{decompose_wrt_exp, poly_degree, TowerLevel};
 
 // ---------------------------------------------------------------------------
@@ -145,49 +146,90 @@ fn integrate_single_exp_term(
     // The antiderivative (if elementary) is v(x) · exp(kη)
     // where v satisfies: v' + k · η'(x) · v = c(x).
 
-    // Try to convert c(x) to a polynomial.
-    let c_poly = expr_to_qpoly(c_expr, var, pool).ok_or_else(|| {
-        IntegrationError::NotImplemented(format!(
-            "coefficient {} of exp(η)^{} is not a polynomial in the integration variable; \
-             only polynomial coefficients are supported",
+    // Build exp(kη) once: for k=1 use exp_gen directly; for k>1 use exp(kη).
+    let exp_k_eta = build_exp_k_eta(k, eta, exp_gen, pool);
+
+    // Non-elementary error shared by the polynomial and rational paths.
+    let non_elementary = || {
+        IntegrationError::NonElementary(format!(
+            "the Risch DE v'(x) + {}·({}(x))·v(x) = {}(x) has no rational solution;\n\
+             the integrand ∫ {} · exp(η)^{} dx is not an elementary function\n\
+             (η = {})",
+            k,
+            pool.display(deta_expr),
             pool.display(c_expr),
-            k
+            pool.display(c_expr),
+            k,
+            pool.display(eta),
         ))
-    })?;
+    };
 
-    // Solve the Risch DE: v' + k·η'·v = c.
-    match solve_poly_rde(k, deta, &c_poly) {
-        Some(v_poly) => {
-            // Elementary: result is v(x) · exp(kη).
-            let v_expr = qpoly_to_expr(&v_poly, var, pool);
-
-            // Build exp(kη): for k=1 use exp_gen directly; for k>1 use exp(kη).
-            let exp_k_eta = build_exp_k_eta(k, eta, exp_gen, pool);
-
-            let result = if is_one(v_expr, pool) {
-                exp_k_eta
-            } else {
-                pool.mul(vec![v_expr, exp_k_eta])
-            };
-
-            log.push(RewriteStep::simple("risch_exp_rde", c_expr, result));
-            Ok(result)
-        }
-        None => {
-            // The Risch DE has no polynomial solution → non-elementary.
-            Err(IntegrationError::NonElementary(format!(
-                "the Risch DE v'(x) + {}·({}(x))·v(x) = {}(x) has no polynomial solution;\n\
-                 the integrand ∫ {} · exp(η)^{} dx is not an elementary function\n\
-                 (η = {})",
-                k,
-                pool.display(deta_expr),
-                pool.display(c_expr),
-                pool.display(c_expr),
-                k,
-                pool.display(eta),
-            )))
-        }
+    // Fast path: polynomial coefficient → polynomial Risch DE (Bronstein §5.2).
+    if let Some(c_poly) = expr_to_qpoly(c_expr, var, pool) {
+        return match solve_poly_rde(k, deta, &c_poly) {
+            Some(v_poly) => {
+                let v_expr = qpoly_to_expr(&v_poly, var, pool);
+                let result = build_v_times_exp(v_expr, exp_k_eta, pool);
+                log.push(RewriteStep::simple("risch_exp_rde", c_expr, result));
+                Ok(result)
+            }
+            None => Err(non_elementary()),
+        };
     }
+
+    // Rational coefficient → rational Risch DE over ℚ(x) (Bronstein §6.1, Gap 1).
+    if let Some((c_num, c_den)) = expr_to_qrational(c_expr, var, pool) {
+        // f = k·η' is a polynomial in the exp tower.
+        let f = poly_scale(&deta.to_vec(), &rug::Rational::from(k));
+        return match solve_rational_rde(&f, &c_num, &c_den) {
+            Some((v_num, v_den)) => {
+                let v_expr = build_rational(&v_num, &v_den, var, pool);
+                let result = build_v_times_exp(v_expr, exp_k_eta, pool);
+                log.push(RewriteStep::simple(
+                    "risch_exp_rde_rational",
+                    c_expr,
+                    result,
+                ));
+                Ok(result)
+            }
+            None => Err(non_elementary()),
+        };
+    }
+
+    // c is neither a polynomial nor a rational function in `var` (e.g. it carries
+    // another transcendental generator) — outside the single-generator subset.
+    Err(IntegrationError::NotImplemented(format!(
+        "coefficient {} of exp(η)^{} is not a rational function in the integration \
+         variable; mixed/multiple generators are not yet supported",
+        pool.display(c_expr),
+        k
+    )))
+}
+
+/// Build `v · exp(kη)`, collapsing the `v = 1` case.
+fn build_v_times_exp(v_expr: ExprId, exp_k_eta: ExprId, pool: &ExprPool) -> ExprId {
+    if is_one(v_expr, pool) {
+        exp_k_eta
+    } else {
+        pool.mul(vec![v_expr, exp_k_eta])
+    }
+}
+
+/// Build the symbolic rational function `num(x) / den(x)`.
+fn build_rational(
+    num: &[rug::Rational],
+    den: &[rug::Rational],
+    var: ExprId,
+    pool: &ExprPool,
+) -> ExprId {
+    let num_expr = qpoly_to_expr(&num.to_vec(), var, pool);
+    // Denominator 1 → just the numerator.
+    if super::poly_rde::degree(&den.to_vec()) <= 0 && den.first().map(|c| *c == 1).unwrap_or(true) {
+        return num_expr;
+    }
+    let den_expr = qpoly_to_expr(&den.to_vec(), var, pool);
+    let den_inv = pool.pow(den_expr, pool.integer(-1_i32));
+    pool.mul(vec![num_expr, den_inv])
 }
 
 // ---------------------------------------------------------------------------
@@ -254,6 +296,21 @@ pub fn needs_exp_risch(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
     needs_exp_risch_inner(expr, var, pool)
 }
 
+/// Returns `true` if `expr` is a negative integer power of a `var`-dependent
+/// base — i.e. a denominator that makes the surrounding coefficient a rational
+/// function in `var`.
+fn is_var_dependent_denominator(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    use crate::kernel::ExprData;
+    if let ExprData::Pow { base, exp } = pool.get(expr) {
+        if let ExprData::Integer(n) = pool.get(exp) {
+            if n.0.to_i64().is_some_and(|v| v < 0) {
+                return !is_free_of_var(base, var, pool);
+            }
+        }
+    }
+    false
+}
+
 fn needs_exp_risch_inner(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
     use crate::kernel::ExprData;
 
@@ -280,6 +337,10 @@ fn needs_exp_risch_inner(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
             let mut has_linear_exp = false;
             let mut max_poly_deg: u32 = 0;
             let mut has_nonlinear_exp = false;
+            // A var-dependent denominator (negative power) makes the exp coefficient
+            // a rational function — handled by the rational Risch DE (Gap 1), not the
+            // basic engine.
+            let mut has_rational_coeff = false;
 
             for &a in &args {
                 match pool.get(a) {
@@ -301,6 +362,8 @@ fn needs_exp_risch_inner(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
                         // Track degree of non-exp factors.
                         if let Some(d) = poly_degree(a, var, pool) {
                             max_poly_deg = max_poly_deg.max(d);
+                        } else if is_var_dependent_denominator(a, var, pool) {
+                            has_rational_coeff = true;
                         }
                     }
                 }
@@ -311,6 +374,11 @@ fn needs_exp_risch_inner(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
             }
             // Linear exp + polynomial factor of degree ≥ 2: Risch needed.
             if has_linear_exp && max_poly_deg >= 2 {
+                return true;
+            }
+            // Any exp generator with a rational (denominator-bearing) coefficient:
+            // route to the rational Risch DE.
+            if (has_linear_exp || has_nonlinear_exp) && has_rational_coeff {
                 return true;
             }
             // Check sub-expressions for nested cases.

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -14,7 +14,9 @@
 //! | `poly(x)·log(h)` | `x·log(x)`, `x²·log(x)` | ✓ |
 //! | Mixed exp + rational base | `x·exp(x²) + x²` | ✓ |
 //! | `ratfn(x)·exp(η)`, η polynomial | `(x−1)/x²·exp(x)` | ✓ (rational RDE) |
+//! | `A(x)/D(x)`, D squarefree, ℚ residues | `1/(x²−1)`, `2x/(x²+1)` | ✓ (Rothstein–Trager) |
 //! | `sin(x)/x`, `exp(x)/x` | Ei, Si functions | ✗ (NonElementary) |
+//! | `1/(x²+1)` | arctan (complex residues) | ✗ (NotImplemented) |
 //! | `exp(x²)/sqrt(x)` | Mixed algebraic+transcendental | ✗ (NotImplemented) |
 //!
 //! ## Architecture
@@ -24,6 +26,8 @@
 //! - [`tower`]: Differential field tower construction and generator detection.
 //! - [`poly_rde`]: Polynomial Risch Differential Equation (RDE) solver over ℚ\[x\].
 //! - [`rational_rde`]: Rational RDE solver over ℚ(x) (exp tower; Bronstein §6.1).
+//! - [`rational_integrate`]: Rational-function integration via Rothstein–Trager
+//!   (logarithmic part; Bronstein §2.5).
 //! - [`exp_case`]: Integration in the hyperexponential tower (t = exp(η)).
 //! - [`log_case`]: Integration in the hyperlogarithmic tower (t = log(h)).
 //!
@@ -39,10 +43,13 @@
 //!   coefficients there fall through to `NotImplemented`. Coefficients are
 //!   restricted to ℚ (no algebraic-number coefficients), and η must be a
 //!   polynomial.
-//! - **No logarithmic-part output (Rothstein–Trager).** Integrals whose
-//!   antiderivative requires *new* `log` terms (the rational-function logarithmic
-//!   part) are not yet produced; such cases are reported `NonElementary` /
-//!   `NotImplemented` rather than completed.
+//! - **Rothstein–Trager is partial** ([`rational_integrate`]). The logarithmic
+//!   part is produced for a **squarefree** denominator whose resultant roots are
+//!   **rational** (ℚ-linear combinations of `log`s of ℚ-polynomials). Still
+//!   missing: **Hermite reduction** for repeated factors (non-squarefree
+//!   denominators), and **non-rational residues** (e.g. `1/(x²+1)`, whose answer
+//!   needs `arctan`/algebraic-number logs). Those cases fall back to the rule
+//!   engine and surface as `NotImplemented`.
 //! - **Single generator only.** Multiple interacting generators (e.g.
 //!   `exp(x)·log(x)`) and mixed algebraic+transcendental towers are unsupported;
 //!   independent sums are handled term-by-term.
@@ -56,6 +63,7 @@
 pub mod exp_case;
 pub mod log_case;
 pub mod poly_rde;
+pub mod rational_integrate;
 pub mod rational_rde;
 pub mod tower;
 

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -43,13 +43,13 @@
 //!   coefficients there fall through to `NotImplemented`. Coefficients are
 //!   restricted to ℚ (no algebraic-number coefficients), and η must be a
 //!   polynomial.
-//! - **Rothstein–Trager is partial** ([`rational_integrate`]). The logarithmic
-//!   part is produced for a **squarefree** denominator whose resultant roots are
-//!   **rational** (ℚ-linear combinations of `log`s of ℚ-polynomials). Still
-//!   missing: **Hermite reduction** for repeated factors (non-squarefree
-//!   denominators), and **non-rational residues** (e.g. `1/(x²+1)`, whose answer
-//!   needs `arctan`/algebraic-number logs). Those cases fall back to the rule
-//!   engine and surface as `NotImplemented`.
+//! - **Rational-function integration is partial** ([`rational_integrate`]).
+//!   Hermite reduction (repeated factors) and the Rothstein–Trager logarithmic
+//!   part (rational residues) are implemented, so `∫ A/D` with `D` factoring into
+//!   ℚ-linear factors is complete. Still missing: **non-rational residues** —
+//!   irreducible factors of degree ≥ 2 (e.g. `1/(x²+1)`, whose answer needs
+//!   `arctan`/algebraic-number logs). Those fall back and surface as
+//!   `NotImplemented`.
 //! - **Single generator only.** Multiple interacting generators (e.g.
 //!   `exp(x)·log(x)`) and mixed algebraic+transcendental towers are unsupported;
 //!   independent sums are handled term-by-term.

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -13,6 +13,7 @@
 //! | `log(h)^n`, n ≥ 2 | `log(x)²`, `log(x)³` | ✓ |
 //! | `poly(x)·log(h)` | `x·log(x)`, `x²·log(x)` | ✓ |
 //! | Mixed exp + rational base | `x·exp(x²) + x²` | ✓ |
+//! | `ratfn(x)·exp(η)`, η polynomial | `(x−1)/x²·exp(x)` | ✓ (rational RDE) |
 //! | `sin(x)/x`, `exp(x)/x` | Ei, Si functions | ✗ (NonElementary) |
 //! | `exp(x²)/sqrt(x)` | Mixed algebraic+transcendental | ✗ (NotImplemented) |
 //!
@@ -22,8 +23,29 @@
 //!
 //! - [`tower`]: Differential field tower construction and generator detection.
 //! - [`poly_rde`]: Polynomial Risch Differential Equation (RDE) solver over ℚ\[x\].
+//! - [`rational_rde`]: Rational RDE solver over ℚ(x) (exp tower; Bronstein §6.1).
 //! - [`exp_case`]: Integration in the hyperexponential tower (t = exp(η)).
 //! - [`log_case`]: Integration in the hyperlogarithmic tower (t = log(h)).
+//!
+//! ## Current limitations
+//!
+//! This is a complete decision procedure only within the subset above; the
+//! known gaps (tracked against the project's Risch gap analysis) are:
+//!
+//! - **Rational RDE is exp-tower only** ([`rational_rde`]). The denominator bound
+//!   `E = gcd(B, B')` relies on the coefficient `f = k·η'` being a *polynomial*
+//!   (no poles), which holds in the exp tower for polynomial η. The **log tower**
+//!   ([`log_case`]) still handles polynomial coefficients only; rational
+//!   coefficients there fall through to `NotImplemented`. Coefficients are
+//!   restricted to ℚ (no algebraic-number coefficients), and η must be a
+//!   polynomial.
+//! - **No logarithmic-part output (Rothstein–Trager).** Integrals whose
+//!   antiderivative requires *new* `log` terms (the rational-function logarithmic
+//!   part) are not yet produced; such cases are reported `NonElementary` /
+//!   `NotImplemented` rather than completed.
+//! - **Single generator only.** Multiple interacting generators (e.g.
+//!   `exp(x)·log(x)`) and mixed algebraic+transcendental towers are unsupported;
+//!   independent sums are handled term-by-term.
 //!
 //! ## References
 //!

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -14,9 +14,10 @@
 //! | `poly(x)·log(h)` | `x·log(x)`, `x²·log(x)` | ✓ |
 //! | Mixed exp + rational base | `x·exp(x²) + x²` | ✓ |
 //! | `ratfn(x)·exp(η)`, η polynomial | `(x−1)/x²·exp(x)` | ✓ (rational RDE) |
-//! | `A(x)/D(x)`, D squarefree, ℚ residues | `1/(x²−1)`, `2x/(x²+1)` | ✓ (Rothstein–Trager) |
+//! | `A(x)/D(x)`, D splits over ℚ | `1/(x²−1)`, `x/(x−1)³` | ✓ (Hermite + Rothstein–Trager) |
+//! | `A(x)/D(x)`, irreducible quadratics | `1/(x²+1)`, `(x+1)/(x²+1)` | ✓ (log + arctan) |
 //! | `sin(x)/x`, `exp(x)/x` | Ei, Si functions | ✗ (NonElementary) |
-//! | `1/(x²+1)` | arctan (complex residues) | ✗ (NotImplemented) |
+//! | `1/(x²−2)` | algebraic-number logs | ✗ (NotImplemented) |
 //! | `exp(x²)/sqrt(x)` | Mixed algebraic+transcendental | ✗ (NotImplemented) |
 //!
 //! ## Architecture
@@ -43,13 +44,13 @@
 //!   coefficients there fall through to `NotImplemented`. Coefficients are
 //!   restricted to ℚ (no algebraic-number coefficients), and η must be a
 //!   polynomial.
-//! - **Rational-function integration is partial** ([`rational_integrate`]).
-//!   Hermite reduction (repeated factors) and the Rothstein–Trager logarithmic
-//!   part (rational residues) are implemented, so `∫ A/D` with `D` factoring into
-//!   ℚ-linear factors is complete. Still missing: **non-rational residues** —
-//!   irreducible factors of degree ≥ 2 (e.g. `1/(x²+1)`, whose answer needs
-//!   `arctan`/algebraic-number logs). Those fall back and surface as
-//!   `NotImplemented`.
+//! - **Rational-function integration** ([`rational_integrate`]) covers Hermite
+//!   reduction (repeated factors), the Rothstein–Trager logarithmic part
+//!   (rational residues → `log`), and irreducible **quadratic** factors with
+//!   negative discriminant (→ `log` + `arctan`). Still missing: irreducible
+//!   factors of **degree ≥ 3**, and quadratics with **positive discriminant**
+//!   (real irrational roots → algebraic-number `log`s); these fall back and
+//!   surface as `NotImplemented`.
 //! - **Single generator only.** Multiple interacting generators (e.g.
 //!   `exp(x)·log(x)`) and mixed algebraic+transcendental towers are unsupported;
 //!   independent sums are handled term-by-term.

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -34,6 +34,7 @@
 pub mod exp_case;
 pub mod log_case;
 pub mod poly_rde;
+pub mod rational_rde;
 pub mod tower;
 
 use crate::deriv::log::{DerivationLog, DerivedExpr};
@@ -401,6 +402,81 @@ mod tests {
 
         let antideriv = result.unwrap().value;
         verify_antiderivative(&pool, x, f, antideriv, "log(x)³");
+    }
+
+    // -----------------------------------------------------------------------
+    // Rational coefficients in the exp tower (Gap 1: rational Risch DE)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rational_coeff_exp_elementary() {
+        // ∫ (x−1)/x² · exp(x) dx = exp(x)/x.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let num = pool.add(vec![x, pool.integer(-1_i32)]); // x − 1
+        let inv_x2 = pool.pow(x, pool.integer(-2_i32)); // x⁻²
+        let f = pool.mul(vec![num, inv_x2, exp_x]);
+
+        // Must be routed to Risch and solved as elementary.
+        assert!(contains_risch_form(f, x, &pool), "should route to Risch");
+        let result = integrate_risch(f, x, &pool);
+        assert!(
+            result.is_ok(),
+            "∫ (x−1)/x²·exp(x) dx should be elementary; got {result:?}"
+        );
+
+        // Verify d/dx F = f numerically at several points (the simplifier does not
+        // fully normalise rational sums, so a symbolic-zero check is too strict).
+        let antideriv = result.unwrap().value;
+        let d = crate::diff::diff(antideriv, x, &pool).unwrap();
+        for &xv in &[1.3_f64, 2.7, 4.1] {
+            let lhs = eval_f64(d.value, x, xv, &pool);
+            let rhs = eval_f64(f, x, xv, &pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-9,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs}"
+            );
+        }
+    }
+
+    /// Minimal numeric evaluator for verification (Integer/Rational/Add/Mul/Pow/exp).
+    fn eval_f64(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        use crate::kernel::ExprData;
+        if expr == x {
+            return xv;
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => n.0.to_f64(),
+            ExprData::Rational(r) => r.0.to_f64(),
+            ExprData::Add(args) => args.iter().map(|&a| eval_f64(a, x, xv, pool)).sum(),
+            ExprData::Mul(args) => args.iter().map(|&a| eval_f64(a, x, xv, pool)).product(),
+            ExprData::Pow { base, exp } => {
+                eval_f64(base, x, xv, pool).powf(eval_f64(exp, x, xv, pool))
+            }
+            ExprData::Func { ref name, ref args } if name == "exp" && args.len() == 1 => {
+                eval_f64(args[0], x, xv, pool).exp()
+            }
+            other => panic!("eval_f64: unsupported node {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rational_coeff_exp_nonelementary() {
+        // ∫ x²/(x+1) · exp(x) dx leaves an Ei term — non-elementary.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let inv_xp1 = pool.pow(pool.add(vec![x, pool.integer(1_i32)]), pool.integer(-1_i32));
+        let f = pool.mul(vec![x2, inv_xp1, exp_x]);
+
+        assert!(contains_risch_form(f, x, &pool), "should route to Risch");
+        let result = integrate_risch(f, x, &pool);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ x²/(x+1)·exp(x) dx should be NonElementary; got {result:?}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -15,9 +15,9 @@
 //! | Mixed exp + rational base | `x·exp(x²) + x²` | ✓ |
 //! | `ratfn(x)·exp(η)`, η polynomial | `(x−1)/x²·exp(x)` | ✓ (rational RDE) |
 //! | `A(x)/D(x)`, D splits over ℚ | `1/(x²−1)`, `x/(x−1)³` | ✓ (Hermite + Rothstein–Trager) |
-//! | `A(x)/D(x)`, irreducible quadratics | `1/(x²+1)`, `(x+1)/(x²+1)` | ✓ (log + arctan) |
+//! | `A(x)/D(x)`, irreducible quadratics | `1/(x²+1)`, `1/(x²−2)` | ✓ (log + arctan / √-log) |
 //! | `sin(x)/x`, `exp(x)/x` | Ei, Si functions | ✗ (NonElementary) |
-//! | `1/(x²−2)` | algebraic-number logs | ✗ (NotImplemented) |
+//! | `1/(x³+x+1)` | degree-≥3 algebraic residues (RootSum) | ✗ (NotImplemented) |
 //! | `exp(x²)/sqrt(x)` | Mixed algebraic+transcendental | ✗ (NotImplemented) |
 //!
 //! ## Architecture
@@ -44,12 +44,15 @@
 //!   coefficients there fall through to `NotImplemented`. Coefficients are
 //!   restricted to ℚ (no algebraic-number coefficients), and η must be a
 //!   polynomial.
-//! - **Rational-function integration** ([`rational_integrate`]) covers Hermite
-//!   reduction (repeated factors), the Rothstein–Trager logarithmic part
-//!   (rational residues → `log`), and irreducible **quadratic** factors with
-//!   negative discriminant (→ `log` + `arctan`). Still missing: irreducible
-//!   factors of **degree ≥ 3**, and quadratics with **positive discriminant**
-//!   (real irrational roots → algebraic-number `log`s); these fall back and
+//! - **Rational-function integration** ([`rational_integrate`]) is complete for
+//!   any denominator that factors over ℚ into **linear and quadratic** factors:
+//!   Hermite reduction (repeated factors), the Rothstein–Trager logarithmic part
+//!   (rational residues → `log`), and irreducible quadratics (negative
+//!   discriminant → `log` + `arctan`; positive discriminant → `log` with `√Δ`
+//!   coefficients). The one remaining gap is irreducible factors of **degree ≥ 3**,
+//!   whose antiderivative is a `Σ` over degree-≥3 algebraic residues; expressing
+//!   it needs a symbolic **`RootSum`** node in the kernel (with its own diff/eval/
+//!   simplify support), which is not yet implemented — those cases fall back and
 //!   surface as `NotImplemented`.
 //! - **Single generator only.** Multiple interacting generators (e.g.
 //!   `exp(x)·log(x)`) and mixed algebraic+transcendental towers are unsupported;

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -15,13 +15,17 @@
 //!
 //! ## Scope of this implementation
 //!
-//! - Handles a **squarefree** denominator with **rational** resultant roots
-//!   (so the answer is a ℚ-linear combination of `log`s of ℚ-polynomials).
-//! - Returns `None` (so the caller falls back) when:
-//!   * the denominator is **not squarefree** — Hermite reduction is not yet wired
-//!     in, so repeated factors are left to the rule engine; or
-//!   * the resultant has **non-rational roots** — e.g. `1/(x²+1)` (residues `±i/2`),
-//!     whose antiderivative needs `arctan`/algebraic-number logs not yet emitted.
+//! - **Hermite reduction** (Yun squarefree factorization + partial fractions +
+//!   per-factor reduction) handles **repeated factors**, peeling off the rational
+//!   part of the antiderivative and leaving a proper fraction with a squarefree
+//!   denominator for the logarithmic part.
+//! - **Rothstein–Trager** then produces the logs for the squarefree remainder
+//!   when its resultant roots are **rational** (a ℚ-linear combination of `log`s
+//!   of ℚ-polynomials).
+//! - Returns `None` (so the caller falls back) when the resultant has
+//!   **non-rational roots** — e.g. `1/(x²+1)` (residues `±i/2`), whose
+//!   antiderivative needs `arctan`/algebraic-number logs. (Handled separately in
+//!   the arctan path once `atan` differentiation is available.)
 //!
 //! References: Rothstein (1976); Trager (1976); Bronstein (2005) §2.2–2.5;
 //! SymPy `sympy/integrals/risch.py` (`residue_reduce`, `log_part`).
@@ -32,7 +36,8 @@ use crate::kernel::{Domain, ExprId, ExprPool};
 use crate::poly::UniPoly;
 
 use super::poly_rde::{
-    degree, poly_deriv, poly_integrate, poly_scale, qpoly_to_expr, rational_to_expr, trim, QPoly,
+    degree, poly_add, poly_deriv, poly_integrate, poly_mul, poly_one, poly_scale, poly_zero,
+    qpoly_to_expr, rational_to_expr, trim, QPoly,
 };
 use super::rational_rde::{
     expr_to_qrational, poly_div_exact, poly_divrem, poly_gcd, poly_monic, poly_sub,
@@ -77,13 +82,23 @@ pub fn try_integrate_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Opt
     }
 
     if !r.is_empty() {
-        // The proper part R/D needs a squarefree D for this Rothstein–Trager path.
-        let dprime = poly_deriv(&d);
-        if degree(&poly_gcd(&d, &dprime)) > 0 {
-            return None; // not squarefree → Hermite reduction (future work)
+        // Hermite reduction: split R/D into a rational part (added directly) plus a
+        // proper fraction H/Drad with a *squarefree* denominator for the log part.
+        let (rational_terms, h, drad) = hermite_reduce(&r, &d, var, pool)?;
+        terms.extend(rational_terms);
+
+        let h = trim(h);
+        if !h.is_empty() {
+            // Reduce H/Drad and apply Rothstein–Trager to the squarefree remainder.
+            let g = poly_gcd(&h, &drad);
+            let h = poly_div_exact(&h, &g);
+            let drad = poly_monic(&poly_div_exact(&drad, &g));
+            if degree(&drad) >= 1 {
+                let dprime = poly_deriv(&drad);
+                let logs = rothstein_trager(&h, &drad, &dprime, var, pool)?;
+                terms.extend(logs);
+            }
         }
-        let logs = rothstein_trager(&r, &d, &dprime, var, pool)?;
-        terms.extend(logs);
     }
 
     Some(match terms.len() {
@@ -91,6 +106,193 @@ pub fn try_integrate_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Opt
         1 => terms[0],
         _ => pool.add(terms),
     })
+}
+
+// ---------------------------------------------------------------------------
+// Hermite reduction (Bronstein §2.2)
+// ---------------------------------------------------------------------------
+
+/// Remainder of `a mod m`.
+fn poly_mod(a: &QPoly, m: &QPoly) -> QPoly {
+    poly_divrem(a, m).1
+}
+
+/// Extended GCD over ℚ[x]: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
+fn ext_gcd(a: &QPoly, b: &QPoly) -> (QPoly, QPoly, QPoly) {
+    let (mut old_r, mut r) = (trim(a.clone()), trim(b.clone()));
+    let (mut old_s, mut s) = (poly_one(), poly_zero());
+    let (mut old_t, mut t) = (poly_zero(), poly_one());
+    while !r.is_empty() {
+        let (q, rem) = poly_divrem(&old_r, &r);
+        old_r = r;
+        r = rem;
+        let ns = poly_sub(&old_s, &poly_mul(&q, &s));
+        old_s = s;
+        s = ns;
+        let nt = poly_sub(&old_t, &poly_mul(&q, &t));
+        old_t = t;
+        t = nt;
+    }
+    let dg = degree(&old_r);
+    if dg < 0 {
+        return (poly_zero(), old_s, old_t);
+    }
+    let inv = Rational::from(1) / old_r[dg as usize].clone();
+    (
+        poly_scale(&old_r, &inv),
+        poly_scale(&old_s, &inv),
+        poly_scale(&old_t, &inv),
+    )
+}
+
+/// Inverse of `w` modulo `v` (requires `gcd(w, v) = 1`), else `None`.
+fn mod_inverse(w: &QPoly, v: &QPoly) -> Option<QPoly> {
+    let (g, s, _t) = ext_gcd(w, v);
+    if degree(&g) != 0 {
+        return None; // not coprime
+    }
+    Some(poly_mod(&s, v))
+}
+
+/// Yun squarefree factorization of a monic polynomial: returns `(Vᵢ, i)` for
+/// each non-constant `Vᵢ`, with `f = ∏ Vᵢ^i` and the `Vᵢ` squarefree & coprime.
+fn yun(f: &QPoly) -> Option<Vec<(QPoly, usize)>> {
+    let f = poly_monic(f);
+    if degree(&f) <= 0 {
+        return Some(vec![]);
+    }
+    let fp = poly_deriv(&f);
+    let a0 = poly_gcd(&f, &fp);
+    if degree(&a0) == 0 {
+        return Some(vec![(f, 1)]); // already squarefree
+    }
+    let mut b = poly_div_exact(&f, &a0);
+    let c = poly_div_exact(&fp, &a0);
+    let mut d = poly_sub(&c, &poly_deriv(&b));
+    let mut result = Vec::new();
+    let mut i = 1usize;
+    let cap = degree(&f) as usize + 2;
+    while degree(&b) > 0 {
+        if i > cap {
+            return None; // safety: should never trigger in characteristic 0
+        }
+        let vi = poly_gcd(&b, &d);
+        if degree(&vi) > 0 {
+            result.push((poly_monic(&vi), i));
+        }
+        let b_next = poly_div_exact(&b, &vi);
+        let c_next = poly_div_exact(&d, &vi);
+        d = poly_sub(&c_next, &poly_deriv(&b_next));
+        b = b_next;
+        i += 1;
+    }
+    Some(result)
+}
+
+/// Partial-fraction decomposition over pairwise-coprime moduli: returns `Aᵢ`
+/// with `num/∏mᵢ = Σ Aᵢ/mᵢ` and `deg Aᵢ < deg mᵢ`.
+fn partial_fractions(num: &QPoly, moduli: &[QPoly]) -> Option<Vec<QPoly>> {
+    let n = moduli.len();
+    if n == 0 {
+        return None;
+    }
+    if n == 1 {
+        return Some(vec![poly_mod(num, &moduli[0])]);
+    }
+    let mut result = Vec::with_capacity(n);
+    let mut cur = trim(num.clone());
+    for i in 0..n - 1 {
+        let mi = &moduli[i];
+        let rest = moduli[i + 1..]
+            .iter()
+            .fold(poly_one(), |acc, m| poly_mul(&acc, m));
+        let (g, _s, t) = ext_gcd(mi, &rest);
+        if degree(&g) != 0 {
+            return None; // moduli not coprime
+        }
+        let ai = poly_mod(&poly_mul(&cur, &t), mi);
+        let s = poly_div_exact(&poly_sub(&cur, &poly_mul(&ai, &rest)), mi);
+        result.push(ai);
+        cur = s;
+    }
+    result.push(cur);
+    Some(result)
+}
+
+/// Hermite reduction of `aᵢ / V^k` (`V` squarefree, the surrounding cofactor is 1).
+///
+/// Returns the rational-part terms `B / V^p` (as `(B, p)`) and the leftover
+/// numerator over `V^1` (the contribution to the squarefree logarithmic part).
+fn hermite_factor(ai: &QPoly, v: &QPoly, k: usize) -> Option<(Vec<(QPoly, usize)>, QPoly)> {
+    let vp = poly_deriv(v);
+    let mut a = trim(ai.clone());
+    let mut terms = Vec::new();
+    let mut power = k;
+    while power >= 2 {
+        let factor = Rational::from((power - 1) as i64);
+        let coeff = poly_mod(&poly_scale(&vp, &factor), v);
+        let inv = mod_inverse(&coeff, v)?;
+        let b = poly_mod(&poly_mul(&poly_scale(&a, &Rational::from(-1)), &inv), v);
+        // numerator = a − (B'·V − (k−1)·V'·B)
+        let inner = poly_sub(
+            &poly_mul(&poly_deriv(&b), v),
+            &poly_scale(&poly_mul(&vp, &b), &factor),
+        );
+        a = poly_div_exact(&poly_sub(&a, &inner), v);
+        terms.push((b, power - 1));
+        power -= 1;
+    }
+    Some((terms, a))
+}
+
+/// Full Hermite reduction of a proper fraction `r/d` (`d` monic, `gcd(r,d)=1`).
+///
+/// Returns `(rational_terms, H, Drad)`: the symbolic rational part, and the
+/// proper fraction `H/Drad` (`Drad` squarefree) feeding the logarithmic part.
+fn hermite_reduce(
+    r: &QPoly,
+    d: &QPoly,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(Vec<ExprId>, QPoly, QPoly)> {
+    let sqf = yun(d)?;
+    if sqf.is_empty() {
+        return Some((vec![], r.clone(), d.clone()));
+    }
+    let moduli: Vec<QPoly> = sqf
+        .iter()
+        .map(|(v, i)| {
+            let mut m = poly_one();
+            for _ in 0..*i {
+                m = poly_mul(&m, v);
+            }
+            m
+        })
+        .collect();
+    let parts = partial_fractions(r, &moduli)?;
+
+    let drad: QPoly = sqf.iter().fold(poly_one(), |acc, (v, _)| poly_mul(&acc, v));
+    let mut rational_terms: Vec<ExprId> = Vec::new();
+    let mut h = poly_zero();
+
+    for ((v, i), ai) in sqf.iter().zip(parts.iter()) {
+        let cofactor = poly_div_exact(&drad, v); // Drad / V_i
+        if *i == 1 {
+            // Already squarefree: the whole part feeds the log part.
+            h = poly_add(&h, &poly_mul(ai, &cofactor));
+            continue;
+        }
+        let (terms, leftover) = hermite_factor(ai, v, *i)?;
+        let v_expr = qpoly_to_expr(v, var, pool);
+        for (b, p) in terms {
+            let b_expr = qpoly_to_expr(&b, var, pool);
+            let v_pow = pool.pow(v_expr, pool.integer(-(p as i32)));
+            rational_terms.push(pool.mul(vec![b_expr, v_pow]));
+        }
+        h = poly_add(&h, &poly_mul(&leftover, &cofactor));
+    }
+
+    Some((rational_terms, trim(h), drad))
 }
 
 /// Rothstein–Trager logarithmic part of `∫ R/D dx` (`D` squarefree, monic,
@@ -303,13 +505,59 @@ mod tests {
     }
 
     #[test]
-    fn non_squarefree_unsupported() {
-        // ∫ 1/(x+1)² dx = −1/(x+1): squarefree-only RT path declines (Hermite needed).
+    fn hermite_one_over_x_plus_1_squared() {
+        // ∫ 1/(x+1)² dx = −1/(x+1)  (pure rational part, no log).
         let pool = pool();
         let x = pool.symbol("x", Domain::Real);
         let xp1 = pool.add(vec![x, pool.integer(1_i32)]);
         let f = pool.pow(xp1, pool.integer(-2_i32));
-        assert!(try_integrate_rational(f, x, &pool).is_none());
+        let result = try_integrate_rational(f, x, &pool).expect("Hermite reduction");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn hermite_repeated_with_log_part() {
+        // ∫ 1/(x²(x+1)) dx = −1/x − log(x) + log(x+1): rational part + two logs.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let xp1 = pool.add(vec![x, pool.integer(1_i32)]);
+        let den = pool.mul(vec![x2, xp1]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        let result = try_integrate_rational(f, x, &pool).expect("Hermite + RT");
+        verify(f, result, x, &pool);
+        assert!(
+            pool.display(result).to_string().contains("log"),
+            "expected a logarithmic part"
+        );
+    }
+
+    #[test]
+    fn hermite_cubic_repeated() {
+        // ∫ x/(x−1)³ dx — repeated linear factor of multiplicity 3.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let xm1 = pool.add(vec![x, pool.integer(-1_i32)]);
+        let f = pool.mul(vec![x, pool.pow(xm1, pool.integer(-3_i32))]);
+        let result = try_integrate_rational(f, x, &pool).expect("Hermite reduction");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn hermite_mixed_multiplicity() {
+        // ∫ (2x+1)/((x+1)²(x+2)) dx — multiplicity 2 and 1 factors together.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let xp1 = pool.add(vec![x, pool.integer(1_i32)]);
+        let xp2 = pool.add(vec![x, pool.integer(2_i32)]);
+        let den = pool.mul(vec![pool.pow(xp1, pool.integer(2_i32)), xp2]);
+        let num = pool.add(vec![
+            pool.mul(vec![pool.integer(2_i32), x]),
+            pool.integer(1_i32),
+        ]);
+        let f = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+        let result = try_integrate_rational(f, x, &pool).expect("Hermite + RT");
+        verify(f, result, x, &pool);
     }
 
     fn poly_to_expr(coeffs: &[Rational], x: ExprId, pool: &ExprPool) -> ExprId {

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -22,10 +22,13 @@
 //! - **Rothstein–Trager** then produces the logs for the squarefree remainder
 //!   when its resultant roots are **rational** (a ℚ-linear combination of `log`s
 //!   of ℚ-polynomials).
-//! - Returns `None` (so the caller falls back) when the resultant has
-//!   **non-rational roots** — e.g. `1/(x²+1)` (residues `±i/2`), whose
-//!   antiderivative needs `arctan`/algebraic-number logs. (Handled separately in
-//!   the arctan path once `atan` differentiation is available.)
+//! - Otherwise, [`partial_fraction_log_arctan`] factors the squarefree
+//!   denominator over ℚ and integrates each irreducible factor: linear → `log`,
+//!   irreducible quadratic → `log` + `arctan` (negative discriminant) or `log`
+//!   with `√Δ` coefficients (positive discriminant).
+//! - Returns `None` (so the caller falls back) only for irreducible factors of
+//!   **degree ≥ 3**, whose antiderivative is a sum over degree-≥3 algebraic
+//!   residues and needs a symbolic `RootSum` representation not yet available.
 //!
 //! References: Rothstein (1976); Trager (1976); Bronstein (2005) §2.2–2.5;
 //! SymPy `sympy/integrals/risch.py` (`residue_reduce`, `log_part`).
@@ -430,10 +433,15 @@ fn scaled(c: &Rational, e: ExprId, pool: &ExprPool) -> ExprId {
 }
 
 /// Integrate a proper fraction `h/d` (`d` squarefree, monic, `gcd(h,d)=1`) by
-/// partial fractions over the ℚ-irreducible factorization, emitting `log` for
-/// linear factors and `log + arctan` for irreducible quadratics with negative
-/// discriminant.  Returns `None` for any factor of degree ≥ 3, or a quadratic
-/// with non-negative discriminant (real irrational roots — algebraic logs).
+/// partial fractions over the ℚ-irreducible factorization:
+///   - **linear** factor `x+a` → `c·log(x+a)`;
+///   - **irreducible quadratic** `x²+bx+c0` with discriminant `Δ = b²−4c0`:
+///     * `Δ < 0` → `(M/2)·log(x²+bx+c0) + ((2N−Mb)/√(−Δ))·atan((2x+b)/√(−Δ))`;
+///     * `Δ > 0` → `(M/2)·log(x²+bx+c0) + ((2N−Mb)/(2√Δ))·[log(2x+b−√Δ) − log(2x+b+√Δ)]`
+///       (real irrational roots; the antiderivative carries `√Δ` coefficients).
+///
+/// Returns `None` for any irreducible factor of degree ≥ 3, which would require a
+/// symbolic `RootSum` over the (degree ≥ 3) algebraic residues — see module docs.
 fn partial_fraction_log_arctan(
     h: &QPoly,
     d: &QPoly,
@@ -465,12 +473,6 @@ fn partial_fraction_log_arctan(
                 let c0 = at(p, 0);
                 let big_m = at(&n, 1);
                 let big_n = at(&n, 0);
-                // Discriminant b² − 4c0; require < 0 (complex conjugate roots).
-                let disc = b.clone() * b.clone() - Rational::from(4) * c0.clone();
-                if disc >= 0 {
-                    return None; // real roots → algebraic logs, not handled
-                }
-                let d2 = Rational::from(4) * c0.clone() - b.clone() * b.clone(); // = −disc > 0
 
                 // Log part: (M/2)·log(x² + b·x + c0).
                 if big_m != 0 {
@@ -479,22 +481,48 @@ fn partial_fraction_log_arctan(
                     terms.push(scaled(&(big_m.clone() / Rational::from(2)), logp, pool));
                 }
 
-                // Arctan part: (2N − M·b)/√d2 · atan((2x + b)/√d2).
                 let coeff_num = Rational::from(2) * big_n.clone() - big_m.clone() * b.clone();
-                if coeff_num != 0 {
-                    let sqrt_d2 = pool.func("sqrt", vec![rational_to_expr(&d2, pool)]);
-                    let sqrt_inv = pool.pow(sqrt_d2, pool.integer(-1_i32));
-                    let two_x_plus_b = pool.add(vec![
-                        pool.mul(vec![pool.integer(2_i32), var]),
-                        rational_to_expr(&b, pool),
-                    ]);
-                    let arg = pool.mul(vec![two_x_plus_b, sqrt_inv]);
-                    let atan = pool.func("atan", vec![arg]);
-                    let coeff = pool.mul(vec![rational_to_expr(&coeff_num, pool), sqrt_inv]);
-                    terms.push(pool.mul(vec![coeff, atan]));
+                let disc = b.clone() * b.clone() - Rational::from(4) * c0.clone();
+                let two_x_plus_b = pool.add(vec![
+                    pool.mul(vec![pool.integer(2_i32), var]),
+                    rational_to_expr(&b, pool),
+                ]);
+
+                if disc < 0 {
+                    // Complex conjugate roots → arctan.
+                    // (2N − Mb)/√(−Δ) · atan((2x + b)/√(−Δ)).
+                    if coeff_num != 0 {
+                        let neg_disc = Rational::from(-1) * disc.clone();
+                        let sqrt = pool.func("sqrt", vec![rational_to_expr(&neg_disc, pool)]);
+                        let sqrt_inv = pool.pow(sqrt, pool.integer(-1_i32));
+                        let arg = pool.mul(vec![two_x_plus_b, sqrt_inv]);
+                        let atan = pool.func("atan", vec![arg]);
+                        let coeff = pool.mul(vec![rational_to_expr(&coeff_num, pool), sqrt_inv]);
+                        terms.push(pool.mul(vec![coeff, atan]));
+                    }
+                } else {
+                    // disc > 0 (irreducible ⇒ Δ not a perfect square): real irrational
+                    // roots → log with √Δ.
+                    // (2N − Mb)/(2√Δ) · [log(2x+b−√Δ) − log(2x+b+√Δ)].
+                    if coeff_num != 0 {
+                        let sqrt = pool.func("sqrt", vec![rational_to_expr(&disc, pool)]);
+                        let sqrt_inv = pool.pow(sqrt, pool.integer(-1_i32));
+                        let neg_sqrt = pool.mul(vec![pool.integer(-1_i32), sqrt]);
+                        let arg_minus = pool.add(vec![two_x_plus_b, neg_sqrt]);
+                        let arg_plus = pool.add(vec![two_x_plus_b, sqrt]);
+                        let log_diff = pool.add(vec![
+                            pool.func("log", vec![arg_minus]),
+                            pool.mul(vec![pool.integer(-1_i32), pool.func("log", vec![arg_plus])]),
+                        ]);
+                        // coeff = (2N − Mb) / (2√Δ)
+                        let half = Rational::from((1, 2));
+                        let coeff =
+                            pool.mul(vec![rational_to_expr(&(coeff_num * half), pool), sqrt_inv]);
+                        terms.push(pool.mul(vec![coeff, log_diff]));
+                    }
                 }
             }
-            _ => return None, // irreducible factor of degree ≥ 3
+            _ => return None, // irreducible factor of degree ≥ 3 → RootSum needed
         }
     }
     Some(terms)
@@ -673,15 +701,43 @@ mod tests {
     }
 
     #[test]
-    fn real_irrational_roots_decline() {
-        // ∫ 1/(x²−2) dx has real irrational residues (±1/(2√2)) — algebraic logs,
-        // not emitted by this path → None.
+    fn real_irrational_roots_via_sqrt_log() {
+        // ∫ 1/(x²−2) dx = (1/(2√2))·[log(2x−2√2) − log(2x+2√2)]: irreducible
+        // quadratic with positive discriminant → log with √Δ.
         let pool = pool();
         let x = pool.symbol("x", Domain::Real);
         let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-2_i32)]);
         let f = pool.pow(den, pool.integer(-1_i32));
-        // x²−2 = (x−√2)(x+√2): rational residues? No — RT resultant roots ±1/(2√2)
-        // are irrational, and the quadratic has positive discriminant → declines.
+        let result = try_integrate_rational(f, x, &pool).expect("sqrt-log path");
+        verify(f, result, x, &pool);
+        assert!(pool.display(result).to_string().contains("sqrt"));
+    }
+
+    #[test]
+    fn mixed_numerator_real_quadratic() {
+        // ∫ (x+3)/(x²−2) dx = ½·log(x²−2) + (3/(2√2))·[log(2x−2√2) − log(2x+2√2)].
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-2_i32)]);
+        let num = pool.add(vec![x, pool.integer(3_i32)]);
+        let f = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+        let result = try_integrate_rational(f, x, &pool).expect("log + sqrt-log");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn degree_three_irreducible_declines() {
+        // ∫ 1/(x³+x+1) dx — x³+x+1 is irreducible over ℚ with a degree-3 algebraic
+        // root; expressing the antiderivative needs a symbolic RootSum (not yet
+        // implemented) → declines.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            x,
+            pool.integer(1_i32),
+        ]);
+        let f = pool.pow(den, pool.integer(-1_i32));
         assert!(try_integrate_rational(f, x, &pool).is_none());
     }
 

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -95,7 +95,13 @@ pub fn try_integrate_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Opt
             let drad = poly_monic(&poly_div_exact(&drad, &g));
             if degree(&drad) >= 1 {
                 let dprime = poly_deriv(&drad);
-                let logs = rothstein_trager(&h, &drad, &dprime, var, pool)?;
+                // Rothstein–Trager for rational residues; otherwise fall back to a
+                // partial-fraction pass that emits log + arctan for irreducible
+                // quadratic factors.
+                let logs = match rothstein_trager(&h, &drad, &dprime, var, pool) {
+                    Some(logs) => logs,
+                    None => partial_fraction_log_arctan(&h, &drad, var, pool)?,
+                };
                 terms.extend(logs);
             }
         }
@@ -383,6 +389,118 @@ fn lcm_denoms(polys: &[&QPoly]) -> Integer {
 }
 
 // ---------------------------------------------------------------------------
+// Non-rational residues: irreducible-quadratic → log + arctan
+// ---------------------------------------------------------------------------
+
+/// Factor a monic polynomial over ℚ into its monic irreducible factors
+/// (multiplicities expanded), via FLINT integer factorization.
+fn factor_monic_q(d: &QPoly, var: ExprId, pool: &ExprPool) -> Option<Vec<QPoly>> {
+    let m = lcm_denoms(&[d]);
+    let d_int = poly_scale(d, &Rational::from(m));
+    let d_expr = qpoly_to_expr(&d_int, var, pool);
+    let up = UniPoly::from_symbolic(d_expr, var, pool).ok()?;
+    let fac = up.factor_z().ok()?;
+    let mut factors = Vec::new();
+    for (f, mult) in fac.factors {
+        let qp: QPoly = f
+            .coefficients()
+            .iter()
+            .map(|c| Rational::from(c.clone()))
+            .collect();
+        let qp = poly_monic(&qp);
+        for _ in 0..mult {
+            factors.push(qp.clone());
+        }
+    }
+    Some(factors)
+}
+
+/// Coefficient of `x^i`, or 0.
+fn at(p: &QPoly, i: usize) -> Rational {
+    p.get(i).cloned().unwrap_or_else(|| Rational::from(0))
+}
+
+/// `c · e`, collapsing `c = 1`.
+fn scaled(c: &Rational, e: ExprId, pool: &ExprPool) -> ExprId {
+    if *c == 1 {
+        e
+    } else {
+        pool.mul(vec![rational_to_expr(c, pool), e])
+    }
+}
+
+/// Integrate a proper fraction `h/d` (`d` squarefree, monic, `gcd(h,d)=1`) by
+/// partial fractions over the ℚ-irreducible factorization, emitting `log` for
+/// linear factors and `log + arctan` for irreducible quadratics with negative
+/// discriminant.  Returns `None` for any factor of degree ≥ 3, or a quadratic
+/// with non-negative discriminant (real irrational roots — algebraic logs).
+fn partial_fraction_log_arctan(
+    h: &QPoly,
+    d: &QPoly,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Vec<ExprId>> {
+    let factors = factor_monic_q(d, var, pool)?;
+    if factors.is_empty() {
+        return None;
+    }
+    let nums = partial_fractions(h, &factors)?;
+    let mut terms: Vec<ExprId> = Vec::new();
+
+    for (p, n) in factors.iter().zip(nums.iter()) {
+        let n = trim(n.clone());
+        if n.is_empty() {
+            continue;
+        }
+        match degree(p) {
+            1 => {
+                // p = x + a (monic); n is a constant c → c·log(p).
+                let p_expr = qpoly_to_expr(p, var, pool);
+                let logp = pool.func("log", vec![p_expr]);
+                terms.push(scaled(&at(&n, 0), logp, pool));
+            }
+            2 => {
+                // p = x² + b·x + c0;  n = M·x + N.
+                let b = at(p, 1);
+                let c0 = at(p, 0);
+                let big_m = at(&n, 1);
+                let big_n = at(&n, 0);
+                // Discriminant b² − 4c0; require < 0 (complex conjugate roots).
+                let disc = b.clone() * b.clone() - Rational::from(4) * c0.clone();
+                if disc >= 0 {
+                    return None; // real roots → algebraic logs, not handled
+                }
+                let d2 = Rational::from(4) * c0.clone() - b.clone() * b.clone(); // = −disc > 0
+
+                // Log part: (M/2)·log(x² + b·x + c0).
+                if big_m != 0 {
+                    let p_expr = qpoly_to_expr(p, var, pool);
+                    let logp = pool.func("log", vec![p_expr]);
+                    terms.push(scaled(&(big_m.clone() / Rational::from(2)), logp, pool));
+                }
+
+                // Arctan part: (2N − M·b)/√d2 · atan((2x + b)/√d2).
+                let coeff_num = Rational::from(2) * big_n.clone() - big_m.clone() * b.clone();
+                if coeff_num != 0 {
+                    let sqrt_d2 = pool.func("sqrt", vec![rational_to_expr(&d2, pool)]);
+                    let sqrt_inv = pool.pow(sqrt_d2, pool.integer(-1_i32));
+                    let two_x_plus_b = pool.add(vec![
+                        pool.mul(vec![pool.integer(2_i32), var]),
+                        rational_to_expr(&b, pool),
+                    ]);
+                    let arg = pool.mul(vec![two_x_plus_b, sqrt_inv]);
+                    let atan = pool.func("atan", vec![arg]);
+                    let coeff = pool.mul(vec![rational_to_expr(&coeff_num, pool), sqrt_inv]);
+                    terms.push(pool.mul(vec![coeff, atan]));
+                }
+            }
+            _ => return None, // irreducible factor of degree ≥ 3
+        }
+    }
+    Some(terms)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -406,8 +524,14 @@ mod tests {
             ExprData::Add(args) => args.iter().map(|&a| eval(a, x, xv, pool)).sum(),
             ExprData::Mul(args) => args.iter().map(|&a| eval(a, x, xv, pool)).product(),
             ExprData::Pow { base, exp } => eval(base, x, xv, pool).powf(eval(exp, x, xv, pool)),
-            ExprData::Func { ref name, ref args } if name == "log" && args.len() == 1 => {
-                eval(args[0], x, xv, pool).ln()
+            ExprData::Func { ref name, ref args } if args.len() == 1 => {
+                let a = eval(args[0], x, xv, pool);
+                match name.as_str() {
+                    "log" => a.ln(),
+                    "atan" => a.atan(),
+                    "sqrt" => a.sqrt(),
+                    other => panic!("eval: unsupported func {other}"),
+                }
             }
             other => panic!("eval: unsupported {other:?}"),
         }
@@ -495,12 +619,69 @@ mod tests {
     }
 
     #[test]
-    fn complex_residues_unsupported() {
-        // ∫ 1/(x²+1) dx needs arctan (residues ±i/2) — not handled here → None.
+    fn arctan_one_over_x2_plus_1() {
+        // ∫ 1/(x²+1) dx = atan(x).
         let pool = pool();
         let x = pool.symbol("x", Domain::Real);
         let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
         let f = pool.pow(den, pool.integer(-1_i32));
+        let result = try_integrate_rational(f, x, &pool).expect("arctan path");
+        verify(f, result, x, &pool);
+        assert!(pool.display(result).to_string().contains("atan"));
+    }
+
+    #[test]
+    fn arctan_one_over_x2_plus_4() {
+        // ∫ 1/(x²+4) dx = ½·atan(x/2).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(4_i32)]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        let result = try_integrate_rational(f, x, &pool).expect("arctan path");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn log_plus_arctan_mixed_numerator() {
+        // ∫ (x+1)/(x²+1) dx = ½·log(x²+1) + atan(x): both a log and an arctan term.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let num = pool.add(vec![x, pool.integer(1_i32)]);
+        let f = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+        let result = try_integrate_rational(f, x, &pool).expect("log + arctan");
+        verify(f, result, x, &pool);
+        let s = pool.display(result).to_string();
+        assert!(
+            s.contains("atan") && s.contains("log"),
+            "expected log and atan: {s}"
+        );
+    }
+
+    #[test]
+    fn linear_and_quadratic_factors() {
+        // ∫ 1/((x−1)(x²+1)) dx — a linear (log) and an irreducible quadratic
+        // (log + arctan) factor together.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let xm1 = pool.add(vec![x, pool.integer(-1_i32)]);
+        let x2p1 = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let den = pool.mul(vec![xm1, x2p1]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        let result = try_integrate_rational(f, x, &pool).expect("mixed factors");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn real_irrational_roots_decline() {
+        // ∫ 1/(x²−2) dx has real irrational residues (±1/(2√2)) — algebraic logs,
+        // not emitted by this path → None.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-2_i32)]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        // x²−2 = (x−√2)(x+√2): rational residues? No — RT resultant roots ±1/(2√2)
+        // are irrational, and the quadratic has positive discriminant → declines.
         assert!(try_integrate_rational(f, x, &pool).is_none());
     }
 

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -22,8 +22,8 @@
 //! - **Rothstein–Trager** then produces the logs for the squarefree remainder
 //!   when its resultant roots are **rational** (a ℚ-linear combination of `log`s
 //!   of ℚ-polynomials).
-//! - Otherwise, [`partial_fraction_log_arctan`] factors the squarefree
-//!   denominator over ℚ and integrates each irreducible factor: linear → `log`,
+//! - Otherwise, a partial-fraction pass factors the squarefree denominator over
+//!   ℚ and integrates each irreducible factor: linear → `log`,
 //!   irreducible quadratic → `log` + `arctan` (negative discriminant) or `log`
 //!   with `√Δ` coefficients (positive discriminant).
 //! - Returns `None` (so the caller falls back) only for irreducible factors of

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -1,0 +1,318 @@
+//! Rational-function integration via Rothstein–Trager (Risch Gap 3).
+//!
+//! Computes the **logarithmic part** of `∫ A(x)/D(x) dx` for a rational function
+//! over ℚ.  The classical pipeline is:
+//!
+//! 1. **Polynomial division** `A = Q·D + R` (deg R < deg D): `∫Q` is elementary.
+//! 2. **Rothstein–Trager** on the proper part `R/D` with `D` squarefree, monic,
+//!    `gcd(R, D) = 1`:
+//!    ```text
+//!      R(t) = res_x(R − t·D′, D),
+//!      ∫ R/D dx = Σ_{c : R(c)=0}  c · log( gcd_x(R − c·D′, D) ).
+//!    ```
+//!    The roots `c` of the **resultant** are the residues; each contributes one
+//!    logarithm whose argument is a polynomial GCD.
+//!
+//! ## Scope of this implementation
+//!
+//! - Handles a **squarefree** denominator with **rational** resultant roots
+//!   (so the answer is a ℚ-linear combination of `log`s of ℚ-polynomials).
+//! - Returns `None` (so the caller falls back) when:
+//!   * the denominator is **not squarefree** — Hermite reduction is not yet wired
+//!     in, so repeated factors are left to the rule engine; or
+//!   * the resultant has **non-rational roots** — e.g. `1/(x²+1)` (residues `±i/2`),
+//!     whose antiderivative needs `arctan`/algebraic-number logs not yet emitted.
+//!
+//! References: Rothstein (1976); Trager (1976); Bronstein (2005) §2.2–2.5;
+//! SymPy `sympy/integrals/risch.py` (`residue_reduce`, `log_part`).
+
+use rug::{Integer, Rational};
+
+use crate::kernel::{Domain, ExprId, ExprPool};
+use crate::poly::UniPoly;
+
+use super::poly_rde::{
+    degree, poly_deriv, poly_integrate, poly_scale, qpoly_to_expr, rational_to_expr, trim, QPoly,
+};
+use super::rational_rde::{
+    expr_to_qrational, poly_div_exact, poly_divrem, poly_gcd, poly_monic, poly_sub,
+};
+
+/// Attempt to integrate `expr` as a rational function of `var`.
+///
+/// Returns `Some(F)` with the antiderivative (no constant of integration) when
+/// the Rothstein–Trager path succeeds, or `None` when `expr` is not a rational
+/// function or falls outside the supported subset (see module docs), so the
+/// caller can fall back to its existing behaviour.
+pub fn try_integrate_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<ExprId> {
+    let (a, d) = expr_to_qrational(expr, var, pool)?;
+    let a = trim(a);
+    let d = trim(d);
+    if d.is_empty() {
+        return None; // division by zero — malformed
+    }
+    if degree(&d) < 1 {
+        return None; // polynomial integrand — leave to the rule engine
+    }
+
+    // Normalise: make D monic and reduce A/D to lowest terms.
+    let lc_inv = Rational::from(1) / d[degree(&d) as usize].clone();
+    let d = poly_scale(&d, &lc_inv);
+    let a = poly_scale(&a, &lc_inv);
+    let g = poly_gcd(&a, &d);
+    let a = poly_div_exact(&a, &g);
+    let d = poly_monic(&poly_div_exact(&d, &g));
+    if degree(&d) < 1 {
+        return None; // reduced to a polynomial
+    }
+
+    // Polynomial part: A = Q·D + R.
+    let (q, r) = poly_divrem(&a, &d);
+    let poly_int = poly_integrate(&q);
+    let r = trim(r);
+
+    let mut terms: Vec<ExprId> = Vec::new();
+    if !trim(poly_int.clone()).is_empty() {
+        terms.push(qpoly_to_expr(&poly_int, var, pool));
+    }
+
+    if !r.is_empty() {
+        // The proper part R/D needs a squarefree D for this Rothstein–Trager path.
+        let dprime = poly_deriv(&d);
+        if degree(&poly_gcd(&d, &dprime)) > 0 {
+            return None; // not squarefree → Hermite reduction (future work)
+        }
+        let logs = rothstein_trager(&r, &d, &dprime, var, pool)?;
+        terms.extend(logs);
+    }
+
+    Some(match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    })
+}
+
+/// Rothstein–Trager logarithmic part of `∫ R/D dx` (`D` squarefree, monic,
+/// `gcd(R, D) = 1`).  Returns `None` if any resultant root is non-rational.
+fn rothstein_trager(
+    r: &QPoly,
+    d: &QPoly,
+    dprime: &QPoly,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Vec<ExprId>> {
+    // Build R(t) = res_x(R − t·D′, D) over ℤ.  Clear denominators of R and D′ by a
+    // *single* common factor L so the resultant's roots are exactly the residues.
+    let l = lcm_denoms(&[r, dprime]);
+    let r_int = poly_scale(r, &Rational::from(l.clone()));
+    let dp_int = poly_scale(dprime, &Rational::from(l));
+    let m = lcm_denoms(&[d]);
+    let d_int = poly_scale(d, &Rational::from(m));
+
+    let t = pool.symbol("$rt_param$", Domain::Complex);
+    let r_expr = qpoly_to_expr(&r_int, var, pool);
+    let dp_expr = qpoly_to_expr(&dp_int, var, pool);
+    // P(x, t) = R(x) − t·D′(x)
+    let p_expr = pool.add(vec![
+        r_expr,
+        pool.mul(vec![pool.integer(-1_i32), t, dp_expr]),
+    ]);
+    let d_expr = qpoly_to_expr(&d_int, var, pool);
+
+    let res = crate::poly::resultant(p_expr, d_expr, var, pool).ok()?;
+    let rt_poly = UniPoly::from_symbolic(res.value, t, pool).ok()?;
+    if rt_poly.degree() < 1 {
+        return None;
+    }
+    let fac = rt_poly.factor_z().ok()?;
+
+    // Collect distinct rational roots (residues); bail on any non-linear factor.
+    let mut residues: Vec<Rational> = Vec::new();
+    for (f, _mult) in &fac.factors {
+        if f.degree() != 1 {
+            return None; // non-rational residue — needs algebraic extension / arctan
+        }
+        let coeffs = f.coefficients(); // ascending: [b, a] for a·t + b
+        let b = Rational::from(coeffs[0].clone());
+        let a = Rational::from(coeffs[1].clone());
+        let c = -b / a;
+        if !residues.contains(&c) {
+            residues.push(c);
+        }
+    }
+
+    // Each residue c contributes c·log(gcd_x(R − c·D′, D)).
+    let mut logs: Vec<ExprId> = Vec::new();
+    let mut covered = 0i64;
+    for c in &residues {
+        let shifted = poly_sub(r, &poly_scale(dprime, c));
+        let gc = poly_monic(&poly_gcd(&shifted, d));
+        if degree(&gc) <= 0 {
+            continue;
+        }
+        covered += degree(&gc);
+        let arg = qpoly_to_expr(&gc, var, pool);
+        let log_arg = pool.func("log", vec![arg]);
+        let term = if *c == 1 {
+            log_arg
+        } else {
+            pool.mul(vec![rational_to_expr(c, pool), log_arg])
+        };
+        logs.push(term);
+    }
+
+    // Soundness guard: every root of D must be accounted for by some residue.
+    if covered != degree(d) {
+        return None;
+    }
+    Some(logs)
+}
+
+/// LCM of all coefficient denominators across the given polynomials.
+fn lcm_denoms(polys: &[&QPoly]) -> Integer {
+    let mut l = Integer::from(1);
+    for p in polys {
+        for c in p.iter() {
+            l = l.lcm(c.denom());
+        }
+    }
+    l
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::ExprData;
+
+    fn pool() -> ExprPool {
+        ExprPool::new()
+    }
+
+    /// Numeric evaluator for verification (Integer/Rational/Add/Mul/Pow/log).
+    fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        if expr == x {
+            return xv;
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => n.0.to_f64(),
+            ExprData::Rational(r) => r.0.to_f64(),
+            ExprData::Add(args) => args.iter().map(|&a| eval(a, x, xv, pool)).sum(),
+            ExprData::Mul(args) => args.iter().map(|&a| eval(a, x, xv, pool)).product(),
+            ExprData::Pow { base, exp } => eval(base, x, xv, pool).powf(eval(exp, x, xv, pool)),
+            ExprData::Func { ref name, ref args } if name == "log" && args.len() == 1 => {
+                eval(args[0], x, xv, pool).ln()
+            }
+            other => panic!("eval: unsupported {other:?}"),
+        }
+    }
+
+    /// Verify d/dx F = integrand numerically at several points.
+    fn verify(expr: ExprId, antideriv: ExprId, x: ExprId, pool: &ExprPool) {
+        let d = crate::diff::diff(antideriv, x, pool).unwrap();
+        let ds = crate::simplify::engine::simplify(d.value, pool).value;
+        for &xv in &[1.7_f64, 2.3, 3.9] {
+            let lhs = eval(ds, x, xv, pool);
+            let rhs = eval(expr, x, xv, pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-7,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs} (F={})",
+                pool.display(antideriv)
+            );
+        }
+    }
+
+    #[test]
+    fn one_over_x2_minus_1() {
+        // ∫ 1/(x²−1) dx = ½ log(x−1) − ½ log(x+1).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = poly_to_expr(
+            &[Rational::from(-1), Rational::from(0), Rational::from(1)],
+            x,
+            &pool,
+        );
+        let f = pool.mul(vec![
+            pool.integer(1_i32),
+            pool.pow(den, pool.integer(-1_i32)),
+        ]);
+        let result = try_integrate_rational(f, x, &pool).expect("rational integral");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn two_x_over_x2_plus_1() {
+        // ∫ 2x/(x²+1) dx = log(x²+1).  (Residue c = 1, rational.)
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let x2p1 = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let f = pool.mul(vec![
+            pool.integer(2_i32),
+            x,
+            pool.pow(x2p1, pool.integer(-1_i32)),
+        ]);
+        let result = try_integrate_rational(f, x, &pool).expect("rational integral");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn one_over_x2_minus_x() {
+        // ∫ 1/(x²−x) dx = ∫ 1/(x(x−1)) dx = −log(x) + log(x−1).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = poly_to_expr(
+            &[Rational::from(0), Rational::from(-1), Rational::from(1)],
+            x,
+            &pool,
+        );
+        let f = pool.pow(den, pool.integer(-1_i32));
+        let result = try_integrate_rational(f, x, &pool).expect("rational integral");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn improper_with_log_part() {
+        // ∫ x³/(x²−1) dx = x²/2 + ½ log(x²−1)  (improper: polynomial + log part).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = poly_to_expr(
+            &[Rational::from(-1), Rational::from(0), Rational::from(1)],
+            x,
+            &pool,
+        );
+        let f = pool.mul(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            pool.pow(den, pool.integer(-1_i32)),
+        ]);
+        let result = try_integrate_rational(f, x, &pool).expect("rational integral");
+        verify(f, result, x, &pool);
+    }
+
+    #[test]
+    fn complex_residues_unsupported() {
+        // ∫ 1/(x²+1) dx needs arctan (residues ±i/2) — not handled here → None.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        assert!(try_integrate_rational(f, x, &pool).is_none());
+    }
+
+    #[test]
+    fn non_squarefree_unsupported() {
+        // ∫ 1/(x+1)² dx = −1/(x+1): squarefree-only RT path declines (Hermite needed).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let xp1 = pool.add(vec![x, pool.integer(1_i32)]);
+        let f = pool.pow(xp1, pool.integer(-2_i32));
+        assert!(try_integrate_rational(f, x, &pool).is_none());
+    }
+
+    fn poly_to_expr(coeffs: &[Rational], x: ExprId, pool: &ExprPool) -> ExprId {
+        qpoly_to_expr(&coeffs.to_vec(), x, pool)
+    }
+}

--- a/alkahest-core/src/integrate/risch/rational_rde.rs
+++ b/alkahest-core/src/integrate/risch/rational_rde.rs
@@ -49,7 +49,7 @@ use super::poly_rde::{
 // ---------------------------------------------------------------------------
 
 /// Subtract `b` from `a`.
-fn poly_sub(a: &QPoly, b: &QPoly) -> QPoly {
+pub fn poly_sub(a: &QPoly, b: &QPoly) -> QPoly {
     poly_add(a, &poly_scale(b, &Rational::from(-1)))
 }
 
@@ -65,7 +65,7 @@ fn coeff(p: &QPoly, i: i64) -> Rational {
 
 /// Long division over ℚ: returns `(q, r)` with `a = q·b + r`, `deg r < deg b`.
 /// `b` must be nonzero.
-fn poly_divrem(a: &QPoly, b: &QPoly) -> (QPoly, QPoly) {
+pub fn poly_divrem(a: &QPoly, b: &QPoly) -> (QPoly, QPoly) {
     let b = trim(b.clone());
     let bd = degree(&b);
     debug_assert!(bd >= 0, "poly_divrem: division by zero polynomial");
@@ -99,7 +99,7 @@ fn poly_divrem(a: &QPoly, b: &QPoly) -> (QPoly, QPoly) {
 
 /// Make a polynomial monic (leading coefficient 1).  The zero polynomial is
 /// returned unchanged.
-fn poly_monic(p: &QPoly) -> QPoly {
+pub fn poly_monic(p: &QPoly) -> QPoly {
     let p = trim(p.clone());
     let d = degree(&p);
     if d < 0 {
@@ -110,7 +110,7 @@ fn poly_monic(p: &QPoly) -> QPoly {
 }
 
 /// Monic GCD of `a` and `b` over ℚ (Euclidean algorithm).
-fn poly_gcd(a: &QPoly, b: &QPoly) -> QPoly {
+pub fn poly_gcd(a: &QPoly, b: &QPoly) -> QPoly {
     let mut a = trim(a.clone());
     let mut b = trim(b.clone());
     while !b.is_empty() {
@@ -122,7 +122,7 @@ fn poly_gcd(a: &QPoly, b: &QPoly) -> QPoly {
 }
 
 /// Exact division `a / b` (panics in debug if the remainder is nonzero).
-fn poly_div_exact(a: &QPoly, b: &QPoly) -> QPoly {
+pub fn poly_div_exact(a: &QPoly, b: &QPoly) -> QPoly {
     let (q, r) = poly_divrem(a, b);
     debug_assert!(trim(r).is_empty(), "poly_div_exact: nonzero remainder");
     q

--- a/alkahest-core/src/integrate/risch/rational_rde.rs
+++ b/alkahest-core/src/integrate/risch/rational_rde.rs
@@ -1,0 +1,480 @@
+//! Rational Risch Differential Equation (RDE) solver over ℚ(x) (Risch Gap 1).
+//!
+//! Extends [`super::poly_rde`] from polynomial coefficients to **rational**
+//! coefficients.  Solves
+//! ```text
+//!   v'(x) + f(x)·v(x) = c(x)
+//! ```
+//! where `f ∈ ℚ[x]` (in the exp tower, `f = k·η'`, always a polynomial) and
+//! `c ∈ ℚ(x)` is a rational function, returning `v ∈ ℚ(x)` when one exists.
+//!
+//! ## Algorithm (Bronstein 2005, §6.1)
+//!
+//! Because `f` is a polynomial (no poles), a Laurent-series analysis at any pole
+//! `α` of `v` shows that `v'` raises the pole order by one while `f·v` keeps it,
+//! so the pole order of `v` at `α` is exactly one less than that of `c`.  Hence
+//! the denominator of any rational solution divides
+//! ```text
+//!   E = gcd(B, B')
+//! ```
+//! where `B` is the (reduced, monic) denominator of `c`.  Writing `v = N/E` for
+//! an unknown polynomial `N`, substituting, and clearing denominators yields a
+//! **polynomial identity** that is *linear* in the coefficients of `N`:
+//! ```text
+//!   G·E·N' − G·E'·N + G·E·f·N − C·E = 0,     G = B/E,  c = C/B.
+//! ```
+//! Equating coefficients gives a linear system over ℚ.  A consistent system
+//! certifies an elementary antiderivative `v·exp(kη)`; an inconsistent one
+//! certifies that the integral is **non-elementary** (the leftover simple-pole
+//! residues are exactly the Ei/Li-type logarithmic part the exp tower cannot
+//! express).
+//!
+//! The homogeneous equation `v' + f·v = 0` has no nonzero rational solution when
+//! `f ≠ 0` (its solutions are `const·exp(−∫f)`), so the rational solution is
+//! unique — extra unknowns in an over-sized ansatz are forced to zero, and a
+//! final substitution check guards against an under-sized degree bound.
+//!
+//! References:
+//!   - Bronstein (2005). *Symbolic Integration I*, §6.1 (RischDE, normal part).
+//!   - SymPy `sympy/integrals/rde.py` (`bound_degree`, `spde`, `no_cancel_*`).
+
+use rug::Rational;
+
+use super::poly_rde::{
+    degree, poly_add, poly_deriv, poly_mul, poly_one, poly_scale, poly_zero, trim, QPoly,
+};
+
+// ---------------------------------------------------------------------------
+// Polynomial arithmetic over ℚ not already provided by `poly_rde`
+// ---------------------------------------------------------------------------
+
+/// Subtract `b` from `a`.
+fn poly_sub(a: &QPoly, b: &QPoly) -> QPoly {
+    poly_add(a, &poly_scale(b, &Rational::from(-1)))
+}
+
+/// Coefficient of `x^i` (0 outside the stored range or for negative `i`).
+fn coeff(p: &QPoly, i: i64) -> Rational {
+    if i < 0 {
+        return Rational::from(0);
+    }
+    p.get(i as usize)
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0))
+}
+
+/// Long division over ℚ: returns `(q, r)` with `a = q·b + r`, `deg r < deg b`.
+/// `b` must be nonzero.
+fn poly_divrem(a: &QPoly, b: &QPoly) -> (QPoly, QPoly) {
+    let b = trim(b.clone());
+    let bd = degree(&b);
+    debug_assert!(bd >= 0, "poly_divrem: division by zero polynomial");
+    let lcb = b[bd as usize].clone();
+
+    let mut r = trim(a.clone());
+    let ad = degree(&r);
+    if ad < bd {
+        return (poly_zero(), r);
+    }
+    let mut q = vec![Rational::from(0); (ad - bd + 1) as usize];
+
+    loop {
+        let rd = degree(&r);
+        if rd < bd {
+            break;
+        }
+        let shift = (rd - bd) as usize;
+        let factor = r[rd as usize].clone() / lcb.clone();
+        q[shift] += factor.clone();
+        for (i, bc) in b.iter().enumerate() {
+            r[shift + i] -= factor.clone() * bc.clone();
+        }
+        r = trim(r);
+        if r.is_empty() {
+            break;
+        }
+    }
+    (trim(q), trim(r))
+}
+
+/// Make a polynomial monic (leading coefficient 1).  The zero polynomial is
+/// returned unchanged.
+fn poly_monic(p: &QPoly) -> QPoly {
+    let p = trim(p.clone());
+    let d = degree(&p);
+    if d < 0 {
+        return p;
+    }
+    let lc = p[d as usize].clone();
+    poly_scale(&p, &(Rational::from(1) / lc))
+}
+
+/// Monic GCD of `a` and `b` over ℚ (Euclidean algorithm).
+fn poly_gcd(a: &QPoly, b: &QPoly) -> QPoly {
+    let mut a = trim(a.clone());
+    let mut b = trim(b.clone());
+    while !b.is_empty() {
+        let (_, r) = poly_divrem(&a, &b);
+        a = b;
+        b = r;
+    }
+    poly_monic(&a)
+}
+
+/// Exact division `a / b` (panics in debug if the remainder is nonzero).
+fn poly_div_exact(a: &QPoly, b: &QPoly) -> QPoly {
+    let (q, r) = poly_divrem(a, b);
+    debug_assert!(trim(r).is_empty(), "poly_div_exact: nonzero remainder");
+    q
+}
+
+/// `p^n` for `n ≥ 0`.
+fn poly_pow(p: &QPoly, n: u32) -> QPoly {
+    let mut acc = poly_one();
+    for _ in 0..n {
+        acc = poly_mul(&acc, p);
+    }
+    acc
+}
+
+fn polys_equal(a: &QPoly, b: &QPoly) -> bool {
+    trim(a.clone()) == trim(b.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Exact linear system solver over ℚ
+// ---------------------------------------------------------------------------
+
+/// Solve `mat · x = rhs` over ℚ by Gauss–Jordan elimination.
+///
+/// Returns a particular solution (free variables set to 0), or `None` if the
+/// system is inconsistent.  `mat` is `rows × cols`.
+fn solve_linear_system(
+    mut mat: Vec<Vec<Rational>>,
+    mut rhs: Vec<Rational>,
+    cols: usize,
+) -> Option<Vec<Rational>> {
+    let rows = mat.len();
+    let mut pivot_row_of_col: Vec<Option<usize>> = vec![None; cols];
+    let mut row = 0usize;
+
+    for col in 0..cols {
+        if row >= rows {
+            break;
+        }
+        // Find a pivot in this column at or below `row`.
+        let Some(sel) = (row..rows).find(|&r| mat[r][col] != 0) else {
+            continue;
+        };
+        mat.swap(row, sel);
+        rhs.swap(row, sel);
+
+        // Normalise the pivot row.
+        let piv = mat[row][col].clone();
+        for cell in mat[row][col..cols].iter_mut() {
+            *cell /= piv.clone();
+        }
+        rhs[row] /= piv.clone();
+
+        // Eliminate the column from every other row.
+        let pivot_row = mat[row].clone();
+        let pivot_rhs = rhs[row].clone();
+        for r in 0..rows {
+            if r != row && mat[r][col] != 0 {
+                let factor = mat[r][col].clone();
+                for (cell, pv) in mat[r][col..cols]
+                    .iter_mut()
+                    .zip(pivot_row[col..cols].iter())
+                {
+                    *cell -= factor.clone() * pv.clone();
+                }
+                rhs[r] -= factor.clone() * pivot_rhs.clone();
+            }
+        }
+        pivot_row_of_col[col] = Some(row);
+        row += 1;
+    }
+
+    // Consistency: an all-zero row in `mat` with nonzero `rhs` has no solution.
+    for r in 0..rows {
+        if mat[r].iter().all(|v| *v == 0) && rhs[r] != 0 {
+            return None;
+        }
+    }
+
+    let mut x = vec![Rational::from(0); cols];
+    for (col, pr) in pivot_row_of_col.iter().enumerate() {
+        if let Some(pr) = pr {
+            x[col] = rhs[*pr].clone();
+        }
+    }
+    Some(x)
+}
+
+// ---------------------------------------------------------------------------
+// Rational RDE solver
+// ---------------------------------------------------------------------------
+
+/// Solve `v' + f·v = c_num/c_den` for `v ∈ ℚ(x)`.
+///
+/// `f` is a polynomial (the exp-tower coefficient `k·η'`).  Returns the solution
+/// as a reduced `(numerator, denominator)` pair, or `None` if no rational
+/// solution exists (which certifies a non-elementary integral in the exp tower).
+pub fn solve_rational_rde(f: &QPoly, c_num: &QPoly, c_den: &QPoly) -> Option<(QPoly, QPoly)> {
+    let c_num = trim(c_num.clone());
+    let c_den = trim(c_den.clone());
+
+    // c = 0 → v = 0.
+    if c_num.is_empty() {
+        return Some((poly_zero(), poly_one()));
+    }
+    if c_den.is_empty() {
+        return None; // division by zero — malformed input
+    }
+
+    // Reduce c = C/B to lowest terms with B monic.
+    let g = poly_gcd(&c_num, &c_den);
+    let big_c = poly_div_exact(&c_num, &g);
+    let b_raw = poly_div_exact(&c_den, &g);
+    // Scale so that B is monic, applying the same scale to C.
+    let bd = degree(&b_raw);
+    let scale = Rational::from(1) / b_raw[bd as usize].clone();
+    let big_b = poly_scale(&b_raw, &scale);
+    let big_c = poly_scale(&big_c, &scale);
+
+    // Denominator bound for v: E = gcd(B, B').  G = B / E.
+    let bprime = poly_deriv(&big_b);
+    let e_poly = poly_gcd(&big_b, &bprime);
+    let g_poly = poly_div_exact(&big_b, &e_poly);
+    let eprime = poly_deriv(&e_poly);
+
+    // Precompute the polynomial multipliers of the linear identity
+    //   Σ_j n_j · P_j(x) = C·E,   P_j = G·E·(j x^{j-1}) − G·E'·x^j + G·E·f·x^j.
+    let ge = poly_mul(&g_poly, &e_poly); // G·E
+    let gep = poly_mul(&g_poly, &eprime); // G·E'
+    let gef = poly_mul(&ge, f); // G·E·f
+    let target = poly_mul(&big_c, &e_poly); // C·E
+
+    // Degree bound for N (= numerator of v = N/E).
+    let deg_b = degree(&big_b);
+    let deg_c = degree(&big_c);
+    let deg_e = degree(&e_poly).max(0);
+    let deg_f = degree(f).max(0);
+    let poly_part = (deg_c - deg_b).max(0);
+    let dbound = (deg_e + poly_part.max(deg_f) + 2).max(0) as usize;
+    let cols = dbound + 1; // unknowns n_0..n_dbound
+
+    // Maximum degree appearing in the identity.
+    let max_deg = (degree(&gef) + dbound as i64)
+        .max(degree(&ge) + dbound as i64)
+        .max(degree(&gep) + dbound as i64)
+        .max(degree(&target))
+        .max(0) as usize;
+    let n_rows = max_deg + 1;
+
+    // Assemble the linear system M·n = target.
+    let mut mat = vec![vec![Rational::from(0); cols]; n_rows];
+    for (d, row) in mat.iter_mut().enumerate() {
+        let d = d as i64;
+        for (j, cell) in row.iter_mut().enumerate() {
+            let jj = j as i64;
+            // [G·E·(j x^{j-1})]_d = j · (G·E)[d-j+1]
+            let mut v = Rational::from(jj) * coeff(&ge, d - jj + 1);
+            // − [G·E'·x^j]_d = −(G·E')[d-j]
+            v -= coeff(&gep, d - jj);
+            // + [G·E·f·x^j]_d = (G·E·f)[d-j]
+            v += coeff(&gef, d - jj);
+            *cell = v;
+        }
+    }
+    let rhs: Vec<Rational> = (0..n_rows).map(|d| coeff(&target, d as i64)).collect();
+
+    let solution = solve_linear_system(mat, rhs, cols)?;
+    let n_poly = trim(solution);
+
+    // Verify: (N'E − N E' + f N E)·B == C·E²   (i.e. v'+f v == C/B with v=N/E).
+    let np = poly_deriv(&n_poly);
+    let lhs = poly_mul(
+        &poly_add(
+            &poly_sub(&poly_mul(&np, &e_poly), &poly_mul(&n_poly, &eprime)),
+            &poly_mul(&poly_mul(f, &n_poly), &e_poly),
+        ),
+        &big_b,
+    );
+    let rhs_check = poly_mul(&big_c, &poly_mul(&e_poly, &e_poly));
+    if !polys_equal(&lhs, &rhs_check) {
+        return None;
+    }
+
+    // Reduce v = N/E to lowest terms.
+    if n_poly.is_empty() {
+        return Some((poly_zero(), poly_one()));
+    }
+    let gve = poly_gcd(&n_poly, &e_poly);
+    let num = poly_div_exact(&n_poly, &gve);
+    let den = poly_monic(&poly_div_exact(&e_poly, &gve));
+    Some((num, den))
+}
+
+// ---------------------------------------------------------------------------
+// Conversion: ExprId → rational function (numerator, denominator) over ℚ
+// ---------------------------------------------------------------------------
+
+use crate::kernel::{ExprData, ExprId, ExprPool};
+
+/// Parse `expr` as a rational function in `var` over ℚ, returning
+/// `(numerator, denominator)` as `QPoly`s, or `None` if it is not a rational
+/// function (e.g. contains a transcendental generator or a foreign symbol).
+pub fn expr_to_qrational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<(QPoly, QPoly)> {
+    if expr == var {
+        return Some((vec![Rational::from(0), Rational::from(1)], poly_one()));
+    }
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some((vec![Rational::from(n.0.to_i64()?)], poly_one())),
+        ExprData::Rational(r) => Some((vec![r.0.clone()], poly_one())),
+        ExprData::Add(args) => {
+            let mut acc = (poly_zero(), poly_one());
+            for a in &args {
+                let term = expr_to_qrational(*a, var, pool)?;
+                acc = rat_add(&acc, &term);
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc = (poly_one(), poly_one());
+            for a in &args {
+                let factor = expr_to_qrational(*a, var, pool)?;
+                acc = rat_mul(&acc, &factor);
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            let n = match pool.get(exp) {
+                ExprData::Integer(n) => n.0.to_i64()?,
+                _ => return None,
+            };
+            let (bn, bd) = expr_to_qrational(base, var, pool)?;
+            if n >= 0 {
+                Some((poly_pow(&bn, n as u32), poly_pow(&bd, n as u32)))
+            } else {
+                let m = (-n) as u32;
+                if trim(bn.clone()).is_empty() {
+                    return None; // 1 / 0
+                }
+                Some((poly_pow(&bd, m), poly_pow(&bn, m)))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn rat_add(a: &(QPoly, QPoly), b: &(QPoly, QPoly)) -> (QPoly, QPoly) {
+    // a.0/a.1 + b.0/b.1 = (a.0·b.1 + b.0·a.1) / (a.1·b.1)
+    let num = poly_add(&poly_mul(&a.0, &b.1), &poly_mul(&b.0, &a.1));
+    let den = poly_mul(&a.1, &b.1);
+    (num, den)
+}
+
+fn rat_mul(a: &(QPoly, QPoly), b: &(QPoly, QPoly)) -> (QPoly, QPoly) {
+    (poly_mul(&a.0, &b.0), poly_mul(&a.1, &b.1))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rat(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    // ∫ (x-1)/x² · exp(x) dx = exp(x)/x.
+    // RDE: v' + v = (x-1)/x²  →  v = 1/x.
+    #[test]
+    fn rational_elementary_exp_x() {
+        let f = vec![rat(1)]; // f = 1 (η = x, k = 1)
+        let c_num = vec![rat(-1), rat(1)]; // x - 1
+        let c_den = vec![rat(0), rat(0), rat(1)]; // x²
+        let sol = solve_rational_rde(&f, &c_num, &c_den).expect("elementary");
+        // v = 1/x  ⇒  num = 1, den = x.
+        assert_eq!(trim(sol.0.clone()), vec![rat(1)], "numerator should be 1");
+        assert_eq!(trim(sol.1.clone()), vec![rat(0), rat(1)], "denominator x");
+    }
+
+    // ∫ x²/(x+1) · exp(x) dx is NON-elementary (leaves an Ei term).
+    #[test]
+    fn rational_nonelementary_x2_over_x_plus_1() {
+        let f = vec![rat(1)];
+        let c_num = vec![rat(0), rat(0), rat(1)]; // x²
+        let c_den = vec![rat(1), rat(1)]; // x + 1
+        assert!(
+            solve_rational_rde(&f, &c_num, &c_den).is_none(),
+            "x²/(x+1)·exp(x) must be certified non-elementary"
+        );
+    }
+
+    // ∫ exp(x)/x dx = Ei(x): RDE v' + v = 1/x has no rational solution.
+    #[test]
+    fn rational_nonelementary_one_over_x() {
+        let f = vec![rat(1)];
+        let c_num = vec![rat(1)]; // 1
+        let c_den = vec![rat(0), rat(1)]; // x
+        assert!(solve_rational_rde(&f, &c_num, &c_den).is_none());
+    }
+
+    // exp(x)/x² is non-elementary (residual 1/x simple pole → Ei).
+    #[test]
+    fn rational_nonelementary_one_over_x2() {
+        let f = vec![rat(1)];
+        let c_num = vec![rat(1)];
+        let c_den = vec![rat(0), rat(0), rat(1)]; // x²
+        assert!(solve_rational_rde(&f, &c_num, &c_den).is_none());
+    }
+
+    // Polynomial RHS still works through the rational solver (E = 1).
+    // ∫ x·exp(x²) dx: f = 2x, c = x  →  v = 1/2.
+    #[test]
+    fn rational_reduces_to_polynomial_case() {
+        let f = vec![rat(0), rat(2)]; // 2x
+        let c_num = vec![rat(0), rat(1)]; // x
+        let c_den = poly_one();
+        let sol = solve_rational_rde(&f, &c_num, &c_den).expect("elementary");
+        assert_eq!(trim(sol.0), vec![Rational::from((1, 2))]);
+        assert_eq!(trim(sol.1), vec![rat(1)]);
+    }
+
+    // gcd / divrem sanity.
+    #[test]
+    fn divrem_gcd_basic() {
+        // (x² − 1) = (x + 1)(x − 1) + 0
+        let a = vec![rat(-1), rat(0), rat(1)];
+        let b = vec![rat(1), rat(1)];
+        let (q, r) = poly_divrem(&a, &b);
+        assert_eq!(trim(q), vec![rat(-1), rat(1)]); // x − 1
+        assert!(trim(r).is_empty());
+        // gcd(x²−1, x²−2x+1) = x − 1 (monic)
+        let c = vec![rat(1), rat(-2), rat(1)];
+        let g = poly_gcd(&a, &c);
+        assert_eq!(trim(g), vec![rat(-1), rat(1)]);
+    }
+
+    #[test]
+    fn qrational_parse() {
+        use crate::kernel::{Domain, ExprPool};
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // (x - 1)/x²
+        let num = pool.add(vec![x, pool.integer(-1_i32)]);
+        let den = pool.pow(x, pool.integer(-2_i32));
+        let expr = pool.mul(vec![num, den]);
+        let (n, d) = expr_to_qrational(expr, x, &pool).expect("parse");
+        // Should equal (x-1)/x² up to a common factor.
+        // Cross-check: n · x² == d · (x-1).
+        let lhs = poly_mul(&n, &vec![rat(0), rat(0), rat(1)]);
+        let rhs = poly_mul(&d, &vec![rat(-1), rat(1)]);
+        assert!(polys_equal(&lhs, &rhs), "n={n:?} d={d:?}");
+    }
+}


### PR DESCRIPTION
Implements the highest-priority items from the Risch gap analysis (`tmp/temp-alkahest/risch.md`): non-elementary certification + a crash fix (Gap 6), the rational Risch DE over ℚ(x) for the exp tower (Gap 1), and full rational-function integration via Rothstein–Trager + Hermite reduction, including `arctan` and √-coefficient logs (Gap 3).

All work is verified by differentiation and the full core lib suite is green (**643 passed, 0 failed**); `clippy` and `cargo fmt --check` are clean.

## Gap 6 — non-elementary certification + recursion-crash fix
- Fixed a stack-overflow in `integrate_raw`'s `Mul` handler when every factor involves the variable (`sin(x)/x`, `exp(x)/x` previously segfaulted): guard against self-recursion.
- Added a conservative structural pre-check certifying `f(linear)/poly` (Ei/Si/Ci/Shi/Chi) and `1/log(linear)` (li) as `NonElementary` (Liouville's theorem).

## Gap 1 — rational Risch DE over ℚ(x) (exp tower)
- New `integrate/risch/rational_rde.rs`: solves `v' + f·v = C/B` for `v ∈ ℚ(x)` via the denominator bound `E = gcd(B, B')` and exact ℚ linear algebra (Bronstein §6.1). Sound **and** complete for a single `c·exp(kη)` monomial with polynomial η and rational coefficient.
- Handles e.g. `∫ (x−1)/x²·exp(x) = exp(x)/x`; certifies `∫ x²/(x+1)·exp(x)`, `∫ exp(x)/x` as `NonElementary`.

## Gap 3 — rational-function integration (Rothstein–Trager + Hermite)
Wired into `integrate()` as a fallback when the rule engine returns `NotImplemented`, so existing rules (power rule, `1/(ax+b)`) are untouched.
- **Rothstein–Trager** logarithmic part via the FLINT resultant + `factor_z` (rational residues → `Σ cᵢ·log(gcdᵢ)`).
- **Hermite reduction** (Yun + ext-GCD + partial fractions + per-factor reduction) for repeated factors.
- **Irreducible quadratics**: negative discriminant → `log` + `arctan`; positive discriminant → `log` with `√Δ` coefficients.
- Added `atan` differentiation to both reverse- and forward-mode `diff` (`d/dx atan(u) = u'/(1+u²)`) so the new antiderivatives are first-class and round-trip-verifiable.

Now handled (verified by differentiation): `∫1/(x²−1)`, `∫2x/(x²+1)`, `∫x/(x−1)³`, `∫1/(x²+1)=atan(x)`, `∫1/(x²−2)`, `∫1/((x−1)(x²+1))`, improper `∫x³/(x²−1)`, …

Rational-function integration is now complete for any denominator factoring over ℚ into linear and quadratic factors.

## Documented remaining frontier
The one rational-integration gap left is **irreducible factors of degree ≥ 3**, whose antiderivative is a sum over degree-≥3 algebraic residues and needs a first-class symbolic `RootSum` kernel node (new `ExprData` binder variant + `diff`/`subs`/`simplify`/`display`/numeric support + algebraic-extension polynomial GCD). These decline cleanly and surface as `NotImplemented`. Module docs and the gap analysis spell out exactly what that node requires; it is deliberately deferred to its own dedicated, fully-tested change rather than rushed (the output is unverifiable until `diff` support lands).

## Tests
~40 new unit tests across `engine`, `rational_rde`, `rational_integrate`, and `diff`, plus the existing suite. Every elementary result is checked by differentiation (numeric or polynomial). Non-elementary / unsupported inputs assert the correct `NonElementary` / `NotImplemented` verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)