### PR TITLE
Risch Gap 3: degree-≥3 algebraic residues via a RootSum kernel node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-cas"
-version = "2.4.1"
+version = "3.0.0"
 dependencies = [
  "bitflags 2.11.1",
  "boxcar",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-mlir"
-version = "2.4.1"
+version = "3.0.0"
 dependencies = [
  "alkahest-cas",
  "proptest",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-py"
-version = "2.4.1"
+version = "3.0.0"
 dependencies = [
  "alkahest-cas",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "2.4.1"
+version = "3.0.0"
 edition = "2021"
 authors = ["Alkahest Contributors"]
 license = "Apache-2.0"

--- a/alkahest-core/src/calculus/limits.rs
+++ b/alkahest-core/src/calculus/limits.rs
@@ -436,6 +436,11 @@ fn depends_on(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
         ExprData::Forall { var: bv, body } | ExprData::Exists { var: bv, body } => {
             bv != var && depends_on(body, var, pool)
         }
+        ExprData::RootSum {
+            poly,
+            var: bv,
+            body,
+        } => depends_on(poly, var, pool) || (bv != var && depends_on(body, var, pool)),
         ExprData::BigO(a) => depends_on(a, var, pool),
         ExprData::Integer(_)
         | ExprData::Rational(_)

--- a/alkahest-core/src/calculus/series.rs
+++ b/alkahest-core/src/calculus/series.rs
@@ -193,6 +193,7 @@ fn collect_atom_factors(expr: ExprId, pool: &ExprPool) -> Option<(Vec<ExprId>, V
         | ExprData::Predicate { .. }
         | ExprData::Forall { .. }
         | ExprData::Exists { .. }
+        | ExprData::RootSum { .. }
         | ExprData::BigO(_) => None,
     }
 }

--- a/alkahest-core/src/diff/diff_impl.rs
+++ b/alkahest-core/src/diff/diff_impl.rs
@@ -151,6 +151,11 @@ fn diff_raw(
             branches: Vec<(ExprId, ExprId)>,
             default: ExprId,
         },
+        RootSum {
+            poly: ExprId,
+            rvar: ExprId,
+            body: ExprId,
+        },
     }
 
     let node = pool.with(expr, |data| match data {
@@ -177,6 +182,11 @@ fn diff_raw(
         ExprData::Predicate { .. } => Node::Const,
         ExprData::Forall { .. } | ExprData::Exists { .. } => Node::Const,
         ExprData::BigO(_) => Node::Const,
+        ExprData::RootSum { poly, var, body } => Node::RootSum {
+            poly: *poly,
+            rvar: *var,
+            body: *body,
+        },
     });
 
     match node {
@@ -360,6 +370,16 @@ fn diff_raw(
             log = log.merge(ddefault.log);
             let result = pool.piecewise(new_branches, ddefault.value);
             log.push(RewriteStep::simple("diff_piecewise", expr, result));
+            memo.insert(expr, result);
+            Ok(DerivedExpr::with_log(result, log))
+        }
+        // d/dx Σ_{c:P(c)=0} body(c,x) = Σ_{c:P(c)=0} ∂body/∂x.
+        // The root `c` (rvar) is constant in `x`; `poly` is free of `x`.
+        Node::RootSum { poly, rvar, body } => {
+            let dbody = diff_raw(body, var, pool, memo)?;
+            let result = pool.root_sum(poly, rvar, dbody.value);
+            let mut log = dbody.log;
+            log.push(RewriteStep::simple("diff_root_sum", expr, result));
             memo.insert(expr, result);
             Ok(DerivedExpr::with_log(result, log))
         }

--- a/alkahest-core/src/diff/forward.rs
+++ b/alkahest-core/src/diff/forward.rs
@@ -195,8 +195,19 @@ fn eval_dual(
         IsConst,
         Add(Vec<ExprId>),
         Mul(Vec<ExprId>),
-        Pow { base: ExprId, exp: ExprId },
-        Func { name: String, arg: ExprId },
+        Pow {
+            base: ExprId,
+            exp: ExprId,
+        },
+        Func {
+            name: String,
+            arg: ExprId,
+        },
+        RootSum {
+            poly: ExprId,
+            rvar: ExprId,
+            body: ExprId,
+        },
     }
 
     let node = pool.with(expr, |data| match data {
@@ -224,6 +235,11 @@ fn eval_dual(
         ExprData::Piecewise { .. } | ExprData::Predicate { .. } => Node::IsConst,
         ExprData::Forall { .. } | ExprData::Exists { .. } => Node::IsConst,
         ExprData::BigO(_) => Node::IsConst,
+        ExprData::RootSum { poly, var, body } => Node::RootSum {
+            poly: *poly,
+            rvar: *var,
+            body: *body,
+        },
     });
 
     let result = match node {
@@ -268,6 +284,15 @@ fn eval_dual(
                 "atan" => Ok(inner.atan(pool)),
                 other => Err(DiffError::ForwardUnknownFunction(other.to_string())),
             }
+        }
+        Node::RootSum { poly, rvar, body } => {
+            // d/dx Σ_{c:P(c)=0} body = Σ_{c:P(c)=0} ∂body/∂x; the root `rvar` is
+            // constant in `x` (tangent 0), so threading the dual through `body`
+            // gives the per-root derivative directly.
+            let inner = eval_dual(body, var, pool, memo)?;
+            let value = pool.root_sum(poly, rvar, inner.value);
+            let tangent = pool.root_sum(poly, rvar, inner.tangent);
+            Ok(DualValue::new(value, tangent))
         }
     }?;
 

--- a/alkahest-core/src/diff/reverse.rs
+++ b/alkahest-core/src/diff/reverse.rs
@@ -106,6 +106,9 @@ fn propagate(node: ExprId, adj: ExprId, adjoints: &mut HashMap<ExprId, ExprId>, 
         ExprData::Piecewise { .. } | ExprData::Predicate { .. } => Op::Atom,
         ExprData::Forall { .. } | ExprData::Exists { .. } => Op::Atom,
         ExprData::BigO(_) => Op::Atom,
+        // RootSum is a binder; reverse-mode AD treats it as atomic (use the
+        // symbolic differentiator `diff` for correct RootSum derivatives).
+        ExprData::RootSum { .. } => Op::Atom,
     });
 
     match op {

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -16,8 +16,8 @@
 //! | `ratfn(x)·exp(η)`, η polynomial | `(x−1)/x²·exp(x)` | ✓ (rational RDE) |
 //! | `A(x)/D(x)`, D splits over ℚ | `1/(x²−1)`, `x/(x−1)³` | ✓ (Hermite + Rothstein–Trager) |
 //! | `A(x)/D(x)`, irreducible quadratics | `1/(x²+1)`, `1/(x²−2)` | ✓ (log + arctan / √-log) |
+//! | `A(x)/D(x)`, irreducible deg ≥ 3 | `1/(x³−3x+1)` | ✓ (`RootSum`, Lazard–Rioboo–Trager) |
 //! | `sin(x)/x`, `exp(x)/x` | Ei, Si functions | ✗ (NonElementary) |
-//! | `1/(x³+x+1)` | degree-≥3 algebraic residues (RootSum) | ✗ (NotImplemented) |
 //! | `exp(x²)/sqrt(x)` | Mixed algebraic+transcendental | ✗ (NotImplemented) |
 //!
 //! ## Architecture
@@ -45,15 +45,13 @@
 //!   restricted to ℚ (no algebraic-number coefficients), and η must be a
 //!   polynomial.
 //! - **Rational-function integration** ([`rational_integrate`]) is complete for
-//!   any denominator that factors over ℚ into **linear and quadratic** factors:
-//!   Hermite reduction (repeated factors), the Rothstein–Trager logarithmic part
-//!   (rational residues → `log`), and irreducible quadratics (negative
-//!   discriminant → `log` + `arctan`; positive discriminant → `log` with `√Δ`
-//!   coefficients). The one remaining gap is irreducible factors of **degree ≥ 3**,
-//!   whose antiderivative is a `Σ` over degree-≥3 algebraic residues; expressing
-//!   it needs a symbolic **`RootSum`** node in the kernel (with its own diff/eval/
-//!   simplify support), which is not yet implemented — those cases fall back and
-//!   surface as `NotImplemented`.
+//!   any denominator that factors over ℚ: Hermite reduction (repeated factors),
+//!   the Rothstein–Trager logarithmic part (rational residues → `log`),
+//!   irreducible quadratics (negative discriminant → `log` + `arctan`; positive
+//!   discriminant → `log` with `√Δ`), and irreducible factors of **degree ≥ 3**
+//!   via a [`crate::kernel::ExprData::RootSum`] over the algebraic residues
+//!   (Lazard–Rioboo–Trager; the log argument is computed in the number field
+//!   `ℚ[t]/Q(t)`).
 //! - **Single generator only.** Multiple interacting generators (e.g.
 //!   `exp(x)·log(x)`) and mixed algebraic+transcendental towers are unsupported;
 //!   independent sums are handled term-by-term.

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -790,7 +790,7 @@ mod tests {
                     .iter()
                     .map(|&a| eval_env(a, x, xv, env, pool))
                     .collect();
-                if factors.iter().any(|&v| v == 0.0) {
+                if factors.contains(&0.0) {
                     0.0
                 } else {
                     factors.iter().product()

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -23,15 +23,21 @@
 //!   when its resultant roots are **rational** (a ℚ-linear combination of `log`s
 //!   of ℚ-polynomials).
 //! - Otherwise, a partial-fraction pass factors the squarefree denominator over
-//!   ℚ and integrates each irreducible factor: linear → `log`,
-//!   irreducible quadratic → `log` + `arctan` (negative discriminant) or `log`
-//!   with `√Δ` coefficients (positive discriminant).
-//! - Returns `None` (so the caller falls back) only for irreducible factors of
-//!   **degree ≥ 3**, whose antiderivative is a sum over degree-≥3 algebraic
-//!   residues and needs a symbolic `RootSum` representation not yet available.
+//!   ℚ and integrates each irreducible factor:
+//!   * linear → `log`;
+//!   * irreducible quadratic → `log` + `arctan` (negative discriminant) or `log`
+//!     with `√Δ` coefficients (positive discriminant);
+//!   * irreducible factor of **degree ≥ 3** → a [`crate::kernel::ExprData::RootSum`]
+//!     over the degree-≥3 algebraic residues (Lazard–Rioboo–Trager): the residue
+//!     minimal polynomial is an irreducible factor of `R(t) = res_x(N − t·P', P)`,
+//!     and the log argument `gcd_x(N − t·P', P)` is computed in the number field
+//!     `ℚ[t]/Q(t)`.
 //!
-//! References: Rothstein (1976); Trager (1976); Bronstein (2005) §2.2–2.5;
-//! SymPy `sympy/integrals/risch.py` (`residue_reduce`, `log_part`).
+//! Thus `∫ A/D` is complete for every denominator that factors over ℚ — the only
+//! `None` results are non-rational integrands handled elsewhere.
+//!
+//! References: Rothstein (1976); Trager (1976); Lazard & Rioboo (1990);
+//! Bronstein (2005) §2.2–2.5; SymPy `sympy/integrals/risch.py`.
 
 use rug::{Integer, Rational};
 
@@ -392,6 +398,191 @@ fn lcm_denoms(polys: &[&QPoly]) -> Integer {
 }
 
 // ---------------------------------------------------------------------------
+// Degree-≥3 algebraic residues: RootSum via Rothstein–Trager over ℚ[t]/Q
+// ---------------------------------------------------------------------------
+
+/// Build the Rothstein–Trager resultant `R(t) = res_x(num − t·dprime, d)` as a
+/// ℚ-polynomial in the parameter symbol `param`.
+fn resultant_param_poly(
+    num: &QPoly,
+    dprime: &QPoly,
+    d: &QPoly,
+    var: ExprId,
+    param: ExprId,
+    pool: &ExprPool,
+) -> Option<QPoly> {
+    // Clear denominators of num and dprime by one common factor so the parameter
+    // roots are exactly the residues; d by its own factor (constant in t).
+    let l = lcm_denoms(&[num, dprime]);
+    let num_int = poly_scale(num, &Rational::from(l.clone()));
+    let dp_int = poly_scale(dprime, &Rational::from(l));
+    let m = lcm_denoms(&[d]);
+    let d_int = poly_scale(d, &Rational::from(m));
+
+    let num_expr = qpoly_to_expr(&num_int, var, pool);
+    let dp_expr = qpoly_to_expr(&dp_int, var, pool);
+    let p_expr = pool.add(vec![
+        num_expr,
+        pool.mul(vec![pool.integer(-1_i32), param, dp_expr]),
+    ]);
+    let d_expr = qpoly_to_expr(&d_int, var, pool);
+    let res = crate::poly::resultant(p_expr, d_expr, var, pool).ok()?;
+    let up = UniPoly::from_symbolic(res.value, param, pool).ok()?;
+    if up.degree() < 1 {
+        return None;
+    }
+    Some(
+        up.coefficients()
+            .iter()
+            .map(|c| Rational::from(c.clone()))
+            .collect(),
+    )
+}
+
+// --- Number-field K = ℚ[t]/Q arithmetic (elements are QPolys reduced mod Q) ---
+
+fn k_mul(a: &QPoly, b: &QPoly, q: &QPoly) -> QPoly {
+    poly_mod(&poly_mul(a, b), q)
+}
+fn k_sub(a: &QPoly, b: &QPoly, q: &QPoly) -> QPoly {
+    poly_mod(&poly_sub(a, b), q)
+}
+fn k_is_zero(a: &QPoly) -> bool {
+    trim(a.clone()).is_empty()
+}
+
+/// Degree (in x) of a K-polynomial (coefficients are K-elements).
+fn kdeg(p: &[QPoly]) -> i64 {
+    let mut d = p.len() as i64 - 1;
+    while d >= 0 && k_is_zero(&p[d as usize]) {
+        d -= 1;
+    }
+    d
+}
+
+fn kpoly_trim(mut p: Vec<QPoly>) -> Vec<QPoly> {
+    while p.last().is_some_and(k_is_zero) {
+        p.pop();
+    }
+    p
+}
+
+/// Euclidean division of K-polynomials in `x`; returns `(quot, rem)`.
+fn kpoly_divrem(a: &[QPoly], b: &[QPoly], q: &QPoly) -> Option<(Vec<QPoly>, Vec<QPoly>)> {
+    let bd = kdeg(b);
+    if bd < 0 {
+        return None; // division by zero
+    }
+    let lead_inv = mod_inverse(&b[bd as usize], q)?;
+    let mut r = kpoly_trim(a.to_vec());
+    let ad = kdeg(&r);
+    if ad < bd {
+        return Some((vec![], r));
+    }
+    let mut quot = vec![poly_zero(); (ad - bd + 1) as usize];
+    loop {
+        let rd = kdeg(&r);
+        if rd < bd {
+            break;
+        }
+        let coeff = k_mul(&r[rd as usize], &lead_inv, q);
+        let shift = (rd - bd) as usize;
+        for (i, bi) in b.iter().enumerate() {
+            if shift + i < r.len() {
+                r[shift + i] = k_sub(&r[shift + i], &k_mul(&coeff, bi, q), q);
+            }
+        }
+        quot[shift] = coeff;
+        r = kpoly_trim(r);
+        if r.is_empty() {
+            break;
+        }
+    }
+    Some((kpoly_trim(quot), r))
+}
+
+/// Monic GCD (in `x`) of two K-polynomials over `K = ℚ[t]/Q`.
+fn kpoly_gcd(a: &[QPoly], b: &[QPoly], q: &QPoly) -> Option<Vec<QPoly>> {
+    let mut a = kpoly_trim(a.to_vec());
+    let mut b = kpoly_trim(b.to_vec());
+    while kdeg(&b) >= 0 {
+        let (_, rem) = kpoly_divrem(&a, &b, q)?;
+        a = b;
+        b = rem;
+    }
+    let ad = kdeg(&a);
+    if ad < 0 {
+        return None;
+    }
+    // Make monic in x.
+    let lead_inv = mod_inverse(&a[ad as usize], q)?;
+    Some(a.iter().map(|c| k_mul(c, &lead_inv, q)).collect())
+}
+
+/// The Lazard–Rioboo–Trager log argument `S(t, x) = gcd_x(num − t·dprime, d)`
+/// computed over `K = ℚ[t]/Q`, returned as a symbolic polynomial in `x` whose
+/// coefficients are expressions in the root symbol `rvar`.
+fn alg_log_argument(
+    num: &QPoly,
+    dprime: &QPoly,
+    d: &QPoly,
+    q: &QPoly,
+    var: ExprId,
+    rvar: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    let width = (degree(num).max(degree(dprime)) + 1).max(0) as usize;
+    // A = num − t·dprime  (K-poly in x): A[i] = num[i] − dprime[i]·t.
+    let a: Vec<QPoly> = (0..width)
+        .map(|i| {
+            let ni = coeff_at(num, i);
+            let ppi = coeff_at(dprime, i);
+            poly_mod(&vec![ni, -ppi], q)
+        })
+        .collect();
+    // B = d  (K-poly in x): each coefficient is a K-constant.
+    let b: Vec<QPoly> = d
+        .iter()
+        .map(|c| {
+            if *c == 0 {
+                poly_zero()
+            } else {
+                vec![c.clone()]
+            }
+        })
+        .collect();
+
+    let s = kpoly_gcd(&a, &b, q)?;
+    if kdeg(&s) < 1 {
+        return None; // no nontrivial common factor — not a valid residue
+    }
+    // Build Σ_i coeff_i(rvar) · x^i.
+    let mut terms: Vec<ExprId> = Vec::new();
+    for (i, c) in s.iter().enumerate() {
+        if k_is_zero(c) {
+            continue;
+        }
+        let c_expr = qpoly_to_expr(c, rvar, pool);
+        let term = match i {
+            0 => c_expr,
+            1 => pool.mul(vec![c_expr, var]),
+            _ => pool.mul(vec![c_expr, pool.pow(var, pool.integer(i as i32))]),
+        };
+        terms.push(term);
+    }
+    Some(match terms.len() {
+        0 => return None,
+        1 => terms[0],
+        _ => pool.add(terms),
+    })
+}
+
+/// Coefficient of `x^i` in a QPoly, or 0.
+fn coeff_at(p: &QPoly, i: usize) -> Rational {
+    p.get(i).cloned().unwrap_or_else(|| Rational::from(0))
+}
+
+// ---------------------------------------------------------------------------
 // Non-rational residues: irreducible-quadratic → log + arctan
 // ---------------------------------------------------------------------------
 
@@ -522,7 +713,38 @@ fn partial_fraction_log_arctan(
                     }
                 }
             }
-            _ => return None, // irreducible factor of degree ≥ 3 → RootSum needed
+            _ => {
+                // Irreducible factor of degree ≥ 3: residues are algebraic numbers
+                // of degree ≥ 2 → emit a RootSum (Lazard–Rioboo–Trager).
+                let pp = poly_deriv(p);
+                let rvar = pool.symbol("$root$", Domain::Complex);
+                let rt = resultant_param_poly(&n, &pp, p, var, rvar, pool)?;
+                // Radical of R(t): distinct residues only.
+                let rad = poly_monic(&poly_div_exact(&rt, &poly_gcd(&rt, &poly_deriv(&rt))));
+                let factors_t = factor_monic_q(&rad, rvar, pool)?;
+                for qf in &factors_t {
+                    match degree(qf) {
+                        d if d <= 0 => {}
+                        1 => {
+                            // Rational residue c (monic linear factor t + a₀ ⇒ c = −a₀).
+                            let c = -coeff_at(qf, 0);
+                            let shifted = poly_sub(&n, &poly_scale(&pp, &c));
+                            let gc = poly_monic(&poly_gcd(&shifted, p));
+                            if degree(&gc) >= 1 {
+                                let logp = pool.func("log", vec![qpoly_to_expr(&gc, var, pool)]);
+                                terms.push(scaled(&c, logp, pool));
+                            }
+                        }
+                        _ => {
+                            // RootSum(Q, t, t·log(S(t,x))).
+                            let s_expr = alg_log_argument(&n, &pp, p, qf, var, rvar, pool)?;
+                            let body = pool.mul(vec![rvar, pool.func("log", vec![s_expr])]);
+                            let q_expr = qpoly_to_expr(qf, rvar, pool);
+                            terms.push(pool.root_sum(q_expr, rvar, body));
+                        }
+                    }
+                }
+            }
         }
     }
     Some(terms)
@@ -541,19 +763,52 @@ mod tests {
         ExprPool::new()
     }
 
-    /// Numeric evaluator for verification (Integer/Rational/Add/Mul/Pow/log).
+    /// Numeric evaluator for verification (Integer/Rational/Add/Mul/Pow/log/…),
+    /// including `RootSum` via a real-root environment binding `env`.
     fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        eval_env(expr, x, xv, &[], pool)
+    }
+
+    fn eval_env(expr: ExprId, x: ExprId, xv: f64, env: &[(ExprId, f64)], pool: &ExprPool) -> f64 {
         if expr == x {
             return xv;
+        }
+        for &(sym, val) in env {
+            if expr == sym {
+                return val;
+            }
         }
         match pool.get(expr) {
             ExprData::Integer(n) => n.0.to_f64(),
             ExprData::Rational(r) => r.0.to_f64(),
-            ExprData::Add(args) => args.iter().map(|&a| eval(a, x, xv, pool)).sum(),
-            ExprData::Mul(args) => args.iter().map(|&a| eval(a, x, xv, pool)).product(),
-            ExprData::Pow { base, exp } => eval(base, x, xv, pool).powf(eval(exp, x, xv, pool)),
+            ExprData::Add(args) => args.iter().map(|&a| eval_env(a, x, xv, env, pool)).sum(),
+            ExprData::Mul(args) => {
+                // Short-circuit on an exact-zero factor: `0 · log(negative)` must be
+                // 0, not `0 · NaN`.  (Unsimplified `0·…` terms can appear inside a
+                // differentiated RootSum body, which `simplify` leaves opaque.)
+                let factors: Vec<f64> = args
+                    .iter()
+                    .map(|&a| eval_env(a, x, xv, env, pool))
+                    .collect();
+                if factors.iter().any(|&v| v == 0.0) {
+                    0.0
+                } else {
+                    factors.iter().product()
+                }
+            }
+            ExprData::Pow { base, exp } => {
+                let b = eval_env(base, x, xv, env, pool);
+                // Use integer power when possible — `powf` returns NaN for a
+                // negative base with a (float-typed) integer exponent.
+                if let ExprData::Integer(n) = pool.get(exp) {
+                    if let Some(k) = n.0.to_i32() {
+                        return b.powi(k);
+                    }
+                }
+                b.powf(eval_env(exp, x, xv, env, pool))
+            }
             ExprData::Func { ref name, ref args } if args.len() == 1 => {
-                let a = eval(args[0], x, xv, pool);
+                let a = eval_env(args[0], x, xv, env, pool);
                 match name.as_str() {
                     "log" => a.ln(),
                     "atan" => a.atan(),
@@ -561,8 +816,109 @@ mod tests {
                     other => panic!("eval: unsupported func {other}"),
                 }
             }
+            ExprData::RootSum { poly, var, body } => {
+                // Σ over the real roots of `poly` of body[var := root].
+                let coeffs = real_coeffs(poly, var, pool);
+                real_roots_f64(&coeffs)
+                    .into_iter()
+                    .map(|r| {
+                        let mut e = env.to_vec();
+                        e.push((var, r));
+                        eval_env(body, x, xv, &e, pool)
+                    })
+                    .sum()
+            }
             other => panic!("eval: unsupported {other:?}"),
         }
+    }
+
+    /// Real coefficient vector (ascending) of a polynomial in `var`.
+    fn real_coeffs(expr: ExprId, var: ExprId, pool: &ExprPool) -> Vec<f64> {
+        if expr == var {
+            return vec![0.0, 1.0];
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => vec![n.0.to_f64()],
+            ExprData::Rational(r) => vec![r.0.to_f64()],
+            ExprData::Add(args) => {
+                let mut acc = vec![0.0];
+                for a in &args {
+                    let c = real_coeffs(*a, var, pool);
+                    if c.len() > acc.len() {
+                        acc.resize(c.len(), 0.0);
+                    }
+                    for (i, v) in c.iter().enumerate() {
+                        acc[i] += v;
+                    }
+                }
+                acc
+            }
+            ExprData::Mul(args) => {
+                let mut acc = vec![1.0];
+                for a in &args {
+                    let c = real_coeffs(*a, var, pool);
+                    let mut prod = vec![0.0; acc.len() + c.len() - 1];
+                    for (i, ai) in acc.iter().enumerate() {
+                        for (j, cj) in c.iter().enumerate() {
+                            prod[i + j] += ai * cj;
+                        }
+                    }
+                    acc = prod;
+                }
+                acc
+            }
+            ExprData::Pow { base, exp } => {
+                let k = match pool.get(exp) {
+                    ExprData::Integer(n) => n.0.to_i64().unwrap(),
+                    _ => panic!("real_coeffs: non-integer exponent"),
+                };
+                assert!(k >= 0, "real_coeffs: negative exponent");
+                let c = real_coeffs(base, var, pool);
+                let mut acc = vec![1.0];
+                for _ in 0..k {
+                    let mut prod = vec![0.0; acc.len() + c.len() - 1];
+                    for (i, ai) in acc.iter().enumerate() {
+                        for (j, cj) in c.iter().enumerate() {
+                            prod[i + j] += ai * cj;
+                        }
+                    }
+                    acc = prod;
+                }
+                acc
+            }
+            other => panic!("real_coeffs: unsupported {other:?}"),
+        }
+    }
+
+    /// Real roots (bracket + bisection) of a polynomial with ascending `coeffs`.
+    fn real_roots_f64(coeffs: &[f64]) -> Vec<f64> {
+        let horner = |t: f64| coeffs.iter().rev().fold(0.0, |acc, c| acc * t + c);
+        let (lo, hi, n) = (-60.0_f64, 60.0_f64, 240_000);
+        let mut roots = Vec::new();
+        let step = (hi - lo) / n as f64;
+        let mut prev_t = lo;
+        let mut prev_v = horner(lo);
+        for i in 1..=n {
+            let t = lo + step * i as f64;
+            let v = horner(t);
+            if prev_v == 0.0 {
+                roots.push(prev_t);
+            } else if prev_v * v < 0.0 {
+                let (mut a, mut b) = (prev_t, t);
+                for _ in 0..80 {
+                    let m = 0.5 * (a + b);
+                    if horner(a) * horner(m) <= 0.0 {
+                        b = m;
+                    } else {
+                        a = m;
+                    }
+                }
+                roots.push(0.5 * (a + b));
+            }
+            prev_t = t;
+            prev_v = v;
+        }
+        roots
     }
 
     /// Verify d/dx F = integrand numerically at several points.
@@ -726,10 +1082,42 @@ mod tests {
     }
 
     #[test]
-    fn degree_three_irreducible_declines() {
-        // ∫ 1/(x³+x+1) dx — x³+x+1 is irreducible over ℚ with a degree-3 algebraic
-        // root; expressing the antiderivative needs a symbolic RootSum (not yet
-        // implemented) → declines.
+    fn degree_three_real_roots_root_sum() {
+        // ∫ 1/(x³−3x+1) dx — irreducible over ℚ with three real roots, so the
+        // residues are real algebraic numbers of degree 3 → a RootSum.  Verified
+        // by differentiation (the derivative is real-valued for real residues).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            pool.mul(vec![pool.integer(-3_i32), x]),
+            pool.integer(1_i32),
+        ]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+        let result = try_integrate_rational(f, x, &pool).expect("RootSum path");
+        assert!(
+            pool.display(result).to_string().contains("RootSum"),
+            "expected a RootSum: {}",
+            pool.display(result)
+        );
+        // Avoid the denominator's real roots (≈ −1.88, 0.35, 1.53) as test points.
+        let d = crate::diff::diff(result, x, &pool).unwrap();
+        let ds = crate::simplify::engine::simplify(d.value, &pool).value;
+        for &xv in &[3.0_f64, 5.0, -4.0] {
+            let lhs = eval(ds, x, xv, &pool);
+            let rhs = eval(f, x, xv, &pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-6,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs}"
+            );
+        }
+    }
+
+    #[test]
+    fn degree_three_with_one_real_root_via_root_sum() {
+        // ∫ 1/(x³+x+1) dx — irreducible, one real + two complex roots.  Still
+        // produces a RootSum; check it integrates (full numeric check would need
+        // complex roots, covered structurally here).
         let pool = pool();
         let x = pool.symbol("x", Domain::Real);
         let den = pool.add(vec![
@@ -738,7 +1126,11 @@ mod tests {
             pool.integer(1_i32),
         ]);
         let f = pool.pow(den, pool.integer(-1_i32));
-        assert!(try_integrate_rational(f, x, &pool).is_none());
+        let result = try_integrate_rational(f, x, &pool).expect("RootSum path");
+        assert!(pool.display(result).to_string().contains("RootSum"));
+        // The derivative must differentiate cleanly (diff support for RootSum).
+        let d = crate::diff::diff(result, x, &pool);
+        assert!(d.is_ok());
     }
 
     #[test]

--- a/alkahest-core/src/kernel/display.rs
+++ b/alkahest-core/src/kernel/display.rs
@@ -526,6 +526,12 @@ fn latex_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
             let (a, _) = latex_r(*arg, pool);
             (format!(r"\mathcal{{O}}\!\left({a}\right)"), PREC_ATOM)
         }
+        ExprData::RootSum { poly, var, body } => {
+            let (p, _) = latex_r(*poly, pool);
+            let (v, _) = latex_r(*var, pool);
+            let (b, _) = latex_r(*body, pool);
+            (format!(r"\sum_{{{v} \, : \, {p} = 0}} {b}"), PREC_ATOM)
+        }
     })
 }
 
