### PR TITLE
feat(integrate): number-field ℚ(α) layer + algebraic-coefficient Risch DE (Gap E)

### DIFF
--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -31,7 +31,11 @@ use crate::integrate::engine::IntegrationError;
 use crate::kernel::{ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
-use super::poly_rde::{expr_to_qpoly, is_free_of_var, poly_scale, qpoly_to_expr, solve_poly_rde};
+use super::number_field::{KElem, KPoly, NumberField};
+use super::poly_rde::{
+    expr_to_qpoly, is_free_of_var, poly_scale, qpoly_to_expr, rational_to_expr, solve_poly_rde,
+    solve_poly_rde_k,
+};
 use super::rational_rde::{expr_to_qrational, solve_rational_rde};
 use super::tower::{decompose_wrt_exp, poly_degree, TowerLevel};
 
@@ -205,6 +209,37 @@ fn integrate_single_exp_term(
         };
     }
 
+    // Algebraic-number coefficient → polynomial Risch DE over ℚ(α) (Risch Gap E).
+    // Handles a coefficient that is a polynomial in `var` whose coefficients lie
+    // in a single quadratic field ℚ(√d) and cannot be split off as a constant
+    // factor (e.g. `(x + √2)`).  The rational-coefficient case over ℚ(α) is not
+    // yet handled (it needs the denominator-bound + linear algebra over ℚ(α)).
+    if let Some((d, sqrt_expr)) = detect_sqrt_field(c_rest, pool) {
+        let field = NumberField::new(vec![
+            rug::Rational::from(-d),
+            rug::Rational::from(0),
+            rug::Rational::from(1),
+        ]);
+        if let Some(c_kpoly) = expr_to_kpoly(c_rest, var, sqrt_expr, &field, pool) {
+            // Embed the (ℚ-polynomial) η' into K.
+            let deta_k: KPoly = deta.iter().map(|r| field.from_rational(r)).collect();
+            return match solve_poly_rde_k(&field, k, &deta_k, &c_kpoly) {
+                Some(v) => {
+                    let v_expr = kpoly_to_expr_alg(&v, var, sqrt_expr, pool);
+                    let core = build_v_times_exp(v_expr, exp_k_eta, pool);
+                    let result = apply_const(k_const, core, pool);
+                    log.push(RewriteStep::simple(
+                        "risch_exp_rde_algebraic",
+                        c_expr,
+                        result,
+                    ));
+                    Ok(result)
+                }
+                None => Err(non_elementary()),
+            };
+        }
+    }
+
     // The var-dependent remainder is neither a polynomial nor a rational function
     // in `var` (e.g. it carries another transcendental generator) — outside the
     // single-generator subset.
