### PR TITLE
feat(integrate): exp-tower constant factors + logarithmic-derivative rule

### DIFF
--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -94,6 +94,112 @@ impl crate::errors::AlkahestError for IntegrationError {
 }
 
 // ---------------------------------------------------------------------------
+// Logarithmic-derivative rule:  ∫ (h'/h)·log(h)^n dx
+// ---------------------------------------------------------------------------
+
+/// Integrate `∫ (h'/h)·log(h)^n dx` for an integer `n`.
+///
+/// With `θ = log(h)` the derivation gives `Dθ = h'/h`, so the integrand
+/// `(h'/h)·θ^n = Dθ·θ^n` has antiderivative `θ^{n+1}/(n+1)` for `n ≠ −1` and
+/// `log(θ) = log(log(h))` for `n = −1`.  This is the single-generator
+/// logarithmic case of the Risch algorithm; it covers elementary integrands the
+/// rule engine cannot reduce, e.g. `∫ 1/(x·log x) dx = log(log x)` and
+/// `∫ 1/(x·log(x)^2) dx = −1/log(x)`.
+///
+/// Returns `Some(F)` only when the integrand matches the template exactly (the
+/// coefficient equals `h'/h` as a rational function), so the result is always a
+/// sound, differentiation-verifiable antiderivative; otherwise `None`.
+fn try_log_derivative(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<ExprId> {
+    use super::risch::poly_rde::{poly_mul, rational_to_expr, trim};
+    use super::risch::rational_rde::expr_to_qrational;
+    use super::risch::tower::find_generators;
+
+    // The integrand must involve exactly one transcendental generator, log(h).
+    let gens = find_generators(expr, var, pool);
+    if gens.len() != 1 || !gens[0].is_log() {
+        return None;
+    }
+    let theta = gens[0].generator; // log(h)
+    let h = gens[0].argument(); // h
+
+    // Write expr = coeff · θ^n with a nonzero integer n.
+    let (coeff, n) = extract_log_power(expr, theta, pool)?;
+    if n == 0 {
+        return None;
+    }
+
+    // coeff must be a rational function of `var` (no θ inside).
+    let (cn, cd) = expr_to_qrational(coeff, var, pool)?;
+
+    // Require coeff == h'/h as rational functions.
+    let hp = crate::diff::diff(h, var, pool).ok()?.value;
+    let (hpn, hpd) = expr_to_qrational(hp, var, pool)?;
+    let (hn, hd) = expr_to_qrational(h, var, pool)?;
+    // h'/h = (hpn·hd) / (hpd·hn);  coeff == h'/h  ⇔  cn·(hpd·hn) == (hpn·hd)·cd.
+    let rn = poly_mul(&hpn, &hd);
+    let rd = poly_mul(&hpd, &hn);
+    if trim(poly_mul(&cn, &rd)) != trim(poly_mul(&rn, &cd)) {
+        return None;
+    }
+
+    // Antiderivative.
+    if n == -1 {
+        Some(pool.func("log", vec![theta])) // log(log(h))
+    } else {
+        let np1 = n + 1;
+        let pow = pool.pow(theta, pool.integer(np1));
+        let coeff_expr = rational_to_expr(&rug::Rational::from((1_i64, np1)), pool);
+        Some(pool.mul(vec![coeff_expr, pow]))
+    }
+}
+
+/// Decompose `expr` as `coeff · theta^n` for an integer `n`, returning
+/// `(coeff, n)`.  `coeff` collects every factor other than integer powers of
+/// `theta`.  Returns `None` if `theta` does not appear (or appears only with a
+/// non-integer exponent).
+fn extract_log_power(expr: ExprId, theta: ExprId, pool: &ExprPool) -> Option<(ExprId, i64)> {
+    if expr == theta {
+        return Some((pool.integer(1_i32), 1));
+    }
+    match pool.get(expr) {
+        ExprData::Pow { base, exp } if base == theta => match pool.get(exp) {
+            ExprData::Integer(m) => Some((pool.integer(1_i32), m.0.to_i64()?)),
+            _ => None,
+        },
+        ExprData::Mul(args) => {
+            let mut n: i64 = 0;
+            let mut rest: Vec<ExprId> = Vec::new();
+            for &a in &args {
+                if a == theta {
+                    n += 1;
+                } else if let ExprData::Pow { base, exp } = pool.get(a) {
+                    if base == theta {
+                        match pool.get(exp) {
+                            ExprData::Integer(m) => n += m.0.to_i64()?,
+                            _ => rest.push(a),
+                        }
+                    } else {
+                        rest.push(a);
+                    }
+                } else {
+                    rest.push(a);
+                }
+            }
+            if n == 0 {
+                return None;
+            }
+            let coeff = match rest.len() {
+                0 => pool.integer(1_i32),
+                1 => rest[0],
+                _ => pool.mul(rest),
+            };
+            Some((coeff, n))
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -726,6 +832,26 @@ pub fn integrate(
         return super::risch::integrate_risch(expr, var, pool);
     }
 
+    // Logarithmic-derivative rule: ∫ (h'/h)·log(h)^n dx (single-generator log
+    // case, e.g. ∫ 1/(x·log x) dx = log(log x)).  This must precede the
+    // `known_nonelementary` li pre-check below, which would otherwise mis-certify
+    // ∫ 1/(x·log x) dx as the (non-elementary) logarithmic integral li — it is in
+    // fact elementary because 1/x = (log x)'.  The rule fires only when the
+    // coefficient equals h'/h exactly, so a match is always a correct, verifiable
+    // antiderivative; genuinely non-elementary forms (1/log x, 1/((x+1)·log x))
+    // do not match and fall through to the certification below.
+    if let Some(result) = try_log_derivative(expr, var, pool) {
+        let simplified = simplify(result, pool);
+        let mut rlog = DerivationLog::new();
+        rlog.push(RewriteStep::simple(
+            "log_derivative_rule",
+            expr,
+            simplified.value,
+        ));
+        let final_log = rlog.merge(simplified.log);
+        return Ok(DerivedExpr::with_log(simplified.value, final_log));
+    }
+
     // Risch Gap 6: certify classic non-elementary special-function integrands
     // (Ei/Si/Ci/Shi/Chi/li) before the rule-based engine, which would otherwise
     // return the weaker `NotImplemented` verdict.
@@ -1257,5 +1383,122 @@ mod tests {
         let f = pool.func("sin", vec![x]);
         assert!(integrate(f, x, &pool).is_ok());
         assert!(known_nonelementary(f, x, &pool).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Logarithmic-derivative rule: ∫ (h'/h)·log(h)^n dx
+    // -----------------------------------------------------------------------
+
+    /// Numeric evaluator supporting log (the rule emits log/log-of-log terms).
+    fn eval_log(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        if expr == x {
+            return xv;
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => n.0.to_f64(),
+            ExprData::Rational(r) => r.0.to_f64(),
+            ExprData::Add(args) => args.iter().map(|&a| eval_log(a, x, xv, pool)).sum(),
+            ExprData::Mul(args) => args.iter().map(|&a| eval_log(a, x, xv, pool)).product(),
+            ExprData::Pow { base, exp } => {
+                eval_log(base, x, xv, pool).powf(eval_log(exp, x, xv, pool))
+            }
+            ExprData::Func { ref name, ref args } if args.len() == 1 => {
+                let a = eval_log(args[0], x, xv, pool);
+                match name.as_str() {
+                    "log" => a.ln(),
+                    other => panic!("eval_log: unsupported func {other}"),
+                }
+            }
+            other => panic!("eval_log: unsupported node {other:?}"),
+        }
+    }
+
+    /// Integrate and assert `d/dx F = integrand` numerically at a few points > 1
+    /// (so all logs are positive).
+    fn verify_log(f: ExprId, x: ExprId, pool: &ExprPool) {
+        let r = integrate(f, x, pool).unwrap_or_else(|e| panic!("expected elementary: {e:?}"));
+        let d = diff(r.value, x, pool).unwrap();
+        let ds = simplify(d.value, pool).value;
+        for &xv in &[1.3_f64, 2.1, 3.4] {
+            let lhs = eval_log(ds, x, xv, pool);
+            let rhs = eval_log(f, x, xv, pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-7,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs}\n  F = {}",
+                pool.display(r.value)
+            );
+        }
+    }
+
+    #[test]
+    fn log_derivative_one_over_x_log_x() {
+        // ∫ 1/(x·log x) dx = log(log x)   (n = −1)
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let logx = pool.func("log", vec![x]);
+        let f = pool.mul(vec![
+            pool.pow(x, pool.integer(-1)),
+            pool.pow(logx, pool.integer(-1)),
+        ]);
+        verify_log(f, x, &pool);
+        let r = integrate(f, x, &pool).unwrap();
+        assert!(
+            pool.display(r.value).to_string().contains("log(log"),
+            "expected log(log(x)); got {}",
+            pool.display(r.value)
+        );
+    }
+
+    #[test]
+    fn log_derivative_negative_powers() {
+        // ∫ 1/(x·log(x)^2) dx = −1/log(x)   (n = −2)
+        // ∫ 1/(x·log(x)^3) dx = −1/(2·log(x)^2)   (n = −3)
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let logx = pool.func("log", vec![x]);
+        for m in [2_i32, 3] {
+            let f = pool.mul(vec![
+                pool.pow(x, pool.integer(-1)),
+                pool.pow(logx, pool.integer(-m)),
+            ]);
+            verify_log(f, x, &pool);
+        }
+    }
+
+    #[test]
+    fn log_derivative_polynomial_argument() {
+        // ∫ (2x/(x²+1))·1/log(x²+1) dx = log(log(x²+1))   (h = x²+1, n = −1)
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let h = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let logh = pool.func("log", vec![h]);
+        let dh_over_h = pool.mul(vec![pool.integer(2_i32), x, pool.pow(h, pool.integer(-1))]);
+        let f = pool.mul(vec![dh_over_h, pool.pow(logh, pool.integer(-1))]);
+        verify_log(f, x, &pool);
+    }
+
+    #[test]
+    fn log_derivative_does_not_misfire() {
+        // The rule must fire ONLY when the coefficient is exactly h'/h.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let logx = pool.func("log", vec![x]);
+
+        // ∫ 1/log(x) dx = li(x): coefficient 1 ≠ 1/x → must stay NonElementary.
+        let f = pool.pow(logx, pool.integer(-1));
+        assert!(
+            matches!(
+                integrate(f, x, &pool),
+                Err(IntegrationError::NonElementary(_))
+            ),
+            "∫ 1/log(x) dx must remain NonElementary"
+        );
+
+        // ∫ x/log(x) dx: coefficient x ≠ 1/x → the rule must not produce a result.
+        let f = pool.mul(vec![x, pool.pow(logx, pool.integer(-1))]);
+        assert!(
+            integrate(f, x, &pool).is_err(),
+            "∫ x/log(x) dx must not be (mis)integrated by the log-derivative rule"
+        );
     }
 }

--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -149,6 +149,13 @@ fn integrate_single_exp_term(
     // Build exp(kη) once: for k=1 use exp_gen directly; for k>1 use exp(kη).
     let exp_k_eta = build_exp_k_eta(k, eta, exp_gen, pool);
 
+    // Split off any var-free (constant) factor of the coefficient:
+    //   ∫ K·g(x)·exp(kη) dx = K · ∫ g(x)·exp(kη) dx,   K free of `var`.
+    // This lets the RDE work on the purely var-dependent remainder `g` over ℚ,
+    // while `K` may be an arbitrary symbolic/algebraic constant (e.g. √2, π) that
+    // the ℚ-coefficient RDE solver cannot represent (Gap E).
+    let (k_const, c_rest) = split_const_factor(c_expr, var, pool);
+
     // Non-elementary error shared by the polynomial and rational paths.
     let non_elementary = || {
         IntegrationError::NonElementary(format!(
@@ -165,11 +172,12 @@ fn integrate_single_exp_term(
     };
 
     // Fast path: polynomial coefficient → polynomial Risch DE (Bronstein §5.2).
-    if let Some(c_poly) = expr_to_qpoly(c_expr, var, pool) {
+    if let Some(c_poly) = expr_to_qpoly(c_rest, var, pool) {
         return match solve_poly_rde(k, deta, &c_poly) {
             Some(v_poly) => {
                 let v_expr = qpoly_to_expr(&v_poly, var, pool);
-                let result = build_v_times_exp(v_expr, exp_k_eta, pool);
+                let core = build_v_times_exp(v_expr, exp_k_eta, pool);
+                let result = apply_const(k_const, core, pool);
                 log.push(RewriteStep::simple("risch_exp_rde", c_expr, result));
                 Ok(result)
             }
@@ -178,13 +186,14 @@ fn integrate_single_exp_term(
     }
 
     // Rational coefficient → rational Risch DE over ℚ(x) (Bronstein §6.1, Gap 1).
-    if let Some((c_num, c_den)) = expr_to_qrational(c_expr, var, pool) {
+    if let Some((c_num, c_den)) = expr_to_qrational(c_rest, var, pool) {
         // f = k·η' is a polynomial in the exp tower.
         let f = poly_scale(&deta.to_vec(), &rug::Rational::from(k));
         return match solve_rational_rde(&f, &c_num, &c_den) {
             Some((v_num, v_den)) => {
                 let v_expr = build_rational(&v_num, &v_den, var, pool);
-                let result = build_v_times_exp(v_expr, exp_k_eta, pool);
+                let core = build_v_times_exp(v_expr, exp_k_eta, pool);
+                let result = apply_const(k_const, core, pool);
                 log.push(RewriteStep::simple(
                     "risch_exp_rde_rational",
                     c_expr,
@@ -196,8 +205,9 @@ fn integrate_single_exp_term(
         };
     }
 
-    // c is neither a polynomial nor a rational function in `var` (e.g. it carries
-    // another transcendental generator) — outside the single-generator subset.
+    // The var-dependent remainder is neither a polynomial nor a rational function
+    // in `var` (e.g. it carries another transcendental generator) — outside the
+    // single-generator subset.
     Err(IntegrationError::NotImplemented(format!(
         "coefficient {} of exp(η)^{} is not a rational function in the integration \
          variable; mixed/multiple generators are not yet supported",
@@ -212,6 +222,57 @@ fn build_v_times_exp(v_expr: ExprId, exp_k_eta: ExprId, pool: &ExprPool) -> Expr
         exp_k_eta
     } else {
         pool.mul(vec![v_expr, exp_k_eta])
+    }
+}
+
+/// Split a coefficient `c` into `(K, g)` with `c = K · g`, where `K` collects all
+/// factors free of `var` (an arbitrary symbolic/algebraic constant) and `g`
+/// carries the var-dependent part.  Returns `(1, c)` when there is no constant
+/// factor and `(c, 1)` when `c` itself is constant.
+fn split_const_factor(c: ExprId, var: ExprId, pool: &ExprPool) -> (ExprId, ExprId) {
+    use crate::kernel::ExprData;
+    let one = pool.integer(1_i32);
+    match pool.get(c) {
+        ExprData::Mul(args) => {
+            let mut consts: Vec<ExprId> = Vec::new();
+            let mut vars: Vec<ExprId> = Vec::new();
+            for &a in &args {
+                if is_free_of_var(a, var, pool) {
+                    consts.push(a);
+                } else {
+                    vars.push(a);
+                }
+            }
+            if consts.is_empty() {
+                return (one, c);
+            }
+            let k_const = match consts.len() {
+                1 => consts[0],
+                _ => pool.mul(consts),
+            };
+            let rest = match vars.len() {
+                0 => one,
+                1 => vars[0],
+                _ => pool.mul(vars),
+            };
+            (k_const, rest)
+        }
+        _ => {
+            if is_free_of_var(c, var, pool) {
+                (c, one)
+            } else {
+                (one, c)
+            }
+        }
+    }
+}
+
+/// Multiply `core` by the constant `k_const`, collapsing the `k_const = 1` case.
+fn apply_const(k_const: ExprId, core: ExprId, pool: &ExprPool) -> ExprId {
+    if is_one(k_const, pool) {
+        core
+    } else {
+        pool.mul(vec![k_const, core])
     }
 }
 
@@ -523,5 +584,153 @@ mod tests {
         // x * exp(x^2): needs Risch
         let x_times_exp_x2 = pool.mul(vec![x, exp_x2]);
         assert!(needs_exp_risch(x_times_exp_x2, x, &pool));
+    }
+
+    // -----------------------------------------------------------------------
+    // Constant (symbolic / algebraic) coefficient factor (Gap E, exp tower)
+    // -----------------------------------------------------------------------
+
+    /// Numeric evaluator supporting the nodes that appear in these antiderivatives
+    /// (Integer/Rational/Add/Mul/Pow/exp/sqrt).
+    fn eval_f64(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        use crate::kernel::ExprData;
+        if expr == x {
+            return xv;
+        }
+        match pool.get(expr) {
+            // Opaque symbolic constant used in the symbolic-factor test: assign it
+            // a fixed value so `d/dx F = f` can be checked numerically.
+            ExprData::Symbol { ref name, .. } if name == "pi" => std::f64::consts::PI,
+            ExprData::Integer(n) => n.0.to_f64(),
+            ExprData::Rational(r) => r.0.to_f64(),
+            ExprData::Add(args) => args.iter().map(|&a| eval_f64(a, x, xv, pool)).sum(),
+            ExprData::Mul(args) => args.iter().map(|&a| eval_f64(a, x, xv, pool)).product(),
+            ExprData::Pow { base, exp } => {
+                eval_f64(base, x, xv, pool).powf(eval_f64(exp, x, xv, pool))
+            }
+            ExprData::Func { ref name, ref args } if args.len() == 1 => {
+                let a = eval_f64(args[0], x, xv, pool);
+                match name.as_str() {
+                    "exp" => a.exp(),
+                    "log" => a.ln(),
+                    "sqrt" => a.sqrt(),
+                    other => panic!("eval_f64: unsupported func {other}"),
+                }
+            }
+            other => panic!("eval_f64: unsupported node {other:?}"),
+        }
+    }
+
+    /// Integrate via the exp tower and assert `d/dx F = integrand` numerically.
+    fn verify_exp_tower(integrand: ExprId, x: ExprId, pool: &ExprPool) {
+        use super::super::tower::find_generators;
+        let gens = find_generators(integrand, x, pool);
+        let level = gens.iter().find(|g| g.is_exp()).expect("an exp generator");
+        let mut log = DerivationLog::new();
+        let f =
+            integrate_exp_tower(integrand, level, x, pool, &mut log).expect("should be elementary");
+        let d = crate::diff::diff(f, x, pool).unwrap();
+        let ds = crate::simplify::engine::simplify(d.value, pool).value;
+        for &xv in &[0.7_f64, 1.3, 2.1] {
+            let lhs = eval_f64(ds, x, xv, pool);
+            let rhs = eval_f64(integrand, x, xv, pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-7,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs}\n  F = {}",
+                pool.display(f)
+            );
+        }
+    }
+
+    #[test]
+    fn rational_const_factor_exp_x2() {
+        // ∫ (1/2)·x·exp(x²) dx = (1/4)·exp(x²).  Before the constant-factor split
+        // the ℚ-constant rode along in the coefficient and the conversion failed.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x2 = pool.func("exp", vec![pool.pow(x, pool.integer(2_i32))]);
+        let half = pool.rational(1_i32, 2_i32);
+        let integrand = pool.mul(vec![half, x, exp_x2]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    #[test]
+    fn algebraic_const_factor_exp_x2() {
+        // ∫ √2·x·exp(x²) dx = (√2/2)·exp(x²).  √2 is an algebraic constant the
+        // ℚ-coefficient RDE cannot represent; the split pulls it out (Gap E).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x2 = pool.func("exp", vec![pool.pow(x, pool.integer(2_i32))]);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let integrand = pool.mul(vec![sqrt2, x, exp_x2]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    #[test]
+    fn symbolic_const_factor_poly_exp_x() {
+        // ∫ π·x²·exp(x) dx = π·(x²−2x+2)·exp(x).  π is an opaque symbolic constant.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let pi = pool.symbol("pi", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let integrand = pool.mul(vec![pi, pool.pow(x, pool.integer(2_i32)), exp_x]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    #[test]
+    fn algebraic_const_factor_rational_coeff() {
+        // ∫ √2·(x−1)/x²·exp(x) dx = √2·exp(x)/x.  Constant factor on top of a
+        // *rational* coefficient (exercises the rational-RDE branch after the split).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let num = pool.add(vec![x, pool.integer(-1_i32)]);
+        let inv_x2 = pool.pow(x, pool.integer(-2_i32));
+        let integrand = pool.mul(vec![sqrt2, num, inv_x2, exp_x]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    #[test]
+    fn algebraic_const_factor_nonelementary_preserved() {
+        // ∫ √2·exp(x²) dx is still non-elementary: pulling out √2 leaves ∫exp(x²).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x2 = pool.func("exp", vec![pool.pow(x, pool.integer(2_i32))]);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let integrand = pool.mul(vec![sqrt2, exp_x2]);
+
+        use super::super::tower::find_generators;
+        let gens = find_generators(integrand, x, &pool);
+        let level = gens.iter().find(|g| g.is_exp()).unwrap();
+        let mut log = DerivationLog::new();
+        let result = integrate_exp_tower(integrand, level, x, &pool, &mut log);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ √2·exp(x²) dx must remain NonElementary; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn split_const_factor_cases() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+
+        // √2·x → (√2, x)
+        let c = pool.mul(vec![sqrt2, x]);
+        let (k, rest) = split_const_factor(c, x, &pool);
+        assert_eq!(k, sqrt2);
+        assert_eq!(rest, x);
+
+        // pure constant √2 → (√2, 1)
+        let (k, rest) = split_const_factor(sqrt2, x, &pool);
+        assert_eq!(k, sqrt2);
+        assert_eq!(rest, pool.integer(1_i32));
+
+        // pure variable x → (1, x)
+        let (k, rest) = split_const_factor(x, x, &pool);
+        assert_eq!(k, pool.integer(1_i32));
+        assert_eq!(rest, x);
     }
 }


### PR DESCRIPTION
## Summary

Two self-contained, fully-tested Risch-integration improvements, each verified by differentiation. Worked against a fresh empirical probe of the actual frontier on `main @ v3.0.0` (a couple of the tracked gap entries turned out to be stale — Gap A's rational log-tower base case already works).

### Component 1 — constant coefficient factors in the exp tower (`risch/exp_case.rs`)
`∫ √2·x·exp(x²)` and `∫ π·x²·exp(x)` previously failed (`NotImplemented` / "irreducible product of var-dependent factors") even though `∫ x·exp(x²)` worked, because the var-free factor `√2`/`π` rode along inside the exp-tower coefficient and broke the ℚ-polynomial/rational conversion. Now `integrate_single_exp_term` splits any var-free factor `K` out first:

```
∫ K·g(x)·exp(kη) dx = K · ∫ g(x)·exp(kη) dx,   K free of x
```

solves the RDE on the var-dependent remainder `g` over ℚ as before, and re-multiplies by `K` (which may be any symbolic/algebraic constant). Non-elementary verdicts are preserved — `∫ √2·exp(x²)` stays non-elementary. This is the constant-factor slice of Gap E.

### Component 2 — logarithmic-derivative rule `∫ (h'/h)·log(h)^n dx` (`engine.rs`)
Adds the single-generator logarithmic case (θ = log(h), Dθ = h'/h):

```
∫ (h'/h)·θ^n dx = θ^(n+1)/(n+1)   (n ≠ −1),   = log(log(h))   (n = −1)
```

This also **fixes a latent soundness bug**: `∫ 1/(x·log x) dx = log(log x)` is elementary, but the `known_nonelementary` pre-check was mis-certifying it as the non-elementary logarithmic integral `li` (it saw the `log(linear)^(−1)` factor and ignored that the accompanying `1/x` is exactly `(log x)'`). The new rule runs **before** `known_nonelementary` and fires only when the coefficient equals `h'/h` as a rational function (exact ℚ cross-multiplication), so a match is always a differentiation-verifiable antiderivative, while genuinely non-elementary forms (`∫ 1/log x` → `li`, `∫ 1/((x+1)·log x)`) still fall through correctly.

New verified results: `∫ 1/(x·log x) = log(log x)`, `∫ 1/(x·log(x)²) = −1/log(x)`, `∫ 1/(x·log(x)³)`, `∫ 2x/(x²+1)/log(x²+1) = log(log(x²+1))`.

## Testing
- `cargo test -p alkahest-cas` — all passing, 0 failed
- `cargo fmt --check` and `cargo clippy -p alkahest-cas --lib --tests` clean
- `cargo build --workspace` ok
- New tests cover both components incl. soundness guards (NE-preservation, non-matching forms), numerically verified by differentiation.

## Still open
Tower composition (Gap B), mixed algebraic+transcendental (C), nested/rational exponents (F), and full ℚ(α)-coefficient support (E) remain — the genuinely hard multi-module items, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)