@@ -837,6 +843,12 @@ fn unicode_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
         ExprData::BigO(arg) => {
             let (a, _) = unicode_r(*arg, pool);
             (format!("O({a})"), PREC_ATOM)
+        }
+        ExprData::RootSum { poly, var, body } => {
+            let (p, _) = unicode_r(*poly, pool);
+            let (v, _) = unicode_r(*var, pool);
+            let (b, _) = unicode_r(*body, pool);
+            (format!("∑_{{{v}:{p}=0}} {b}"), PREC_ATOM)
         }
     })
 }

--- a/alkahest-core/src/kernel/expr.rs
+++ b/alkahest-core/src/kernel/expr.rs
@@ -217,4 +217,16 @@ pub enum ExprData {
     },
     /// Landau big-O remainder: `O(arg)` as a symbolic order bound (V2-15 series API).
     BigO(ExprId),
+    /// Sum over the roots of a polynomial: `Σ_{c : poly(c)=0} body[var := c]`.
+    ///
+    /// A binder (like [`ExprData::Exists`]): `var` is the bound root placeholder,
+    /// `poly` is a univariate polynomial in `var`, and `body` is the summand
+    /// (an expression in `var` and the free variables).  Used to represent the
+    /// logarithmic part of a rational-function integral whose residues are
+    /// algebraic numbers of degree ≥ 2 (Rothstein–Trager / Lazard–Rioboo–Trager).
+    RootSum {
+        poly: ExprId,
+        var: ExprId,
+        body: ExprId,
+    },
 }

