### PR TITLE
Risch: log-tower radicand (∛(x+log x)) — LogTowerField + generic tower integrator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,11 @@ permissions:
   pages: write
   id-token: write
 
-# One deploy at a time; newer push cancels an in-progress deploy.
+# One run at a time per ref (newer push to the same ref cancels the older one).
+# Scoped by ref so a PR's doc build is not cancelled by another ref's run
+# (e.g. main's deploy) — the old static `pages` group cancelled across all refs.
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -137,7 +137,12 @@ fn outermost_exp_generator<'a>(exp_gens: &[&'a TowerLevel], pool: &ExprPool) -> 
 /// - `log(h)^n` for `n ≥ 2`
 /// - `p(x)·log(h)` for non-constant polynomial `p`
 pub fn contains_risch_form(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
-    needs_exp_risch(expr, var, pool) || needs_log_risch(expr, var, pool)
+    needs_exp_risch(expr, var, pool)
+        || needs_log_risch(expr, var, pool)
+        // A radical whose radicand involves a transcendental (e.g. ∛(x+log x))
+        // is a Risch/MD form even when the transcendental appears only inside
+        // the radicand — route it to the tower integrator, not the algebraic one.
+        || tower_integrate::detect_radical_with_transcendental_radicand(expr, var, pool).is_some()
 }
 
 // ---------------------------------------------------------------------------
