### PR TITLE
Risch M0 generic quotient core, AlgExtension, MA simple-radical integral part, fractional-power diff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 * If asked to fix CI: check CI status using `gh` CLI if available, otherwise check https://github.com/alkahest-cas/alkahest/
 * If asked to generate a report: write it to `temp-alkahest/testing/` or `temp-alkahest/planning/` depending on what label describes the report better, include at the top — the date, the agent and model writing it (e.g. "Claude Code claude-sonnet-4-6"), and the full git commit hash being reviewed
 * A `LOCAL-AGENTS.md` file may exist at the repo root — it is untracked by git and contains device-specific instructions (paths, local tooling, machine-specific overrides). If present, follow its instructions in addition to this file.
+* If asked to write a report do not include time estimates for how long implementation will take like "~1 week" etc
 
 ## Demo playground
 

--- a/alkahest-core/src/diff/diff_impl.rs
+++ b/alkahest-core/src/diff/diff_impl.rs
@@ -5,6 +5,18 @@ use crate::simplify::engine::simplify;
 use std::collections::HashMap;
 use std::fmt;
 
+/// Build a canonical constant node for a rational `r`: an `Integer` when `r` is
+/// integer-valued, otherwise a `Rational`.  Shared by all three diff modes for
+/// the constant-exponent power rule.
+pub(crate) fn const_node(pool: &ExprPool, r: rug::Rational) -> ExprId {
+    if *r.denom() == 1 {
+        pool.integer(r.numer().clone())
+    } else {
+        let (n, d) = r.into_numer_denom();
+        pool.rational(n, d)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Error type
 // ---------------------------------------------------------------------------
@@ -262,26 +274,30 @@ fn diff_raw(
             memo.insert(expr, result.value);
             Ok(result)
         }
-        // Power rule (integer exponent): d/dx f^n = n · f^(n-1) · f'
+        // Power rule, constant exponent (integer or rational):
+        //   d/dx f^r = r · f^(r-1) · f'.
+        // A var-dependent / non-constant exponent (e.g. x^y, x^x) is a different
+        // rule (logarithmic differentiation) and remains unsupported.
         Node::Pow { base, exp } => {
             // Read the exponent without holding the pool lock during recursion.
-            let n = pool
+            let r = pool
                 .with(exp, |data| match data {
-                    ExprData::Integer(n) => Some(n.0.clone()),
+                    ExprData::Integer(n) => Some(rug::Rational::from(n.0.clone())),
+                    ExprData::Rational(q) => Some(q.0.clone()),
                     _ => None,
                 })
                 .ok_or(DiffError::NonIntegerExponent)?;
 
-            // Special case n=0: d/dx f^0 = 0
-            if n == 0 {
+            // Special case r=0: d/dx f^0 = 0
+            if r == 0 {
                 let zero = pool.integer(0_i32);
                 let mut log = DerivationLog::new();
                 log.push(RewriteStep::simple("power_rule_n0", expr, zero));
                 memo.insert(expr, zero);
                 return Ok(DerivedExpr::with_log(zero, log));
             }
-            // Special case n=1: d/dx f^1 = f'
-            if n == 1 {
+            // Special case r=1: d/dx f^1 = f'
+            if r == 1 {
                 let mut result = diff_raw(base, var, pool, memo)?;
                 result
                     .log
@@ -293,10 +309,10 @@ fn diff_raw(
             let mut log = DerivationLog::new();
             let df = diff_raw(base, var, pool, memo)?;
             log = log.merge(df.log);
-            let n_id = pool.integer(n.clone());
-            let n_minus_1 = pool.integer(n - 1);
-            let base_pow = pool.pow(base, n_minus_1);
-            let result_id = pool.mul(vec![n_id, base_pow, df.value]);
+            let r_id = const_node(pool, r.clone());
+            let r_minus_1 = const_node(pool, r - 1);
+            let base_pow = pool.pow(base, r_minus_1);
+            let result_id = pool.mul(vec![r_id, base_pow, df.value]);
             log.push(RewriteStep::simple("power_rule", expr, result_id));
             memo.insert(expr, result_id);
             Ok(DerivedExpr::with_log(result_id, log))
@@ -603,8 +619,58 @@ mod tests {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let y = pool.symbol("y", Domain::Real);
+        // A *var-dependent* exponent still needs logarithmic differentiation and
+        // remains unsupported.
         let err = diff(pool.pow(x, y), x, &pool);
         assert!(matches!(err, Err(DiffError::NonIntegerExponent)));
+    }
+
+    #[test]
+    fn diff_fractional_power() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        // d/dx x^{1/2} = (1/2) x^{-1/2}.
+        let half = pool.pow(x, pool.rational(1_i32, 2_i32));
+        let d = diff(half, x, &pool).unwrap();
+        let expected = pool.mul(vec![
+            pool.rational(1_i32, 2_i32),
+            pool.pow(x, pool.rational(-1_i32, 2_i32)),
+        ]);
+        assert_eq!(
+            simplify(d.value, &pool).value,
+            simplify(expected, &pool).value
+        );
+
+        // d/dx x^{2/3} = (2/3) x^{-1/3}.
+        let two_thirds = pool.pow(x, pool.rational(2_i32, 3_i32));
+        let d = diff(two_thirds, x, &pool).unwrap();
+        let expected = pool.mul(vec![
+            pool.rational(2_i32, 3_i32),
+            pool.pow(x, pool.rational(-1_i32, 3_i32)),
+        ]);
+        assert_eq!(
+            simplify(d.value, &pool).value,
+            simplify(expected, &pool).value
+        );
+    }
+
+    #[test]
+    fn diff_fractional_power_chain_rule() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        // d/dx (x²+1)^{3/2} = (3/2)(x²+1)^{1/2}·2x = 3x·(x²+1)^{1/2}.
+        let base = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let expr = pool.pow(base, pool.rational(3_i32, 2_i32));
+        let d = diff(expr, x, &pool).unwrap();
+        let expected = pool.mul(vec![
+            pool.integer(3_i32),
+            x,
+            pool.pow(base, pool.rational(1_i32, 2_i32)),
+        ]);
+        assert_eq!(
+            simplify(d.value, &pool).value,
+            simplify(expected, &pool).value
+        );
     }
 
     #[test]

--- a/alkahest-core/src/diff/forward.rs
+++ b/alkahest-core/src/diff/forward.rs
@@ -115,6 +115,16 @@ impl DualValue {
         DualValue::new(value, tangent)
     }
 
+    /// `f^r` for a constant rational `r`: `d/dx f^r = r · f^{r-1} · f'`.
+    fn pow_rat(self, r: rug::Rational, pool: &ExprPool) -> Self {
+        let r_id = super::diff_impl::const_node(pool, r.clone());
+        let r_minus_1 = super::diff_impl::const_node(pool, r - 1);
+        let value = pool.pow(self.value, r_id);
+        let base_pow = pool.pow(self.value, r_minus_1);
+        let tangent = pool.mul(vec![r_id, base_pow, self.tangent]);
+        DualValue::new(value, tangent)
+    }
+
     fn sin(self, pool: &ExprPool) -> Self {
         // d/dx sin(f) = cos(f) * f'
         let value = pool.func("sin", vec![self.value]);
@@ -179,6 +189,12 @@ impl DualValue {
 /// `memo` maps `ExprId → DualValue` so that shared subexpressions are
 /// evaluated only once per `diff_forward` call.  `DualValue` holds two
 /// `ExprId` values and is cheap to clone.
+/// A recognized constant power exponent: integer or rational.
+enum ExpKind {
+    Int(rug::Integer),
+    Rat(rug::Rational),
+}
+
 fn eval_dual(
     expr: ExprId,
     var: ExprId,
@@ -260,14 +276,19 @@ fn eval_dual(
             Ok(acc)
         }
         Node::Pow { base, exp } => {
-            let n = pool
+            // Constant exponent: integer → pow_int, rational → pow_rat.
+            let exp_kind = pool
                 .with(exp, |data| match data {
-                    ExprData::Integer(n) => Some(n.0.clone()),
+                    ExprData::Integer(n) => Some(ExpKind::Int(n.0.clone())),
+                    ExprData::Rational(q) => Some(ExpKind::Rat(q.0.clone())),
                     _ => None,
                 })
                 .ok_or(DiffError::ForwardNonIntegerExponent)?;
             let b = eval_dual(base, var, pool, memo)?;
-            Ok(b.pow_int(n, pool))
+            Ok(match exp_kind {
+                ExpKind::Int(n) => b.pow_int(n, pool),
+                ExpKind::Rat(q) => b.pow_rat(q, pool),
+            })
         }
         Node::Func { name, arg } => {
             // Protect against the dummy self-referential node from multi-arg fns
@@ -396,6 +417,20 @@ mod tests {
         let fwd_poly = UniPoly::from_symbolic(fwd.value, x, &pool).unwrap();
         let sym_poly = UniPoly::from_symbolic(sym.value, x, &pool).unwrap();
         assert_eq!(fwd_poly.coefficients_i64(), sym_poly.coefficients_i64());
+    }
+
+    #[test]
+    fn forward_diff_fractional_power_agrees_with_symbolic() {
+        // d/dx x^{2/3} via forward vs symbolic.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.pow(x, pool.rational(2_i32, 3_i32));
+        let fwd = diff_forward(expr, x, &pool).unwrap().value;
+        let sym = sym_diff(expr, x, &pool).unwrap().value;
+        assert_eq!(
+            crate::simplify::engine::simplify(fwd, &pool).value,
+            crate::simplify::engine::simplify(sym, &pool).value
+        );
     }
 
     #[test]

--- a/alkahest-core/src/diff/reverse.rs
+++ b/alkahest-core/src/diff/reverse.rs
@@ -142,22 +142,20 @@ fn propagate(node: ExprId, adj: ExprId, adjoints: &mut HashMap<ExprId, ExprId>, 
             }
         }
 
-        // d(base^n) / d(base) = n * base^(n-1)   (integer n only)
+        // d(base^r) / d(base) = r * base^(r-1)   (constant integer or rational r)
         Op::Pow { base, exp } => {
-            let maybe_n = pool.with(exp, |d| {
-                if let ExprData::Integer(n) = d {
-                    Some(n.0.clone())
-                } else {
-                    None
-                }
+            let maybe_r = pool.with(exp, |d| match d {
+                ExprData::Integer(n) => Some(rug::Rational::from(n.0.clone())),
+                ExprData::Rational(q) => Some(q.0.clone()),
+                _ => None,
             });
-            if let Some(n) = maybe_n {
-                let n_minus_1 = pool.integer(n - 1i32);
-                let base_pow = pool.pow(base, n_minus_1);
+            if let Some(r) = maybe_r {
+                let r_minus_1 = super::diff_impl::const_node(pool, r - 1);
+                let base_pow = pool.pow(base, r_minus_1);
                 let contrib = pool.mul(vec![adj, exp, base_pow]);
                 add_adj(base, contrib, adjoints, pool);
             }
-            // Non-integer exponent: no propagation (same conservative choice as diff_impl)
+            // Var-dependent exponent: no propagation (conservative; same as diff_impl)
         }
 
         // Chain rule: d(f(u)) / d(u) = f'(u)
@@ -322,6 +320,22 @@ mod tests {
         assert!(
             dx_str.contains("x") && dx_str.contains("y"),
             "got: {dx_str}"
+        );
+    }
+
+    #[test]
+    fn grad_fractional_power_agrees_with_diff() {
+        // ∂/∂x (x²+1)^{1/2} via grad vs symbolic diff.
+        use crate::diff::diff;
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let base = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let f = pool.pow(base, pool.rational(1_i32, 2_i32));
+        let sym = diff(f, x, &pool).unwrap().value;
+        let rev = grad(f, &[x], &pool)[0];
+        assert_eq!(
+            crate::simplify::engine::simplify(sym, &pool).value,
+            crate::simplify::engine::simplify(rev, &pool).value
         );
     }
 

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -135,6 +135,16 @@ pub fn integrate_algebraic(
     var: ExprId,
     pool: &ExprPool,
 ) -> Result<DerivedExpr<ExprId>, IntegrationError> {
+    // MA (Risch M0/M1): degree-≥3 simple radical `p(x)^{1/n}` over ℚ(x).  The
+    // genus-0 sqrt engine below only covers degree 2; the simple-radical
+    // integral part handles higher degrees (squarefree radicand).  Returns
+    // `None` when not applicable, so degree-2 and unsupported cases fall through.
+    if let Some(res) =
+        crate::integrate::risch::simple_radical::try_integrate_simple_radical(expr, var, pool)
+    {
+        return res;
+    }
+
     let mut log = DerivationLog::new();
 
     // Step 1: Find the unique sqrt generator y = sqrt(P(x))

--- a/alkahest-core/src/integrate/risch/alg_field.rs
+++ b/alkahest-core/src/integrate/risch/alg_field.rs
@@ -1,0 +1,558 @@
+//! `x`-dependent algebraic *function* field extension `ℚ(x)[y]/(q(x, y))`
+//! carrying a derivation — Risch milestone **M0**.
+//!
+//! Where [`super::number_field`] models a *constant* algebraic extension
+//! `ℚ[t]/(q)` (the coefficient field `ℚ` has zero derivation), this module
+//! models an algebraic extension of the **rational-function field** `ℚ(x)`,
+//! whose generator `y` satisfies `q(x, y) = 0` and therefore has a non-trivial
+//! derivative `D(y) = −q_x / q_y` forced by differentiating that relation.
+//! This is the substrate the mixed algebraic + transcendental integrator (MA,
+//! M1) builds on: it generalizes the rank-2 `KPair` (`α² = p(x)`,
+//! `α' = (p'/2p)·α`) in [`super::exp_case`] to **arbitrary degree `d`**.
+//!
+//! ## How it reuses the generic core
+//!
+//! The whole point of the M0 refactor in [`super::number_field`] was that the
+//! polynomial-quotient arithmetic is generic over a [`CoeffField`].  Here the
+//! coefficient field is [`RationalFunctionField`] (`ℚ(x)`), and the extension
+//! ring is exactly [`Quotient`]`<`[`RationalFunctionField`]`>` — no quotient
+//! arithmetic is re-implemented.  The genuinely new primitive this module adds
+//! is the **derivation** `D` on that ring (everything else is inherited).
+//!
+//! The derivation of a general element `a = Σⱼ bⱼ(x) yʲ` is
+//!
+//! ```text
+//!   D(a) = Σⱼ bⱼ'(x) yʲ  +  (∂a/∂y) · D(y)            (reduced mod q)
+//! ```
+//!
+//! — the first sum is the coefficient-field derivation applied coefficient-wise
+//! (the "explicit `x`" part); the second is the chain-rule term through the
+//! algebraic generator, where `D(y) = −q_x/q_y` is computed once at
+//! construction.
+
+use rug::Rational;
+
+use super::number_field::{CoeffField, GPoly, Quotient};
+use super::poly_rde::{degree, poly_deriv, poly_mul, poly_one, poly_scale, poly_zero, trim, QPoly};
+use super::rational_rde::{poly_div_exact, poly_gcd, poly_sub};
+
+// ===========================================================================
+// ℚ(x) — the rational-function coefficient field
+// ===========================================================================
+
+/// An element of `ℚ(x)`: a rational function `num/den`, kept in canonical form
+/// (coprime `num`/`den`, monic `den`, `0 = ⟨⟩/1`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RatFn {
+    num: QPoly,
+    den: QPoly,
+}
+
+impl RatFn {
+    /// Build `num/den` in canonical form.  Panics if `den` is the zero
+    /// polynomial.
+    pub fn new(num: QPoly, den: QPoly) -> Self {
+        let num = trim(num);
+        let den = trim(den);
+        assert!(!den.is_empty(), "RatFn: zero denominator");
+        if num.is_empty() {
+            return Self {
+                num: Vec::new(),
+                den: poly_one(),
+            };
+        }
+        // Reduce by gcd.
+        let g = poly_gcd(&num, &den);
+        let mut num = poly_div_exact(&num, &g);
+        let mut den = poly_div_exact(&den, &g);
+        // Normalize so the denominator is monic.
+        let lc = den[degree(&den) as usize].clone();
+        if lc != 1 {
+            let inv = Rational::from(1) / lc;
+            num = poly_scale(&num, &inv);
+            den = poly_scale(&den, &inv);
+        }
+        Self { num, den }
+    }
+
+    /// A rational function from a polynomial `p(x)` (denominator 1).
+    pub fn from_poly(p: &QPoly) -> Self {
+        Self::new(p.clone(), poly_one())
+    }
+
+    /// The integer constant `n`.
+    pub fn int(n: i64) -> Self {
+        Self::new(vec![Rational::from(n)], poly_one())
+    }
+
+    /// The numerator (canonical form).
+    pub fn numer(&self) -> &QPoly {
+        &self.num
+    }
+
+    /// The denominator (canonical form, monic).
+    pub fn denom(&self) -> &QPoly {
+        &self.den
+    }
+
+    fn is_zero(&self) -> bool {
+        self.num.is_empty()
+    }
+
+    fn add(&self, other: &Self) -> Self {
+        // a/b + c/d = (a·d + c·b)/(b·d)
+        let num = super::poly_rde::poly_add(
+            &poly_mul(&self.num, &other.den),
+            &poly_mul(&other.num, &self.den),
+        );
+        let den = poly_mul(&self.den, &other.den);
+        Self::new(num, den)
+    }
+
+    fn mul(&self, other: &Self) -> Self {
+        Self::new(
+            poly_mul(&self.num, &other.num),
+            poly_mul(&self.den, &other.den),
+        )
+    }
+
+    fn neg(&self) -> Self {
+        Self::new(poly_scale(&self.num, &Rational::from(-1)), self.den.clone())
+    }
+
+    fn inv(&self) -> Option<Self> {
+        if self.is_zero() {
+            None
+        } else {
+            // (num/den)⁻¹ = den/num; `new` re-canonicalizes the sign.
+            Some(Self::new(self.den.clone(), self.num.clone()))
+        }
+    }
+
+    /// `d/dx (num/den) = (num'·den − num·den') / den²`.
+    fn derivative(&self) -> Self {
+        let np = poly_deriv(&self.num);
+        let dp = poly_deriv(&self.den);
+        let numer = poly_sub(&poly_mul(&np, &self.den), &poly_mul(&self.num, &dp));
+        let denom = poly_mul(&self.den, &self.den);
+        Self::new(numer, denom)
+    }
+}
+
+/// The rational-function field `ℚ(x)` — the coefficient field of an
+/// [`AlgExtension`].  Its [`derivation`](CoeffField::derivation) is `d/dx`.
+#[derive(Clone, Debug, Default)]
+pub struct RationalFunctionField;
+
+impl CoeffField for RationalFunctionField {
+    type Elem = RatFn;
+
+    fn zero(&self) -> RatFn {
+        RatFn::int(0)
+    }
+    fn one(&self) -> RatFn {
+        RatFn::int(1)
+    }
+    fn from_i64(&self, n: i64) -> RatFn {
+        RatFn::int(n)
+    }
+    fn add(&self, a: &RatFn, b: &RatFn) -> RatFn {
+        a.add(b)
+    }
+    fn sub(&self, a: &RatFn, b: &RatFn) -> RatFn {
+        a.add(&b.neg())
+    }
+    fn mul(&self, a: &RatFn, b: &RatFn) -> RatFn {
+        a.mul(b)
+    }
+    fn neg(&self, a: &RatFn) -> RatFn {
+        a.neg()
+    }
+    fn inv(&self, a: &RatFn) -> Option<RatFn> {
+        a.inv()
+    }
+    fn is_zero(&self, a: &RatFn) -> bool {
+        a.is_zero()
+    }
+    fn eq(&self, a: &RatFn, b: &RatFn) -> bool {
+        a == b
+    }
+    fn derivation(&self, a: &RatFn) -> RatFn {
+        a.derivative()
+    }
+}
+
+// ===========================================================================
+// AlgExtension — ℚ(x)[y]/(q(x,y)) with a derivation
+// ===========================================================================
+
+/// An element of the extension: coefficients of `1, y, …, y^{d−1}`, each in
+/// `ℚ(x)`.  (Generalizes the rank-2 `KPair`.)
+pub type AlgElem = GPoly<RationalFunctionField>;
+
+/// An algebraic function field extension `E = ℚ(x)[y]/(q(x, y))` of degree
+/// `d = deg_y q`, with the derivation `D` extended from `d/dx` on `ℚ(x)` to `E`
+/// via `D(y) = −q_x/q_y`.
+#[derive(Clone, Debug)]
+pub struct AlgExtension {
+    quotient: Quotient<RationalFunctionField>,
+    /// `D(y)`, the derivative of the generator, precomputed once.
+    dy: AlgElem,
+}
+
+impl AlgExtension {
+    /// Build `ℚ(x)[y]/(q)` from the minimal polynomial `q(x, y) = Σⱼ qⱼ(x) yʲ`,
+    /// given as its coefficients `qⱼ(x) ∈ ℚ[x]` ascending in `y`.
+    ///
+    /// `q` should be squarefree and monic in `y`.  Panics if `q_y` (the formal
+    /// `y`-derivative of `q`) is not invertible modulo `q` — i.e. if `q` is not
+    /// separable, which never happens for a squarefree `q` in characteristic 0.
+    pub fn new(q: &[QPoly]) -> Self {
+        let field = RationalFunctionField;
+        let modulus: AlgElem = q.iter().map(RatFn::from_poly).collect();
+        let quotient = Quotient::new(field, modulus.clone());
+
+        // q_x = ∂q/∂x (coefficient-wise d/dx, holding y), as a poly in y.
+        let qx: AlgElem = modulus.iter().map(|c| c.derivative()).collect();
+        // q_y = ∂q/∂y (formal y-derivative), as a poly in y.
+        let qy = dpoly_dy(&RationalFunctionField, &modulus);
+
+        let qx_red = quotient.reduce(&qx);
+        let qy_red = quotient.reduce(&qy);
+        let qy_inv = quotient
+            .inv(&qy_red)
+            .expect("q is separable (squarefree, char 0): q_y is invertible mod q");
+        // D(y) = −q_x / q_y.
+        let dy = quotient.mul(&quotient.neg(&qx_red), &qy_inv);
+
+        Self { quotient, dy }
+    }
+
+    /// Build a simple radical extension `ℚ(x)[y]/(yⁿ − p(x))`, i.e. `y = p^{1/n}`.
+    ///
+    /// `n ≥ 2`; `p` must be a nonzero polynomial.  This is the common case the
+    /// mixed-integration entry points produce (`∛x`, `x^{p/q}`, …).
+    pub fn radical(n: usize, p: &QPoly) -> Self {
+        debug_assert!(n >= 2, "radical extension needs degree ≥ 2");
+        let mut q: Vec<QPoly> = vec![poly_zero(); n + 1];
+        q[0] = poly_scale(p, &Rational::from(-1)); // −p
+        q[n] = poly_one(); // yⁿ
+        Self::new(&q)
+    }
+
+    /// The underlying generic quotient ring `ℚ(x)[y]/(q)`.
+    pub fn quotient(&self) -> &Quotient<RationalFunctionField> {
+        &self.quotient
+    }
+
+    /// Extension degree `d = deg_y q`.
+    pub fn degree(&self) -> i64 {
+        self.quotient.degree()
+    }
+
+    /// `D(y)`, the derivative of the algebraic generator.
+    pub fn dy(&self) -> &AlgElem {
+        &self.dy
+    }
+
+    /// The generator `y` as an element.
+    pub fn generator(&self) -> AlgElem {
+        vec![RatFn::int(0), RatFn::int(1)]
+    }
+
+    /// The constant element `r ∈ ℚ(x)`.
+    pub fn constant(&self, r: RatFn) -> AlgElem {
+        self.quotient.reduce(&[r])
+    }
+
+    /// Embed an integer.
+    pub fn from_int(&self, n: i64) -> AlgElem {
+        self.quotient.from_int(n)
+    }
+
+    /// Reduce an arbitrary `ℚ(x)`-polynomial in `y` mod `q`.
+    pub fn reduce(&self, a: &[RatFn]) -> AlgElem {
+        self.quotient.reduce(a)
+    }
+
+    /// `a + b`.
+    pub fn add(&self, a: &[RatFn], b: &[RatFn]) -> AlgElem {
+        self.quotient.add(a, b)
+    }
+
+    /// `a − b`.
+    pub fn sub(&self, a: &[RatFn], b: &[RatFn]) -> AlgElem {
+        self.quotient.sub(a, b)
+    }
+
+    /// `a · b`.
+    pub fn mul(&self, a: &[RatFn], b: &[RatFn]) -> AlgElem {
+        self.quotient.mul(a, b)
+    }
+
+    /// `−a`.
+    pub fn neg(&self, a: &[RatFn]) -> AlgElem {
+        self.quotient.neg(a)
+    }
+
+    /// `a⁻¹`, or `None` when `a` is a zero divisor / zero.
+    pub fn inv(&self, a: &[RatFn]) -> Option<AlgElem> {
+        self.quotient.inv(a)
+    }
+
+    /// `aⁿ` for any integer `n` (negative powers via [`inv`](AlgExtension::inv)).
+    /// `None` only when `n < 0` and `a` is not invertible.
+    pub fn pow(&self, a: &[RatFn], n: i64) -> Option<AlgElem> {
+        if n == 0 {
+            return Some(self.from_int(1));
+        }
+        if n < 0 {
+            let inv = self.inv(a)?;
+            return self.pow(&inv, -n);
+        }
+        let mut acc = self.from_int(1);
+        for _ in 0..n {
+            acc = self.mul(&acc, a);
+        }
+        Some(acc)
+    }
+
+    /// Is `a` equal to `b`?
+    pub fn elem_eq(&self, a: &[RatFn], b: &[RatFn]) -> bool {
+        self.quotient.elem_eq(a, b)
+    }
+
+    /// Is `a` zero?
+    pub fn is_zero(&self, a: &[RatFn]) -> bool {
+        self.quotient.elem_is_zero(a)
+    }
+
+    /// The derivation `D(a)` for `a = Σⱼ bⱼ(x) yʲ`:
+    ///
+    /// ```text
+    ///   D(a) = Σⱼ bⱼ'(x) yʲ  +  (∂a/∂y) · D(y)        (reduced mod q)
+    /// ```
+    pub fn derivation(&self, a: &[RatFn]) -> AlgElem {
+        let field = RationalFunctionField;
+        // Explicit-x part: differentiate each coefficient.
+        let coeff_part: AlgElem = a.iter().map(|c| field.derivation(c)).collect();
+        // Chain-rule part: (∂a/∂y) · D(y).
+        let da_dy = dpoly_dy(&field, a);
+        let chain = self.quotient.mul(&da_dy, &self.dy);
+        self.quotient.add(&coeff_part, &chain)
+    }
+}
+
+/// Formal derivative with respect to `y` of a polynomial-in-`y`
+/// `Σⱼ cⱼ yʲ ↦ Σⱼ j cⱼ y^{j−1}`, with coefficients in `F` (the `cⱼ` treated as
+/// constants).
+fn dpoly_dy<F: CoeffField>(field: &F, p: &[F::Elem]) -> GPoly<F> {
+    if p.len() <= 1 {
+        return Vec::new();
+    }
+    p[1..]
+        .iter()
+        .enumerate()
+        .map(|(i, c)| field.mul(&field.from_i64(i as i64 + 1), c))
+        .collect()
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn rat(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    /// `1/(c·x^k)` as a `RatFn`.
+    fn inv_monomial(c: i64, k: usize) -> RatFn {
+        let mut den = vec![Rational::from(0); k + 1];
+        den[k] = Rational::from(c);
+        RatFn::new(vec![Rational::from(1)], den)
+    }
+
+    #[test]
+    fn ratfn_canonicalizes() {
+        // (2x)/(2) = x.
+        let r = RatFn::new(vec![rat(0), rat(2)], vec![rat(2)]);
+        assert_eq!(r, RatFn::from_poly(&vec![rat(0), rat(1)]));
+        // 0/(x²) = 0/1.
+        let z = RatFn::new(vec![], vec![rat(0), rat(0), rat(1)]);
+        assert!(z.is_zero());
+        assert_eq!(z.denom(), &poly_one());
+    }
+
+    #[test]
+    fn ratfn_field_derivation_quotient_rule() {
+        let f = RationalFunctionField;
+        // d/dx (1/x) = −1/x².
+        let one_over_x = inv_monomial(1, 1);
+        let d = f.derivation(&one_over_x);
+        assert_eq!(d, RatFn::new(vec![rat(-1)], vec![rat(0), rat(0), rat(1)]));
+        // d/dx (x²) = 2x.
+        let x2 = RatFn::from_poly(&vec![rat(0), rat(0), rat(1)]);
+        assert_eq!(f.derivation(&x2), RatFn::from_poly(&vec![rat(0), rat(2)]));
+    }
+
+    #[test]
+    fn derivation_of_cbrt_x() {
+        // E = ℚ(x)(∛x) = ℚ(x)[y]/(y³ − x); modulus coeffs [−x, 0, 0, 1].
+        // y³ = x ⇒ D(y) = 1/(3x) · y    (i.e. (1/3)x^{−2/3}).
+        let e = AlgExtension::new(&[
+            vec![rat(0), rat(-1)], // −x
+            vec![rat(0)],
+            vec![rat(0)],
+            vec![rat(1)],
+        ]);
+        assert_eq!(e.degree(), 3);
+        let y = e.generator();
+        let dy = e.derivation(&y);
+        // Expected: coefficient of y is 1/(3x), others zero.
+        let expected = vec![RatFn::int(0), inv_monomial(3, 1), RatFn::int(0)];
+        assert!(e.elem_eq(&dy, &expected), "D(∛x) = y/(3x); got {dy:?}");
+        // And it equals the stored dy.
+        assert!(e.elem_eq(e.dy(), &expected));
+    }
+
+    #[test]
+    fn derivation_of_sqrt_x_matches_kpair() {
+        // E = ℚ(x)(√x) = ℚ(x)[y]/(y² − x).  D(y) = 1/(2x)·y = (1/(2√x)).
+        let e = AlgExtension::new(&[vec![rat(0), rat(-1)], vec![rat(0)], vec![rat(1)]]);
+        let y = e.generator();
+        let dy = e.derivation(&y);
+        let expected = vec![RatFn::int(0), inv_monomial(2, 1)];
+        assert!(e.elem_eq(&dy, &expected), "D(√x) = y/(2x); got {dy:?}");
+    }
+
+    #[test]
+    fn derivation_consistency_y_cubed_is_x() {
+        // D(y³) must reduce to D(x) = 1 (since y³ = x in the ring).
+        let e = AlgExtension::new(&[
+            vec![rat(0), rat(-1)], // −x
+            vec![rat(0)],
+            vec![rat(0)],
+            vec![rat(1)],
+        ]);
+        let y = e.generator();
+        let y3 = e.mul(&e.mul(&y, &y), &y); // = x  (reduced)
+        let dy3 = e.derivation(&y3);
+        assert!(e.elem_eq(&dy3, &e.from_int(1)), "D(y³)=D(x)=1; got {dy3:?}");
+    }
+
+    #[test]
+    fn derivation_of_y_squared() {
+        // y³ = x.  D(y²) = 2y·D(y) = 2y·(y/(3x)) = (2/(3x))·y².
+        let e = AlgExtension::new(&[
+            vec![rat(0), rat(-1)],
+            vec![rat(0)],
+            vec![rat(0)],
+            vec![rat(1)],
+        ]);
+        let y = e.generator();
+        let y2 = e.mul(&y, &y);
+        let dy2 = e.derivation(&y2);
+        // (2/(3x))·y²  →  coefficient of y² is 2/(3x).
+        let two_over_3x = RatFn::new(vec![rat(2)], vec![rat(0), rat(3)]);
+        let expected = vec![RatFn::int(0), RatFn::int(0), two_over_3x];
+        assert!(e.elem_eq(&dy2, &expected), "D(y²); got {dy2:?}");
+    }
+
+    #[test]
+    fn leibniz_rule_deterministic() {
+        // D(α·β) = D(α)·β + α·D(β) for concrete α, β in ℚ(x)(∛x).
+        let e = AlgExtension::new(&[
+            vec![rat(0), rat(-1)],
+            vec![rat(0)],
+            vec![rat(0)],
+            vec![rat(1)],
+        ]);
+        // α = x + y,  β = y² − 1/x.
+        let alpha = vec![RatFn::from_poly(&vec![rat(0), rat(1)]), RatFn::int(1)];
+        let beta = vec![inv_monomial(1, 1).neg(), RatFn::int(0), RatFn::int(1)];
+        let lhs = e.derivation(&e.mul(&alpha, &beta));
+        let rhs = e.add(
+            &e.mul(&e.derivation(&alpha), &beta),
+            &e.mul(&alpha, &e.derivation(&beta)),
+        );
+        assert!(e.elem_eq(&lhs, &rhs), "Leibniz: {lhs:?} vs {rhs:?}");
+    }
+
+    // -- proptest: ring axioms + Leibniz over ℚ(x)(∛x) --
+
+    /// A small random `RatFn` with low-degree integer num/den.
+    fn small_ratfn() -> impl Strategy<Value = RatFn> {
+        let coeff = -3i64..=3;
+        let nz = prop_oneof![1i64..=3, -3i64..=-1];
+        (
+            prop::collection::vec(coeff.clone(), 0..=2),
+            prop::collection::vec(coeff, 0..=1),
+            nz,
+        )
+            .prop_map(|(n, d, lead)| {
+                let num: QPoly = n.into_iter().map(Rational::from).collect();
+                let mut den: QPoly = d.into_iter().map(Rational::from).collect();
+                den.push(Rational::from(lead)); // ensure nonzero denominator
+                RatFn::new(num, den)
+            })
+    }
+
+    fn small_elem() -> impl Strategy<Value = AlgElem> {
+        // Degree < 3 element of ℚ(x)(∛x).
+        prop::collection::vec(small_ratfn(), 0..=3)
+    }
+
+    fn cbrt_ext() -> AlgExtension {
+        AlgExtension::new(&[
+            vec![rat(0), rat(-1)],
+            vec![rat(0)],
+            vec![rat(0)],
+            vec![rat(1)],
+        ])
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        #[test]
+        fn prop_ring_axioms(a in small_elem(), b in small_elem(), c in small_elem()) {
+            let e = cbrt_ext();
+            // commutativity of + and ·
+            prop_assert!(e.elem_eq(&e.add(&a, &b), &e.add(&b, &a)));
+            prop_assert!(e.elem_eq(&e.mul(&a, &b), &e.mul(&b, &a)));
+            // additive identity & inverse
+            prop_assert!(e.elem_eq(&e.add(&a, &e.from_int(0)), &a));
+            prop_assert!(e.is_zero(&e.add(&a, &e.neg(&a))));
+            // multiplicative identity
+            prop_assert!(e.elem_eq(&e.mul(&a, &e.from_int(1)), &a));
+            // distributivity a·(b+c) = a·b + a·c
+            let lhs = e.mul(&a, &e.add(&b, &c));
+            let rhs = e.add(&e.mul(&a, &b), &e.mul(&a, &c));
+            prop_assert!(e.elem_eq(&lhs, &rhs));
+        }
+
+        #[test]
+        fn prop_leibniz(a in small_elem(), b in small_elem()) {
+            let e = cbrt_ext();
+            let lhs = e.derivation(&e.mul(&a, &b));
+            let rhs = e.add(
+                &e.mul(&e.derivation(&a), &b),
+                &e.mul(&a, &e.derivation(&b)),
+            );
+            prop_assert!(e.elem_eq(&lhs, &rhs));
+        }
+
+        #[test]
+        fn prop_derivation_is_additive(a in small_elem(), b in small_elem()) {
+            let e = cbrt_ext();
+            let lhs = e.derivation(&e.add(&a, &b));
+            let rhs = e.add(&e.derivation(&a), &e.derivation(&b));
+            prop_assert!(e.elem_eq(&lhs, &rhs));
+        }
+    }
+}

--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -31,6 +31,7 @@ use crate::integrate::engine::IntegrationError;
 use crate::kernel::{ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
+use super::alg_field::{AlgElem, AlgExtension, RatFn};
 use super::number_field::{KElem, KPoly, NumberField};
 use super::poly_rde::{
     apply_const, contains_subexpr, degree, expr_to_qpoly, is_free_of_var, poly_add, poly_deriv,
@@ -1803,7 +1804,7 @@ fn build_krational(
 }
 
 /// Build the symbolic rational function `num(x) / den(x)`.
-fn build_rational(
+pub(super) fn build_rational(
     num: &[rug::Rational],
     den: &[rug::Rational],
     var: ExprId,
@@ -2134,6 +2135,171 @@ fn decompose_over_alpha(
     }
 }
 
+// --- Degree-d generalization: decompose over an arbitrary radical generator --
+//
+// These generalize `decompose_over_alpha` (rank-2, KPair) to a degree-`n`
+// simple radical extension `ℚ(x)[y]/(yⁿ − p)` represented by `alg_field`.  They
+// are the symbolic→`AlgElem` bridge the mixed-integration integral part (MA /
+// M1, see temp-alkahest/planning/risch.md) consumes; not yet wired into the
+// integrator, hence `#[allow(dead_code)]`.
+
+/// Detect a single x-dependent simple-radical generator `p(x)^{1/n}` (`n ≥ 2`)
+/// in `expr`.  Returns `(n, p)` iff there is **exactly one** distinct such
+/// generator (keyed by radicand `p` and index `n`): `sqrt`→`n=2`, `cbrt`→`n=3`,
+/// `base^{a/n}`→`n =` the reduced exponent denominator.  Returns `None` for no
+/// generator or for two distinct ones (a compositum — out of MA scope).
+pub(super) fn detect_radical_generator(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(usize, QPoly)> {
+    let mut found: Vec<(usize, QPoly)> = Vec::new();
+    scan_radical_generator(expr, var, pool, &mut found);
+    let mut distinct: Vec<(usize, QPoly)> = Vec::new();
+    for (n, p) in found {
+        if !distinct
+            .iter()
+            .any(|(m, q)| *m == n && trim(q.clone()) == trim(p.clone()))
+        {
+            distinct.push((n, p));
+        }
+    }
+    if distinct.len() == 1 {
+        Some(distinct.remove(0))
+    } else {
+        None
+    }
+}
+
+fn scan_radical_generator(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+    out: &mut Vec<(usize, QPoly)>,
+) {
+    use crate::kernel::ExprData;
+    match pool.get(expr) {
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            if let Some(p) = expr_to_qpoly(args[0], var, pool) {
+                if degree(&p) >= 1 {
+                    out.push((2, p));
+                }
+            }
+        }
+        ExprData::Func { ref name, ref args } if name == "cbrt" && args.len() == 1 => {
+            if let Some(p) = expr_to_qpoly(args[0], var, pool) {
+                if degree(&p) >= 1 {
+                    out.push((3, p));
+                }
+            }
+        }
+        ExprData::Pow { base, exp } => {
+            if let ExprData::Rational(r) = pool.get(exp) {
+                if let Some(den) = r.0.denom().to_i64() {
+                    if den >= 2 {
+                        if let Some(p) = expr_to_qpoly(base, var, pool) {
+                            if degree(&p) >= 1 {
+                                out.push((den as usize, p));
+                                return; // don't recurse into the radicand
+                            }
+                        }
+                    }
+                }
+            }
+            scan_radical_generator(base, var, pool, out);
+        }
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for &a in &args {
+                scan_radical_generator(a, var, pool, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Decompose `expr` as `Σⱼ cⱼ(x) yʲ ∈ ℚ(x)[y]/(yⁿ − p)` where `y = p^{1/n}`,
+/// returning the coefficient vector as an [`AlgElem`].  The degree-`n`
+/// generalization of [`decompose_over_alpha`].  Returns `None` if `expr` is not
+/// a polynomial-in-`y` over `ℚ(x)` with this single generator.
+pub(super) fn decompose_over_alg_generator(
+    expr: ExprId,
+    n: usize,
+    p_radicand: &QPoly,
+    e: &AlgExtension,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<AlgElem> {
+    use crate::kernel::ExprData;
+
+    // Generator-free → a pure rational function of x → a constant element.
+    if let Some((num, den)) = expr_to_qrational(expr, var, pool) {
+        return Some(e.constant(RatFn::new(num, den)));
+    }
+
+    // `base^{a/d}` with `base` the radicand and `d | n` → `y^{a·(n/d)}`.
+    let as_generator_power = |base: ExprId, numr: i64, den: i64| -> Option<AlgElem> {
+        if den >= 2 && (n as i64) % den == 0 {
+            let bp = expr_to_qpoly(base, var, pool)?;
+            if trim(bp) == trim(p_radicand.clone()) {
+                return e.pow(&e.generator(), numr * (n as i64 / den));
+            }
+        }
+        None
+    };
+
+    match pool.get(expr) {
+        ExprData::Add(args) => {
+            let mut acc = e.from_int(0);
+            for &a in &args {
+                let t = decompose_over_alg_generator(a, n, p_radicand, e, var, pool)?;
+                acc = e.add(&acc, &t);
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc = e.from_int(1);
+            for &a in &args {
+                let t = decompose_over_alg_generator(a, n, p_radicand, e, var, pool)?;
+                acc = e.mul(&acc, &t);
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => match pool.get(exp) {
+            ExprData::Integer(m) => {
+                let m = m.0.to_i64()?;
+                let b = decompose_over_alg_generator(base, n, p_radicand, e, var, pool)?;
+                e.pow(&b, m)
+            }
+            ExprData::Rational(r) => {
+                as_generator_power(base, r.0.numer().to_i64()?, r.0.denom().to_i64()?)
+            }
+            _ => None,
+        },
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            as_generator_power(args[0], 1, 2)
+        }
+        ExprData::Func { ref name, ref args } if name == "cbrt" && args.len() == 1 => {
+            as_generator_power(args[0], 1, 3)
+        }
+        _ => None,
+    }
+}
+
+/// Detect the radical generator in `expr` and decompose it over the
+/// corresponding [`AlgExtension`].  The MA entry point: returns the extension
+/// `ℚ(x)[y]/(yⁿ − p)` together with `expr` written as an [`AlgElem`].
+#[allow(dead_code)] // consumed by MA (mixed alg+trans integral part, M1)
+fn decompose_radical(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(AlgExtension, AlgElem)> {
+    let (n, p) = detect_radical_generator(expr, var, pool)?;
+    let e = AlgExtension::radical(n, &p);
+    let elem = decompose_over_alg_generator(expr, n, &p, &e, var, pool)?;
+    Some((e, elem))
+}
+
 /// Try to integrate `c_rest · exp(kη)` when `c_rest` contains a single
 /// x-dependent `sqrt(p(x))` algebraic generator (Gap C).
 ///
@@ -2349,6 +2515,101 @@ mod tests {
 
     fn pool() -> ExprPool {
         ExprPool::new()
+    }
+
+    // -- degree-d radical decomposition (decompose_over_alpha generalization) --
+
+    fn qp(coeffs: &[i64]) -> QPoly {
+        coeffs.iter().map(|&c| rug::Rational::from(c)).collect()
+    }
+
+    #[test]
+    fn detect_radical_generator_forms() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        // cbrt(x) → (3, x).
+        let cbrt_x = pool.func("cbrt", vec![x]);
+        assert_eq!(
+            detect_radical_generator(cbrt_x, x, &pool),
+            Some((3, qp(&[0, 1])))
+        );
+        // x^(1/3) → (3, x).
+        let x_pow = pool.pow(x, pool.rational(1_i32, 3_i32));
+        assert_eq!(
+            detect_radical_generator(x_pow, x, &pool),
+            Some((3, qp(&[0, 1])))
+        );
+        // sqrt(x+1) → (2, x+1).
+        let sqrt = pool.func("sqrt", vec![pool.add(vec![x, pool.integer(1_i32)])]);
+        assert_eq!(
+            detect_radical_generator(sqrt, x, &pool),
+            Some((2, qp(&[1, 1])))
+        );
+        // No radical → None.
+        assert_eq!(
+            detect_radical_generator(pool.add(vec![x, pool.integer(1_i32)]), x, &pool),
+            None
+        );
+        // Two distinct generators (compositum) → None.
+        let mixed = pool.add(vec![pool.func("sqrt", vec![x]), pool.func("cbrt", vec![x])]);
+        assert_eq!(detect_radical_generator(mixed, x, &pool), None);
+    }
+
+    #[test]
+    fn decompose_x_plus_cbrt_x() {
+        // x + ∛x  over  ℚ(x)[y]/(y³ − x)  →  [x, 1, 0].
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![x, pool.func("cbrt", vec![x])]);
+        let (e, elem) = decompose_radical(expr, x, &pool).expect("decomposes");
+        assert_eq!(e.degree(), 3);
+        let expected = vec![RatFn::from_poly(&qp(&[0, 1])), RatFn::int(1)];
+        assert!(e.elem_eq(&elem, &expected), "got {elem:?}");
+    }
+
+    #[test]
+    fn decompose_cbrt_x_squared() {
+        // (∛x)²  →  y²  →  [0, 0, 1];  and x^(2/3) gives the same.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sq = pool.pow(pool.func("cbrt", vec![x]), pool.integer(2_i32));
+        let (e, elem) = decompose_radical(sq, x, &pool).expect("decomposes");
+        let expected = vec![RatFn::int(0), RatFn::int(0), RatFn::int(1)];
+        assert!(e.elem_eq(&elem, &expected), "got {elem:?}");
+
+        let frac = pool.pow(x, pool.rational(2_i32, 3_i32));
+        let (e2, elem2) = decompose_radical(frac, x, &pool).expect("decomposes");
+        assert!(e2.elem_eq(&elem2, &expected), "x^(2/3): got {elem2:?}");
+    }
+
+    #[test]
+    fn decompose_inverse_of_one_plus_cbrt_x() {
+        // 1/(1 + ∛x) over ℚ(x)(∛x): the decomposition inverts (1+y); check by
+        // multiplying back to 1.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let base = pool.add(vec![pool.integer(1_i32), pool.func("cbrt", vec![x])]);
+        let inv_expr = pool.pow(base, pool.integer(-1_i32));
+        let (e, inv_elem) = decompose_radical(inv_expr, x, &pool).expect("decomposes");
+        let base_elem = vec![RatFn::int(1), RatFn::int(1)]; // 1 + y
+        let product = e.mul(&inv_elem, &base_elem);
+        assert!(
+            e.elem_eq(&product, &e.from_int(1)),
+            "inv·(1+y) = {product:?}"
+        );
+    }
+
+    #[test]
+    fn decompose_degree2_matches_kpair_semantics() {
+        // x + √x over ℚ(x)(√x) → [x, 1] — the rank-2 KPair (c₀=x, c₁=1) as an
+        // AlgElem of length 2.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![x, pool.func("sqrt", vec![x])]);
+        let (e, elem) = decompose_radical(expr, x, &pool).expect("decomposes");
+        assert_eq!(e.degree(), 2);
+        let expected = vec![RatFn::from_poly(&qp(&[0, 1])), RatFn::int(1)];
+        assert!(e.elem_eq(&elem, &expected), "got {elem:?}");
     }
 
     #[test]

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -36,8 +36,13 @@
 //! - [`rational_rde`]: Rational RDE solver over ℚ(x) (exp tower; Bronstein §6.1).
 //!   Also contains [`rational_rde::solve_rational_rde_generalized`] for the
 //!   rational-exponent case `f = k·η' ∈ ℚ(x)` (Gap F, Bronstein §5.4).
-//! - [`number_field`]: Algebraic number field `ℚ[t]/(q)` arithmetic (used for
-//!   degree-≥3 algebraic residues and ℚ(√d) coefficients in the exp tower).
+//! - [`number_field`]: Generic polynomial-quotient core ([`number_field::CoeffField`],
+//!   [`number_field::Quotient`]) plus the algebraic number field `ℚ[t]/(q)`
+//!   ([`number_field::NumberField`], used for degree-≥3 algebraic residues and
+//!   ℚ(√d) coefficients in the exp tower).
+//! - [`alg_field`]: `x`-dependent algebraic *function* field `ℚ(x)[y]/(q(x,y))`
+//!   with a derivation `D(y) = −q_x/q_y` (Risch M0; substrate for mixed
+//!   algebraic + transcendental integration).
 //! - [`rational_integrate`]: Rational-function integration via Rothstein–Trager
 //!   (logarithmic part; Bronstein §2.5).
 //! - [`exp_case`]: Integration in the hyperexponential tower (t = exp(η)), both
@@ -70,12 +75,14 @@
 //! - Bronstein (2005). *Symbolic Integration I: Transcendental Functions*. Springer.
 //! - Geddes, Czapor, Labahn (1992). *Algorithms for Computer Algebra*. Kluwer.
 
+pub mod alg_field;
 pub mod exp_case;
 pub mod log_case;
 pub mod number_field;
 pub mod poly_rde;
 pub mod rational_integrate;
 pub mod rational_rde;
+pub mod simple_radical;
 pub mod tower;
 
 use crate::deriv::log::{DerivationLog, DerivedExpr};

--- a/alkahest-core/src/integrate/risch/number_field.rs
+++ b/alkahest-core/src/integrate/risch/number_field.rs
@@ -1,4 +1,5 @@
-//! Algebraic number field `K = ℚ[t]/(q(t))` arithmetic.
+//! Algebraic number field `K = ℚ[t]/(q(t))` arithmetic, built on a **generic
+//! polynomial-quotient core**.
 //!
 //! An element of `K` is represented as a [`QPoly`] of degree `< deg(q)` — a
 //! ℚ-polynomial in the field generator `t`, reduced modulo the minimal
@@ -8,71 +9,624 @@
 //! This module concentrates the quotient-ring primitives that were previously
 //! private to [`super::rational_integrate`] (where they were introduced for the
 //! Lazard–Rioboo–Trager degree-≥3 `RootSum` log argument, computing
-//! `gcd_x(N − t·P', P)` in `ℚ(c)`).  They are factored out here so the same
-//! arithmetic can back the **ℚ(α)-coefficient RDE work** (Risch Gap E): the
-//! polynomial and rational Risch DE solvers currently operate over `ℚ` only;
-//! threading a [`NumberField`] through them is what lets `√2·exp(x)`-style
-//! algebraic-number *coefficients* (as opposed to constant factors) be handled.
+//! `gcd_x(N − t·P', P)` in `ℚ(c)`).  They were first factored out here to back
+//! the **ℚ(α)-coefficient RDE work** (Risch Gap E).
+//!
+//! ## Generic core (Risch M0)
+//!
+//! The quotient-ring arithmetic is *identical up to the coefficient ring* for
+//! the constant case (coefficients in `ℚ`) and the function-field case
+//! (coefficients in `ℚ(x)` rational functions): only the scalar type changes.
+//! Accordingly the polynomial operations (`gpoly_*`, [`gext_gcd`],
+//! [`gpoly_mod`], [`gmod_inverse`]) and the quotient ring [`Quotient`] are
+//! generic over a [`CoeffField`] trait — the scalar field, optionally carrying a
+//! `derivation`.  [`NumberField`] is then exactly the `CoeffField = `[`RationalField`]
+//! (`ℚ`) instantiation, and the forthcoming `x`-dependent algebraic *function*
+//! field (`alg_field.rs`, with a non-trivial derivation `D(y) = −q_x/q_y` over a
+//! `ℚ(x)` base) is the other instantiation.  Both reuse this one implementation
+//! of the polynomial-quotient plumbing rather than forking it.
 //!
 //! The three free functions [`poly_mod`], [`ext_gcd`], and [`mod_inverse`] are
-//! generic `ℚ[x]`-modulo-a-polynomial operations (the modulus need not be
-//! irreducible); they underpin both [`NumberField`] and the Hermite-reduction
-//! step in [`super::rational_integrate`].
+//! the `ℚ`-coefficient specializations (the modulus need not be irreducible);
+//! they underpin both [`NumberField`] and the Hermite-reduction step in
+//! [`super::rational_integrate`].
 
 use rug::Rational;
 
-use super::poly_rde::{degree, poly_add, poly_mul, poly_one, poly_scale, poly_zero, trim, QPoly};
-use super::rational_rde::{poly_divrem, poly_sub};
+use super::poly_rde::{trim, QPoly};
+
+// ===========================================================================
+// CoeffField — the scalar field the quotient ring is built over
+// ===========================================================================
+
+/// A field of scalars over which polynomial / quotient-ring arithmetic is done.
+///
+/// Implementors so far: [`RationalField`] (`ℚ`, the constant field — its
+/// [`derivation`](CoeffField::derivation) is identically zero).  The Risch M0
+/// work adds a `ℚ(x)` rational-function instantiation whose derivation is
+/// `d/dx`; that is what turns [`Quotient`] into an algebraic *function* field.
+pub trait CoeffField {
+    /// The scalar type.
+    type Elem: Clone + std::fmt::Debug;
+
+    /// The additive identity `0`.
+    fn zero(&self) -> Self::Elem;
+    /// The multiplicative identity `1`.
+    fn one(&self) -> Self::Elem;
+    /// Embed an integer.  (Takes `&self`: a coefficient field may need its own
+    /// data to embed — e.g. a prime field reduces mod `p`.)
+    #[allow(clippy::wrong_self_convention)]
+    fn from_i64(&self, n: i64) -> Self::Elem;
+
+    /// `a + b`.
+    fn add(&self, a: &Self::Elem, b: &Self::Elem) -> Self::Elem;
+    /// `a − b`.
+    fn sub(&self, a: &Self::Elem, b: &Self::Elem) -> Self::Elem;
+    /// `a · b`.
+    fn mul(&self, a: &Self::Elem, b: &Self::Elem) -> Self::Elem;
+    /// `−a`.
+    fn neg(&self, a: &Self::Elem) -> Self::Elem;
+    /// `a⁻¹`, or `None` if `a` is zero.  (A field: every nonzero element is a
+    /// unit.)
+    fn inv(&self, a: &Self::Elem) -> Option<Self::Elem>;
+
+    /// Is `a` the zero element?
+    fn is_zero(&self, a: &Self::Elem) -> bool;
+    /// Are `a` and `b` equal?
+    fn eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool;
+
+    /// The derivation `D` of the field.  Defaults to `0` — i.e. the field is
+    /// treated as a field of *constants* (correct for `ℚ`).  An `x`-dependent
+    /// coefficient field overrides this with `d/dx`.
+    fn derivation(&self, a: &Self::Elem) -> Self::Elem {
+        let _ = a;
+        self.zero()
+    }
+}
+
+/// The rational field `ℚ` — the constant coefficient field.
+#[derive(Clone, Debug, Default)]
+pub struct RationalField;
+
+impl CoeffField for RationalField {
+    type Elem = Rational;
+
+    fn zero(&self) -> Rational {
+        Rational::from(0)
+    }
+    fn one(&self) -> Rational {
+        Rational::from(1)
+    }
+    fn from_i64(&self, n: i64) -> Rational {
+        Rational::from(n)
+    }
+    fn add(&self, a: &Rational, b: &Rational) -> Rational {
+        Rational::from(a + b)
+    }
+    fn sub(&self, a: &Rational, b: &Rational) -> Rational {
+        Rational::from(a - b)
+    }
+    fn mul(&self, a: &Rational, b: &Rational) -> Rational {
+        Rational::from(a * b)
+    }
+    fn neg(&self, a: &Rational) -> Rational {
+        Rational::from(-a)
+    }
+    fn inv(&self, a: &Rational) -> Option<Rational> {
+        if *a == 0 {
+            None
+        } else {
+            Some(Rational::from(1) / a.clone())
+        }
+    }
+    fn is_zero(&self, a: &Rational) -> bool {
+        *a == 0
+    }
+    fn eq(&self, a: &Rational, b: &Rational) -> bool {
+        a == b
+    }
+    // derivation defaults to 0 — ℚ is the constant field for d/dx.
+}
+
+// ===========================================================================
+// Generic polynomial arithmetic over an arbitrary CoeffField
+// ===========================================================================
+
+/// A polynomial over `F` (ascending degree), as a coefficient vector.
+pub type GPoly<F> = Vec<<F as CoeffField>::Elem>;
+
+/// A polynomial in `x` whose coefficients live in a [`Quotient`]`<F>`
+/// (ascending degree in `x`).
+pub type KPolyG<F> = Vec<GPoly<F>>;
+
+/// Drop trailing zero coefficients.
+pub fn gtrim<F: CoeffField>(f: &F, mut p: GPoly<F>) -> GPoly<F> {
+    while p.last().is_some_and(|c| f.is_zero(c)) {
+        p.pop();
+    }
+    p
+}
+
+/// Degree (returns `-1` for the zero polynomial).
+pub fn gdegree<F: CoeffField>(f: &F, p: &[F::Elem]) -> i64 {
+    let mut d = p.len() as i64 - 1;
+    while d >= 0 && f.is_zero(&p[d as usize]) {
+        d -= 1;
+    }
+    d
+}
+
+/// The zero polynomial.
+pub fn gpoly_zero<F: CoeffField>() -> GPoly<F> {
+    Vec::new()
+}
+
+/// The constant polynomial `1`.
+pub fn gpoly_one<F: CoeffField>(f: &F) -> GPoly<F> {
+    vec![f.one()]
+}
+
+/// `a + b`.
+pub fn gpoly_add<F: CoeffField>(f: &F, a: &[F::Elem], b: &[F::Elem]) -> GPoly<F> {
+    let n = a.len().max(b.len());
+    let mut r: GPoly<F> = (0..n).map(|_| f.zero()).collect();
+    for (i, c) in a.iter().enumerate() {
+        r[i] = f.add(&r[i], c);
+    }
+    for (i, c) in b.iter().enumerate() {
+        r[i] = f.add(&r[i], c);
+    }
+    gtrim(f, r)
+}
+
+/// `a − b`.
+pub fn gpoly_sub<F: CoeffField>(f: &F, a: &[F::Elem], b: &[F::Elem]) -> GPoly<F> {
+    let n = a.len().max(b.len());
+    let mut r: GPoly<F> = (0..n).map(|_| f.zero()).collect();
+    for (i, c) in a.iter().enumerate() {
+        r[i] = f.add(&r[i], c);
+    }
+    for (i, c) in b.iter().enumerate() {
+        r[i] = f.sub(&r[i], c);
+    }
+    gtrim(f, r)
+}
+
+/// Scale `p` by the scalar `s`.
+pub fn gpoly_scale<F: CoeffField>(f: &F, p: &[F::Elem], s: &F::Elem) -> GPoly<F> {
+    if f.is_zero(s) || p.is_empty() {
+        return Vec::new();
+    }
+    gtrim(f, p.iter().map(|c| f.mul(c, s)).collect())
+}
+
+/// `a · b`.
+pub fn gpoly_mul<F: CoeffField>(f: &F, a: &[F::Elem], b: &[F::Elem]) -> GPoly<F> {
+    if a.is_empty() || b.is_empty() {
+        return Vec::new();
+    }
+    let mut r: GPoly<F> = (0..a.len() + b.len() - 1).map(|_| f.zero()).collect();
+    for (i, ca) in a.iter().enumerate() {
+        if f.is_zero(ca) {
+            continue;
+        }
+        for (j, cb) in b.iter().enumerate() {
+            let p = f.mul(ca, cb);
+            r[i + j] = f.add(&r[i + j], &p);
+        }
+    }
+    gtrim(f, r)
+}
+
+/// Long division: returns `(q, r)` with `a = q·b + r`, `deg r < deg b`.  `b`
+/// must be nonzero; its leading coefficient must be invertible (always true in
+/// a field).
+pub fn gpoly_divrem<F: CoeffField>(f: &F, a: &[F::Elem], b: &[F::Elem]) -> (GPoly<F>, GPoly<F>) {
+    let b = gtrim(f, b.to_vec());
+    let bd = gdegree(f, &b);
+    debug_assert!(bd >= 0, "gpoly_divrem: division by zero polynomial");
+    let lc_inv = f
+        .inv(&b[bd as usize])
+        .expect("leading coefficient of a field element is invertible");
+
+    let mut r = gtrim(f, a.to_vec());
+    let ad = gdegree(f, &r);
+    if ad < bd {
+        return (Vec::new(), r);
+    }
+    let mut q: GPoly<F> = (0..(ad - bd + 1) as usize).map(|_| f.zero()).collect();
+    loop {
+        let rd = gdegree(f, &r);
+        if rd < bd {
+            break;
+        }
+        let shift = (rd - bd) as usize;
+        let factor = f.mul(&r[rd as usize], &lc_inv);
+        q[shift] = f.add(&q[shift], &factor);
+        for (i, bc) in b.iter().enumerate() {
+            let prod = f.mul(&factor, bc);
+            r[shift + i] = f.sub(&r[shift + i], &prod);
+        }
+        r = gtrim(f, r);
+        if r.is_empty() {
+            break;
+        }
+    }
+    (gtrim(f, q), r)
+}
+
+/// Extended GCD: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
+pub fn gext_gcd<F: CoeffField>(
+    f: &F,
+    a: &[F::Elem],
+    b: &[F::Elem],
+) -> (GPoly<F>, GPoly<F>, GPoly<F>) {
+    let (mut old_r, mut r) = (gtrim(f, a.to_vec()), gtrim(f, b.to_vec()));
+    let (mut old_s, mut s) = (gpoly_one(f), gpoly_zero::<F>());
+    let (mut old_t, mut t) = (gpoly_zero::<F>(), gpoly_one(f));
+    while !r.is_empty() {
+        let (q, rem) = gpoly_divrem(f, &old_r, &r);
+        old_r = r;
+        r = rem;
+        let ns = gpoly_sub(f, &old_s, &gpoly_mul(f, &q, &s));
+        old_s = s;
+        s = ns;
+        let nt = gpoly_sub(f, &old_t, &gpoly_mul(f, &q, &t));
+        old_t = t;
+        t = nt;
+    }
+    let dg = gdegree(f, &old_r);
+    if dg < 0 {
+        return (Vec::new(), old_s, old_t);
+    }
+    let inv = f
+        .inv(&old_r[dg as usize])
+        .expect("nonzero leading coefficient of a field element is invertible");
+    (
+        gpoly_scale(f, &old_r, &inv),
+        gpoly_scale(f, &old_s, &inv),
+        gpoly_scale(f, &old_t, &inv),
+    )
+}
+
+/// Remainder of `a mod m`.
+pub fn gpoly_mod<F: CoeffField>(f: &F, a: &[F::Elem], m: &[F::Elem]) -> GPoly<F> {
+    gpoly_divrem(f, a, m).1
+}
+
+/// Inverse of `w` modulo `v` (requires `gcd(w, v) = 1`), else `None`.
+pub fn gmod_inverse<F: CoeffField>(f: &F, w: &[F::Elem], v: &[F::Elem]) -> Option<GPoly<F>> {
+    let (g, s, _t) = gext_gcd(f, w, v);
+    if gdegree(f, &g) != 0 {
+        return None; // not coprime
+    }
+    Some(gpoly_mod(f, &s, v))
+}
+
+/// Coefficient-wise equality after trimming.
+pub fn gpoly_eq<F: CoeffField>(f: &F, a: &[F::Elem], b: &[F::Elem]) -> bool {
+    let a = gtrim(f, a.to_vec());
+    let b = gtrim(f, b.to_vec());
+    a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| f.eq(x, y))
+}
 
 // ---------------------------------------------------------------------------
-// Base field: ℚ[x] modular arithmetic (modulus need not be irreducible)
+// Base field: ℚ[x] modular arithmetic (the RationalField specialization)
 // ---------------------------------------------------------------------------
 
 /// Remainder of `a mod m` in `ℚ[x]`.
 pub fn poly_mod(a: &QPoly, m: &QPoly) -> QPoly {
-    poly_divrem(a, m).1
+    gpoly_mod(&RationalField, a, m)
 }
 
 /// Extended GCD over `ℚ[x]`: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
 pub fn ext_gcd(a: &QPoly, b: &QPoly) -> (QPoly, QPoly, QPoly) {
-    let (mut old_r, mut r) = (trim(a.clone()), trim(b.clone()));
-    let (mut old_s, mut s) = (poly_one(), poly_zero());
-    let (mut old_t, mut t) = (poly_zero(), poly_one());
-    while !r.is_empty() {
-        let (q, rem) = poly_divrem(&old_r, &r);
-        old_r = r;
-        r = rem;
-        let ns = poly_sub(&old_s, &poly_mul(&q, &s));
-        old_s = s;
-        s = ns;
-        let nt = poly_sub(&old_t, &poly_mul(&q, &t));
-        old_t = t;
-        t = nt;
-    }
-    let dg = degree(&old_r);
-    if dg < 0 {
-        return (poly_zero(), old_s, old_t);
-    }
-    let inv = Rational::from(1) / old_r[dg as usize].clone();
-    (
-        poly_scale(&old_r, &inv),
-        poly_scale(&old_s, &inv),
-        poly_scale(&old_t, &inv),
-    )
+    gext_gcd(&RationalField, a, b)
 }
 
 /// Inverse of `w` modulo `v` (requires `gcd(w, v) = 1`), else `None`.
 pub fn mod_inverse(w: &QPoly, v: &QPoly) -> Option<QPoly> {
-    let (g, s, _t) = ext_gcd(w, v);
-    if degree(&g) != 0 {
-        return None; // not coprime
-    }
-    Some(poly_mod(&s, v))
+    gmod_inverse(&RationalField, w, v)
 }
 
-// ---------------------------------------------------------------------------
-// Number field K = ℚ[t]/(q)
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Generic quotient ring  F[t]/(modulus)  and  F[t]/(q) [x]  arithmetic
+// ===========================================================================
+
+/// The quotient ring `F[t]/(modulus)` over a coefficient field `F`, together
+/// with arithmetic of polynomials in a second variable `x` over that quotient.
+///
+/// With `F = `[`RationalField`] this is an algebraic *number* field `ℚ[t]/(q)`
+/// (see [`NumberField`]).  With an `x`-dependent `F = ℚ(x)` and a non-trivial
+/// [`CoeffField::derivation`] it is an algebraic *function* field — the M0
+/// substrate `alg_field.rs` builds on.
+#[derive(Clone, Debug)]
+pub struct Quotient<F: CoeffField> {
+    field: F,
+    modulus: GPoly<F>,
+}
+
+impl<F: CoeffField> Quotient<F> {
+    /// Build `F[t]/(modulus)`.
+    pub fn new(field: F, modulus: GPoly<F>) -> Self {
+        let modulus = gtrim(&field, modulus);
+        Self { field, modulus }
+    }
+
+    /// The coefficient field `F`.
+    pub fn field(&self) -> &F {
+        &self.field
+    }
+
+    /// The defining (minimal) polynomial.
+    pub fn modulus(&self) -> &GPoly<F> {
+        &self.modulus
+    }
+
+    /// Extension degree `deg(modulus)`.
+    pub fn degree(&self) -> i64 {
+        gdegree(&self.field, &self.modulus)
+    }
+
+    /// The zero element of the quotient.
+    pub fn elem_zero() -> GPoly<F> {
+        Vec::new()
+    }
+
+    /// Is the quotient element zero?
+    pub fn elem_is_zero(&self, a: &[F::Elem]) -> bool {
+        gtrim(&self.field, a.to_vec()).is_empty()
+    }
+
+    /// Coefficient-wise equality of two quotient elements.
+    pub fn elem_eq(&self, a: &[F::Elem], b: &[F::Elem]) -> bool {
+        gpoly_eq(&self.field, a, b)
+    }
+
+    /// Reduce an arbitrary `F`-polynomial in `t` into canonical form.
+    pub fn reduce(&self, a: &[F::Elem]) -> GPoly<F> {
+        gpoly_mod(&self.field, a, &self.modulus)
+    }
+
+    /// `a + b`.
+    pub fn add(&self, a: &[F::Elem], b: &[F::Elem]) -> GPoly<F> {
+        self.reduce(&gpoly_add(&self.field, a, b))
+    }
+
+    /// `a − b`.
+    pub fn sub(&self, a: &[F::Elem], b: &[F::Elem]) -> GPoly<F> {
+        self.reduce(&gpoly_sub(&self.field, a, b))
+    }
+
+    /// `a · b`.
+    pub fn mul(&self, a: &[F::Elem], b: &[F::Elem]) -> GPoly<F> {
+        self.reduce(&gpoly_mul(&self.field, a, b))
+    }
+
+    /// `−a`.
+    pub fn neg(&self, a: &[F::Elem]) -> GPoly<F> {
+        let neg_one = self.field.neg(&self.field.one());
+        self.reduce(&gpoly_scale(&self.field, a, &neg_one))
+    }
+
+    /// `a⁻¹`, or `None` when `a` is a zero divisor or zero.
+    pub fn inv(&self, a: &[F::Elem]) -> Option<GPoly<F>> {
+        gmod_inverse(&self.field, a, &self.modulus)
+    }
+
+    /// Embed an integer.
+    pub fn from_int(&self, n: i64) -> GPoly<F> {
+        self.reduce(&[self.field.from_i64(n)])
+    }
+
+    // -- polynomials in x over the quotient --
+
+    /// Degree (in `x`) of a quotient-polynomial; `-1` for the zero polynomial.
+    pub fn kdeg(&self, p: &[GPoly<F>]) -> i64 {
+        let mut d = p.len() as i64 - 1;
+        while d >= 0 && self.elem_is_zero(&p[d as usize]) {
+            d -= 1;
+        }
+        d
+    }
+
+    /// Drop trailing zero quotient-coefficients.
+    pub fn kpoly_trim(&self, mut p: Vec<GPoly<F>>) -> Vec<GPoly<F>> {
+        while p.last().is_some_and(|c| self.elem_is_zero(c)) {
+            p.pop();
+        }
+        p
+    }
+
+    /// Coefficient of `x^i`; the zero element for `i < 0` or out of range.
+    pub fn kcoeff(&self, p: &[GPoly<F>], i: i64) -> GPoly<F> {
+        if i < 0 {
+            return Self::elem_zero();
+        }
+        p.get(i as usize).cloned().unwrap_or_else(Self::elem_zero)
+    }
+
+    /// Euclidean division of quotient-polynomials in `x`; `(quot, rem)` with
+    /// `deg_x rem < deg_x b`.  `None` if `b` is zero or a leading coefficient is
+    /// not invertible.
+    pub fn kpoly_divrem(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> Option<(KPolyG<F>, KPolyG<F>)> {
+        let bd = self.kdeg(b);
+        if bd < 0 {
+            return None;
+        }
+        let lead_inv = self.inv(&b[bd as usize])?;
+        let mut r = self.kpoly_trim(a.to_vec());
+        let ad = self.kdeg(&r);
+        if ad < bd {
+            return Some((vec![], r));
+        }
+        let mut quot = vec![Self::elem_zero(); (ad - bd + 1) as usize];
+        loop {
+            let rd = self.kdeg(&r);
+            if rd < bd {
+                break;
+            }
+            let coeff = self.mul(&r[rd as usize], &lead_inv);
+            let shift = (rd - bd) as usize;
+            for (i, bi) in b.iter().enumerate() {
+                if shift + i < r.len() {
+                    r[shift + i] = self.sub(&r[shift + i], &self.mul(&coeff, bi));
+                }
+            }
+            quot[shift] = coeff;
+            r = self.kpoly_trim(r);
+            if r.is_empty() {
+                break;
+            }
+        }
+        Some((self.kpoly_trim(quot), r))
+    }
+
+    /// Monic (in `x`) GCD of two quotient-polynomials.
+    pub fn kpoly_gcd(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> Option<Vec<GPoly<F>>> {
+        let mut a = self.kpoly_trim(a.to_vec());
+        let mut b = self.kpoly_trim(b.to_vec());
+        while self.kdeg(&b) >= 0 {
+            let (_, rem) = self.kpoly_divrem(&a, &b)?;
+            a = b;
+            b = rem;
+        }
+        let ad = self.kdeg(&a);
+        if ad < 0 {
+            return None;
+        }
+        let lead_inv = self.inv(&a[ad as usize])?;
+        Some(a.iter().map(|c| self.mul(c, &lead_inv)).collect())
+    }
+
+    /// `a + b` of two quotient-polynomials in `x`.
+    pub fn kpoly_add(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> Vec<GPoly<F>> {
+        let n = a.len().max(b.len());
+        let mut r = vec![Self::elem_zero(); n];
+        for (i, c) in a.iter().enumerate() {
+            r[i] = self.add(&r[i], c);
+        }
+        for (i, c) in b.iter().enumerate() {
+            r[i] = self.add(&r[i], c);
+        }
+        self.kpoly_trim(r)
+    }
+
+    /// `a − b` of two quotient-polynomials in `x`.
+    pub fn kpoly_sub(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> Vec<GPoly<F>> {
+        let n = a.len().max(b.len());
+        let mut r = vec![Self::elem_zero(); n];
+        for (i, c) in a.iter().enumerate() {
+            r[i] = self.add(&r[i], c);
+        }
+        for (i, c) in b.iter().enumerate() {
+            r[i] = self.sub(&r[i], c);
+        }
+        self.kpoly_trim(r)
+    }
+
+    /// Scale a quotient-polynomial in `x` by a quotient element.
+    pub fn kpoly_scale(&self, p: &[GPoly<F>], s: &[F::Elem]) -> Vec<GPoly<F>> {
+        if self.elem_is_zero(s) {
+            return Vec::new();
+        }
+        self.kpoly_trim(p.iter().map(|c| self.mul(c, s)).collect())
+    }
+
+    /// `a · b` of two quotient-polynomials in `x`.
+    pub fn kpoly_mul(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> Vec<GPoly<F>> {
+        if self.kdeg(a) < 0 || self.kdeg(b) < 0 {
+            return Vec::new();
+        }
+        let mut r = vec![Self::elem_zero(); a.len() + b.len() - 1];
+        for (i, ca) in a.iter().enumerate() {
+            if self.elem_is_zero(ca) {
+                continue;
+            }
+            for (j, cb) in b.iter().enumerate() {
+                let p = self.mul(ca, cb);
+                r[i + j] = self.add(&r[i + j], &p);
+            }
+        }
+        self.kpoly_trim(r)
+    }
+
+    /// `d/dx` of a quotient-polynomial in `x`.
+    ///
+    /// Note: this differentiates only with respect to the explicit `x`; it does
+    /// **not** apply the coefficient field's own [`CoeffField::derivation`] to
+    /// the coefficients (correct for the `ℚ`/constant case).  A function-field
+    /// derivation that also acts on coefficients is layered on top in M0.
+    pub fn kpoly_deriv(&self, p: &[GPoly<F>]) -> Vec<GPoly<F>> {
+        if p.len() <= 1 {
+            return Vec::new();
+        }
+        self.kpoly_trim(
+            p[1..]
+                .iter()
+                .enumerate()
+                .map(|(i, c)| self.mul(&self.from_int(i as i64 + 1), c))
+                .collect(),
+        )
+    }
+
+    /// `∫ dx` of a quotient-polynomial in `x` (constant of integration 0).
+    pub fn kpoly_integrate(&self, p: &[GPoly<F>]) -> Vec<GPoly<F>> {
+        let p = self.kpoly_trim(p.to_vec());
+        if p.is_empty() {
+            return Vec::new();
+        }
+        let mut r = vec![Self::elem_zero()];
+        for (i, c) in p.iter().enumerate() {
+            let inv = self
+                .inv(&self.from_int(i as i64 + 1))
+                .expect("nonzero integer is invertible in a field");
+            r.push(self.mul(c, &inv));
+        }
+        self.kpoly_trim(r)
+    }
+
+    /// `p^n` of a quotient-polynomial in `x` (`n ≥ 0`; `p^0 = 1`).
+    pub fn kpoly_pow(&self, p: &[GPoly<F>], n: u32) -> Vec<GPoly<F>> {
+        let mut acc = vec![self.from_int(1)];
+        for _ in 0..n {
+            acc = self.kpoly_mul(&acc, p);
+        }
+        acc
+    }
+
+    /// Make a quotient-polynomial monic in `x`.  The zero polynomial is returned
+    /// unchanged; `None` if the leading coefficient is not invertible.
+    pub fn kpoly_monic(&self, p: &[GPoly<F>]) -> Option<Vec<GPoly<F>>> {
+        let d = self.kdeg(p);
+        if d < 0 {
+            return Some(Vec::new());
+        }
+        let inv = self.inv(&p[d as usize])?;
+        Some(self.kpoly_trim(p.iter().map(|c| self.mul(c, &inv)).collect()))
+    }
+
+    /// Exact division `a / b`; `None` if `b` does not divide `a` evenly.
+    pub fn kpoly_div_exact(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> Option<Vec<GPoly<F>>> {
+        let (q, r) = self.kpoly_divrem(a, b)?;
+        if self.kdeg(&r) >= 0 {
+            return None;
+        }
+        Some(q)
+    }
+
+    /// Equality of two quotient-polynomials in `x` (coefficient-wise after
+    /// trimming).
+    pub fn kpoly_eq(&self, a: &[GPoly<F>], b: &[GPoly<F>]) -> bool {
+        let a = self.kpoly_trim(a.to_vec());
+        let b = self.kpoly_trim(b.to_vec());
+        a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| self.elem_eq(x, y))
+    }
+}
+
+// ===========================================================================
+// NumberField = the ℚ instantiation  Quotient<RationalField>
+// ===========================================================================
 
 /// An element of `K` — a ℚ-polynomial in the generator `t`, reduced mod `q`.
 pub type KElem = QPoly;
@@ -86,58 +640,76 @@ pub type KPoly = Vec<KElem>;
 /// `q` should be squarefree (irreducible for a genuine field; squarefree is
 /// enough for the residue-by-residue Lazard–Rioboo–Trager use, where any
 /// non-invertible leading coefficient simply makes an operation return `None`).
+///
+/// This is a thin wrapper over [`Quotient`]`<`[`RationalField`]`>`: the algebraic
+/// number field is exactly the constant-coefficient (`ℚ`) instantiation of the
+/// generic polynomial-quotient core.  The number-theoretic surface
+/// ([`norm`](NumberField::norm), [`trace`](NumberField::trace),
+/// [`field_degree`](NumberField::field_degree)) lives here because it is
+/// specific to the constant field.
 #[derive(Clone, Debug)]
 pub struct NumberField {
-    modulus: QPoly,
+    inner: Quotient<RationalField>,
 }
 
 impl NumberField {
     /// Build `K = ℚ[t]/(modulus)`.
     pub fn new(modulus: QPoly) -> Self {
         Self {
-            modulus: trim(modulus),
+            inner: Quotient::new(RationalField, modulus),
         }
+    }
+
+    /// The underlying generic quotient ring.
+    pub fn quotient(&self) -> &Quotient<RationalField> {
+        &self.inner
     }
 
     /// The defining (minimal) polynomial `q(t)`.
     pub fn modulus(&self) -> &QPoly {
-        &self.modulus
+        self.inner.modulus()
     }
 
     /// Field degree `[K : ℚ] = deg q`.
     pub fn degree(&self) -> i64 {
-        degree(&self.modulus)
+        self.inner.degree()
+    }
+
+    /// Field degree `[K : ℚ]` (alias of [`degree`](NumberField::degree); part of
+    /// the §7.3 algebraic-number-field surface).
+    pub fn field_degree(&self) -> i64 {
+        self.inner.degree()
     }
 
     /// Reduce an arbitrary ℚ-polynomial in `t` into canonical `K`-element form.
     pub fn reduce(&self, a: &KElem) -> KElem {
-        poly_mod(a, &self.modulus)
+        self.inner.reduce(a)
     }
 
     /// `a + b` in `K`.
     pub fn add(&self, a: &KElem, b: &KElem) -> KElem {
-        self.reduce(&poly_add(a, b))
+        self.inner.add(a, b)
     }
 
     /// `a − b` in `K`.
     pub fn sub(&self, a: &KElem, b: &KElem) -> KElem {
-        self.reduce(&poly_sub(a, b))
+        self.inner.sub(a, b)
     }
 
     /// `a · b` in `K`.
     pub fn mul(&self, a: &KElem, b: &KElem) -> KElem {
-        self.reduce(&poly_mul(a, b))
+        self.inner.mul(a, b)
     }
 
     /// `−a` in `K`.
     pub fn neg(&self, a: &KElem) -> KElem {
-        self.reduce(&poly_scale(a, &Rational::from(-1)))
+        self.inner.neg(a)
     }
 
     /// Multiplicative inverse `a⁻¹` in `K`, or `None` when `a` is a zero divisor
     /// (e.g. shares a factor with a non-irreducible modulus) or zero.
     pub fn inv(&self, a: &KElem) -> Option<KElem> {
-        mod_inverse(a, &self.modulus)
+        self.inner.inv(a)
     }
 
     /// Is the `K`-element zero?
@@ -145,7 +717,7 @@ impl NumberField {
         trim(a.clone()).is_empty()
     }
 
-    // -- polynomials in x over K --
+    // -- polynomials in x over K (delegated to the generic quotient) --
 
     /// Degree (in `x`) of a `K`-polynomial; `-1` for the zero polynomial.
     pub fn kdeg(p: &[KElem]) -> i64 {
@@ -168,64 +740,15 @@ impl NumberField {
     /// `a = quot·b + rem` and `deg_x rem < deg_x b`.  `None` if `b` is zero or a
     /// leading coefficient is not invertible in `K`.
     pub fn kpoly_divrem(&self, a: &[KElem], b: &[KElem]) -> Option<(KPoly, KPoly)> {
-        let bd = Self::kdeg(b);
-        if bd < 0 {
-            return None; // division by zero
-        }
-        let lead_inv = self.inv(&b[bd as usize])?;
-        let mut r = Self::kpoly_trim(a.to_vec());
-        let ad = Self::kdeg(&r);
-        if ad < bd {
-            return Some((vec![], r));
-        }
-        let mut quot = vec![poly_zero(); (ad - bd + 1) as usize];
-        loop {
-            let rd = Self::kdeg(&r);
-            if rd < bd {
-                break;
-            }
-            let coeff = self.mul(&r[rd as usize], &lead_inv);
-            let shift = (rd - bd) as usize;
-            for (i, bi) in b.iter().enumerate() {
-                if shift + i < r.len() {
-                    r[shift + i] = self.sub(&r[shift + i], &self.mul(&coeff, bi));
-                }
-            }
-            quot[shift] = coeff;
-            r = Self::kpoly_trim(r);
-            if r.is_empty() {
-                break;
-            }
-        }
-        Some((Self::kpoly_trim(quot), r))
+        self.inner.kpoly_divrem(a, b)
     }
 
     /// Monic (in `x`) GCD of two `K`-polynomials.  `None` if both are zero or a
     /// leading coefficient is not invertible in `K`.
     pub fn kpoly_gcd(&self, a: &[KElem], b: &[KElem]) -> Option<KPoly> {
-        let mut a = Self::kpoly_trim(a.to_vec());
-        let mut b = Self::kpoly_trim(b.to_vec());
-        while Self::kdeg(&b) >= 0 {
-            let (_, rem) = self.kpoly_divrem(&a, &b)?;
-            a = b;
-            b = rem;
-        }
-        let ad = Self::kdeg(&a);
-        if ad < 0 {
-            return None;
-        }
-        // Make monic in x.
-        let lead_inv = self.inv(&a[ad as usize])?;
-        Some(a.iter().map(|c| self.mul(c, &lead_inv)).collect())
+        self.inner.kpoly_gcd(a, b)
     }
-}
 
-// ---------------------------------------------------------------------------
-// K-element constructors and K-polynomial-in-x arithmetic
-// (used by the polynomial Risch DE over ℚ(α); see `poly_rde::solve_poly_rde_k`)
-// ---------------------------------------------------------------------------
-
-impl NumberField {
     /// The zero `K`-element.
     pub fn k_zero() -> KElem {
         Vec::new()
@@ -233,127 +756,60 @@ impl NumberField {
 
     /// Embed an integer into `K`.
     pub fn from_int(&self, n: i64) -> KElem {
-        self.reduce(&vec![Rational::from(n)])
+        self.inner.from_int(n)
     }
 
     /// Embed a rational into `K`.
     pub fn from_rational(&self, r: &Rational) -> KElem {
-        self.reduce(&vec![r.clone()])
+        self.inner.reduce(std::slice::from_ref(r))
     }
 
     /// `a + b` of two `K`-polynomials in `x`.
     pub fn kpoly_add(&self, a: &[KElem], b: &[KElem]) -> KPoly {
-        let n = a.len().max(b.len());
-        let mut r = vec![Self::k_zero(); n];
-        for (i, c) in a.iter().enumerate() {
-            r[i] = self.add(&r[i], c);
-        }
-        for (i, c) in b.iter().enumerate() {
-            r[i] = self.add(&r[i], c);
-        }
-        Self::kpoly_trim(r)
+        self.inner.kpoly_add(a, b)
     }
 
     /// `a − b` of two `K`-polynomials in `x`.
     pub fn kpoly_sub(&self, a: &[KElem], b: &[KElem]) -> KPoly {
-        let n = a.len().max(b.len());
-        let mut r = vec![Self::k_zero(); n];
-        for (i, c) in a.iter().enumerate() {
-            r[i] = self.add(&r[i], c);
-        }
-        for (i, c) in b.iter().enumerate() {
-            r[i] = self.sub(&r[i], c);
-        }
-        Self::kpoly_trim(r)
+        self.inner.kpoly_sub(a, b)
     }
 
     /// Scale a `K`-polynomial in `x` by a `K`-element.
     pub fn kpoly_scale(&self, p: &[KElem], s: &KElem) -> KPoly {
-        if Self::is_zero(s) {
-            return Vec::new();
-        }
-        Self::kpoly_trim(p.iter().map(|c| self.mul(c, s)).collect())
+        self.inner.kpoly_scale(p, s)
     }
 
     /// `a · b` of two `K`-polynomials in `x`.
     pub fn kpoly_mul(&self, a: &[KElem], b: &[KElem]) -> KPoly {
-        if Self::kdeg(a) < 0 || Self::kdeg(b) < 0 {
-            return Vec::new();
-        }
-        let mut r = vec![Self::k_zero(); a.len() + b.len() - 1];
-        for (i, ca) in a.iter().enumerate() {
-            if Self::is_zero(ca) {
-                continue;
-            }
-            for (j, cb) in b.iter().enumerate() {
-                let p = self.mul(ca, cb);
-                r[i + j] = self.add(&r[i + j], &p);
-            }
-        }
-        Self::kpoly_trim(r)
+        self.inner.kpoly_mul(a, b)
     }
 
     /// `d/dx` of a `K`-polynomial in `x`.
     pub fn kpoly_deriv(&self, p: &[KElem]) -> KPoly {
-        if p.len() <= 1 {
-            return Vec::new();
-        }
-        Self::kpoly_trim(
-            p[1..]
-                .iter()
-                .enumerate()
-                .map(|(i, c)| self.mul(&self.from_int(i as i64 + 1), c))
-                .collect(),
-        )
+        self.inner.kpoly_deriv(p)
     }
 
     /// `∫ dx` of a `K`-polynomial in `x` (constant of integration 0).
     pub fn kpoly_integrate(&self, p: &[KElem]) -> KPoly {
-        let p = Self::kpoly_trim(p.to_vec());
-        if p.is_empty() {
-            return Vec::new();
-        }
-        let mut r = vec![Self::k_zero()]; // constant term 0
-        for (i, c) in p.iter().enumerate() {
-            let inv = self
-                .inv(&self.from_int(i as i64 + 1))
-                .expect("nonzero integer is invertible in a number field");
-            r.push(self.mul(c, &inv));
-        }
-        Self::kpoly_trim(r)
+        self.inner.kpoly_integrate(p)
     }
 
     /// `p^n` of a `K`-polynomial in `x` (`n ≥ 0`; `p^0 = 1`).
     pub fn kpoly_pow(&self, p: &[KElem], n: u32) -> KPoly {
-        let mut acc = vec![self.from_int(1)];
-        for _ in 0..n {
-            acc = self.kpoly_mul(&acc, p);
-        }
-        acc
+        self.inner.kpoly_pow(p, n)
     }
 
     /// Make a `K`-polynomial monic in `x` (divide by its leading coefficient).
     /// The zero polynomial is returned unchanged; `None` if the leading
     /// coefficient is not invertible in `K`.
     pub fn kpoly_monic(&self, p: &[KElem]) -> Option<KPoly> {
-        let d = Self::kdeg(p);
-        if d < 0 {
-            return Some(Vec::new());
-        }
-        let inv = self.inv(&p[d as usize])?;
-        Some(Self::kpoly_trim(
-            p.iter().map(|c| self.mul(c, &inv)).collect(),
-        ))
+        self.inner.kpoly_monic(p)
     }
 
     /// Exact division `a / b` of `K`-polynomials in `x`; `None` if `b` does not
     /// divide `a` evenly (or `b` is zero / has a non-invertible leading term).
     pub fn kpoly_div_exact(&self, a: &[KElem], b: &[KElem]) -> Option<KPoly> {
-        let (q, r) = self.kpoly_divrem(a, b)?;
-        if Self::kdeg(&r) >= 0 {
-            return None; // nonzero remainder
-        }
-        Some(q)
+        self.inner.kpoly_div_exact(a, b)
     }
 
     /// Coefficient of `x^i` in a `K`-polynomial; the zero element for `i < 0` or
@@ -376,15 +832,84 @@ impl NumberField {
             .zip(b.iter())
             .all(|(x, y)| trim(x.clone()) == trim(y.clone()))
     }
+
+    // -- number-theoretic surface (mathematical-coverage.md §7.3 slice) --
+
+    /// The multiplication-by-`a` matrix `M` of the ℚ-linear endomorphism `b ↦ a·b`
+    /// of `K`, in the power basis `1, t, …, t^{d−1}`.  `M[i][j]` is the
+    /// coefficient of `t^i` in `a·t^j` reduced mod `q`.
+    fn mult_matrix(&self, a: &KElem) -> Vec<Vec<Rational>> {
+        let d = self.degree();
+        if d < 1 {
+            // Degenerate: K is (a quotient of) ℚ itself.
+            let c = self.reduce(a);
+            let v = c.first().cloned().unwrap_or_else(|| Rational::from(0));
+            return vec![vec![v]];
+        }
+        let d = d as usize;
+        let a_red = self.reduce(a);
+        let mut m = vec![vec![Rational::from(0); d]; d];
+        for j in 0..d {
+            // a · t^j, reduced mod q, gives column j in the power basis.
+            let mut mono = vec![Rational::from(0); j + 1];
+            mono[j] = Rational::from(1);
+            let col = self.mul(&a_red, &mono);
+            for (i, row) in m.iter_mut().enumerate() {
+                row[j] = col.get(i).cloned().unwrap_or_else(|| Rational::from(0));
+            }
+        }
+        m
+    }
+
+    /// Field norm `N_{K/ℚ}(a)` — the determinant of multiplication by `a`.
+    pub fn norm(&self, a: &KElem) -> Rational {
+        rat_det(self.mult_matrix(a))
+    }
+
+    /// Field trace `Tr_{K/ℚ}(a)` — the trace of multiplication by `a`.
+    pub fn trace(&self, a: &KElem) -> Rational {
+        let m = self.mult_matrix(a);
+        m.iter()
+            .enumerate()
+            .fold(Rational::from(0), |s, (i, row)| s + row[i].clone())
+    }
 }
 
-// ---------------------------------------------------------------------------
+/// Determinant of a square rational matrix via Gaussian elimination.
+fn rat_det(mut m: Vec<Vec<Rational>>) -> Rational {
+    let n = m.len();
+    let mut det = Rational::from(1);
+    for col in 0..n {
+        let Some(piv) = (col..n).find(|&r| m[r][col] != 0) else {
+            return Rational::from(0);
+        };
+        if piv != col {
+            m.swap(piv, col);
+            det = -det;
+        }
+        let pivot = m[col][col].clone();
+        det *= pivot.clone();
+        let pivot_row: Vec<Rational> = m[col][col..n].to_vec();
+        for row in m.iter_mut().skip(col + 1) {
+            if row[col] != 0 {
+                let factor = row[col].clone() / pivot.clone();
+                for (dst, src) in row[col..n].iter_mut().zip(pivot_row.iter()) {
+                    *dst -= factor.clone() * src.clone();
+                }
+            }
+        }
+    }
+    det
+}
+
+// ===========================================================================
 // Tests
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::integrate::risch::poly_rde::{poly_mul, poly_zero};
 
     fn rat(n: i64) -> Rational {
         Rational::from(n)
@@ -474,5 +999,145 @@ mod tests {
         for (a, b) in p_t.iter().zip(back_t.iter()) {
             assert_eq!(trim(a.clone()), trim(b.clone()));
         }
+    }
+
+    // -- M0 additions --
+
+    #[test]
+    fn rational_field_derivation_is_zero() {
+        // ℚ is the constant field: D(a) = 0 for all a.
+        let f = RationalField;
+        assert!(f.is_zero(&f.derivation(&rat(5))));
+        assert!(f.is_zero(&f.derivation(&frac(3, 7))));
+    }
+
+    #[test]
+    fn norm_and_trace_over_sqrt2() {
+        let k = q_sqrt2();
+        assert_eq!(k.field_degree(), 2);
+        let t = vec![rat(0), rat(1)]; // √2
+                                      // N(√2) = −2, Tr(√2) = 0.
+        assert_eq!(k.norm(&t), rat(-2));
+        assert_eq!(k.trace(&t), rat(0));
+        // N(1+√2) = (1+√2)(1−√2) = −1, Tr(1+√2) = 2.
+        let one_plus = vec![rat(1), rat(1)];
+        assert_eq!(k.norm(&one_plus), rat(-1));
+        assert_eq!(k.trace(&one_plus), rat(2));
+        // N(3) = 3² = 9 for a degree-2 field, Tr(3) = 6.
+        let three = vec![rat(3)];
+        assert_eq!(k.norm(&three), rat(9));
+        assert_eq!(k.trace(&three), rat(6));
+    }
+
+    #[test]
+    fn norm_over_cube_root_field() {
+        // K = ℚ(∛2) = ℚ[t]/(t³−2); N(∛2) = 2 (= constant term, up to sign for
+        // t³−2 the norm of the generator is 2).
+        let k = NumberField::new(vec![rat(-2), rat(0), rat(0), rat(1)]);
+        assert_eq!(k.field_degree(), 3);
+        let cbrt2 = vec![rat(0), rat(1)];
+        assert_eq!(k.norm(&cbrt2), rat(2));
+        assert_eq!(k.trace(&cbrt2), rat(0));
+    }
+
+    /// A second `CoeffField` — the prime field `F_p` — to exercise the generic
+    /// polynomial core over a non-ℚ field (the whole point of M0's
+    /// generalization).
+    #[derive(Clone, Debug)]
+    struct Fp {
+        p: i64,
+    }
+
+    fn modp(a: i64, p: i64) -> i64 {
+        ((a % p) + p) % p
+    }
+    fn modpow(mut b: i64, mut e: i64, p: i64) -> i64 {
+        let mut acc = 1i64;
+        b = modp(b, p);
+        while e > 0 {
+            if e & 1 == 1 {
+                acc = modp(acc * b, p);
+            }
+            b = modp(b * b, p);
+            e >>= 1;
+        }
+        acc
+    }
+
+    impl CoeffField for Fp {
+        type Elem = i64;
+        fn zero(&self) -> i64 {
+            0
+        }
+        fn one(&self) -> i64 {
+            1 % self.p
+        }
+        fn from_i64(&self, n: i64) -> i64 {
+            modp(n, self.p)
+        }
+        fn add(&self, a: &i64, b: &i64) -> i64 {
+            modp(a + b, self.p)
+        }
+        fn sub(&self, a: &i64, b: &i64) -> i64 {
+            modp(a - b, self.p)
+        }
+        fn mul(&self, a: &i64, b: &i64) -> i64 {
+            modp(a * b, self.p)
+        }
+        fn neg(&self, a: &i64) -> i64 {
+            modp(-a, self.p)
+        }
+        fn inv(&self, a: &i64) -> Option<i64> {
+            if modp(*a, self.p) == 0 {
+                None
+            } else {
+                Some(modpow(*a, self.p - 2, self.p)) // Fermat (p prime)
+            }
+        }
+        fn is_zero(&self, a: &i64) -> bool {
+            modp(*a, self.p) == 0
+        }
+        fn eq(&self, a: &i64, b: &i64) -> bool {
+            modp(a - b, self.p) == 0
+        }
+    }
+
+    #[test]
+    fn generic_gcd_over_f5() {
+        // Over F_5: gcd(x²−1, x−1) = x−1, returned monic.
+        let f = Fp { p: 5 };
+        let a = vec![f.from_i64(-1), f.from_i64(0), f.from_i64(1)]; // x²−1
+        let b = vec![f.from_i64(-1), f.from_i64(1)]; // x−1
+        let (g, _s, _t) = gext_gcd(&f, &a, &b);
+        assert_eq!(gdegree(&f, &g), 1);
+        // Monic x−1 over F_5 = [4, 1].
+        assert_eq!(g, vec![4, 1]);
+        // Bézout sanity: g | a and g | b.
+        assert!(gpoly_mod(&f, &a, &g).is_empty() || gdegree(&f, &gpoly_mod(&f, &a, &g)) < 0);
+        assert!(gdegree(&f, &gpoly_mod(&f, &b, &g)) < 0);
+    }
+
+    #[test]
+    fn generic_quotient_over_f7() {
+        // F_7[t]/(t²+1): t is a square root of −1 = 6.  t·t = −1 = 6.
+        let f = Fp { p: 7 };
+        let q = Quotient::new(f.clone(), vec![f.from_i64(1), f.from_i64(0), f.from_i64(1)]);
+        let t = vec![0i64, 1];
+        let tt = q.mul(&t, &t);
+        assert!(q.elem_eq(&tt, &[6])); // t² = −1 = 6
+                                       // Inverse of t: t·t⁻¹ = 1.  t⁻¹ = −t = 6t.
+        let inv = q.inv(&t).expect("t invertible mod t²+1");
+        assert!(q.elem_eq(&q.mul(&t, &inv), &[1]));
+    }
+
+    #[test]
+    fn numberfield_matches_generic_quotient() {
+        // NumberField delegates to Quotient<RationalField>; cross-check directly.
+        let modulus = vec![rat(-2), rat(0), rat(1)]; // t²−2
+        let nf = NumberField::new(modulus.clone());
+        let q = Quotient::new(RationalField, modulus);
+        let a = vec![rat(1), rat(1)]; // 1+√2
+        assert_eq!(nf.mul(&a, &a), q.mul(&a, &a));
+        assert_eq!(nf.inv(&a), q.inv(&a));
     }
 }

--- a/alkahest-core/src/integrate/risch/simple_radical.rs
+++ b/alkahest-core/src/integrate/risch/simple_radical.rs
@@ -1,0 +1,294 @@
+//! MA — simple-radical integral part (pure-algebraic case).
+//!
+//! Integrates `∫ R(x, y) dx` where `y = p(x)^{1/n}` is a **simple radical** of
+//! degree `n ≥ 3` over `ℚ(x)` and `R` is a polynomial in `y` with rational-
+//! function coefficients.  This is the pure-algebraic (`K(t) = ℚ(x)`, no
+//! transcendental tower) slice of milestone **MA** in
+//! `temp-alkahest/planning/risch.md` — the *integral part* (Steps 1–3 there),
+//! built on the [`super::alg_field`] M0 substrate.
+//!
+//! ## Method (eqs 22–24)
+//!
+//! For a **squarefree** radicand `p`, the radical integral basis (eq 11)
+//! collapses to the power basis `{1, y, …, y^{n−1}}` (all `D_{i−1} = 1`), and
+//! `D(yʲ) = ωⱼ·yʲ` with `ωⱼ = (j/n)·p'/p` (eq 22).  Writing the integrand and a
+//! candidate antiderivative in that basis, `D(Σⱼ vⱼ yʲ) = Σⱼ (vⱼ' + ωⱼ vⱼ) yʲ`,
+//! so the integral **decouples per power `j`**:
+//!
+//! - `j = 0` (eq 23): `v₀' = b₀` — an ordinary `∫ b₀ dx` over `ℚ(x)`, handed to
+//!   the rational integrator (this is where any new logarithms appear).
+//! - `j ≥ 1` (eq 24): `vⱼ' + ωⱼ vⱼ = bⱼ` — a Risch differential equation over
+//!   `ℚ(x)`, solved by [`solve_rational_rde_generalized`].  No rational
+//!   solution ⇒ the integral is **non-elementary**.
+//!
+//! ## Scope (what this slice does *not* do)
+//!
+//! - **Non-squarefree radicand** (e.g. `∛(x²)`): needs the general van Hoeij
+//!   integral basis (MB) — returns `None` (caller falls back).
+//! - **Mixed algebraic + transcendental** (`∛x·exp(x)`, `∛(x+eˣ)`): the
+//!   transcendental tower / mutual recursion is MD; such integrands are routed
+//!   to the Risch engine, not here.
+//! - **Genuine new-logarithm / torsion logic** beyond what the `j = 0` rational
+//!   integration yields (the MC logarithmic part) is not attempted.
+
+use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
+use crate::integrate::engine::{integrate_raw, IntegrationError};
+use crate::kernel::{ExprId, ExprPool};
+use crate::simplify::engine::simplify;
+
+use super::alg_field::AlgExtension;
+use super::exp_case::{build_rational, decompose_over_alg_generator, detect_radical_generator};
+use super::poly_rde::{degree, poly_deriv, poly_scale, qpoly_to_expr, trim, QPoly};
+use super::rational_rde::poly_gcd;
+use super::rational_rde::solve_rational_rde_generalized;
+
+/// Attempt MA's integral part for a degree-`≥ 3` simple radical `y = p^{1/n}`
+/// over `ℚ(x)` (pure-algebraic).
+///
+/// Returns:
+/// - `None` — not applicable (no radical, degree `< 3`, non-squarefree radicand,
+///   or the integrand is not a polynomial in `y` over `ℚ(x)`); the caller should
+///   fall back to the existing algebraic engine.
+/// - `Some(Err(NonElementary))` — a component Risch DE has no rational solution.
+/// - `Some(Ok(F))` — the antiderivative `F`.
+pub fn try_integrate_simple_radical(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>> {
+    let (n, p) = detect_radical_generator(expr, var, pool)?;
+    if n < 3 {
+        return None; // degree 2 → existing genus-0 sqrt path
+    }
+    let p = trim(p);
+    if degree(&p) < 1 {
+        return None;
+    }
+    // Power-basis shortcut requires a squarefree radicand (eq 11 with all
+    // `D_{i−1} = 1`).  Otherwise defer to the general integral basis (MB).
+    let p_prime = poly_deriv(&p);
+    if degree(&poly_gcd(&p, &p_prime)) >= 1 {
+        return None;
+    }
+
+    let e = AlgExtension::radical(n, &p);
+    let elem = decompose_over_alg_generator(expr, n, &p, &e, var, pool)?;
+
+    let mut log = DerivationLog::new();
+    let mut terms: Vec<ExprId> = Vec::new();
+
+    for j in 0..n {
+        // Coefficient `bⱼ = numⱼ/denⱼ` of `yʲ` in the integrand (0 if absent).
+        let (num, den) = match elem.get(j) {
+            Some(r) => (r.numer().clone(), r.denom().clone()),
+            None => (QPoly::new(), vec![rug::Rational::from(1)]),
+        };
+        if trim(num.clone()).is_empty() {
+            continue; // bⱼ = 0 ⇒ vⱼ = 0
+        }
+
+        if j == 0 {
+            // eq 23: ∫ b₀ dx over ℚ(x) (the rational/logarithmic part).
+            let b0 = build_rational(&num, &den, var, pool);
+            match integrate_raw(b0, var, pool, &mut log) {
+                Ok(v0) => terms.push(v0),
+                Err(err) => return Some(Err(err)),
+            }
+        } else {
+            // eq 24: vⱼ' + (j·p'/(n·p))·vⱼ = bⱼ.
+            let f_num = poly_scale(&p_prime, &rug::Rational::from(j as i64));
+            let f_den = poly_scale(&p, &rug::Rational::from(n as i64));
+            let (vn, vd) = match solve_rational_rde_generalized(&f_num, &f_den, &num, &den) {
+                Some(sol) => sol,
+                None => return Some(Err(non_elementary(expr, pool))),
+            };
+            if trim(vn.clone()).is_empty() {
+                continue;
+            }
+            let v_expr = build_rational(&vn, &vd, var, pool);
+            // Multiply by yʲ = p^{j/n}.
+            let p_expr = qpoly_to_expr(&p, var, pool);
+            let yj = pool.pow(p_expr, pool.rational(j as i32, n as i32));
+            terms.push(pool.mul(vec![v_expr, yj]));
+        }
+    }
+
+    let raw = match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    };
+    let simplified = simplify(raw, pool);
+    log = log.merge(simplified.log);
+    log.push(RewriteStep::simple(
+        "simple_radical_risch",
+        expr,
+        simplified.value,
+    ));
+    Some(Ok(DerivedExpr::with_log(simplified.value, log)))
+}
+
+fn non_elementary(expr: ExprId, pool: &ExprPool) -> IntegrationError {
+    IntegrationError::NonElementary(format!(
+        "∫ {} dx: the Risch differential equation over ℚ(x) for a simple-radical \
+         component has no rational solution",
+        pool.display(expr),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::{Domain, ExprData};
+
+    fn pool() -> ExprPool {
+        ExprPool::new()
+    }
+
+    /// Numeric evaluator supporting Add/Mul/Pow(rational)/Integer/Rational/var,
+    /// `cbrt`, `sqrt`, `log` — enough for these antiderivatives and integrands.
+    fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> f64 {
+        if expr == x {
+            return xv;
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => n.0.to_f64(),
+            ExprData::Rational(r) => r.0.to_f64(),
+            ExprData::Add(args) => args.iter().map(|&a| eval(a, x, xv, pool)).sum(),
+            ExprData::Mul(args) => args.iter().map(|&a| eval(a, x, xv, pool)).product(),
+            ExprData::Pow { base, exp } => eval(base, x, xv, pool).powf(eval(exp, x, xv, pool)),
+            ExprData::Func { ref name, ref args } if args.len() == 1 => {
+                let a = eval(args[0], x, xv, pool);
+                match name.as_str() {
+                    "cbrt" => a.cbrt(),
+                    "sqrt" => a.sqrt(),
+                    "log" => a.ln(),
+                    "exp" => a.exp(),
+                    other => panic!("eval: unsupported func {other}"),
+                }
+            }
+            other => panic!("eval: unsupported node {other:?}"),
+        }
+    }
+
+    /// Integrate via the MA path, differentiate the result symbolically (now
+    /// that `diff` handles fractional-power exponents), and assert
+    /// `d/dx F = integrand` numerically.
+    fn verify(integrand: ExprId, x: ExprId, pool: &ExprPool) {
+        let res = try_integrate_simple_radical(integrand, x, pool)
+            .expect("recognized as a simple radical")
+            .expect("should be elementary");
+        let f = res.value;
+        let df = crate::diff::diff(f, x, pool).expect("F is differentiable");
+        let ds = simplify(df.value, pool).value;
+        for &xv in &[0.6_f64, 1.4, 2.7] {
+            let lhs = eval(ds, x, xv, pool);
+            let rhs = eval(integrand, x, xv, pool);
+            assert!(
+                (lhs - rhs).abs() < 1e-9,
+                "d/dx F ≠ f at x={xv}: {lhs} vs {rhs}\n  F = {}",
+                pool.display(f)
+            );
+        }
+    }
+
+    #[test]
+    fn integral_of_cbrt_x() {
+        // ∫ ∛x dx = (3/4) x^{4/3}.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        verify(pool.func("cbrt", vec![x]), x, &pool);
+    }
+
+    #[test]
+    fn integral_of_x_times_cbrt_x() {
+        // ∫ x·∛x dx = (3/7) x^{7/3}.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let integrand = pool.mul(vec![x, pool.func("cbrt", vec![x])]);
+        verify(integrand, x, &pool);
+    }
+
+    #[test]
+    fn integral_of_x_pow_two_thirds() {
+        // ∫ x^{2/3} dx = (3/5) x^{5/3}.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let integrand = pool.pow(x, pool.rational(2_i32, 3_i32));
+        verify(integrand, x, &pool);
+    }
+
+    #[test]
+    fn integral_of_cbrt_x_over_x() {
+        // ∫ ∛x / x dx = ∫ x^{-2/3} dx = 3 x^{1/3}.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let integrand = pool.mul(vec![
+            pool.func("cbrt", vec![x]),
+            pool.pow(x, pool.integer(-1_i32)),
+        ]);
+        verify(integrand, x, &pool);
+    }
+
+    #[test]
+    fn fifth_root_integral() {
+        // ∫ x^{2/5} dx = (5/7) x^{7/5}  (degree-5 radical, squarefree radicand).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let integrand = pool.pow(x, pool.rational(2_i32, 5_i32));
+        verify(integrand, x, &pool);
+    }
+
+    #[test]
+    fn cbrt_over_x2_plus_1_is_nonelementary() {
+        // ∫ ∛x / (x²+1) dx is non-elementary.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let x2p1 = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let integrand = pool.mul(vec![
+            pool.func("cbrt", vec![x]),
+            pool.pow(x2p1, pool.integer(-1_i32)),
+        ]);
+        let res = try_integrate_simple_radical(integrand, x, &pool).expect("recognized");
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "expected NonElementary, got {res:?}"
+        );
+    }
+
+    #[test]
+    fn routed_through_algebraic_engine() {
+        // End-to-end: the pure-algebraic engine entry dispatches ∛x here.
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let res =
+            crate::integrate::algebraic::integrate_algebraic(pool.func("cbrt", vec![x]), x, &pool)
+                .expect("∫∛x dx is elementary");
+        let f = res.value;
+        let h = 1e-6;
+        let dnum = (eval(f, x, 1.4 + h, &pool) - eval(f, x, 1.4 - h, &pool)) / (2.0 * h);
+        assert!(
+            (dnum - 1.4_f64.cbrt()).abs() < 1e-4,
+            "F = {}",
+            pool.display(f)
+        );
+    }
+
+    #[test]
+    fn degree_two_returns_none() {
+        // √x is degree 2 — left to the genus-0 sqrt engine (returns None here).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        assert!(try_integrate_simple_radical(pool.func("sqrt", vec![x]), x, &pool).is_none());
+    }
+
+    #[test]
+    fn non_squarefree_radicand_returns_none() {
+        // ∛(x²): radicand x² is not squarefree → deferred to MB (None).
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let cbrt_x2 = pool.func("cbrt", vec![x2]);
+        assert!(try_integrate_simple_radical(cbrt_x2, x, &pool).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Implements Risch milestone **M0** (algebraic differential-field infrastructure), the pure-algebraic slice of **MA** (simple-radical integral part), and extends `diff` to fractional-power exponents.

### M0 — generic polynomial-quotient core
- **`number_field.rs`**: extracted a `CoeffField` trait + generic `Quotient<F>` ring; `NumberField` is now the `ℚ` instantiation. Added `norm`/`trace`/`field_degree` (the constant-field §7.3 surface).
- **`alg_field.rs`** (new): `RationalFunctionField` (`ℚ(x)`, with `d/dx`) + `AlgExtension` (`ℚ(x)[y]/(q(x,y))`) carrying the derivation `D(y) = −q_x/q_y`, plus `radical`/`pow` constructors.
- **`exp_case.rs`**: generalized `decompose_over_alpha` (rank-2 `KPair`) to arbitrary degree `d` — `detect_radical_generator` / `decompose_over_alg_generator` / `decompose_radical`.

### MA — simple-radical integral part (pure-algebraic)
- **`simple_radical.rs`** (new): `try_integrate_simple_radical` for `y = p(x)^{1/n}`, `n ≥ 3`, **squarefree** `p` over `ℚ(x)`. Per-power decoupling (eqs 23–24) via the existing rational RDE solvers; wired into the algebraic engine (degree ≥ 3, non-regressing — degree 2 falls through to the genus-0 sqrt path).
- Handles `∫∛x`, `∫x^{2/3}`, `∫∛x/x`, degree-5 roots; `∫∛x/(x²+1)` → `NonElementary`.

### diff — fractional-power exponents
- All three modes (`diff_impl`, `forward`, `reverse`) now apply `d/dx f^r = r·f^{r-1}·f'` for rational `r` (shared `const_node` helper). A var-dependent exponent (`x^y`) still returns `NonIntegerExponent` (needs logarithmic differentiation).

### Scope / not included
Full MA remains future work: Hermite reduction for non-squarefree/non-trivial denominators (MB), the mixed algebraic+transcendental tower (`∛x·exp`, MD), and the logarithmic/torsion part (MC).

## Testing
- `cargo test --workspace`: **816 passed, 0 failed** (incl. MA antiderivatives verified by symbolic `d/dx`, fractional-power diff across all 3 modes, ring-axiom/Leibniz proptests for `AlgExtension`).
- `cargo fmt` clean; `cargo clippy --all-targets -- -D warnings` clean.
- Pure Rust; no PyO3/Python-surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)