--- a/alkahest-core/src/kernel/expr_props.rs
+++ b/alkahest-core/src/kernel/expr_props.rs
@@ -29,6 +29,9 @@ pub fn mult_tree_is_commutative(pool: &ExprPool, expr: ExprId) -> bool {
             mult_tree_is_commutative(pool, *var) && mult_tree_is_commutative(pool, *body)
         }
         ExprData::BigO(inner) => mult_tree_is_commutative(pool, *inner),
+        ExprData::RootSum { poly, body, .. } => {
+            mult_tree_is_commutative(pool, *poly) && mult_tree_is_commutative(pool, *body)
+        }
     })
 }
 
@@ -64,5 +67,9 @@ pub fn expr_contains_noncommutative_symbol(pool: &ExprPool, expr: ExprId) -> boo
                 || expr_contains_noncommutative_symbol(pool, *body)
         }
         ExprData::BigO(inner) => expr_contains_noncommutative_symbol(pool, *inner),
+        ExprData::RootSum { poly, body, .. } => {
+            expr_contains_noncommutative_symbol(pool, *poly)
+                || expr_contains_noncommutative_symbol(pool, *body)
+        }
     })
 }

--- a/alkahest-core/src/kernel/pool.rs
+++ b/alkahest-core/src/kernel/pool.rs
@@ -297,6 +297,11 @@ impl ExprPool {
         self.intern(ExprData::Exists { var, body })
     }
 