@@ -169,11 +174,13 @@ pub fn integrate_risch(
     var: ExprId,
     pool: &ExprPool,
 ) -> Result<DerivedExpr<ExprId>, IntegrationError> {
-    // MD: a radical whose radicand involves the transcendental (e.g. ∛(x+eˣ)).
-    // The radical is the outermost generator; handle it before the exp/log
-    // dispatch (which would mis-treat the radical as a coefficient).  Returns
-    // `None` when not of this shape, so ordinary towers fall through.
-    if let Some(result) = tower_integrate::try_integrate_radical_over_exp(expr, var, pool) {
+    // MD: a radical whose radicand involves the transcendental (e.g. ∛(x+eˣ) or
+    // ∛(x+log x)).  The radical is the outermost generator; handle it before the
+    // exp/log dispatch (which would mis-treat the radical as a coefficient).
+    // Returns `None` when not of this shape, so ordinary towers fall through.
+    if let Some(result) =
+        tower_integrate::try_integrate_radical_over_transcendental(expr, var, pool)
+    {
         return result;
     }
 

--- a/alkahest-core/src/integrate/risch/tower_field.rs
+++ b/alkahest-core/src/integrate/risch/tower_field.rs
@@ -137,9 +137,9 @@ impl TExpr {
     }
 }
 
-/// `D(P)` for a `t`-polynomial `P = Σⱼ cⱼ tʲ`: `Σⱼ (cⱼ' + j·η'·cⱼ) tʲ`,
-/// where `cⱼ' = d/dx cⱼ` and `η' = deta`.
-fn tpoly_derivation(p: &TPoly, deta: &RatFn) -> TPoly {
+/// `D(P)` for a `t`-polynomial `P = Σⱼ cⱼ tʲ` in an **exponential** tower
+/// (`Dt = η'·t`): `Σⱼ (cⱼ' + j·η'·cⱼ) tʲ` — the `t`-degree is preserved.
+fn exp_tpoly_derivation(p: &TPoly, deta: &RatFn) -> TPoly {
     let f = qx();
     let mut out: TPoly = Vec::with_capacity(p.len());
     for (j, cj) in p.iter().enumerate() {
@@ -148,6 +148,35 @@ fn tpoly_derivation(p: &TPoly, deta: &RatFn) -> TPoly {
         out.push(f.add(&dc, &drift));
     }
     gtrim(&f, out)
+}
+
+/// `D(P)` for a `t`-polynomial `P = Σⱼ cⱼ tʲ` in a **logarithmic** tower
+/// (`Dt = h'/h`, free of `t`): `D(cⱼ tʲ) = cⱼ' tʲ + j·(h'/h)·cⱼ·t^{j−1}`, so
+/// collecting at degree `p` gives `cₚ' + (p+1)·(h'/h)·cₚ₊₁` — the `t`-degree is
+/// *lowered* by one in the drift term.
+fn log_tpoly_derivation(p: &TPoly, dh_over_h: &RatFn) -> TPoly {
+    let f = qx();
+    let mut out: TPoly = (0..p.len()).map(|_| f.zero()).collect();
+    for (j, cj) in p.iter().enumerate() {
+        out[j] = f.add(&out[j], &f.derivation(cj)); // cⱼ' at degree j
+        if j >= 1 {
+            // j·(h'/h)·cⱼ at degree j−1
+            let term = f.mul(&f.mul(&RatFn::int(j as i64), dh_over_h), cj);
+            out[j - 1] = f.add(&out[j - 1], &term);
+        }
+    }
+    gtrim(&f, out)
+}
+
+/// Apply the quotient rule given the `t`-derivatives of numerator/denominator:
+/// `D(num/den) = (D(num)·den − num·D(den)) / den²`.
+fn texpr_from_quotient_rule(num: &TPoly, den: &TPoly, dnum: &TPoly, dden: &TPoly) -> TExpr {
+    let f = qx();
+    let lhs = gpoly_mul(&f, dnum, den);
+    let rhs = gpoly_mul(&f, num, dden);
+    let neg1 = f.neg(&f.one());
+    let numer = gpoly_add(&f, &lhs, &gpoly_scale(&f, &rhs, &neg1));
+    TExpr::new(numer, gpoly_mul(&f, den, den))
 }
 
 /// The exponential tower `ℚ(x)(t)`, `t = exp(η)`, parameterized by `η' = deta`.
@@ -197,20 +226,69 @@ impl CoeffField for ExpTowerField {
         a == b
     }
 
-    /// `D(num/den) = (D(num)·den − num·D(den)) / den²`, with `D` the tower
-    /// derivation on `t`-polynomials.
+    /// `D(num/den)`, with the exponential-tower `t`-derivation.
     fn derivation(&self, a: &TExpr) -> TExpr {
-        let f = qx();
-        let dnum = tpoly_derivation(&a.num, &self.deta);
-        let dden = tpoly_derivation(&a.den, &self.deta);
-        let numer = {
-            let lhs = gpoly_mul(&f, &dnum, &a.den);
-            let rhs = gpoly_mul(&f, &a.num, &dden);
-            let neg1 = f.neg(&f.one());
-            gpoly_add(&f, &lhs, &gpoly_scale(&f, &rhs, &neg1))
-        };
-        let denom = gpoly_mul(&f, &a.den, &a.den);
-        TExpr::new(numer, denom)
+        let dnum = exp_tpoly_derivation(&a.num, &self.deta);
+        let dden = exp_tpoly_derivation(&a.den, &self.deta);
+        texpr_from_quotient_rule(&a.num, &a.den, &dnum, &dden)
+    }
+}
+
+/// The logarithmic tower `ℚ(x)(t)`, `t = log(h)`, parameterized by `h'/h`.
+///
+/// Same element type and arithmetic as [`ExpTowerField`]; only the derivation
+/// differs (`Dt = h'/h`, which lowers the `t`-degree in the drift term).
+#[derive(Clone, Debug)]
+pub struct LogTowerField {
+    /// `h'/h` — the logarithmic derivative of the inner argument, a `ℚ(x)` element.
+    pub dh_over_h: RatFn,
+}
+
+impl LogTowerField {
+    pub fn new(dh_over_h: RatFn) -> Self {
+        Self { dh_over_h }
+    }
+}
+
+impl CoeffField for LogTowerField {
+    type Elem = TExpr;
+
+    fn zero(&self) -> TExpr {
+        TExpr::int(0)
+    }
+    fn one(&self) -> TExpr {
+        TExpr::int(1)
+    }
+    fn from_i64(&self, n: i64) -> TExpr {
+        TExpr::int(n)
+    }
+    fn add(&self, a: &TExpr, b: &TExpr) -> TExpr {
+        a.add(b)
+    }
+    fn sub(&self, a: &TExpr, b: &TExpr) -> TExpr {
+        a.add(&b.neg())
+    }
+    fn mul(&self, a: &TExpr, b: &TExpr) -> TExpr {
+        a.mul(b)
+    }
+    fn neg(&self, a: &TExpr) -> TExpr {
+        a.neg()
+    }
+    fn inv(&self, a: &TExpr) -> Option<TExpr> {
+        a.inv()
+    }
+    fn is_zero(&self, a: &TExpr) -> bool {
+        a.is_zero()
+    }
+    fn eq(&self, a: &TExpr, b: &TExpr) -> bool {
+        a == b
+    }
+
+    /// `D(num/den)`, with the logarithmic-tower `t`-derivation.
+    fn derivation(&self, a: &TExpr) -> TExpr {
+        let dnum = log_tpoly_derivation(&a.num, &self.dh_over_h);
+        let dden = log_tpoly_derivation(&a.den, &self.dh_over_h);
+        texpr_from_quotient_rule(&a.num, &a.den, &dnum, &dden)
     }
 }
 
@@ -261,7 +339,11 @@ fn monomial(j: usize, k: usize, coeff: &Rational) -> TExpr {
 /// `Some` is always correct.  `None` means "no solution `U/D` was found for any
 /// tried `D` within the degree caps" — it is **not** a non-elementarity
 /// certificate.
-pub fn solve_tower_rde(field: &ExpTowerField, omega: &TExpr, c: &TExpr) -> Option<TExpr> {
+pub fn solve_tower_rde<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    omega: &TExpr,
+    c: &TExpr,
+) -> Option<TExpr> {
     candidate_denominators(field, omega, c)
         .iter()
         .find_map(|d| solve_with_denominator(field, omega, c, d))
@@ -271,7 +353,11 @@ pub fn solve_tower_rde(field: &ExpTowerField, omega: &TExpr, c: &TExpr) -> Optio
 /// denominators of `c` and `ω`, and a few products/powers.  Over-clearing is
 /// harmless (the numerator ansatz just needs more terms); verification guards
 /// correctness.
-fn candidate_denominators(field: &ExpTowerField, omega: &TExpr, c: &TExpr) -> Vec<TExpr> {
+fn candidate_denominators<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    omega: &TExpr,
+    c: &TExpr,
+) -> Vec<TExpr> {
     let one = field.one();
     let dc = full_denominator(c);
     let dw = full_denominator(omega);
@@ -308,8 +394,8 @@ fn full_denominator(e: &TExpr) -> TExpr {
 }
 
 /// Solve `v' + ω·v = c` seeking `v = (Σⱼₖ cⱼₖ xᵏ tʲ)/D` for the fixed `D`.
-fn solve_with_denominator(
-    field: &ExpTowerField,
+fn solve_with_denominator<F: CoeffField<Elem = TExpr>>(
+    field: &F,
     omega: &TExpr,
     c: &TExpr,
     d: &TExpr,

--- a/alkahest-core/src/integrate/risch/tower_field.rs
+++ b/alkahest-core/src/integrate/risch/tower_field.rs
@@ -339,7 +339,7 @@ fn monomial(j: usize, k: usize, coeff: &Rational) -> TExpr {
 /// `Some` is always correct.  `None` means "no solution `U/D` was found for any
 /// tried `D` within the degree caps" — it is **not** a non-elementarity
 /// certificate.
-pub fn solve_tower_rde<F: CoeffField<Elem = TExpr>>(
+pub(crate) fn solve_tower_rde_generic<F: CoeffField<Elem = TExpr>>(
     field: &F,
     omega: &TExpr,
     c: &TExpr,
@@ -347,6 +347,13 @@ pub fn solve_tower_rde<F: CoeffField<Elem = TExpr>>(
     candidate_denominators(field, omega, c)
         .iter()
         .find_map(|d| solve_with_denominator(field, omega, c, d))
+}
+
+/// Solve `v' + ω·v = c` over the exponential tower `ℚ(x)(eˣ)` (the concrete,
+/// stable public entry).  `solve_tower_rde_generic` is the field-generic form
+/// (also used for the logarithmic tower).
+pub fn solve_tower_rde(field: &ExpTowerField, omega: &TExpr, c: &TExpr) -> Option<TExpr> {
+    solve_tower_rde_generic(field, omega, c)
 }
 
 /// Candidate denominators for `v`, in increasing complexity: `1`, the full

--- a/alkahest-core/src/integrate/risch/tower_integrate.rs
+++ b/alkahest-core/src/integrate/risch/tower_integrate.rs
@@ -2,35 +2,38 @@
 //! transcendental** — the Risch MD case, e.g. tutorial Example 15
 //! `∫ (3(x+eˣ)^{1/3} + (2x²+3x)eˣ + 5x²)/(x(x+eˣ)^{1/3}) dx = 3x(x+eˣ)^{2/3} + 3log x`.
 //!
-//! Ties together the M0 generic quotient ring, the [`ExpTowerField`] tower
-//! ([`super::tower_field`]), and the [`solve_tower_rde`] tower Risch-DE solver:
+//! The log analogue works the same way over a `t = log(h)` tower (e.g.
+//! `∫ (1+1/x)/(3(x+log x)^{2/3}) dx = (x+log x)^{1/3}`).
+//!
+//! Ties together the M0 generic quotient ring, the [`ExpTowerField`] /
+//! [`LogTowerField`] towers ([`super::tower_field`]), and the [`solve_tower_rde`]
+//! tower Risch-DE solver:
 //!
 //! 1. detect the outermost radical `y = a^{1/n}` whose radicand `a` involves a
-//!    single exponential generator `t = exp(η)`;
+//!    single transcendental generator `t = exp(η)` or `t = log(h)`;
 //! 2. parse `a` and the integrand's coefficients into `ℚ(x)(t)` ([`TExpr`]) and
-//!    decompose the integrand over the power basis `{1, y, …, y^{n−1}}` via
-//!    `Quotient<ExpTowerField>` (reducing `yⁿ = a`);
+//!    decompose the integrand over the power basis `{1, y, …, y^{n−1}}` via the
+//!    generic `Quotient` (reducing `yⁿ = a`);
 //! 3. per power: `i = 0` is `∫c₀ dx` (recurse into the engine); `i ≥ 1` is the
 //!    tower Risch DE `vᵢ' + (i/n)(a'/a)·vᵢ = cᵢ` solved by [`solve_tower_rde`];
 //! 4. reconstruct `F = Σ vᵢ·a^{i/n} + ∫c₀` and **verify `d/dx F = integrand`
 //!    numerically** — so the whole path is sound (a wrong reconstruction or an
 //!    unsolved component yields `None`, never an incorrect antiderivative).
 //!
-//! Scope: a single exp generator, polynomial `η`, and per-component solutions
-//! within [`solve_tower_rde`]'s ansatz.  Anything else → `None` (the caller
-//! falls back).
+//! Scope: a single exp/log generator, polynomial `η`/`h`, and per-component
+//! solutions within [`solve_tower_rde`]'s ansatz.  Anything else → `None`.
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
 use crate::integrate::engine::IntegrationError;
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
-use super::alg_field::{radical_dy, RatFn};
+use super::alg_field::RatFn;
 use super::exp_case::build_rational;
 use super::number_field::{CoeffField, Quotient};
 use super::poly_rde::{expr_to_qpoly, is_free_of_var, poly_deriv};
 use super::tower::find_generators;
-use super::tower_field::{solve_tower_rde, ExpTowerField, TExpr};
+use super::tower_field::{solve_tower_rde, ExpTowerField, LogTowerField, TExpr};
 
 use rug::Rational;
 
@@ -38,42 +41,66 @@ use rug::Rational;
 /// `1, y, …, y^{n−1}`, each in `ℚ(x)(t)`.
 type TowerElem = Vec<TExpr>;
 
-/// Public entry: try to integrate a radical-over-exp integrand.  Returns `None`
-/// when the integrand is not of this shape or cannot be handled, so the caller
-/// falls through to the ordinary Risch dispatch.
-pub fn try_integrate_radical_over_exp(
+/// Public entry: try to integrate a radical whose radicand involves a single
+/// **exp or log** transcendental generator.  Returns `None` when the integrand
+/// is not of this shape, so the caller falls through to the ordinary dispatch.
+pub fn try_integrate_radical_over_transcendental(
     expr: ExprId,
     var: ExprId,
     pool: &ExprPool,
 ) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>> {
     let (n, a_expr) = detect_radical_with_transcendental_radicand(expr, var, pool)?;
 
-    // The radicand must involve exactly one exponential generator.
+    // The radicand must involve exactly one transcendental generator.
     let gens = find_generators(a_expr, var, pool);
-    if gens.len() != 1 || !gens[0].is_exp() {
+    if gens.len() != 1 {
         return None;
     }
-    let eta = gens[0].argument();
-    let exp_gen = pool.func("exp", vec![eta]);
+    let g = &gens[0];
+    if g.is_exp() {
+        // t = exp(η),  Dt = η'·t.
+        let eta = g.argument();
+        let t_gen = pool.func("exp", vec![eta]);
+        let eta_poly = expr_to_qpoly(eta, var, pool)?;
+        let field = ExpTowerField::new(RatFn::from_poly(&poly_deriv(&eta_poly)));
+        integrate_radical_over_tower(&field, t_gen, expr, n, a_expr, var, pool)
+    } else if g.is_log() {
+        // t = log(h),  Dt = h'/h.
+        let h = g.argument();
+        let t_gen = pool.func("log", vec![h]);
+        let h_poly = expr_to_qpoly(h, var, pool)?;
+        let dh_over_h = RatFn::new(poly_deriv(&h_poly), h_poly);
+        let field = LogTowerField::new(dh_over_h);
+        integrate_radical_over_tower(&field, t_gen, expr, n, a_expr, var, pool)
+    } else {
+        None
+    }
+}
 
-    // η must be a polynomial in x (hyperexponential monomial); η' = d/dx η.
-    let eta_poly = expr_to_qpoly(eta, var, pool)?;
-    let deta = RatFn::from_poly(&poly_deriv(&eta_poly));
-    let field = ExpTowerField::new(deta);
-
-    // Radicand a as a ℚ(x)(t) element.
-    let a_tx = expr_to_texpr(&field, a_expr, var, exp_gen, pool)?;
-
-    // Build the quotient ℚ(x)(t)[y]/(yⁿ − a) and D(y).
+/// The field-generic integration core: decompose over the radical, solve each
+/// component (`i=0` → engine, `i≥1` → [`solve_tower_rde`]), reconstruct, and
+/// verify `d/dx F = integrand`.
+fn integrate_radical_over_tower<F>(
+    field: &F,
+    t_gen: ExprId,
+    expr: ExprId,
+    n: usize,
+    a_expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>>
+where
+    F: CoeffField<Elem = TExpr> + Clone,
+{
+    // Radicand a as a ℚ(x)(t) element, and the quotient ℚ(x)(t)[y]/(yⁿ − a).
+    let a_tx = expr_to_texpr(field, a_expr, var, t_gen, pool)?;
     let mut modulus = vec![field.zero(); n + 1];
     modulus[0] = field.neg(&a_tx);
     modulus[n] = field.one();
     let q = Quotient::new(field.clone(), modulus);
-    let dy = radical_dy(&q);
-    let _ = &dy; // dy is implied by ω below; kept for clarity / future use.
 
     // Decompose the integrand over the power basis {1, y, …, y^{n-1}}.
-    let elem = decompose_over_tower_radical(expr, n, a_expr, &q, &field, var, exp_gen, pool)?;
+    let elem = decompose_over_tower_radical(expr, n, a_expr, &q, field, var, t_gen, pool)?;
 
     // a'/a in the tower (for ωᵢ).
     let a_prime = field.derivation(&a_tx);
@@ -89,7 +116,7 @@ pub fn try_integrate_radical_over_exp(
         }
         if i == 0 {
             // eq 23: ∫ c₀ dx — recurse into the engine.
-            let c0_expr = texpr_to_expr(ci, var, exp_gen, pool);
+            let c0_expr = texpr_to_expr(ci, var, t_gen, pool);
             match crate::integrate::engine::integrate(c0_expr, var, pool) {
                 Ok(d) => terms.push(d.value),
                 Err(_) => return None,
@@ -101,11 +128,11 @@ pub fn try_integrate_radical_over_exp(
                 vec![Rational::from(n as i64)],
             ));
             let omega = field.mul(&scale, &log_deriv_a);
-            let vi = solve_tower_rde(&field, &omega, ci)?;
+            let vi = solve_tower_rde(field, &omega, ci)?;
             if field.is_zero(&vi) {
                 continue;
             }
-            let vi_expr = texpr_to_expr(&vi, var, exp_gen, pool);
+            let vi_expr = texpr_to_expr(&vi, var, t_gen, pool);
             let yi = pool.pow(a_expr, pool.rational(i as i32, n as i32));
             terms.push(pool.mul(vec![vi_expr, yi]));
         }
@@ -122,7 +149,11 @@ pub fn try_integrate_radical_over_exp(
     if !verify_derivative(f, expr, var, pool) {
         return None;
     }
-    log.push(RewriteStep::simple("risch_radical_over_exp", expr, f));
+    log.push(RewriteStep::simple(
+        "risch_radical_over_transcendental",
+        expr,
+        f,
+    ));
     Some(Ok(DerivedExpr::with_log(f, log)))
 }
 
@@ -132,7 +163,7 @@ pub fn try_integrate_radical_over_exp(
 
 /// Find a single radical generator `a^{1/n}` (`n ≥ 2`) whose radicand `a`
 /// depends on `var` and contains a transcendental (exp/log) generator.
-fn detect_radical_with_transcendental_radicand(
+pub(super) fn detect_radical_with_transcendental_radicand(
     expr: ExprId,
     var: ExprId,
     pool: &ExprPool,
@@ -191,7 +222,11 @@ fn scan(expr: ExprId, var: ExprId, pool: &ExprPool, out: &mut Vec<(usize, ExprId
 // Decomposition over y (coefficients in the tower ℚ(x)(t))
 // ---------------------------------------------------------------------------
 
-fn elem_pow(q: &Quotient<ExpTowerField>, base: &[TExpr], m: i64) -> Option<TowerElem> {
+fn elem_pow<F: CoeffField<Elem = TExpr>>(
+    q: &Quotient<F>,
+    base: &[TExpr],
+    m: i64,
+) -> Option<TowerElem> {
     if m == 0 {
         return Some(q.from_int(1));
     }
@@ -207,12 +242,12 @@ fn elem_pow(q: &Quotient<ExpTowerField>, base: &[TExpr], m: i64) -> Option<Tower
 }
 
 #[allow(clippy::too_many_arguments)]
-fn decompose_over_tower_radical(
+fn decompose_over_tower_radical<F: CoeffField<Elem = TExpr>>(
     expr: ExprId,
     n: usize,
     a_expr: ExprId,
-    q: &Quotient<ExpTowerField>,
-    field: &ExpTowerField,
+    q: &Quotient<F>,
+    field: &F,
     var: ExprId,
     exp_gen: ExprId,
     pool: &ExprPool,
@@ -281,7 +316,7 @@ fn ratfn_const(r: &Rational) -> RatFn {
     RatFn::from_poly(&vec![r.clone()])
 }
 
-fn texpr_pow(field: &ExpTowerField, b: &TExpr, m: i64) -> Option<TExpr> {
+fn texpr_pow<F: CoeffField<Elem = TExpr>>(field: &F, b: &TExpr, m: i64) -> Option<TExpr> {
     if m == 0 {
         return Some(field.one());
     }
@@ -300,8 +335,8 @@ fn texpr_pow(field: &ExpTowerField, b: &TExpr, m: i64) -> Option<TExpr> {
 /// exponential generator `t = exp(η)` into a [`TExpr`].  Returns `None` if the
 /// expression is not of that form (e.g. it contains the radical, a different
 /// transcendental, or an irrational constant).
-fn expr_to_texpr(
-    field: &ExpTowerField,
+fn expr_to_texpr<F: CoeffField<Elem = TExpr>>(
+    field: &F,
     expr: ExprId,
     var: ExprId,
     exp_gen: ExprId,
@@ -490,6 +525,35 @@ mod tests {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let f = pool.mul(vec![x, pool.func("exp", vec![x])]);
-        assert!(try_integrate_radical_over_exp(f, x, &pool).is_none());
+        assert!(try_integrate_radical_over_transcendental(f, x, &pool).is_none());
+    }
+
+    /// Log-tower analogue: ∫ (1/3)(1+1/x)·(x+log x)^{−2/3} dx = (x+log x)^{1/3}.
+    /// d/dx ∛(x+log x) = (1+1/x)/(3(x+log x)^{2/3}).
+    #[test]
+    fn cbrt_of_x_plus_log_x_end_to_end() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let log_x = pool.func("log", vec![x]);
+        let a = pool.add(vec![x, log_x]); // x + log x
+        let coeff = pool.mul(vec![
+            pool.rational(1_i32, 3_i32),
+            pool.add(vec![pool.integer(1_i32), pool.pow(x, pool.integer(-1_i32))]),
+        ]); // (1/3)(1 + 1/x)
+        let integrand = pool.mul(vec![coeff, pool.pow(a, pool.rational(-2_i32, 3_i32))]);
+
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(res.is_ok(), "∫ should be elementary; got {res:?}");
+        let g = res.unwrap().value;
+        let ds = simplify(crate::diff::diff(g, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[0.7_f64, 1.5, 2.6] {
+            let lhs = eval(ds, x, xv, &pool).unwrap();
+            let rhs = eval(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, f = {rhs}\n  F = {}",
+                pool.display(g)
+            );
+        }
     }
 }

--- a/alkahest-core/src/integrate/risch/tower_integrate.rs
+++ b/alkahest-core/src/integrate/risch/tower_integrate.rs
@@ -6,7 +6,7 @@
 //! `∫ (1+1/x)/(3(x+log x)^{2/3}) dx = (x+log x)^{1/3}`).
 //!
 //! Ties together the M0 generic quotient ring, the [`ExpTowerField`] /
-//! [`LogTowerField`] towers ([`super::tower_field`]), and the [`solve_tower_rde`]
+//! [`LogTowerField`] towers ([`super::tower_field`]), and the `solve_tower_rde`
 //! tower Risch-DE solver:
 //!
 //! 1. detect the outermost radical `y = a^{1/n}` whose radicand `a` involves a
@@ -15,13 +15,13 @@
 //!    decompose the integrand over the power basis `{1, y, …, y^{n−1}}` via the
 //!    generic `Quotient` (reducing `yⁿ = a`);
 //! 3. per power: `i = 0` is `∫c₀ dx` (recurse into the engine); `i ≥ 1` is the
-//!    tower Risch DE `vᵢ' + (i/n)(a'/a)·vᵢ = cᵢ` solved by [`solve_tower_rde`];
+//!    tower Risch DE `vᵢ' + (i/n)(a'/a)·vᵢ = cᵢ` solved by `solve_tower_rde`;
 //! 4. reconstruct `F = Σ vᵢ·a^{i/n} + ∫c₀` and **verify `d/dx F = integrand`
 //!    numerically** — so the whole path is sound (a wrong reconstruction or an
 //!    unsolved component yields `None`, never an incorrect antiderivative).
 //!
 //! Scope: a single exp/log generator, polynomial `η`/`h`, and per-component
-//! solutions within [`solve_tower_rde`]'s ansatz.  Anything else → `None`.
+//! solutions within `solve_tower_rde`'s ansatz.  Anything else → `None`.
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
 use crate::integrate::engine::IntegrationError;
@@ -33,13 +33,24 @@ use super::exp_case::build_rational;
 use super::number_field::{CoeffField, Quotient};
 use super::poly_rde::{expr_to_qpoly, is_free_of_var, poly_deriv};
 use super::tower::find_generators;
-use super::tower_field::{solve_tower_rde, ExpTowerField, LogTowerField, TExpr};
+use super::tower_field::{solve_tower_rde_generic, ExpTowerField, LogTowerField, TExpr};
 
 use rug::Rational;
 
 /// Element of the radical extension over the tower: coefficients of
 /// `1, y, …, y^{n−1}`, each in `ℚ(x)(t)`.
 type TowerElem = Vec<TExpr>;
+
+/// Backwards-compatible alias of [`try_integrate_radical_over_transcendental`]
+/// (originally exp-only; now also handles log towers).  Retained as a stable
+/// public symbol.
+pub fn try_integrate_radical_over_exp(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>> {
+    try_integrate_radical_over_transcendental(expr, var, pool)
+}
 
 /// Public entry: try to integrate a radical whose radicand involves a single
 /// **exp or log** transcendental generator.  Returns `None` when the integrand
@@ -78,7 +89,7 @@ pub fn try_integrate_radical_over_transcendental(
 }
 
 /// The field-generic integration core: decompose over the radical, solve each
-/// component (`i=0` → engine, `i≥1` → [`solve_tower_rde`]), reconstruct, and
+/// component (`i=0` → engine, `i≥1` → `solve_tower_rde`), reconstruct, and
 /// verify `d/dx F = integrand`.
 fn integrate_radical_over_tower<F>(
     field: &F,
@@ -128,7 +139,7 @@ where
                 vec![Rational::from(n as i64)],
             ));
             let omega = field.mul(&scale, &log_deriv_a);
-            let vi = solve_tower_rde(field, &omega, ci)?;
+            let vi = solve_tower_rde_generic(field, &omega, ci)?;
             if field.is_zero(&vi) {
                 continue;
             }


### PR DESCRIPTION
Follow-up to #93 (merged). Adds the **log-tower radicand** case — the logarithmic analogue of the exp radical-over-tower integrator.

## What

- **`LogTowerField`** (`t = log(h)`, `Dt = h'/h`): same `TExpr` element type and arithmetic as `ExpTowerField`; only the derivation differs — `D(tʲ) = j(h'/h)t^{j−1}` *lowers* the `t`-degree (vs exp, which preserves it). The shared quotient-rule helper is factored out; the exp/log `t`-polynomial derivations are split.
- **Genericized** `solve_tower_rde` (and `candidate_denominators`/`solve_with_denominator`) and the entire `tower_integrate` core (`expr_to_texpr` / decomposition / orchestrator) over `F: CoeffField<Elem = TExpr>`. The public entry `try_integrate_radical_over_transcendental` dispatches exp vs log by generator kind.
- **Routing fix:** `contains_risch_form` now also returns true when a radical's radicand contains a transcendental, so `∛(x+log x)` (where `log` appears only inside the radicand) reaches the tower integrator instead of the algebraic engine. Pure-algebraic radicals (`∛x`, `∛(x²)`) are unaffected — no transcendental radicand, still routed to `simple_radical`.

## Verified end-to-end (public engine, symbolic `d/dx`)
`∫ (1/3)(1+1/x)·(x+log x)^{−2/3} dx = (x+log x)^{1/3}` — and tutorial Example 15 (exp) still works.

## Still out of scope
Multiple generators in the radicand; non-monic non-squarefree radicands; the MC logarithmic/torsion part.

## Testing
- `cargo test --workspace`: **839 passed, 0 failed**.
- `cargo fmt` clean; `cargo clippy --all-targets -- -D warnings` clean; `cargo doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)