@@ -273,6 +308,197 @@ fn apply_const(k_const: ExprId, core: ExprId, pool: &ExprPool) -> ExprId {
         core
     } else {
         pool.mul(vec![k_const, core])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Algebraic-number coefficients ℚ(√d)  (Risch Gap E, polynomial RDE)
+// ---------------------------------------------------------------------------
+
+/// Detect a single quadratic algebraic constant `√d` (`d` a non-square integer
+/// `> 1`) in `expr`.  Returns `(d, sqrt_expr)` when exactly one distinct such
+/// radical is present, else `None` (no radical, or a compositum of several
+/// distinct radicals — out of scope for the single-quadratic-field path).
+fn detect_sqrt_field(expr: ExprId, pool: &ExprPool) -> Option<(i64, ExprId)> {
+    let mut found: Vec<(i64, ExprId)> = Vec::new();
+    scan_sqrt(expr, pool, &mut found);
+    let mut distinct: Vec<(i64, ExprId)> = Vec::new();
+    for (d, e) in found {
+        if !distinct.iter().any(|(dd, _)| *dd == d) {
+            distinct.push((d, e));
+        }
+    }
+    match distinct.len() {
+        1 => Some(distinct[0]),
+        _ => None,
+    }
+}
+
+/// Collect every `sqrt(integer)` radical (non-square, `> 1`) occurring in `expr`.
+fn scan_sqrt(expr: ExprId, pool: &ExprPool, out: &mut Vec<(i64, ExprId)>) {
+    use crate::kernel::ExprData;
+    match pool.get(expr) {
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            if let ExprData::Integer(n) = pool.get(args[0]) {
+                if let Some(d) = n.0.to_i64() {
+                    if d > 1 && !is_perfect_square(d) {
+                        out.push((d, expr));
+                    }
+                }
+            }
+        }
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for &a in &args {
+                scan_sqrt(a, pool, out);
+            }
+        }
+        ExprData::Pow { base, exp } => {
+            scan_sqrt(base, pool, out);
+            scan_sqrt(exp, pool, out);
+        }
+        ExprData::Func { ref args, .. } => {
+            for &a in args {
+                scan_sqrt(a, pool, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Is `d` a perfect square?
+fn is_perfect_square(d: i64) -> bool {
+    if d < 0 {
+        return false;
+    }
+    let r = (d as f64).sqrt() as i64;
+    (r - 1..=r + 1).any(|c| c >= 0 && c * c == d)
+}
+
+/// Parse `expr` as a polynomial in `var` whose coefficients lie in `K = ℚ(√d)`
+/// (where `√d` is the symbol `sqrt_expr`), returning a [`KPoly`] ascending in
+/// `var`, or `None` if `expr` is not such a polynomial (e.g. a `var` appears in a
+/// denominator, or a foreign generator is present).
+fn expr_to_kpoly(
+    expr: ExprId,
+    var: ExprId,
+    sqrt_expr: ExprId,
+    field: &NumberField,
+    pool: &ExprPool,
+) -> Option<KPoly> {
+    use crate::kernel::ExprData;
+    if expr == var {
+        return Some(vec![NumberField::k_zero(), field.from_int(1)]);
+    }
+    if expr == sqrt_expr {
+        // The field generator √d as a K-constant: 0 + 1·t.
+        return Some(vec![vec![rug::Rational::from(0), rug::Rational::from(1)]]);
+    }
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some(vec![
+            field.from_rational(&rug::Rational::from(n.0.to_i64()?))
+        ]),
+        ExprData::Rational(r) => Some(vec![field.from_rational(&r.0)]),
+        ExprData::Add(args) => {
+            let mut acc: KPoly = Vec::new();
+            for a in &args {
+                let p = expr_to_kpoly(*a, var, sqrt_expr, field, pool)?;
+                acc = field.kpoly_add(&acc, &p);
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc: KPoly = vec![field.from_int(1)];
+            for a in &args {
+                let p = expr_to_kpoly(*a, var, sqrt_expr, field, pool)?;
+                acc = field.kpoly_mul(&acc, &p);
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            let n = match pool.get(exp) {
+                ExprData::Integer(n) => n.0.to_i64()?,
+                _ => return None,
+            };
+            let b = expr_to_kpoly(base, var, sqrt_expr, field, pool)?;
+            if n >= 0 {
+                let mut acc: KPoly = vec![field.from_int(1)];
+                for _ in 0..n {
+                    acc = field.kpoly_mul(&acc, &b);
+                }
+                Some(acc)
+            } else {
+                // Negative power: only a (var-free) constant base is admissible for
+                // a *polynomial* coefficient.
+                if NumberField::kdeg(&b) != 0 {
+                    return None;
+                }
+                let inv = field.inv(&b[0])?;
+                let mut acc = field.from_int(1);
+                for _ in 0..(-n) {
+                    acc = field.mul(&acc, &inv);
+                }
+                Some(vec![acc])
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Reconstruct a `K = ℚ(√d)` element `a + b·√d` as a symbolic expression.
+fn kelem_to_expr(e: &KElem, sqrt_expr: ExprId, pool: &ExprPool) -> ExprId {
+    let a = e.first().cloned().unwrap_or_else(|| rug::Rational::from(0));
+    let b = e.get(1).cloned().unwrap_or_else(|| rug::Rational::from(0));
+    let mut terms: Vec<ExprId> = Vec::new();
+    if a != 0 {
+        terms.push(rational_to_expr(&a, pool));
+    }
+    if b != 0 {
+        let bt = if b == 1 {
+            sqrt_expr
+        } else {
+            pool.mul(vec![rational_to_expr(&b, pool), sqrt_expr])
+        };
+        terms.push(bt);
+    }
+    match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    }
+}
+
+/// Reconstruct a [`KPoly`] in `var` over `ℚ(√d)` as a symbolic expression.
+fn kpoly_to_expr_alg(p: &KPoly, var: ExprId, sqrt_expr: ExprId, pool: &ExprPool) -> ExprId {
+    let mut terms: Vec<ExprId> = Vec::new();
+    for (i, c) in p.iter().enumerate() {
+        if NumberField::is_zero(c) {
+            continue;
+        }
+        let ce = kelem_to_expr(c, sqrt_expr, pool);
+        let term = match i {
+            0 => ce,
+            1 => {
+                if is_one(ce, pool) {
+                    var
+                } else {
+                    pool.mul(vec![ce, var])
+                }
+            }
+            _ => {
+                let xp = pool.pow(var, pool.integer(i as i32));
+                if is_one(ce, pool) {
+                    xp
+                } else {
+                    pool.mul(vec![ce, xp])
+                }
+            }
+        };
+        terms.push(term);
+    }
+    match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
     }
 }
 
@@ -709,6 +935,85 @@ mod tests {
             matches!(result, Err(IntegrationError::NonElementary(_))),
             "∫ √2·exp(x²) dx must remain NonElementary; got {result:?}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Algebraic-number coefficients ℚ(√d) entangled with x (Gap E, poly RDE)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn algebraic_coeff_linear_exp_x() {
+        // ∫ (x + √2)·exp(x) dx = (x + √2 − 1)·exp(x).  The coefficient (x + √2)
+        // lives in ℚ(√2)[x] and cannot be split as a constant factor.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let exp_x = pool.func("exp", vec![x]);
+        let coeff = pool.add(vec![x, sqrt2]);
+        let integrand = pool.mul(vec![coeff, exp_x]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    #[test]
+    fn algebraic_coeff_quadratic_exp_x() {
+        // ∫ (√3·x² + x)·exp(x) dx — √3 entangled with x².
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt3 = pool.func("sqrt", vec![pool.integer(3_i32)]);
+        let exp_x = pool.func("exp", vec![x]);
+        let coeff = pool.add(vec![
+            pool.mul(vec![sqrt3, pool.pow(x, pool.integer(2_i32))]),
+            x,
+        ]);
+        let integrand = pool.mul(vec![coeff, exp_x]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    #[test]
+    fn algebraic_coeff_nonelementary_preserved() {
+        // ∫ (x + √2)·exp(x²) dx is non-elementary: the √2·exp(x²) part has no
+        // elementary antiderivative, so the RDE over ℚ(√2) has no solution.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let exp_x2 = pool.func("exp", vec![pool.pow(x, pool.integer(2_i32))]);
+        let coeff = pool.add(vec![x, sqrt2]);
+        let integrand = pool.mul(vec![coeff, exp_x2]);
+
+        use super::super::tower::find_generators;
+        let gens = find_generators(integrand, x, &pool);
+        let level = gens.iter().find(|g| g.is_exp()).unwrap();
+        let mut log = DerivationLog::new();
+        let result = integrate_exp_tower(integrand, level, x, &pool, &mut log);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ (x+√2)·exp(x²) dx must be NonElementary; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn detect_sqrt_field_cases() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+
+        // x + √2 → field ℚ(√2).
+        let e = pool.add(vec![x, sqrt2]);
+        assert_eq!(detect_sqrt_field(e, &pool).map(|(d, _)| d), Some(2));
+
+        // √4 = 2 is a perfect square → not a field extension.
+        let sqrt4 = pool.func("sqrt", vec![pool.integer(4_i32)]);
+        let e = pool.add(vec![x, sqrt4]);
+        assert_eq!(detect_sqrt_field(e, &pool), None);
+
+        // Two distinct radicals (compositum) → out of scope.
+        let sqrt3 = pool.func("sqrt", vec![pool.integer(3_i32)]);
+        let e = pool.add(vec![sqrt2, sqrt3]);
+        assert_eq!(detect_sqrt_field(e, &pool), None);
+
+        // No radical at all.
+        let e = pool.add(vec![x, pool.integer(1_i32)]);
+        assert_eq!(detect_sqrt_field(e, &pool), None);
     }
 
     #[test]

--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -34,9 +34,9 @@ use crate::simplify::engine::simplify;
 use super::number_field::{KElem, KPoly, NumberField};
 use super::poly_rde::{
     expr_to_qpoly, is_free_of_var, poly_scale, qpoly_to_expr, rational_to_expr, solve_poly_rde,
-    solve_poly_rde_k,
+    solve_poly_rde_k, trim,
 };
-use super::rational_rde::{expr_to_qrational, solve_rational_rde};
+use super::rational_rde::{expr_to_qrational, solve_rational_rde, solve_rational_rde_k};
 use super::tower::{decompose_wrt_exp, poly_degree, TowerLevel};
 
 // ---------------------------------------------------------------------------
@@ -209,20 +209,21 @@ fn integrate_single_exp_term(
         };
     }
 
-    // Algebraic-number coefficient → polynomial Risch DE over ℚ(α) (Risch Gap E).
-    // Handles a coefficient that is a polynomial in `var` whose coefficients lie
-    // in a single quadratic field ℚ(√d) and cannot be split off as a constant
-    // factor (e.g. `(x + √2)`).  The rational-coefficient case over ℚ(α) is not
-    // yet handled (it needs the denominator-bound + linear algebra over ℚ(α)).
+    // Algebraic-number coefficient → Risch DE over ℚ(α) (Risch Gap E).  Handles a
+    // coefficient whose constants lie in a single quadratic field ℚ(√d) and that
+    // cannot be split off as a constant factor — both the *polynomial* case
+    // (e.g. `x + √2`) and the *rational* case (e.g. `(x−√2−1)/(x−√2)²`).
     if let Some((d, sqrt_expr)) = detect_sqrt_field(c_rest, pool) {
         let field = NumberField::new(vec![
             rug::Rational::from(-d),
             rug::Rational::from(0),
             rug::Rational::from(1),
         ]);
+        // Embed the (ℚ-polynomial) η' into K once.
+        let deta_k: KPoly = deta.iter().map(|r| field.from_rational(r)).collect();
+
+        // Polynomial coefficient over ℚ(√d).
         if let Some(c_kpoly) = expr_to_kpoly(c_rest, var, sqrt_expr, &field, pool) {
-            // Embed the (ℚ-polynomial) η' into K.
-            let deta_k: KPoly = deta.iter().map(|r| field.from_rational(r)).collect();
             return match solve_poly_rde_k(&field, k, &deta_k, &c_kpoly) {
                 Some(v) => {
                     let v_expr = kpoly_to_expr_alg(&v, var, sqrt_expr, pool);
@@ -230,6 +231,26 @@ fn integrate_single_exp_term(
                     let result = apply_const(k_const, core, pool);
                     log.push(RewriteStep::simple(
                         "risch_exp_rde_algebraic",
+                        c_expr,
+                        result,
+                    ));
+                    Ok(result)
+                }
+                None => Err(non_elementary()),
+            };
+        }
+
+        // Rational coefficient over ℚ(√d): rational RDE over the number field.
+        if let Some((c_num, c_den)) = expr_to_krational(c_rest, var, sqrt_expr, &field, pool) {
+            // f = k·η' embedded in K.
+            let f_k = field.kpoly_scale(&deta_k, &field.from_int(k));
+            return match solve_rational_rde_k(&field, &f_k, &c_num, &c_den) {
+                Some((v_num, v_den)) => {
+                    let v_expr = build_krational(&v_num, &v_den, var, sqrt_expr, pool);
+                    let core = build_v_times_exp(v_expr, exp_k_eta, pool);
+                    let result = apply_const(k_const, core, pool);
+                    log.push(RewriteStep::simple(
+                        "risch_exp_rde_algebraic_rational",
                         c_expr,
                         result,
                     ));
@@ -500,6 +521,108 @@ fn kpoly_to_expr_alg(p: &KPoly, var: ExprId, sqrt_expr: ExprId, pool: &ExprPool)
         1 => terms[0],
         _ => pool.add(terms),
     }
+}
+
+/// Parse `expr` as a rational function in `var` over `K = ℚ(√d)` (where `√d` is
+/// the symbol `sqrt_expr`), returning `(numerator, denominator)` as `KPoly`s, or
+/// `None` if it is not such a rational function.
+fn expr_to_krational(
+    expr: ExprId,
+    var: ExprId,
+    sqrt_expr: ExprId,
+    field: &NumberField,
+    pool: &ExprPool,
+) -> Option<(KPoly, KPoly)> {
+    use crate::kernel::ExprData;
+    let one: KPoly = vec![field.from_int(1)];
+    if expr == var {
+        return Some((vec![NumberField::k_zero(), field.from_int(1)], one));
+    }
+    if expr == sqrt_expr {
+        return Some((
+            vec![vec![rug::Rational::from(0), rug::Rational::from(1)]],
+            one,
+        ));
+    }
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some((
+            vec![field.from_rational(&rug::Rational::from(n.0.to_i64()?))],
+            one,
+        )),
+        ExprData::Rational(r) => Some((vec![field.from_rational(&r.0)], one)),
+        ExprData::Add(args) => {
+            let mut acc: (KPoly, KPoly) = (Vec::new(), one);
+            for a in &args {
+                let term = expr_to_krational(*a, var, sqrt_expr, field, pool)?;
+                acc = krat_add(field, &acc, &term);
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc: (KPoly, KPoly) = (one.clone(), one);
+            for a in &args {
+                let factor = expr_to_krational(*a, var, sqrt_expr, field, pool)?;
+                acc = krat_mul(field, &acc, &factor);
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            let n = match pool.get(exp) {
+                ExprData::Integer(n) => n.0.to_i64()?,
+                _ => return None,
+            };
+            let (bn, bd) = expr_to_krational(base, var, sqrt_expr, field, pool)?;
+            if n >= 0 {
+                Some((
+                    field.kpoly_pow(&bn, n as u32),
+                    field.kpoly_pow(&bd, n as u32),
+                ))
+            } else {
+                let m = (-n) as u32;
+                if NumberField::kdeg(&bn) < 0 {
+                    return None; // 1 / 0
+                }
+                Some((field.kpoly_pow(&bd, m), field.kpoly_pow(&bn, m)))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// `a/b + c/d = (a·d + c·b)/(b·d)` over `K`.
+fn krat_add(field: &NumberField, a: &(KPoly, KPoly), b: &(KPoly, KPoly)) -> (KPoly, KPoly) {
+    let num = field.kpoly_add(&field.kpoly_mul(&a.0, &b.1), &field.kpoly_mul(&b.0, &a.1));
+    let den = field.kpoly_mul(&a.1, &b.1);
+    (num, den)
+}
+
+/// `(a/b)·(c/d) = (a·c)/(b·d)` over `K`.
+fn krat_mul(field: &NumberField, a: &(KPoly, KPoly), b: &(KPoly, KPoly)) -> (KPoly, KPoly) {
+    (field.kpoly_mul(&a.0, &b.0), field.kpoly_mul(&a.1, &b.1))
+}
+
+/// Reconstruct a `K = ℚ(√d)` rational function `num(x)/den(x)` as a symbolic
+/// expression, collapsing a denominator of 1.
+fn build_krational(
+    num: &KPoly,
+    den: &KPoly,
+    var: ExprId,
+    sqrt_expr: ExprId,
+    pool: &ExprPool,
+) -> ExprId {
+    let num_expr = kpoly_to_expr_alg(num, var, sqrt_expr, pool);
+    // den == 1 (a single K-element equal to 1)?
+    let den_is_one = NumberField::kdeg(den) <= 0
+        && den
+            .first()
+            .map(|c| trim(c.clone()) == vec![rug::Rational::from(1)])
+            .unwrap_or(true);
+    if den_is_one {
+        return num_expr;
+    }
+    let den_expr = kpoly_to_expr_alg(den, var, sqrt_expr, pool);
+    let den_inv = pool.pow(den_expr, pool.integer(-1_i32));
+    pool.mul(vec![num_expr, den_inv])
 }
 
 /// Build the symbolic rational function `num(x) / den(x)`.
@@ -988,6 +1111,67 @@ mod tests {
         assert!(
             matches!(result, Err(IntegrationError::NonElementary(_))),
             "∫ (x+√2)·exp(x²) dx must be NonElementary; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn algebraic_rational_coeff_exp_x() {
+        // ∫ (x − √2 − 1)/(x − √2)² · exp(x) dx = exp(x)/(x − √2).
+        // The coefficient is a rational function over ℚ(√2) (RDE v'+v = c → v =
+        // 1/(x−√2)); exercises the rational RDE over the number field.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let neg_sqrt2 = pool.mul(vec![pool.integer(-1_i32), sqrt2]);
+        let base = pool.add(vec![x, neg_sqrt2]); // x − √2
+        let num = pool.add(vec![x, neg_sqrt2, pool.integer(-1_i32)]); // x − √2 − 1
+        let exp_x = pool.func("exp", vec![x]);
+        let integrand = pool.mul(vec![num, pool.pow(base, pool.integer(-2_i32)), exp_x]);
+
+        use super::super::tower::find_generators;
+        let gens = find_generators(integrand, x, &pool);
+        let level = gens.iter().find(|g| g.is_exp()).expect("exp generator");
+        let mut log = DerivationLog::new();
+        let f = integrate_exp_tower(integrand, level, x, &pool, &mut log)
+            .expect("∫ (x−√2−1)/(x−√2)²·exp(x) dx should be elementary");
+        // Verify d/dx F = integrand at points away from the singularity x = √2.
+        let d = crate::diff::diff(f, x, &pool).unwrap();
+        let ds = crate::simplify::engine::simplify(d.value, &pool).value;
+        for &xv in &[2.5_f64, 3.3, 4.1] {
+            let lhs = eval_f64(ds, x, xv, &pool);
+            let rhs = eval_f64(integrand, x, xv, &pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-7,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs}\n  F = {}",
+                pool.display(f)
+            );
+        }
+    }
+
+    #[test]
+    fn algebraic_rational_coeff_nonelementary() {
+        // ∫ x²/(x − √2) · exp(x) dx leaves an Ei term (simple pole at √2 with
+        // nonzero residue) — non-elementary over ℚ(√2).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let neg_sqrt2 = pool.mul(vec![pool.integer(-1_i32), sqrt2]);
+        let base = pool.add(vec![x, neg_sqrt2]); // x − √2
+        let exp_x = pool.func("exp", vec![x]);
+        let integrand = pool.mul(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.pow(base, pool.integer(-1_i32)),
+            exp_x,
+        ]);
+
+        use super::super::tower::find_generators;
+        let gens = find_generators(integrand, x, &pool);
+        let level = gens.iter().find(|g| g.is_exp()).unwrap();
+        let mut log = DerivationLog::new();
+        let result = integrate_exp_tower(integrand, level, x, &pool, &mut log);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ x²/(x−√2)·exp(x) dx must be NonElementary; got {result:?}"
         );
     }
 

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -27,6 +27,8 @@
 //! - [`tower`]: Differential field tower construction and generator detection.
 //! - [`poly_rde`]: Polynomial Risch Differential Equation (RDE) solver over ℚ\[x\].
 //! - [`rational_rde`]: Rational RDE solver over ℚ(x) (exp tower; Bronstein §6.1).
+//! - [`number_field`]: Algebraic number field `ℚ[t]/(q)` arithmetic (used for
+//!   degree-≥3 algebraic residues and, prospectively, ℚ(α) coefficients).
 //! - [`rational_integrate`]: Rational-function integration via Rothstein–Trager
 //!   (logarithmic part; Bronstein §2.5).
 //! - [`exp_case`]: Integration in the hyperexponential tower (t = exp(η)).
@@ -64,6 +66,7 @@
 
 pub mod exp_case;
 pub mod log_case;
+pub mod number_field;
 pub mod poly_rde;
 pub mod rational_integrate;
 pub mod rational_rde;

--- a/alkahest-core/src/integrate/risch/number_field.rs
+++ b/alkahest-core/src/integrate/risch/number_field.rs
@@ -322,6 +322,60 @@ impl NumberField {
         }
         Self::kpoly_trim(r)
     }
+
+    /// `p^n` of a `K`-polynomial in `x` (`n ≥ 0`; `p^0 = 1`).
+    pub fn kpoly_pow(&self, p: &[KElem], n: u32) -> KPoly {
+        let mut acc = vec![self.from_int(1)];
+        for _ in 0..n {
+            acc = self.kpoly_mul(&acc, p);
+        }
+        acc
+    }
+
+    /// Make a `K`-polynomial monic in `x` (divide by its leading coefficient).
+    /// The zero polynomial is returned unchanged; `None` if the leading
+    /// coefficient is not invertible in `K`.
+    pub fn kpoly_monic(&self, p: &[KElem]) -> Option<KPoly> {
+        let d = Self::kdeg(p);
+        if d < 0 {
+            return Some(Vec::new());
+        }
+        let inv = self.inv(&p[d as usize])?;
+        Some(Self::kpoly_trim(
+            p.iter().map(|c| self.mul(c, &inv)).collect(),
+        ))
+    }
+
+    /// Exact division `a / b` of `K`-polynomials in `x`; `None` if `b` does not
+    /// divide `a` evenly (or `b` is zero / has a non-invertible leading term).
+    pub fn kpoly_div_exact(&self, a: &[KElem], b: &[KElem]) -> Option<KPoly> {
+        let (q, r) = self.kpoly_divrem(a, b)?;
+        if Self::kdeg(&r) >= 0 {
+            return None; // nonzero remainder
+        }
+        Some(q)
+    }
+
+    /// Coefficient of `x^i` in a `K`-polynomial; the zero element for `i < 0` or
+    /// out of range.
+    pub fn kcoeff(p: &[KElem], i: i64) -> KElem {
+        if i < 0 {
+            return Self::k_zero();
+        }
+        p.get(i as usize).cloned().unwrap_or_else(Self::k_zero)
+    }
+
+    /// Equality of two `K`-polynomials in `x` (coefficient-wise after trimming).
+    pub fn kpoly_eq(a: &[KElem], b: &[KElem]) -> bool {
+        let a = Self::kpoly_trim(a.to_vec());
+        let b = Self::kpoly_trim(b.to_vec());
+        if a.len() != b.len() {
+            return false;
+        }
+        a.iter()
+            .zip(b.iter())
+            .all(|(x, y)| trim(x.clone()) == trim(y.clone()))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/alkahest-core/src/integrate/risch/number_field.rs
+++ b/alkahest-core/src/integrate/risch/number_field.rs
@@ -15,7 +15,7 @@
 //! algebraic-number *coefficients* (as opposed to constant factors) be handled.
 //!
 //! The three free functions [`poly_mod`], [`ext_gcd`], and [`mod_inverse`] are
-//! generic ℚ[x]-modulo-a-polynomial operations (the modulus need not be
+//! generic `ℚ[x]`-modulo-a-polynomial operations (the modulus need not be
 //! irreducible); they underpin both [`NumberField`] and the Hermite-reduction
 //! step in [`super::rational_integrate`].
 
@@ -28,12 +28,12 @@ use super::rational_rde::{poly_divrem, poly_sub};
 // Base field: ℚ[x] modular arithmetic (modulus need not be irreducible)
 // ---------------------------------------------------------------------------
 
-/// Remainder of `a mod m` in ℚ[x].
+/// Remainder of `a mod m` in `ℚ[x]`.
 pub fn poly_mod(a: &QPoly, m: &QPoly) -> QPoly {
     poly_divrem(a, m).1
 }
 
-/// Extended GCD over ℚ[x]: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
+/// Extended GCD over `ℚ[x]`: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
 pub fn ext_gcd(a: &QPoly, b: &QPoly) -> (QPoly, QPoly, QPoly) {
     let (mut old_r, mut r) = (trim(a.clone()), trim(b.clone()));
     let (mut old_s, mut s) = (poly_one(), poly_zero());

--- a/alkahest-core/src/integrate/risch/number_field.rs
+++ b/alkahest-core/src/integrate/risch/number_field.rs
@@ -221,6 +221,110 @@ impl NumberField {
 }
 
 // ---------------------------------------------------------------------------
+// K-element constructors and K-polynomial-in-x arithmetic
+// (used by the polynomial Risch DE over ℚ(α); see `poly_rde::solve_poly_rde_k`)
+// ---------------------------------------------------------------------------
+
+impl NumberField {
+    /// The zero `K`-element.
+    pub fn k_zero() -> KElem {
+        Vec::new()
+    }
+
+    /// Embed an integer into `K`.
+    pub fn from_int(&self, n: i64) -> KElem {
+        self.reduce(&vec![Rational::from(n)])
+    }
+
+    /// Embed a rational into `K`.
+    pub fn from_rational(&self, r: &Rational) -> KElem {
+        self.reduce(&vec![r.clone()])
+    }
+
+    /// `a + b` of two `K`-polynomials in `x`.
+    pub fn kpoly_add(&self, a: &[KElem], b: &[KElem]) -> KPoly {
+        let n = a.len().max(b.len());
+        let mut r = vec![Self::k_zero(); n];
+        for (i, c) in a.iter().enumerate() {
+            r[i] = self.add(&r[i], c);
+        }
+        for (i, c) in b.iter().enumerate() {
+            r[i] = self.add(&r[i], c);
+        }
+        Self::kpoly_trim(r)
+    }
+
+    /// `a − b` of two `K`-polynomials in `x`.
+    pub fn kpoly_sub(&self, a: &[KElem], b: &[KElem]) -> KPoly {
+        let n = a.len().max(b.len());
+        let mut r = vec![Self::k_zero(); n];
+        for (i, c) in a.iter().enumerate() {
+            r[i] = self.add(&r[i], c);
+        }
+        for (i, c) in b.iter().enumerate() {
+            r[i] = self.sub(&r[i], c);
+        }
+        Self::kpoly_trim(r)
+    }
+
+    /// Scale a `K`-polynomial in `x` by a `K`-element.
+    pub fn kpoly_scale(&self, p: &[KElem], s: &KElem) -> KPoly {
+        if Self::is_zero(s) {
+            return Vec::new();
+        }
+        Self::kpoly_trim(p.iter().map(|c| self.mul(c, s)).collect())
+    }
+
+    /// `a · b` of two `K`-polynomials in `x`.
+    pub fn kpoly_mul(&self, a: &[KElem], b: &[KElem]) -> KPoly {
+        if Self::kdeg(a) < 0 || Self::kdeg(b) < 0 {
+            return Vec::new();
+        }
+        let mut r = vec![Self::k_zero(); a.len() + b.len() - 1];
+        for (i, ca) in a.iter().enumerate() {
+            if Self::is_zero(ca) {
+                continue;
+            }
+            for (j, cb) in b.iter().enumerate() {
+                let p = self.mul(ca, cb);
+                r[i + j] = self.add(&r[i + j], &p);
+            }
+        }
+        Self::kpoly_trim(r)
+    }
+
+    /// `d/dx` of a `K`-polynomial in `x`.
+    pub fn kpoly_deriv(&self, p: &[KElem]) -> KPoly {
+        if p.len() <= 1 {
+            return Vec::new();
+        }
+        Self::kpoly_trim(
+            p[1..]
+                .iter()
+                .enumerate()
+                .map(|(i, c)| self.mul(&self.from_int(i as i64 + 1), c))
+                .collect(),
+        )
+    }
+
+    /// `∫ dx` of a `K`-polynomial in `x` (constant of integration 0).
+    pub fn kpoly_integrate(&self, p: &[KElem]) -> KPoly {
+        let p = Self::kpoly_trim(p.to_vec());
+        if p.is_empty() {
+            return Vec::new();
+        }
+        let mut r = vec![Self::k_zero()]; // constant term 0
+        for (i, c) in p.iter().enumerate() {
+            let inv = self
+                .inv(&self.from_int(i as i64 + 1))
+                .expect("nonzero integer is invertible in a number field");
+            r.push(self.mul(c, &inv));
+        }
+        Self::kpoly_trim(r)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -285,5 +389,36 @@ mod tests {
         // In ℚ[t]/(t²−1) (not a field), t−1 is a zero divisor → no inverse.
         let k = NumberField::new(vec![rat(-1), rat(0), rat(1)]);
         assert!(k.inv(&vec![rat(-1), rat(1)]).is_none());
+    }
+
+    #[test]
+    fn kpoly_mul_over_sqrt2() {
+        // (x + √2)·(x − √2) = x² − 2  over ℚ(√2).
+        let k = q_sqrt2();
+        let t = vec![rat(0), rat(1)]; // √2
+        let a = vec![t.clone(), vec![rat(1)]]; // √2 + x
+        let b = vec![k.neg(&t), vec![rat(1)]]; // −√2 + x
+        let p = k.kpoly_mul(&a, &b);
+        assert_eq!(NumberField::kdeg(&p), 2);
+        assert_eq!(trim(p[0].clone()), vec![rat(-2)]); // constant −2 (√2·−√2)
+        assert!(NumberField::is_zero(&p[1])); // x coefficient cancels
+        assert_eq!(trim(p[2].clone()), vec![rat(1)]); // x²
+    }
+
+    #[test]
+    fn kpoly_deriv_integrate_roundtrip() {
+        // d/dx ∫ (√2·x² + x) dx == √2·x² + x.
+        let k = q_sqrt2();
+        let t = vec![rat(0), rat(1)];
+        let p = vec![NumberField::k_zero(), vec![rat(1)], t.clone()]; // x + √2·x²
+        let integ = k.kpoly_integrate(&p);
+        let back = k.kpoly_deriv(&integ);
+        // Compare coefficient-wise (trimmed).
+        let p_t = NumberField::kpoly_trim(p);
+        let back_t = NumberField::kpoly_trim(back);
+        assert_eq!(p_t.len(), back_t.len());
+        for (a, b) in p_t.iter().zip(back_t.iter()) {
+            assert_eq!(trim(a.clone()), trim(b.clone()));
+        }
     }
 }

--- a/alkahest-core/src/integrate/risch/number_field.rs
+++ b/alkahest-core/src/integrate/risch/number_field.rs
@@ -1,0 +1,289 @@
+//! Algebraic number field `K = ℚ[t]/(q(t))` arithmetic.
+//!
+//! An element of `K` is represented as a [`QPoly`] of degree `< deg(q)` — a
+//! ℚ-polynomial in the field generator `t`, reduced modulo the minimal
+//! polynomial `q`.  A polynomial in a second variable `x` with coefficients in
+//! `K` is a [`KPoly`] (`Vec<KElem>`, ascending degree in `x`).
+//!
+//! This module concentrates the quotient-ring primitives that were previously
+//! private to [`super::rational_integrate`] (where they were introduced for the
+//! Lazard–Rioboo–Trager degree-≥3 `RootSum` log argument, computing
+//! `gcd_x(N − t·P', P)` in `ℚ(c)`).  They are factored out here so the same
+//! arithmetic can back the **ℚ(α)-coefficient RDE work** (Risch Gap E): the
+//! polynomial and rational Risch DE solvers currently operate over `ℚ` only;
+//! threading a [`NumberField`] through them is what lets `√2·exp(x)`-style
+//! algebraic-number *coefficients* (as opposed to constant factors) be handled.
+//!
+//! The three free functions [`poly_mod`], [`ext_gcd`], and [`mod_inverse`] are
+//! generic ℚ[x]-modulo-a-polynomial operations (the modulus need not be
+//! irreducible); they underpin both [`NumberField`] and the Hermite-reduction
+//! step in [`super::rational_integrate`].
+
+use rug::Rational;
+
+use super::poly_rde::{degree, poly_add, poly_mul, poly_one, poly_scale, poly_zero, trim, QPoly};
+use super::rational_rde::{poly_divrem, poly_sub};
+
+// ---------------------------------------------------------------------------
+// Base field: ℚ[x] modular arithmetic (modulus need not be irreducible)
+// ---------------------------------------------------------------------------
+
+/// Remainder of `a mod m` in ℚ[x].
+pub fn poly_mod(a: &QPoly, m: &QPoly) -> QPoly {
+    poly_divrem(a, m).1
+}
+
+/// Extended GCD over ℚ[x]: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
+pub fn ext_gcd(a: &QPoly, b: &QPoly) -> (QPoly, QPoly, QPoly) {
+    let (mut old_r, mut r) = (trim(a.clone()), trim(b.clone()));
+    let (mut old_s, mut s) = (poly_one(), poly_zero());
+    let (mut old_t, mut t) = (poly_zero(), poly_one());
+    while !r.is_empty() {
+        let (q, rem) = poly_divrem(&old_r, &r);
+        old_r = r;
+        r = rem;
+        let ns = poly_sub(&old_s, &poly_mul(&q, &s));
+        old_s = s;
+        s = ns;
+        let nt = poly_sub(&old_t, &poly_mul(&q, &t));
+        old_t = t;
+        t = nt;
+    }
+    let dg = degree(&old_r);
+    if dg < 0 {
+        return (poly_zero(), old_s, old_t);
+    }
+    let inv = Rational::from(1) / old_r[dg as usize].clone();
+    (
+        poly_scale(&old_r, &inv),
+        poly_scale(&old_s, &inv),
+        poly_scale(&old_t, &inv),
+    )
+}
+
+/// Inverse of `w` modulo `v` (requires `gcd(w, v) = 1`), else `None`.
+pub fn mod_inverse(w: &QPoly, v: &QPoly) -> Option<QPoly> {
+    let (g, s, _t) = ext_gcd(w, v);
+    if degree(&g) != 0 {
+        return None; // not coprime
+    }
+    Some(poly_mod(&s, v))
+}
+
+// ---------------------------------------------------------------------------
+// Number field K = ℚ[t]/(q)
+// ---------------------------------------------------------------------------
+
+/// An element of `K` — a ℚ-polynomial in the generator `t`, reduced mod `q`.
+pub type KElem = QPoly;
+
+/// A polynomial in `x` over `K` (ascending degree in `x`; each coefficient is a
+/// [`KElem`]).
+pub type KPoly = Vec<KElem>;
+
+/// A simple algebraic number field `K = ℚ[t]/(q(t))`.
+///
+/// `q` should be squarefree (irreducible for a genuine field; squarefree is
+/// enough for the residue-by-residue Lazard–Rioboo–Trager use, where any
+/// non-invertible leading coefficient simply makes an operation return `None`).
+#[derive(Clone, Debug)]
+pub struct NumberField {
+    modulus: QPoly,
+}
+
+impl NumberField {
+    /// Build `K = ℚ[t]/(modulus)`.
+    pub fn new(modulus: QPoly) -> Self {
+        Self {
+            modulus: trim(modulus),
+        }
+    }
+
+    /// The defining (minimal) polynomial `q(t)`.
+    pub fn modulus(&self) -> &QPoly {
+        &self.modulus
+    }
+
+    /// Field degree `[K : ℚ] = deg q`.
+    pub fn degree(&self) -> i64 {
+        degree(&self.modulus)
+    }
+
+    /// Reduce an arbitrary ℚ-polynomial in `t` into canonical `K`-element form.
+    pub fn reduce(&self, a: &KElem) -> KElem {
+        poly_mod(a, &self.modulus)
+    }
+
+    /// `a + b` in `K`.
+    pub fn add(&self, a: &KElem, b: &KElem) -> KElem {
+        self.reduce(&poly_add(a, b))
+    }
+
+    /// `a − b` in `K`.
+    pub fn sub(&self, a: &KElem, b: &KElem) -> KElem {
+        self.reduce(&poly_sub(a, b))
+    }
+
+    /// `a · b` in `K`.
+    pub fn mul(&self, a: &KElem, b: &KElem) -> KElem {
+        self.reduce(&poly_mul(a, b))
+    }
+
+    /// `−a` in `K`.
+    pub fn neg(&self, a: &KElem) -> KElem {
+        self.reduce(&poly_scale(a, &Rational::from(-1)))
+    }
+
+    /// Multiplicative inverse `a⁻¹` in `K`, or `None` when `a` is a zero divisor
+    /// (e.g. shares a factor with a non-irreducible modulus) or zero.
+    pub fn inv(&self, a: &KElem) -> Option<KElem> {
+        mod_inverse(a, &self.modulus)
+    }
+
+    /// Is the `K`-element zero?
+    pub fn is_zero(a: &KElem) -> bool {
+        trim(a.clone()).is_empty()
+    }
+
+    // -- polynomials in x over K --
+
+    /// Degree (in `x`) of a `K`-polynomial; `-1` for the zero polynomial.
+    pub fn kdeg(p: &[KElem]) -> i64 {
+        let mut d = p.len() as i64 - 1;
+        while d >= 0 && Self::is_zero(&p[d as usize]) {
+            d -= 1;
+        }
+        d
+    }
+
+    /// Drop trailing zero `K`-coefficients.
+    pub fn kpoly_trim(mut p: KPoly) -> KPoly {
+        while p.last().is_some_and(Self::is_zero) {
+            p.pop();
+        }
+        p
+    }
+
+    /// Euclidean division of `K`-polynomials in `x`; returns `(quot, rem)` with
+    /// `a = quot·b + rem` and `deg_x rem < deg_x b`.  `None` if `b` is zero or a
+    /// leading coefficient is not invertible in `K`.
+    pub fn kpoly_divrem(&self, a: &[KElem], b: &[KElem]) -> Option<(KPoly, KPoly)> {
+        let bd = Self::kdeg(b);
+        if bd < 0 {
+            return None; // division by zero
+        }
+        let lead_inv = self.inv(&b[bd as usize])?;
+        let mut r = Self::kpoly_trim(a.to_vec());
+        let ad = Self::kdeg(&r);
+        if ad < bd {
+            return Some((vec![], r));
+        }
+        let mut quot = vec![poly_zero(); (ad - bd + 1) as usize];
+        loop {
+            let rd = Self::kdeg(&r);
+            if rd < bd {
+                break;
+            }
+            let coeff = self.mul(&r[rd as usize], &lead_inv);
+            let shift = (rd - bd) as usize;
+            for (i, bi) in b.iter().enumerate() {
+                if shift + i < r.len() {
+                    r[shift + i] = self.sub(&r[shift + i], &self.mul(&coeff, bi));
+                }
+            }
+            quot[shift] = coeff;
+            r = Self::kpoly_trim(r);
+            if r.is_empty() {
+                break;
+            }
+        }
+        Some((Self::kpoly_trim(quot), r))
+    }
+
+    /// Monic (in `x`) GCD of two `K`-polynomials.  `None` if both are zero or a
+    /// leading coefficient is not invertible in `K`.
+    pub fn kpoly_gcd(&self, a: &[KElem], b: &[KElem]) -> Option<KPoly> {
+        let mut a = Self::kpoly_trim(a.to_vec());
+        let mut b = Self::kpoly_trim(b.to_vec());
+        while Self::kdeg(&b) >= 0 {
+            let (_, rem) = self.kpoly_divrem(&a, &b)?;
+            a = b;
+            b = rem;
+        }
+        let ad = Self::kdeg(&a);
+        if ad < 0 {
+            return None;
+        }
+        // Make monic in x.
+        let lead_inv = self.inv(&a[ad as usize])?;
+        Some(a.iter().map(|c| self.mul(c, &lead_inv)).collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rat(n: i64) -> Rational {
+        Rational::from(n)
+    }
+    fn frac(n: i64, d: i64) -> Rational {
+        Rational::from((n, d))
+    }
+
+    /// K = ℚ(√2) = ℚ[t]/(t²−2).
+    fn q_sqrt2() -> NumberField {
+        NumberField::new(vec![rat(-2), rat(0), rat(1)])
+    }
+
+    #[test]
+    fn base_field_mod_inverse() {
+        // In ℚ[x]/(x²+1), x·x = −1, so x⁻¹ = −x.
+        let m = vec![rat(1), rat(0), rat(1)]; // x²+1
+        let x = vec![rat(0), rat(1)];
+        let inv = mod_inverse(&x, &m).expect("x is a unit mod x²+1");
+        // x · inv ≡ 1.
+        assert_eq!(trim(poly_mod(&poly_mul(&x, &inv), &m)), vec![rat(1)]);
+    }
+
+    #[test]
+    fn sqrt2_arithmetic() {
+        let k = q_sqrt2();
+        let t = vec![rat(0), rat(1)]; // √2
+                                      // (1+√2)² = 3 + 2√2.
+        let one_plus = k.add(&vec![rat(1)], &t);
+        let sq = k.mul(&one_plus, &one_plus);
+        assert_eq!(trim(sq), vec![rat(3), rat(2)]);
+        // (√2)⁻¹ = √2/2.
+        let inv = k.inv(&t).expect("√2 invertible");
+        assert_eq!(trim(inv.clone()), vec![rat(0), frac(1, 2)]);
+        assert_eq!(trim(k.mul(&t, &inv)), vec![rat(1)]);
+    }
+
+    #[test]
+    fn kpoly_gcd_splits_over_sqrt2() {
+        // Over ℚ(√2), gcd_x(x²−2, x−√2) = x−√2.
+        let k = q_sqrt2();
+        let neg_t = k.neg(&vec![rat(0), rat(1)]); // −√2
+                                                  // a = x²−2  (coeffs in K, constants): [−2, 0, 1].
+        let a: KPoly = vec![vec![rat(-2)], poly_zero(), vec![rat(1)]];
+        // b = x−√2: [−√2, 1].
+        let b: KPoly = vec![neg_t.clone(), vec![rat(1)]];
+        let g = k.kpoly_gcd(&a, &b).expect("gcd exists");
+        // Monic in x: [−√2, 1].
+        assert_eq!(NumberField::kdeg(&g), 1);
+        assert_eq!(trim(g[0].clone()), trim(neg_t));
+        assert_eq!(trim(g[1].clone()), vec![rat(1)]);
+    }
+
+    #[test]
+    fn non_unit_leading_coeff_is_none() {
+        // In ℚ[t]/(t²−1) (not a field), t−1 is a zero divisor → no inverse.
+        let k = NumberField::new(vec![rat(-1), rat(0), rat(1)]);
+        assert!(k.inv(&vec![rat(-1), rat(1)]).is_none());
+    }
+}

--- a/alkahest-core/src/integrate/risch/poly_rde.rs
+++ b/alkahest-core/src/integrate/risch/poly_rde.rs
@@ -17,6 +17,8 @@
 
 use rug::Rational;
 
+use super::number_field::{KPoly, NumberField};
+
 /// A polynomial over ℚ, stored as coefficient vector in ascending degree order.
 /// `poly[i]` is the coefficient of `x^i`.  The zero polynomial is represented
 /// as the empty vector.
@@ -244,6 +246,109 @@ pub fn solve_poly_rde(k: i64, deta: &[Rational], h: &[Rational]) -> Option<QPoly
     } else {
         None
     }
+}
+
+// ---------------------------------------------------------------------------
+// Polynomial RDE over a number field K = ℚ(α)  (Risch Gap E)
+// ---------------------------------------------------------------------------
+
+/// Solve the polynomial Risch Differential Equation `y' + k·Dη·y = h` with
+/// coefficients in a number field `K = ℚ(α)` (represented by `field`).
+///
+/// This mirrors [`solve_poly_rde`] exactly — same degree analysis and downward
+/// coefficient sweep — but every coefficient operation goes through `field`
+/// instead of ℚ.  It handles exp-tower integrands whose coefficient is a
+/// polynomial in `x` with algebraic-number coefficients that cannot be split off
+/// as a constant factor (e.g. `∫ (x + √2)·exp(x) dx`).
+///
+/// `deta` and `h` are `K`-polynomials in `x` (ascending degree).  Returns the
+/// unique `K`-polynomial solution, or `None` when none exists (which certifies a
+/// non-elementary integral over `K`, just as in the ℚ case).
+pub fn solve_poly_rde_k(field: &NumberField, k: i64, deta: &KPoly, h: &KPoly) -> Option<KPoly> {
+    let deta = NumberField::kpoly_trim(deta.clone());
+    let h = NumberField::kpoly_trim(h.clone());
+
+    // h = 0 → y = 0.
+    if h.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let deg_deta = NumberField::kdeg(&deta);
+
+    // Dη = 0: equation is y' = h; solution is ∫ h dx.
+    if deg_deta < 0 {
+        return Some(field.kpoly_integrate(&h));
+    }
+
+    assert!(k != 0, "solve_poly_rde_k called with k=0: caller bug");
+
+    let deg_h = NumberField::kdeg(&h);
+    let m_signed = deg_h - deg_deta;
+    if m_signed < 0 {
+        return None; // degree equation has no solution
+    }
+    let m = m_signed as usize;
+
+    let kk = field.from_int(k);
+    let lc = deta[deg_deta as usize].clone(); // leading coeff of Dη
+    let divisor_inv = field.inv(&field.mul(&kk, &lc))?;
+
+    let mut y: KPoly = vec![NumberField::k_zero(); m + 1];
+    for j in (0..=m).rev() {
+        let target_deg = j as i64 + deg_deta;
+
+        // RHS: h coefficient at target_deg.
+        let mut rhs = if (target_deg as usize) < h.len() {
+            h[target_deg as usize].clone()
+        } else {
+            NumberField::k_zero()
+        };
+
+        // Subtract y' contribution: (target_deg+1)·y[target_deg+1].
+        let deriv_idx = target_deg as usize + 1;
+        if deriv_idx <= m {
+            let coef = field.from_int(target_deg + 1);
+            rhs = field.sub(&rhs, &field.mul(&coef, &y[deriv_idx]));
+        }
+
+        // Subtract k·Dη[i]·y[l] for i < deg_deta (already-known y[l], l > j).
+        for i in 0..deg_deta as usize {
+            let deta_i = deta.get(i).cloned().unwrap_or_else(NumberField::k_zero);
+            let l = (target_deg - i as i64) as usize;
+            if l <= m && l != j {
+                let term = field.mul(&field.mul(&kk, &deta_i), &y[l]);
+                rhs = field.sub(&rhs, &term);
+            }
+        }
+
+        // Solve k·lc(Dη)·y[j] = rhs.
+        y[j] = field.mul(&rhs, &divisor_inv);
+    }
+
+    let y = NumberField::kpoly_trim(y);
+
+    // Verify y' + k·Dη·y == h (guards against an under-sized degree bound and the
+    // over-determined lower-degree equations).
+    let yp = field.kpoly_deriv(&y);
+    let kdeta_y = field.kpoly_scale(&field.kpoly_mul(&deta, &y), &kk);
+    let lhs = field.kpoly_add(&yp, &kdeta_y);
+    if kpoly_eq(&lhs, &h) {
+        Some(y)
+    } else {
+        None
+    }
+}
+
+/// Equality of two `K`-polynomials in `x` (coefficient-wise after trimming).
+fn kpoly_eq(a: &KPoly, b: &KPoly) -> bool {
+    let a = NumberField::kpoly_trim(a.clone());
+    let b = NumberField::kpoly_trim(b.clone());
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .all(|(x, y)| trim(x.clone()) == trim(y.clone()))
 }
 
 /// Compare two polynomials (after trimming) for equality.
@@ -603,5 +708,68 @@ mod tests {
                 );
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Polynomial RDE over a number field K = ℚ(α)  (Gap E)
+    // -----------------------------------------------------------------------
+
+    /// ℚ(√2) = ℚ[t]/(t²−2).
+    fn field_sqrt2() -> NumberField {
+        NumberField::new(vec![rat(-2), rat(0), rat(1)])
+    }
+
+    // ∫ (x + √2)·exp(x) dx = (x + √2 − 1)·exp(x):  y' + y = x + √2  →  y = x + √2 − 1.
+    #[test]
+    fn rde_k_linear_sqrt2() {
+        let field = field_sqrt2();
+        let deta: KPoly = vec![vec![rat(1)]]; // Dη = 1 (constant)
+        let h: KPoly = vec![vec![rat(0), rat(1)], vec![rat(1)]]; // √2 + x
+        let y = solve_poly_rde_k(&field, 1, &deta, &h).expect("elementary");
+        // y = x + (√2 − 1): y[0] = −1 + √2, y[1] = 1.
+        assert_eq!(trim(y[0].clone()), vec![rat(-1), rat(1)]);
+        assert_eq!(trim(y[1].clone()), vec![rat(1)]);
+    }
+
+    // ∫ (√3·x² + x)·exp(x) dx: y' + y = √3·x² + x, solvable over ℚ(√3).
+    #[test]
+    fn rde_k_quadratic_sqrt3() {
+        let field = NumberField::new(vec![rat(-3), rat(0), rat(1)]);
+        let deta: KPoly = vec![vec![rat(1)]]; // Dη = 1
+                                              // h = √3·x² + x: x^0=0, x^1=1, x^2=√3.
+        let h: KPoly = vec![NumberField::k_zero(), vec![rat(1)], vec![rat(0), rat(1)]];
+        let y = solve_poly_rde_k(&field, 1, &deta, &h).expect("elementary");
+        // Check y' + y == h by re-deriving.
+        let yp = field.kpoly_deriv(&y);
+        let lhs = field.kpoly_add(&yp, &y);
+        let lhs = NumberField::kpoly_trim(lhs);
+        let h = NumberField::kpoly_trim(h);
+        assert_eq!(lhs.len(), h.len());
+        for (a, b) in lhs.iter().zip(h.iter()) {
+            assert_eq!(trim(a.clone()), trim(b.clone()));
+        }
+    }
+
+    // ∫ (x + √2)·exp(x²) dx: y' + 2x·y = x + √2 has no polynomial solution
+    // (the √2·exp(x²) part is non-elementary) → None.
+    #[test]
+    fn rde_k_nonelementary_sqrt2_gaussian() {
+        let field = field_sqrt2();
+        let deta: KPoly = vec![NumberField::k_zero(), vec![rat(2)]]; // 2x
+        let h: KPoly = vec![vec![rat(0), rat(1)], vec![rat(1)]]; // √2 + x
+        assert!(solve_poly_rde_k(&field, 1, &deta, &h).is_none());
+    }
+
+    // Sanity: a ℚ-only RDE solved through the K solver matches the ℚ solver.
+    // ∫ x²·exp(x) dx: y' + y = x² → y = x² − 2x + 2.
+    #[test]
+    fn rde_k_reduces_to_rational_case() {
+        let field = field_sqrt2();
+        let deta: KPoly = vec![vec![rat(1)]];
+        let h: KPoly = vec![NumberField::k_zero(), NumberField::k_zero(), vec![rat(1)]]; // x²
+        let y = solve_poly_rde_k(&field, 1, &deta, &h).expect("elementary");
+        assert_eq!(trim(y[0].clone()), vec![rat(2)]);
+        assert_eq!(trim(y[1].clone()), vec![rat(-2)]);
+        assert_eq!(trim(y[2].clone()), vec![rat(1)]);
     }
 }

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -44,6 +44,7 @@ use rug::{Integer, Rational};
 use crate::kernel::{Domain, ExprId, ExprPool};
 use crate::poly::UniPoly;
 
+use super::number_field::{ext_gcd, mod_inverse, poly_mod, NumberField};
 use super::poly_rde::{
     degree, poly_add, poly_deriv, poly_integrate, poly_mul, poly_one, poly_scale, poly_zero,
     qpoly_to_expr, rational_to_expr, trim, QPoly,
@@ -127,47 +128,8 @@ pub fn try_integrate_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Opt
 // Hermite reduction (Bronstein §2.2)
 // ---------------------------------------------------------------------------
 
-/// Remainder of `a mod m`.
-fn poly_mod(a: &QPoly, m: &QPoly) -> QPoly {
-    poly_divrem(a, m).1
-}
-
-/// Extended GCD over ℚ[x]: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
-fn ext_gcd(a: &QPoly, b: &QPoly) -> (QPoly, QPoly, QPoly) {
-    let (mut old_r, mut r) = (trim(a.clone()), trim(b.clone()));
-    let (mut old_s, mut s) = (poly_one(), poly_zero());
-    let (mut old_t, mut t) = (poly_zero(), poly_one());
-    while !r.is_empty() {
-        let (q, rem) = poly_divrem(&old_r, &r);
-        old_r = r;
-        r = rem;
-        let ns = poly_sub(&old_s, &poly_mul(&q, &s));
-        old_s = s;
-        s = ns;
-        let nt = poly_sub(&old_t, &poly_mul(&q, &t));
-        old_t = t;
-        t = nt;
-    }
-    let dg = degree(&old_r);
-    if dg < 0 {
-        return (poly_zero(), old_s, old_t);
-    }
-    let inv = Rational::from(1) / old_r[dg as usize].clone();
-    (
-        poly_scale(&old_r, &inv),
-        poly_scale(&old_s, &inv),
-        poly_scale(&old_t, &inv),
-    )
-}
-
-/// Inverse of `w` modulo `v` (requires `gcd(w, v) = 1`), else `None`.
-fn mod_inverse(w: &QPoly, v: &QPoly) -> Option<QPoly> {
-    let (g, s, _t) = ext_gcd(w, v);
-    if degree(&g) != 0 {
-        return None; // not coprime
-    }
-    Some(poly_mod(&s, v))
-}
+// The ℚ[x] modular helpers `poly_mod`, `ext_gcd`, and `mod_inverse` live in
+// [`super::number_field`] (shared with the number-field arithmetic below).
 
 /// Yun squarefree factorization of a monic polynomial: returns `(Vᵢ, i)` for
 /// each non-constant `Vᵢ`, with `f = ∏ Vᵢ^i` and the `Vᵢ` squarefree & coprime.
@@ -439,89 +401,10 @@ fn resultant_param_poly(
     )
 }
 
-// --- Number-field K = ℚ[t]/Q arithmetic (elements are QPolys reduced mod Q) ---
-
-fn k_mul(a: &QPoly, b: &QPoly, q: &QPoly) -> QPoly {
-    poly_mod(&poly_mul(a, b), q)
-}
-fn k_sub(a: &QPoly, b: &QPoly, q: &QPoly) -> QPoly {
-    poly_mod(&poly_sub(a, b), q)
-}
-fn k_is_zero(a: &QPoly) -> bool {
-    trim(a.clone()).is_empty()
-}
-
-/// Degree (in x) of a K-polynomial (coefficients are K-elements).
-fn kdeg(p: &[QPoly]) -> i64 {
-    let mut d = p.len() as i64 - 1;
-    while d >= 0 && k_is_zero(&p[d as usize]) {
-        d -= 1;
-    }
-    d
-}
-
-fn kpoly_trim(mut p: Vec<QPoly>) -> Vec<QPoly> {
-    while p.last().is_some_and(k_is_zero) {
-        p.pop();
-    }
-    p
-}
-
-/// Euclidean division of K-polynomials in `x`; returns `(quot, rem)`.
-fn kpoly_divrem(a: &[QPoly], b: &[QPoly], q: &QPoly) -> Option<(Vec<QPoly>, Vec<QPoly>)> {
-    let bd = kdeg(b);
-    if bd < 0 {
-        return None; // division by zero
-    }
-    let lead_inv = mod_inverse(&b[bd as usize], q)?;
-    let mut r = kpoly_trim(a.to_vec());
-    let ad = kdeg(&r);
-    if ad < bd {
-        return Some((vec![], r));
-    }
-    let mut quot = vec![poly_zero(); (ad - bd + 1) as usize];
-    loop {
-        let rd = kdeg(&r);
-        if rd < bd {
-            break;
-        }
-        let coeff = k_mul(&r[rd as usize], &lead_inv, q);
-        let shift = (rd - bd) as usize;
-        for (i, bi) in b.iter().enumerate() {
-            if shift + i < r.len() {
-                r[shift + i] = k_sub(&r[shift + i], &k_mul(&coeff, bi, q), q);
-            }
-        }
-        quot[shift] = coeff;
-        r = kpoly_trim(r);
-        if r.is_empty() {
-            break;
-        }
-    }
-    Some((kpoly_trim(quot), r))
-}
-
-/// Monic GCD (in `x`) of two K-polynomials over `K = ℚ[t]/Q`.
-fn kpoly_gcd(a: &[QPoly], b: &[QPoly], q: &QPoly) -> Option<Vec<QPoly>> {
-    let mut a = kpoly_trim(a.to_vec());
-    let mut b = kpoly_trim(b.to_vec());
-    while kdeg(&b) >= 0 {
-        let (_, rem) = kpoly_divrem(&a, &b, q)?;
-        a = b;
-        b = rem;
-    }
-    let ad = kdeg(&a);
-    if ad < 0 {
-        return None;
-    }
-    // Make monic in x.
-    let lead_inv = mod_inverse(&a[ad as usize], q)?;
-    Some(a.iter().map(|c| k_mul(c, &lead_inv, q)).collect())
-}
-
 /// The Lazard–Rioboo–Trager log argument `S(t, x) = gcd_x(num − t·dprime, d)`
-/// computed over `K = ℚ[t]/Q`, returned as a symbolic polynomial in `x` whose
-/// coefficients are expressions in the root symbol `rvar`.
+/// computed over the number field `K = ℚ[t]/Q` (see [`super::number_field`]),
+/// returned as a symbolic polynomial in `x` whose coefficients are expressions
+/// in the root symbol `rvar`.
 fn alg_log_argument(
     num: &QPoly,
     dprime: &QPoly,
@@ -531,13 +414,14 @@ fn alg_log_argument(
     rvar: ExprId,
     pool: &ExprPool,
 ) -> Option<ExprId> {
+    let k = NumberField::new(q.clone());
     let width = (degree(num).max(degree(dprime)) + 1).max(0) as usize;
     // A = num − t·dprime  (K-poly in x): A[i] = num[i] − dprime[i]·t.
     let a: Vec<QPoly> = (0..width)
         .map(|i| {
             let ni = coeff_at(num, i);
             let ppi = coeff_at(dprime, i);
-            poly_mod(&vec![ni, -ppi], q)
+            k.reduce(&vec![ni, -ppi])
         })
         .collect();
     // B = d  (K-poly in x): each coefficient is a K-constant.
@@ -552,14 +436,14 @@ fn alg_log_argument(
         })
         .collect();
 
-    let s = kpoly_gcd(&a, &b, q)?;
-    if kdeg(&s) < 1 {
+    let s = k.kpoly_gcd(&a, &b)?;
+    if NumberField::kdeg(&s) < 1 {
         return None; // no nontrivial common factor — not a valid residue
     }
     // Build Σ_i coeff_i(rvar) · x^i.
     let mut terms: Vec<ExprId> = Vec::new();
     for (i, c) in s.iter().enumerate() {
-        if k_is_zero(c) {
+        if NumberField::is_zero(c) {
             continue;
         }
         let c_expr = qpoly_to_expr(c, rvar, pool);

--- a/alkahest-core/src/integrate/risch/rational_rde.rs
+++ b/alkahest-core/src/integrate/risch/rational_rde.rs
@@ -40,6 +40,7 @@
 
 use rug::Rational;
 
+use super::number_field::{KElem, KPoly, NumberField};
 use super::poly_rde::{
     degree, poly_add, poly_deriv, poly_mul, poly_one, poly_scale, poly_zero, trim, QPoly,
 };
@@ -317,6 +318,191 @@ pub fn solve_rational_rde(f: &QPoly, c_num: &QPoly, c_den: &QPoly) -> Option<(QP
 }
 
 // ---------------------------------------------------------------------------
+// Rational RDE over a number field K = ℚ(α)  (Risch Gap E, rational case)
+// ---------------------------------------------------------------------------
+
+/// Solve `v' + f·v = c_num/c_den` for `v ∈ K(x)`, `K = ℚ(α)`.
+///
+/// This is the number-field analogue of [`solve_rational_rde`]: identical
+/// algorithm — denominator bound `E = gcd(B, B')`, ansatz `v = N/E`, the linear
+/// identity `Σ_j n_j·P_j = C·E`, and the final substitution check — with every
+/// coefficient operation routed through `field` instead of ℚ.  `f`, `c_num`,
+/// `c_den` are `K`-polynomials in `x`.
+///
+/// In the exp tower `f = k·η'` is a polynomial (no poles), so the `E = gcd(B,B')`
+/// bound is exact and an inconsistent/over-determined system correctly certifies
+/// a non-elementary integral over `K` (the residual simple poles are the Ei/Li
+/// part the exp tower cannot express).
+pub fn solve_rational_rde_k(
+    field: &NumberField,
+    f: &KPoly,
+    c_num: &KPoly,
+    c_den: &KPoly,
+) -> Option<(KPoly, KPoly)> {
+    let c_num = NumberField::kpoly_trim(c_num.clone());
+    let c_den = NumberField::kpoly_trim(c_den.clone());
+    let one: KPoly = vec![field.from_int(1)];
+
+    // c = 0 → v = 0.
+    if c_num.is_empty() {
+        return Some((Vec::new(), one));
+    }
+    if c_den.is_empty() {
+        return None; // division by zero — malformed input
+    }
+
+    // Reduce c = C/B to lowest terms with B monic.
+    let g = field.kpoly_gcd(&c_num, &c_den)?;
+    let big_c = field.kpoly_div_exact(&c_num, &g)?;
+    let b_raw = field.kpoly_div_exact(&c_den, &g)?;
+    let bd = NumberField::kdeg(&b_raw);
+    let lead_inv = field.inv(&b_raw[bd as usize])?;
+    let big_b = field.kpoly_scale(&b_raw, &lead_inv);
+    let big_c = field.kpoly_scale(&big_c, &lead_inv);
+
+    // Denominator bound for v: E = gcd(B, B'). G = B / E.
+    let bprime = field.kpoly_deriv(&big_b);
+    let e_poly = field.kpoly_gcd(&big_b, &bprime)?;
+    let g_poly = field.kpoly_div_exact(&big_b, &e_poly)?;
+    let eprime = field.kpoly_deriv(&e_poly);
+
+    // Polynomial multipliers of the identity  Σ_j n_j·P_j = C·E,
+    //   P_j = G·E·(j x^{j-1}) − G·E'·x^j + G·E·f·x^j.
+    let ge = field.kpoly_mul(&g_poly, &e_poly);
+    let gep = field.kpoly_mul(&g_poly, &eprime);
+    let gef = field.kpoly_mul(&ge, f);
+    let target = field.kpoly_mul(&big_c, &e_poly);
+
+    // Degree bound for N (= numerator of v = N/E).
+    let deg_b = NumberField::kdeg(&big_b);
+    let deg_c = NumberField::kdeg(&big_c);
+    let deg_e = NumberField::kdeg(&e_poly).max(0);
+    let deg_f = NumberField::kdeg(f).max(0);
+    let poly_part = (deg_c - deg_b).max(0);
+    let dbound = (deg_e + poly_part.max(deg_f) + 2).max(0) as usize;
+    let cols = dbound + 1;
+
+    let max_deg = (NumberField::kdeg(&gef) + dbound as i64)
+        .max(NumberField::kdeg(&ge) + dbound as i64)
+        .max(NumberField::kdeg(&gep) + dbound as i64)
+        .max(NumberField::kdeg(&target))
+        .max(0) as usize;
+    let n_rows = max_deg + 1;
+
+    // Assemble M·n = target over K.
+    let mut mat = vec![vec![NumberField::k_zero(); cols]; n_rows];
+    for (d, row) in mat.iter_mut().enumerate() {
+        let d = d as i64;
+        for (j, cell) in row.iter_mut().enumerate() {
+            let jj = j as i64;
+            // [G·E·(j x^{j-1})]_d = j · (G·E)[d-j+1]
+            let mut v = field.mul(&field.from_int(jj), &NumberField::kcoeff(&ge, d - jj + 1));
+            // − [G·E'·x^j]_d = −(G·E')[d-j]
+            v = field.sub(&v, &NumberField::kcoeff(&gep, d - jj));
+            // + [G·E·f·x^j]_d = (G·E·f)[d-j]
+            v = field.add(&v, &NumberField::kcoeff(&gef, d - jj));
+            *cell = v;
+        }
+    }
+    let rhs: Vec<KElem> = (0..n_rows)
+        .map(|d| NumberField::kcoeff(&target, d as i64))
+        .collect();
+
+    let solution = solve_linear_system_k(field, mat, rhs, cols)?;
+    let n_poly = NumberField::kpoly_trim(solution);
+
+    // Verify (N'E − N E' + f N E)·B == C·E².
+    let np = field.kpoly_deriv(&n_poly);
+    let lhs = field.kpoly_mul(
+        &field.kpoly_add(
+            &field.kpoly_sub(
+                &field.kpoly_mul(&np, &e_poly),
+                &field.kpoly_mul(&n_poly, &eprime),
+            ),
+            &field.kpoly_mul(&field.kpoly_mul(f, &n_poly), &e_poly),
+        ),
+        &big_b,
+    );
+    let rhs_check = field.kpoly_mul(&big_c, &field.kpoly_mul(&e_poly, &e_poly));
+    if !NumberField::kpoly_eq(&lhs, &rhs_check) {
+        return None;
+    }
+
+    // Reduce v = N/E to lowest terms.
+    if n_poly.is_empty() {
+        return Some((Vec::new(), one));
+    }
+    let gve = field.kpoly_gcd(&n_poly, &e_poly)?;
+    let num = field.kpoly_div_exact(&n_poly, &gve)?;
+    let den = field.kpoly_monic(&field.kpoly_div_exact(&e_poly, &gve)?)?;
+    Some((num, den))
+}
+
+/// Solve `mat · x = rhs` over a number field `K` by Gauss–Jordan elimination.
+/// Returns a particular solution (free variables 0), or `None` if inconsistent.
+fn solve_linear_system_k(
+    field: &NumberField,
+    mut mat: Vec<Vec<KElem>>,
+    mut rhs: Vec<KElem>,
+    cols: usize,
+) -> Option<Vec<KElem>> {
+    let rows = mat.len();
+    let mut pivot_row_of_col: Vec<Option<usize>> = vec![None; cols];
+    let mut row = 0usize;
+
+    for col in 0..cols {
+        if row >= rows {
+            break;
+        }
+        let Some(sel) = (row..rows).find(|&r| !NumberField::is_zero(&mat[r][col])) else {
+            continue;
+        };
+        mat.swap(row, sel);
+        rhs.swap(row, sel);
+
+        // Normalise the pivot row.
+        let piv_inv = field.inv(&mat[row][col])?;
+        for cell in mat[row][col..cols].iter_mut() {
+            *cell = field.mul(cell, &piv_inv);
+        }
+        rhs[row] = field.mul(&rhs[row], &piv_inv);
+
+        // Eliminate the column from every other row.
+        let pivot_row = mat[row].clone();
+        let pivot_rhs = rhs[row].clone();
+        for r in 0..rows {
+            if r != row && !NumberField::is_zero(&mat[r][col]) {
+                let factor = mat[r][col].clone();
+                for (cell, pv) in mat[r][col..cols]
+                    .iter_mut()
+                    .zip(pivot_row[col..cols].iter())
+                {
+                    *cell = field.sub(cell, &field.mul(&factor, pv));
+                }
+                rhs[r] = field.sub(&rhs[r], &field.mul(&factor, &pivot_rhs));
+            }
+        }
+        pivot_row_of_col[col] = Some(row);
+        row += 1;
+    }
+
+    // Consistency: an all-zero row with nonzero rhs has no solution.
+    for r in 0..rows {
+        if mat[r].iter().all(NumberField::is_zero) && !NumberField::is_zero(&rhs[r]) {
+            return None;
+        }
+    }
+
+    let mut x = vec![NumberField::k_zero(); cols];
+    for (col, pr) in pivot_row_of_col.iter().enumerate() {
+        if let Some(pr) = pr {
+            x[col] = rhs[*pr].clone();
+        }
+    }
+    Some(x)
+}
+
+// ---------------------------------------------------------------------------
 // Conversion: ExprId → rational function (numerator, denominator) over ℚ
 // ---------------------------------------------------------------------------
 
@@ -476,5 +662,64 @@ mod tests {
         let lhs = poly_mul(&n, &vec![rat(0), rat(0), rat(1)]);
         let rhs = poly_mul(&d, &vec![rat(-1), rat(1)]);
         assert!(polys_equal(&lhs, &rhs), "n={n:?} d={d:?}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Rational RDE over a number field K = ℚ(√d)  (Gap E, rational case)
+    // -----------------------------------------------------------------------
+
+    /// ℚ(√2) = ℚ[t]/(t²−2).
+    fn field_sqrt2() -> NumberField {
+        NumberField::new(vec![rat(-2), rat(0), rat(1)])
+    }
+
+    /// A K-constant from a rational.
+    fn kc(field: &NumberField, n: i64) -> KElem {
+        field.from_int(n)
+    }
+
+    // ∫ (x − √2 − 1)/(x − √2)² · exp(x) dx = exp(x)/(x − √2).
+    // RDE: v' + v = (x−√2−1)/(x−√2)²  →  v = 1/(x − √2).
+    #[test]
+    fn rational_rde_k_elementary_sqrt2() {
+        let field = field_sqrt2();
+        let f: KPoly = vec![kc(&field, 1)]; // f = 1 (η = x, k = 1)
+        let sqrt2 = vec![rat(0), rat(1)]; // √2 as a K-element
+                                          // c_num = x − √2 − 1: x^0 = −√2 − 1, x^1 = 1.
+        let c0 = field.sub(&field.neg(&sqrt2), &kc(&field, 1));
+        let c_num: KPoly = vec![c0, kc(&field, 1)];
+        // c_den = (x − √2)² = x² − 2√2·x + 2.
+        let base: KPoly = vec![field.neg(&sqrt2), kc(&field, 1)]; // x − √2
+        let c_den = field.kpoly_mul(&base, &base);
+
+        let (vn, vd) = solve_rational_rde_k(&field, &f, &c_num, &c_den).expect("elementary");
+        // v = 1/(x − √2): num = 1, den = x − √2 (monic).
+        assert_eq!(NumberField::kdeg(&vn), 0);
+        assert_eq!(trim(vn[0].clone()), vec![rat(1)]);
+        assert!(NumberField::kpoly_eq(&vd, &base));
+    }
+
+    // ∫ x²/(x − √2) · exp(x) dx is non-elementary (Ei term: simple pole, residue 2).
+    #[test]
+    fn rational_rde_k_nonelementary_sqrt2() {
+        let field = field_sqrt2();
+        let f: KPoly = vec![kc(&field, 1)];
+        let sqrt2 = vec![rat(0), rat(1)];
+        let c_num: KPoly = vec![NumberField::k_zero(), NumberField::k_zero(), kc(&field, 1)]; // x²
+        let c_den: KPoly = vec![field.neg(&sqrt2), kc(&field, 1)]; // x − √2
+        assert!(solve_rational_rde_k(&field, &f, &c_num, &c_den).is_none());
+    }
+
+    // A polynomial RHS still works through the K rational solver (E = 1).
+    // ∫ x·exp(x²) dx: f = 2x, c = x  →  v = 1/2 (a K-constant).
+    #[test]
+    fn rational_rde_k_reduces_to_polynomial() {
+        let field = field_sqrt2();
+        let f: KPoly = vec![NumberField::k_zero(), kc(&field, 2)]; // 2x
+        let c_num: KPoly = vec![NumberField::k_zero(), kc(&field, 1)]; // x
+        let c_den: KPoly = vec![kc(&field, 1)]; // 1
+        let (vn, vd) = solve_rational_rde_k(&field, &f, &c_num, &c_den).expect("elementary");
+        assert_eq!(trim(vn[0].clone()), vec![Rational::from((1, 2))]);
+        assert_eq!(trim(vd[0].clone()), vec![rat(1)]);
     }
 }


### PR DESCRIPTION
## Summary

Three commits continuing the Risch work from #86 (which merged the first two improvements: exp-tower constant factors and the `∫(h'/h)·log(h)ⁿ` rule). These were ready but not yet pushed when #86 merged, so they land here as a clean follow-up branched off current `main`.

This pursues **Risch Gap E** — algebraic-number coefficients in the exp tower — for a single quadratic field ℚ(√d), in both the polynomial and rational coefficient cases (the case where the algebraic constant is *entangled with x* and can't be pulled out as a constant factor).

### 1. Reusable number-field layer (`risch::number_field`, new module)
Extracts the `K = ℚ[t]/(q)` arithmetic that previously lived only inside `rational_integrate.rs` (built for the degree-≥3 RootSum log argument) into a first-class `NumberField` type: element add/sub/mul/neg/inv/reduce, the generic ℚ[x] modular primitives `poly_mod`/`ext_gcd`/`mod_inverse`, and K-polynomial-in-x arithmetic (`kpoly_add/sub/scale/mul/deriv/integrate/pow/monic/div_exact/divrem/gcd/eq`). Behaviour-preserving — the RootSum tests still pass.

### 2. Polynomial Risch DE over ℚ(α) (`poly_rde::solve_poly_rde_k`)
`y' + k·Dη·y = h` solved over `K` — a mirror of `solve_poly_rde` with every op routed through the field. `exp_case` detects a single `√d` radical, parses the coefficient to a K-poly, solves, reconstructs `a + b√d`. Verified: `∫ (x+√2)·eˣ = (x+√2−1)·eˣ`, `∫ (√3·x²+x)·eˣ`. NE preserved: `∫ (x+√2)·exp(x²)` → NonElementary.

### 3. Rational Risch DE over ℚ(α) (`rational_rde::solve_rational_rde_k`)
`v' + f·v = C/B` over `K`: same `E=gcd(B,B')` denominator bound + ansatz `v=N/E` + linear identity, with a Gauss–Jordan `solve_linear_system_k` over `K`. Verified: `∫ (x−√2−1)/(x−√2)²·eˣ = eˣ/(x−√2)`. NE preserved: `∫ x²/(x−√2)·eˣ` → NonElementary (Ei, simple pole residue 2).

The ℚ paths are always tried first, so existing ℚ behaviour is byte-for-byte unchanged.

## Testing
- `cargo test -p alkahest-cas`: **678 passed, 0 failed** (+19 integration-test binary)
- `cargo fmt --check` + `cargo clippy -p alkahest-cas --lib --tests`: clean
- New antiderivatives verified numerically by differentiation; soundness guards assert non-elementary forms stay non-elementary.

## Still deferred (documented)
Fields beyond one quadratic radical (compositums like ℚ(√2,√3), degree ≥ 3 — `NumberField` supports the modulus, but `detect_sqrt_field` only recognises one square root), and the log tower (still ℚ-only). Gaps B (tower composition), C (mixed algebraic+transcendental), F (nested/rational exponents) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)