+    /// `Σ_{c : poly(c)=0} body[var := c]` — a sum over the roots of `poly`.
+    pub fn root_sum(&self, poly: ExprId, var: ExprId, body: ExprId) -> ExprId {
+        self.intern(ExprData::RootSum { poly, var, body })
+    }
+
     /// `O(arg)` — symbolic big-O bound used in truncated series (V2-15).
     pub fn big_o(&self, arg: ExprId) -> ExprId {
         self.intern(ExprData::BigO(arg))
@@ -428,6 +433,15 @@ fn fmt_data(data: &ExprData, pool: &ExprPool, f: &mut fmt::Formatter<'_>) -> fmt
         }
         ExprData::BigO(arg) => {
             write!(f, "O({})", pool.display(*arg))
+        }
+        ExprData::RootSum { poly, var, body } => {
+            write!(
+                f,
+                "RootSum({}, {} . {})",
+                pool.display(*poly),
+                pool.display(*var),
+                pool.display(*body)
+            )
         }
     }
 }

--- a/alkahest-core/src/kernel/pool_persist.rs
+++ b/alkahest-core/src/kernel/pool_persist.rs
@@ -68,7 +68,9 @@ const POOL_FORMAT_V2: u32 = 2;
 const POOL_FORMAT_V3: u32 = 3;
 /// Symbol nodes carry `commutative: u8` after `domain` (V3-2).
 const POOL_FORMAT_V4: u32 = 4;
-const POOL_FORMAT_WRITE: u32 = POOL_FORMAT_V4;
+/// Adds `RootSum` tag 13 (algebraic-residue logarithmic part).
+const POOL_FORMAT_V5: u32 = 5;
+const POOL_FORMAT_WRITE: u32 = POOL_FORMAT_V5;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -356,6 +358,12 @@ fn write_node(w: &mut impl Write, node: &ExprData) -> io::Result<()> {
             write_u8(w, 12)?;
             write_u32(w, inner.0)
         }
+        ExprData::RootSum { poly, var, body } => {
+            write_u8(w, 13)?;
+            write_u32(w, poly.0)?;
+            write_u32(w, var.0)?;
+            write_u32(w, body.0)
+        }
     }
 }
 
@@ -453,6 +461,15 @@ fn read_node(r: &mut impl Read, format_version: u32) -> Result<ExprData, IoError
             let inner = ExprId(read_u32(r)?);
             Ok(ExprData::BigO(inner))
         }
+        13 => {
+            if format_version < POOL_FORMAT_V5 {
+                return Err(IoError::BadTag(13));
+            }
+            let poly = ExprId(read_u32(r)?);
+            let var = ExprId(read_u32(r)?);
+            let body = ExprId(read_u32(r)?);
+            Ok(ExprData::RootSum { poly, var, body })
+        }
         b => Err(IoError::BadTag(b)),
     }
 }
@@ -520,6 +537,7 @@ pub fn load_from(path: impl AsRef<Path>) -> Result<Option<ExprPool>, IoError> {
         && version != POOL_FORMAT_V2
         && version != POOL_FORMAT_V3
         && version != POOL_FORMAT_V4
+        && version != POOL_FORMAT_V5
     {
         return Err(IoError::UnsupportedVersion(version));
     }
@@ -613,6 +631,28 @@ mod tests {
         let q_two = q.integer(2_i32);
         assert_eq!(q_two, two);
 
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn round_trip_root_sum() {
+        // RootSum nodes (format V5) must round-trip through checkpoint/restore.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let t = p.symbol("t", Domain::Complex);
+        let poly = p.add(vec![p.pow(t, p.integer(2_i32)), p.integer(1_i32)]);
+        let body = p.mul(vec![t, p.func("log", vec![p.add(vec![x, t])])]);
+        let rs = p.root_sum(poly, t, body);
+        assert!(matches!(p.get(rs), ExprData::RootSum { .. }));
+
+        let path = tempfile();
+        p.checkpoint(&path).unwrap();
+        let q = ExprPool::open_persistent(&path).unwrap();
+        assert_eq!(q.len(), p.len());
+        for i in 0..p.len() {
+            let id = ExprId(i as u32);
+            assert_eq!(p.get(id), q.get(id), "node {i} mismatch after round-trip");
+        }
         let _ = fs::remove_file(&path);
     }
 

--- a/alkahest-core/src/pattern/matcher.rs
+++ b/alkahest-core/src/pattern/matcher.rs
@@ -184,7 +184,10 @@ fn match_one(
         ExprData::Func { name, args } => PatNode::Func(name.clone(), args.clone()),
         ExprData::Rational(_) | ExprData::Float(_) => PatNode::Literal,
         ExprData::Piecewise { .. } | ExprData::Predicate { .. } => PatNode::Literal,
-        ExprData::Forall { .. } | ExprData::Exists { .. } | ExprData::BigO(_) => PatNode::Literal,
+        ExprData::Forall { .. }
+        | ExprData::Exists { .. }
+        | ExprData::BigO(_)
+        | ExprData::RootSum { .. } => PatNode::Literal,
     });
 
     let expr_node = pool.with(expr, |data| match data {

--- a/alkahest-core/src/plot/dot.rs
+++ b/alkahest-core/src/plot/dot.rs
@@ -39,6 +39,7 @@ fn node_label(pool: &ExprPool, id: ExprId) -> String {
         ExprData::Forall { .. } => "Forall".to_string(),
         ExprData::Exists { .. } => "Exists".to_string(),
         ExprData::BigO(_) => "BigO".to_string(),
+        ExprData::RootSum { .. } => "RootSum".to_string(),
     }
 }
 

--- a/alkahest-core/src/poly/multipoly.rs
+++ b/alkahest-core/src/poly/multipoly.rs
@@ -115,6 +115,7 @@ fn expr_to_multivariate_coeffs(
         | ExprData::Predicate { .. }
         | ExprData::Forall { .. }
         | ExprData::Exists { .. }
+        | ExprData::RootSum { .. }
         | ExprData::BigO(_) => NodeInfo::Func("piecewise_or_predicate".to_string()),
     });
 

--- a/alkahest-core/src/poly/resultant.rs
+++ b/alkahest-core/src/poly/resultant.rs
@@ -110,6 +110,7 @@ fn collect_vars_rec(expr: ExprId, pool: &ExprPool, out: &mut BTreeSet<ExprId>) {
         ExprData::Predicate { args, .. } => args.clone(),
         ExprData::Forall { var, body } | ExprData::Exists { var, body } => vec![*var, *body],
         ExprData::BigO(arg) => vec![*arg],
+        ExprData::RootSum { poly, var, body } => vec![*poly, *var, *body],
     });
     for child in children {
         collect_vars_rec(child, pool, out);

--- a/alkahest-core/src/poly/unipoly.rs
+++ b/alkahest-core/src/poly/unipoly.rs
@@ -213,6 +213,9 @@ fn expr_to_univariate_rat_coeffs(
             ConversionError::NonPolynomialFunction("quantifier".to_string()),
         ),
         ExprData::BigO(_) => Err(ConversionError::NonPolynomialFunction("BigO".to_string())),
+        ExprData::RootSum { .. } => Err(ConversionError::NonPolynomialFunction(
+            "RootSum".to_string(),
+        )),
     }
 }
 
@@ -281,6 +284,9 @@ fn expr_to_univariate_coeffs(
             ConversionError::NonPolynomialFunction("quantifier".to_string()),
         ),
         ExprData::BigO(_) => Err(ConversionError::NonPolynomialFunction("BigO".to_string())),
+        ExprData::RootSum { .. } => Err(ConversionError::NonPolynomialFunction(
+            "RootSum".to_string(),
+        )),
     }
 }
 

--- a/alkahest-core/src/simplify/colored_egraph.rs
+++ b/alkahest-core/src/simplify/colored_egraph.rs
@@ -230,6 +230,11 @@ impl ColoredEgraph {
                 self.rebuild_rec(body, pool, color, visiting),
             ),
             ExprData::BigO(arg) => pool.big_o(self.rebuild_rec(arg, pool, color, visiting)),
+            ExprData::RootSum { poly, var, body } => pool.root_sum(
+                self.rebuild_rec(poly, pool, color, visiting),
+                self.rebuild_rec(var, pool, color, visiting),
+                self.rebuild_rec(body, pool, color, visiting),
+            ),
         };
         visiting.remove(&canon);
         out

--- a/alkahest-core/src/simplify/egraph.rs
+++ b/alkahest-core/src/simplify/egraph.rs
@@ -57,6 +57,7 @@ mod backend {
             | ExprData::Predicate { .. }
             | ExprData::Forall { .. }
             | ExprData::Exists { .. }
+            | ExprData::RootSum { .. }
             | ExprData::BigO(_) => Node::Unsupported,
         });
 
@@ -159,6 +160,11 @@ mod backend {
             }
             ExprData::BigO(arg) => {
                 count_dag_nodes_rec(arg, pool, visited);
+            }
+            ExprData::RootSum { poly, var, body } => {
+                count_dag_nodes_rec(poly, pool, visited);
+                count_dag_nodes_rec(var, pool, visited);
+                count_dag_nodes_rec(body, pool, visited);
             }
             // Leaf nodes
             ExprData::Integer(_)

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -938,6 +938,11 @@ impl PyExpr {
             alkahest_core::ExprData::BigO(inner) => {
                 PyList::new_bound(py, vec!["big_o".into_py(py), wrap!(inner)]).into_py(py)
             }
+            alkahest_core::ExprData::RootSum { poly, var, body } => PyList::new_bound(
+                py,
+                vec!["root_sum".into_py(py), wrap!(poly), wrap!(var), wrap!(body)],
+            )
+            .into_py(py),
         }
     }
 }


### PR DESCRIPTION
Stacked on #83 (base: `worktree-risch-gaps`). Completes rational-function integration for **every denominator that factors over ℚ**, including irreducible factors of **degree ≥ 3**, by adding a first-class symbolic `RootSum` node to the kernel and the Lazard–Rioboo–Trager logarithmic part to the integrator.

> **Breaking change / versioning:** adds the `ExprData::RootSum` variant to the stable-surface `ExprData` enum (semver-major). Workspace version bumped **2.4.1 → 3.0.0** so `cargo semver-checks` stays green.

## Kernel — `ExprData::RootSum { poly, var, body }`
A binder modeled on `Exists` (`Σ_{c : poly(c)=0} body[var := c]`), plus `ExprPool::root_sum()`.
- Plumbed through every exhaustive `ExprData` match: intern/Debug, persistence (new format **V5** + round-trip test), display (Debug/LaTeX/unicode), `expr_props`, pattern matcher, plot/dot, egraph + colored_egraph (treated as opaque), poly conversions (rejected as non-polynomial), `calculus`/`series`, and the `alkahest-py` bridge.
- **`diff`:** `d/dx RootSum(P,c,body) = RootSum(P,c, d/dx body)` in symbolic (`diff_impl`) and forward (dual-number) modes; reverse-mode (`grad`) treats it as atomic, consistent with the other binders. This makes the emitted antiderivatives round-trip-verifiable.

## Integrator — Lazard–Rioboo–Trager
For an irreducible denominator factor of degree ≥ 3, factor `R(t) = res_x(N − t·P', P)` over ℚ; each irreducible factor `Q` of `R` yields a `log` (deg 1) or `RootSum(Q, t, t·log(S))` (deg ≥ 2), where the log argument `S = gcd_x(N − t·P', P)` is computed in the number field **`ℚ[t]/Q`** via new K-element arithmetic (incl. inversion) and a K-polynomial GCD.

## Verification
- `∫ 1/(x³−3x+1) dx` (irreducible, three real roots) emits a `RootSum` whose derivative matches the integrand numerically at several points (a small real-root finder evaluates the sum over residues).
- `∫ 1/(x³+x+1) dx` (one real + two complex roots) emits a `RootSum` and differentiates cleanly (structural check).
- Persistence V5 round-trip test for `RootSum`; `atan`-style diff already covered upstream.

Full core lib suite green (**645 passed**); `clippy`, `rustdoc -D warnings`, and `cargo fmt --check` clean; `alkahest-py` and `alkahest-mlir` compile; the `egraph`-feature test run passes.

Rational-function integration over ℚ is now complete (linear → log; quadratics → log/arctan/√-log; degree ≥ 3 → RootSum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)