### PR TITLE
feat(py): API usability improvements from audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,15 @@ The `jit` feature additionally requires LLVM 15 dev headers (`apt install llvm-1
 ```python
 import alkahest as ak
 
+caps = ak.capabilities()  # groebner, jit, egraph, parallel
 pool = ak.ExprPool()
 x = pool.symbol("x")
 
+# Python int literals work in arithmetic (pool still required for symbols)
+expr = x**2 + 1
+
 # Differentiation with derivation log
-result = ak.diff(ak.sin(x ** 2), x)
+result = ak.diff(ak.sin(expr), x)
 print(result.value)   # 2*x*cos(x^2)
 print(result.steps)   # list of rewrite steps
 
@@ -143,12 +147,13 @@ print(result.steps)   # list of rewrite steps
 r = ak.integrate(ak.exp(x), x)
 print(r.value)        # exp(x)
 
-# Simplification
-s = ak.simplify(x + pool.integer(0))
+# Simplification — use simplify_trig for sin²+cos², not the catch-all simplify
+s = ak.simplify(x + 0)
 print(s.value)        # x
+print(ak.simplify_trig(ak.sin(x)**2 + ak.cos(x)**2).value)  # 1
 
-# JIT-compile to native code
-f = ak.compile_expr(x ** 2 + pool.integer(1), [x])
+# JIT-compile to native code (interpreter fallback when caps["jit"] is False)
+f = ak.compile_expr(x**2 + 1, [x])
 print(f([3.0]))       # 10.0
 ```
 
@@ -442,14 +447,21 @@ print(cs.coordinates, cs.smale_certified, cs.enclosures())
 import alkahest as ak
 
 pool = ak.ExprPool()
+x = pool.symbol("x")
+
+# Expr partials (symbolic, no trace):
+ak.symbolic_grad(ak.sin(x**2), [x])   # list[Expr]
 
 @ak.trace(pool)
 def f(x):
     return ak.sin(x ** 2)
 
-df = ak.grad(f)          # symbolic gradient
+df = ak.grad(f)          # GradTracedFn (∂f/∂inputs at numeric points)
 df_fast = ak.jit(df)     # compiled gradient
 ```
+
+**Naming:** `symbolic_grad(expr, vars)` returns symbolic `Expr` partials.
+`grad(traced_fn)` is the JAX-style transform on a `@trace` function (compose with `jit`).
 
 ### Plotting
 

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -91,6 +91,7 @@ use alkahest_core::pattern::{
 use alkahest_core::{compile_cuda as core_compile_cuda, CudaCompiledFn as CoreCudaCompiledFn};
 use std::sync::Arc;
 // V2-1 — Modular / CRT framework
+use alkahest_core::deriv::RewriteStep;
 use alkahest_core::modular::{
     lift_crt as core_lift_crt, mignotte_bound as core_mignotte_bound,
     rational_reconstruction as core_rational_reconstruction, reduce_mod as core_reduce_mod,
@@ -263,6 +264,92 @@ fn parse_domain(s: &str) -> Domain {
         "nonzero" => Domain::NonZero,
         _ => Domain::Real,
     }
+}
+
+/// Python-visible symbol domain (matches :class:`alkahest_core::kernel::Domain`).
+#[pyclass(name = "Domain")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PyDomain {
+    #[pyo3(name = "Real")]
+    Real,
+    #[pyo3(name = "Complex")]
+    Complex,
+    #[pyo3(name = "Integer")]
+    Integer,
+    #[pyo3(name = "Positive")]
+    Positive,
+    #[pyo3(name = "NonNegative")]
+    NonNegative,
+    #[pyo3(name = "NonZero")]
+    NonZero,
+}
+
+#[pymethods]
+impl PyDomain {
+    fn __str__(&self) -> &'static str {
+        self.wire_str()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Domain.{self:?}")
+    }
+}
+
+impl PyDomain {
+    const fn wire_str(self) -> &'static str {
+        match self {
+            PyDomain::Real => "real",
+            PyDomain::Complex => "complex",
+            PyDomain::Integer => "integer",
+            PyDomain::Positive => "positive",
+            PyDomain::NonNegative => "nonneg",
+            PyDomain::NonZero => "nonzero",
+        }
+    }
+}
+
+impl From<PyDomain> for Domain {
+    fn from(d: PyDomain) -> Self {
+        match d {
+            PyDomain::Real => Domain::Real,
+            PyDomain::Complex => Domain::Complex,
+            PyDomain::Integer => Domain::Integer,
+            PyDomain::Positive => Domain::Positive,
+            PyDomain::NonNegative => Domain::NonNegative,
+            PyDomain::NonZero => Domain::NonZero,
+        }
+    }
+}
+
+impl From<Domain> for PyDomain {
+    fn from(d: Domain) -> Self {
+        match d {
+            Domain::Real => PyDomain::Real,
+            Domain::Complex => PyDomain::Complex,
+            Domain::Integer => PyDomain::Integer,
+            Domain::Positive => PyDomain::Positive,
+            Domain::NonNegative => PyDomain::NonNegative,
+            Domain::NonZero => PyDomain::NonZero,
+        }
+    }
+}
+
+fn parse_domain_arg(ob: Option<&Bound<'_, PyAny>>) -> PyResult<Domain> {
+    let Some(ob) = ob else {
+        return Ok(Domain::Real);
+    };
+    if ob.is_none() {
+        return Ok(Domain::Real);
+    }
+    if let Ok(d) = ob.extract::<PyDomain>() {
+        return Ok(d.into());
+    }
+    if let Ok(s) = ob.extract::<&str>() {
+        return Ok(parse_domain(s));
+    }
+    Err(PyTypeError::new_err(
+        "domain must be a str (e.g. 'real') or alkahest.Domain",
+    ))
 }
 
 fn py_int_decimal(v: &Bound<'_, PyAny>) -> PyResult<String> {
@@ -486,14 +573,14 @@ impl PyExprPool {
     fn symbol(
         slf: PyRef<'_, Self>,
         name: &str,
-        domain: Option<&str>,
+        domain: Option<&Bound<'_, PyAny>>,
         commutative: Option<bool>,
-    ) -> PyExpr {
+    ) -> PyResult<PyExpr> {
         let commutative = commutative.unwrap_or(true);
-        let dom = parse_domain(domain.unwrap_or("real"));
+        let dom = parse_domain_arg(domain)?;
         let id = slf.inner.symbol_commutative(name, dom, commutative);
         let pool: Py<PyExprPool> = slf.into();
-        PyExpr { id, pool }
+        Ok(PyExpr { id, pool })
     }
 
     fn integer(slf: PyRef<'_, Self>, n: &Bound<'_, PyAny>) -> PyResult<PyExpr> {
@@ -1172,6 +1259,40 @@ fn make_derived_result(
         steps_raw,
         raw: derived,
     }
+}
+
+/// Post-process a :class:`DerivedResult` with algebraic :func:`simplify` when
+/// ``context(simplify=True)`` is active (Python layer calls this).
+#[pyfunction]
+#[pyo3(name = "_derived_result_context_simplify")]
+fn py_derived_result_context_simplify(
+    py: Python<'_>,
+    dr: PyRef<PyDerivedResult>,
+) -> PyResult<PyDerivedResult> {
+    let pool_py = dr.value.pool.clone_ref(py);
+    let simplified = {
+        let pool = pool_py.borrow(py);
+        core_simplify(dr.value.id, &pool.inner)
+    };
+    if simplified.value == dr.value.id {
+        return Ok(PyDerivedResult {
+            value: dr.value.clone(),
+            derivation: dr.derivation.clone(),
+            steps_raw: dr.steps_raw.clone(),
+            raw: dr.raw.clone(),
+        });
+    }
+    let mut log = dr.raw.log.clone();
+    log.push(RewriteStep::simple(
+        "context_simplify",
+        dr.raw.value,
+        simplified.value,
+    ));
+    let merged = DerivedExpr {
+        value: simplified.value,
+        log: log.merge(simplified.log),
+    };
+    Ok(make_derived_result(py, merged, pool_py))
 }
 
 // ---------------------------------------------------------------------------
@@ -6107,6 +6228,7 @@ fn py_plot_dot(py: Python<'_>, expr: PyRef<PyExpr>) -> String {
 #[pymodule]
 fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
+    m.add_function(wrap_pyfunction!(py_derived_result_context_simplify, m)?)?;
     m.add_function(wrap_pyfunction!(py_simplify, m)?)?;
     m.add_function(wrap_pyfunction!(py_simplify_egraph, m)?)?;
     m.add_function(wrap_pyfunction!(py_simplify_egraph_with, m)?)?;
@@ -6154,6 +6276,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(atan2, m)?)?;
     m.add_function(wrap_pyfunction!(min_expr, m)?)?;
     m.add_function(wrap_pyfunction!(max_expr, m)?)?;
+    m.add_class::<PyDomain>()?;
     m.add_class::<PyExprPool>()?;
     m.add_class::<PyExpr>()?;
     m.add_class::<PyDerivedResult>()?;

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -30,18 +30,20 @@ maturin develop --release --manifest-path alkahest-py/Cargo.toml --features "par
 
 ## Core mental model
 
-Every expression lives in an **`ExprPool`** (a hash-consed DAG). You must create a pool before making any symbolic expression. Integer and rational constants must be interned through the pool — raw Python ints cannot appear directly in expressions.
+Every expression lives in an **`ExprPool`** (a hash-consed DAG). You must create a pool before making any symbolic expression. **Python `int` and `float` literals work in arithmetic** (`x + 1`, `x * 2.5`, `x**2`); use `pool.rational(p, q)` for exact rationals and `pool.integer(n)` when you need an explicit `Expr` constant (e.g. for APIs that only accept `Expr`).
 
 ```python
 import alkahest as ak
-from alkahest import sin, cos, exp, log, sqrt, diff, integrate, simplify
+from alkahest import sin, cos, exp, log, sqrt, diff, integrate, simplify, simplify_trig
+
+caps = ak.capabilities()  # groebner, jit, egraph, parallel — probe once per session
 
 pool = ak.ExprPool()
-x = pool.symbol("x")
+x = pool.symbol("x", ak.Domain.Real)   # or domain="real"
 y = pool.symbol("y")
 
-two   = pool.integer(2)      # always intern constants
-half  = pool.rational(1, 2)  # p/q form
+expr = x**2 + 1          # int literals in +, -, *, **, / are fine
+half = pool.rational(1, 2)  # exact rationals need pool.rational
 ```
 
 Arithmetic operators (`+`, `-`, `*`, `**`, `/`) are all overloaded on `Expr` — use them freely.
@@ -84,11 +86,13 @@ from alkahest import (
     poly_normal,         # normalize to polynomial form (raises ConversionError if not poly)
 )
 
-r = simplify(x + pool.integer(0))          # → x
-r = simplify_trig(sin(x)**2 + cos(x)**2)  # → 1
+r = simplify(x + 0)                        # → x (algebraic rules)
+r = simplify_trig(sin(x)**2 + cos(x)**2)  # → 1  (trig identities — use this, not simplify)
 r = simplify_log_exp(log(exp(x)))          # → x
-r = collect_like_terms(x + x + two*x + y) # → 4*x + y
+r = collect_like_terms(x + x + 2*x + y)   # → 4*x + y
 ```
+
+**Simplifier choice:** `simplify` is a general algebraic rewriter; it does **not** apply trig identities. For `sin²+cos²` and similar, use `simplify_trig` (or `simplify_egraph`). For `log`/`exp` laws, use `simplify_log_exp`.
 
 `simplify_egraph` / `simplify_egraph_with` run egglog e-graph saturation — use when algebraic rewriting is insufficient.
 
@@ -104,19 +108,29 @@ if HAS_EGRAPH:
 
 ## Differentiation
 
+### `diff` vs `symbolic_grad` vs `grad` (keep these names)
+
+| API | Input | Output | When to use |
+|-----|--------|--------|-------------|
+| **`diff`** | one `Expr`, one variable | `DerivedResult` (`.value`, `.steps`) | Single derivative; need derivation log |
+| **`symbolic_grad`** | one `Expr`, `list[Expr]` vars | `list[Expr]` | All partials of one expression at once |
+| **`grad`** | `TracedFn` from `@trace` | `GradTracedFn` → floats at a point | JAX-style pipeline; compose with `jit` |
+
+Do **not** pass an `Expr` to `grad` — use `symbolic_grad` or `diff`. Do **not** pass a `TracedFn` to `symbolic_grad`.
+
 ```python
 from alkahest import diff, diff_forward, symbolic_grad, jacobian
 
-# Symbolic (reverse-mode internally)
+# Single variable + step log
 d = diff(sin(x**2), x)          # DerivedResult; d.value = 2*x*cos(x^2)
 
-# Forward-mode AD
-d_fwd = diff_forward(x**2, x)   # same result, forward sweep
+# Forward-mode AD (cross-check)
+d_fwd = diff_forward(x**2, x)
 
-# All partial derivatives at once (reverse-mode)
-grads = symbolic_grad(x**2 + y**2, [x, y])  # returns list of Expr
+# All partials of one Expr (no TracedFn)
+grads = symbolic_grad(x**2 + y**2, [x, y])  # list[Expr]: [2*x, 2*y]
 
-# Jacobian matrix of a vector-valued function
+# Vector-valued → matrix
 J = jacobian([x**2 + y, sin(x)*y], [x, y])
 entry = J.get(row, col)  # Expr
 ```
@@ -172,8 +186,8 @@ except IntegrationError as e:
 ```python
 from alkahest import subs, match_pattern, make_rule
 
-# Substitute: replace symbols with expressions or numerics
-result = subs(expr, {x: pool.integer(2), y: cos(x)})
+# Substitute: values may be Expr, DerivedResult, or Python int/float (coerced to Expr)
+result = subs(expr, {x: 2, y: cos(x)})
 
 # Pattern matching
 rule = make_rule("sin(?a)**2 + cos(?a)**2", pool.integer(1))
@@ -269,10 +283,16 @@ ys = numpy_eval_par(f, xs)    # multi-core when built with --features parallel
 
 ## trace / grad / jit (JAX-style transforms)
 
+Here **`grad`** means “gradient of a **traced** function”, not `symbolic_grad`. For partials of a bare `Expr`, use **`symbolic_grad(expr, [x, y])`** (see [Differentiation](#differentiation)).
+
 ```python
 import alkahest as ak
 
 pool = ak.ExprPool()
+x, y = pool.symbol("x"), pool.symbol("y")
+
+# Expr-level partials (no @trace):
+partials = ak.symbolic_grad(x**2 + ak.sin(y), [x, y])  # list[Expr]
 
 @ak.trace(pool)
 def energy(x, y):
@@ -283,14 +303,12 @@ print(energy.expr)          # symbolic expression
 print(energy(1.0, 0.0))     # numeric float
 print(energy.symbols)       # [x, y]
 
-# Gradient
-grad_energy = ak.grad(energy)   # GradTracedFn
+# grad = gradient of TracedFn (GradTracedFn), not symbolic_grad
+grad_energy = ak.grad(energy)
 gs = grad_energy(1.0, 0.0)     # [∂/∂x, ∂/∂y] as floats
 
-# JIT compilation
 fast = ak.jit(energy)          # CompiledTracedFn
-fast(1.0, 0.0)                 # same result, LLVM-backed
-fast(np.linspace(0,1,100), np.zeros(100))  # auto-vectorised
+fast_grad = ak.jit(ak.grad(energy))  # compiled GradTracedFn
 ```
 
 Non-decorator variant: `ak.trace_fn(fn, pool)`.
@@ -392,6 +410,10 @@ pool = ak.ExprPool()
 with ak.context(pool=pool, domain="real", simplify=True):
     x = ak.symbol("x")   # pool and domain inferred
     y = ak.symbol("y")
+    d = ak.diff(x**2 + x**2, x)  # .value is algebraically simplified
+
+# simplify=True applies the general :func:`simplify` rewriter to results of
+# diff / integrate / sum_* / product_* only — not to solve or simplify_trig.
 
 # Inspect active context
 ak.active_pool()
@@ -554,14 +576,14 @@ reg = PrimitiveRegistry()
 
 ## Key rules for agents
 
-1. **Always create a pool first.** `ExprPool()` before any symbol or expression.
-2. **Integers must be interned.** Use `pool.integer(n)` and `pool.rational(p, q)`, never raw Python ints in expressions.
+1. **Always create a pool first.** `ExprPool()` before any symbol or expression. Optional: `with ak.context(pool=pool): x = ak.symbol("x")` to avoid repeating `pool=`.
+2. **Pool first; literals in arithmetic are OK.** Use `x + 1`, not only `x + pool.integer(1)`. Use `pool.rational(p, q)` for exact rationals; `subs` accepts Python `int`/`float` in the mapping.
 3. **Read `.value` for the expression.** Top-level operations return `DerivedResult`, not `Expr`.
 4. **Use specific simplifiers.** Prefer `simplify_trig`, `simplify_log_exp`, `collect_like_terms` over the catch-all `simplify` when the structure is known — it is faster.
 5. **Polynomial conversions raise.** `UniPoly.from_symbolic` and `poly_normal` raise `ConversionError` for non-polynomial input — catch it.
 6. **`solve` / Gröbner-side APIs are available in all PyPI wheels.** The `groebner` Cargo feature is a default since 2.3.1 — no feature flag or `ImportError` guard needed. Default PyPI wheels also include egglog (`HAS_EGRAPH` is typically `True`); use `simplify_egraph` when rule-based simplification is insufficient.
 7. **`trace` requires a pool argument.** Use `@alkahest.trace(pool)` (or `trace_fn(fn, pool)`). `@alkahest.trace` alone is invalid.
-8. **`grad` expects a `TracedFn`.** `jit` accepts a `TracedFn` or `GradTracedFn`; both raise `TypeError` on undecorated callables.
+8. **`grad` ≠ `symbolic_grad`.** `symbolic_grad(expr, [x, y])` → `list[Expr]`. `grad(traced_fn)` → `GradTracedFn` (needs `@trace(pool)` first). `jit` accepts `TracedFn` or `GradTracedFn`.
 9. **`numpy_eval` expects a `CompiledFn`** (from `compile_expr`), not a `TracedFn`.
 10. **Symbols from different pools are incompatible.** Keep one pool per computation graph.
 11. **`plot*` functions detect the backend automatically.** Never import matplotlib/plotly in user code just to call `ak.plot` — let alkahest dispatch. Use `backend="plotly"` or `backend="matplotlib"` to force one. Use `plot_svg` when no plotting library is available.

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,7 +48,7 @@ Current stable feature surface.
 
 - Symbolic differentiation (`diff`, `diff_forward`)
 - Forward-mode automatic differentiation
-- Reverse-mode automatic differentiation (`symbolic_grad`)
+- Reverse-mode partials on `Expr` (`symbolic_grad`) — distinct from JAX-style `grad` on `TracedFn`
 - Symbolic integration: power rule, log, exp tower, linear substitution, trig, and full rational-function integration (Hermite reduction, Rothstein–Trager, arctan for irreducible quadratics, √-coefficient logs, `RootSum` for degree-≥3 factors via Lazard–Rioboo–Trager)
 - Rational Risch DE for `f(x)·exp(η)` integrands with `f ∈ ℚ(x)` (Bronstein §6.1)
 - Non-elementary certification via Liouville's theorem (`E-INT-004`): `sin(x)/x`, `exp(x)/x`, `log(x)^(−n)`, etc. raise `NonElementary` instead of `NotImplemented`
@@ -86,7 +86,7 @@ Current stable feature surface.
 ## Transformations
 
 - `trace` / `trace_fn` — symbolic function tracing
-- `grad` — gradient transformation (symbolically differentiates a traced function)
+- `grad` — gradient of a `TracedFn` (`@trace`); pairs with `jit`. Use `symbolic_grad` for `Expr` partials
 - `jit` — LLVM JIT compilation of traced functions
 - `CompiledTracedFn` for array-vectorised evaluation
 - JAX-style pytree flattening (`flatten_exprs`, `unflatten_exprs`, `map_exprs`)

--- a/docs/mdbook/src/calculus.md
+++ b/docs/mdbook/src/calculus.md
@@ -59,9 +59,16 @@ fwd = diff_forward(x**3, x)
 
 Forward mode is useful for checking that the symbolic rules agree with dual-number evaluation.
 
-## Symbolic gradient
+## Symbolic gradient (`symbolic_grad`)
 
-`symbolic_grad` differentiates with respect to multiple variables:
+`symbolic_grad(expr, vars)` returns a **list of `Expr`** — one partial derivative per
+variable. It does not use `@trace` and is not composable with `jit` directly.
+
+| API | Input | Output |
+|-----|--------|--------|
+| `diff(expr, var)` | one variable | `DerivedResult` with `.steps` |
+| `symbolic_grad(expr, vars)` | many variables | `list[Expr]` |
+| `grad(traced_fn)` | `TracedFn` from `@trace` | `GradTracedFn` (numeric; see [Transformations](./transformations.md)) |
 
 ```python
 from alkahest import symbolic_grad
@@ -76,7 +83,8 @@ grads = symbolic_grad(expr, [x, y])
 # grads[1] = ∂/∂y = x^2 + x*cos(x*y)
 ```
 
-For the traced-function gradient (composable with `jit`), see [Transformations](./transformations.md).
+For the JAX-style gradient of a traced Python function (compose with `jit`), use
+`alkahest.grad` — **not** `symbolic_grad`. See [Transformations](./transformations.md).
 
 ## Integration
 

--- a/docs/mdbook/src/transformations.md
+++ b/docs/mdbook/src/transformations.md
@@ -35,7 +35,10 @@ ys = np.zeros(1000)
 result = f(xs, ys)   # vectorised automatically
 ```
 
-## Gradient
+## Gradient (`grad`, not `symbolic_grad`)
+
+`alkahest.grad` applies to a **TracedFn** from `@trace`. For partial derivatives of a
+bare `Expr`, use [`symbolic_grad`](./calculus.md#symbolic-gradient-symbolic_grad) instead.
 
 `grad` differentiates a traced function symbolically with respect to all (or a subset of) its inputs:
 

--- a/docs/sphinx/api/diff.rst
+++ b/docs/sphinx/api/diff.rst
@@ -42,8 +42,11 @@ Differentiation
    Differentiate *expr* with respect to each variable in *vars*.
 
    Returns a list of ``Expr`` objects (not ``DerivedResult``).
-   For a traced-function gradient composable with ``jit``,
-   see :func:`grad`.
+
+   **Not** the same name as :func:`grad` in :doc:`transform` — that function
+   differentiates a :class:`TracedFn` and returns a :class:`GradTracedFn` for
+   numeric evaluation (often with :func:`jit`). Use ``symbolic_grad`` for bare
+   expressions; use ``grad`` only after ``@trace``.
 
    Example::
 

--- a/docs/sphinx/api/transform.rst
+++ b/docs/sphinx/api/transform.rst
@@ -41,6 +41,13 @@ Tracing
 Gradient
 --------
 
+.. note::
+
+   **``grad`` here is not ``symbolic_grad``.** :func:`symbolic_grad` (see
+   :doc:`diff`) takes an :class:`Expr` and variable list and returns symbolic
+   partials. :func:`grad` below operates on a :class:`TracedFn` from
+   :func:`trace` and is composable with :func:`jit`.
+
 .. function:: grad(fn: TracedFn, *, wrt: list[Expr] = None) -> GradTracedFn
 
    Return a new callable that computes the gradient of *fn*.

--- a/examples/agent_workflow.py
+++ b/examples/agent_workflow.py
@@ -38,20 +38,19 @@ x = pool.symbol("x")
 y = pool.symbol("y")
 z = pool.symbol("z")
 
-# Integer and rational constants must be interned via the pool.
-# Python-native ints cannot be used directly in expressions.
-two = pool.integer(2)
+# Python int/float literals work in arithmetic (x + 1, x * 2); rationals use pool.rational.
+two = 2
 half = pool.rational(1, 2)
 
 # Arithmetic operators (+, *, **, /) are all overloaded on Expr.
-quadratic = x**2 + two * x + pool.integer(1)
+quadratic = x**2 + two * x + 1
 print(f"quadratic   : {quadratic}")
 print(f"rational    : {half * x}")
 print(f"trig combo  : {sin(x)**2 + cos(x)**2}")
 
 # Expressions are hash-consed: identical trees share storage.
-a = x**2 + pool.integer(1)
-b = x**2 + pool.integer(1)
+a = x**2 + 1
+b = x**2 + 1
 print(f"hash-cons   : a is b? {str(a) == str(b)}")
 
 # ---------------------------------------------------------------------------

--- a/examples/calculus.py
+++ b/examples/calculus.py
@@ -4,18 +4,7 @@ Run after `maturin develop`:
     python examples/calculus.py
 """
 
-from alkahest.alkahest import (
-    ExprPool,
-    UniPoly,
-    cos,
-    diff,
-    diff_forward,
-    exp,
-    integrate,
-    log,
-    simplify,
-    sin,
-)
+import alkahest as ak
 
 
 def poly_from_coeffs(pool, x, coeffs):
@@ -39,13 +28,13 @@ def poly_from_coeffs(pool, x, coeffs):
 
 def verify_antiderivative(pool, x, expr, label=""):
     """Assert diff(integrate(f, x), x) == f and print the result."""
-    integral = integrate(expr, x)
-    deriv = diff(integral.value, x)
-    simp = simplify(deriv.value)
+    integral = ak.integrate(expr, x)
+    deriv = ak.diff(integral.value, x)
+    simp = ak.simplify(deriv.value)
 
     try:
-        f_poly = UniPoly.from_symbolic(expr, x)
-        d_poly = UniPoly.from_symbolic(simp.value, x)
+        f_poly = ak.UniPoly.from_symbolic(expr, x)
+        d_poly = ak.UniPoly.from_symbolic(simp.value, x)
         match = f_poly.coefficients() == d_poly.coefficients()
     except Exception:
         # Fall back to string comparison when rational coefficients are present
@@ -56,7 +45,7 @@ def verify_antiderivative(pool, x, expr, label=""):
 
 
 def main():
-    pool = ExprPool()
+    pool = ak.ExprPool()
     x = pool.symbol("x")
 
     # ── Symbolic differentiation ──────────────────────────────────────────
@@ -65,25 +54,25 @@ def main():
 
     # Polynomial
     p = poly_from_coeffs(pool, x, [1, 2, 3, 4])   # 1 + 2x + 3x^2 + 4x^3
-    dp = diff(p, x)
+    dp = ak.diff(p, x)
     print(f"d/dx (1+2x+3x²+4x³) = {dp.value}")
     print(f"   derivation steps  = {len(dp.steps)}")
 
     # Trigonometric: d/dx sin(x) = cos(x)
-    dsin = diff(sin(x), x)
+    dsin = ak.diff(ak.sin(x), x)
     print(f"d/dx sin(x)          = {dsin.value}")
 
     # Chain rule: d/dx sin(x^2) = 2*x*cos(x^2)
-    sin_x2 = sin(x ** 2)
-    dsin_x2 = diff(sin_x2, x)
+    sin_x2 = ak.sin(x ** 2)
+    dsin_x2 = ak.diff(sin_x2, x)
     print(f"d/dx sin(x²)         = {dsin_x2.value}")
 
     # Exponential: d/dx exp(x) = exp(x)
-    dexp = diff(exp(x), x)
+    dexp = ak.diff(ak.exp(x), x)
     print(f"d/dx exp(x)          = {dexp.value}")
 
     # Logarithm: d/dx log(x) = x^(-1)
-    dlog = diff(log(x), x)
+    dlog = ak.diff(ak.log(x), x)
     print(f"d/dx log(x)          = {dlog.value}")
 
     # ── Forward-mode AD ───────────────────────────────────────────────────
@@ -91,8 +80,8 @@ def main():
     print("\n=== Forward-mode Automatic Differentiation ===")
 
     p2 = poly_from_coeffs(pool, x, [0, 0, 1])  # x^2
-    fwd = diff_forward(p2, x)
-    sym = diff(p2, x)
+    fwd = ak.diff_forward(p2, x)
+    sym = ak.diff(p2, x)
     print(f"d/dx x² (forward)    = {fwd.value}")
     print(f"d/dx x² (symbolic)   = {sym.value}")
     print(f"  agree?             = {str(fwd.value) == str(sym.value)}")
@@ -102,16 +91,16 @@ def main():
     print("\n=== Symbolic Integration ===")
 
     # Known functions
-    r_sin = integrate(sin(x), x)
+    r_sin = ak.integrate(ak.sin(x), x)
     print(f"∫ sin(x) dx          = {r_sin.value}")
 
-    r_cos = integrate(cos(x), x)
+    r_cos = ak.integrate(ak.cos(x), x)
     print(f"∫ cos(x) dx          = {r_cos.value}")
 
-    r_exp = integrate(exp(x), x)
+    r_exp = ak.integrate(ak.exp(x), x)
     print(f"∫ exp(x) dx          = {r_exp.value}")
 
-    r_inv = integrate(x ** -1, x)
+    r_inv = ak.integrate(x ** -1, x)
     print(f"∫ 1/x dx             = {r_inv.value}")
 
     # Verification for polynomials
@@ -126,7 +115,7 @@ def main():
 
     print("\n=== Derivation Log ===")
 
-    result = diff(poly_from_coeffs(pool, x, [0, 0, 1]), x)  # d/dx x^2
+    result = ak.diff(poly_from_coeffs(pool, x, [0, 0, 1]), x)  # d/dx x^2
     print(f"Expression: x²")
     print(f"Derivative: {result.value}")
     print(f"Steps ({len(result.steps)}):")

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -63,7 +63,6 @@ from .alkahest import (  # noqa: F401
     # Core expression types
     DerivedResult,
     Domain,
-    _derived_result_context_simplify,
     # V1-15: EgraphConfig and simplify_egraph_with
     EgraphConfig,
     # Phase 20: Hybrid systems
@@ -97,6 +96,7 @@ from .alkahest import (  # noqa: F401
     UniPolyFactorization,
     # V2-7: Polynomial factorization
     UniPolyFactorModP,
+    _derived_result_context_simplify,
     abs,  # symbolic abs — use alkahest.abs(expr); shadows Python builtin within this module
     acos,
     adjoint_system,
@@ -531,9 +531,7 @@ def diff(expr, var):
     >>> d = diff(x**3, x)   # DerivedResult; d.value == 3*x^2
     >>> diff(d, x).value    # second derivative — passes DerivedResult directly
     """
-    return _maybe_context_simplify(
-        _native_diff(_coerce_expr(expr), _coerce_expr(var))
-    )
+    return _maybe_context_simplify(_native_diff(_coerce_expr(expr), _coerce_expr(var)))
 
 
 _native_integrate = integrate
@@ -558,9 +556,7 @@ def integrate(expr, var):
     >>> p = ExprPool(); x = p.symbol("x")
     >>> integrate(x**2, x).value   # x^3/3
     """
-    return _maybe_context_simplify(
-        _native_integrate(_coerce_expr(expr), _coerce_expr(var))
-    )
+    return _maybe_context_simplify(_native_integrate(_coerce_expr(expr), _coerce_expr(var)))
 
 
 _native_subs = subs
@@ -748,9 +744,7 @@ _native_sum_indefinite = sum_indefinite
 
 def sum_indefinite(expr, k):
     """Indefinite symbolic sum of *expr* with respect to index *k*."""
-    return _maybe_context_simplify(
-        _native_sum_indefinite(_coerce_expr(expr), _coerce_expr(k))
-    )
+    return _maybe_context_simplify(_native_sum_indefinite(_coerce_expr(expr), _coerce_expr(k)))
 
 
 _native_sum_definite = sum_definite
@@ -773,9 +767,7 @@ _native_product_indefinite = product_indefinite
 
 def product_indefinite(expr, k):
     """Indefinite symbolic product of *expr* with respect to index *k*."""
-    return _maybe_context_simplify(
-        _native_product_indefinite(_coerce_expr(expr), _coerce_expr(k))
-    )
+    return _maybe_context_simplify(_native_product_indefinite(_coerce_expr(expr), _coerce_expr(k)))
 
 
 _native_product_definite = product_definite

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -62,6 +62,8 @@ from .alkahest import (  # noqa: F401
     CompiledFn,
     # Core expression types
     DerivedResult,
+    Domain,
+    _derived_result_context_simplify,
     # V1-15: EgraphConfig and simplify_egraph_with
     EgraphConfig,
     # Phase 20: Hybrid systems
@@ -188,8 +190,8 @@ from .alkahest import (  # noqa: F401
     version,
 )
 from .alkahest import (
-    # Phase 14: Reverse-mode AD (symbolic gradient; for traced-fn gradient use alkahest.grad)
-    grad as symbolic_grad,
+    # Phase 14: reverse-mode partials on Expr (native name `grad`; exported as symbolic_grad)
+    grad as _native_symbolic_grad,
 )
 
 # V5-7: JAX primitive integration (optional — requires JAX)
@@ -439,6 +441,40 @@ def numpy_eval_par(compiled_fn, *arrays):
 # ---------------------------------------------------------------------------
 
 
+def symbolic_grad(expr, vars):
+    """Symbolic partial derivatives of *expr* with respect to each variable in *vars*.
+
+    This is **not** the same as :func:`grad` from :mod:`alkahest._transform`, which
+    differentiates a :class:`~alkahest.TracedFn` produced by :func:`~alkahest.trace`
+    and returns a :class:`~alkahest.GradTracedFn` for numeric evaluation (often
+    composed with :func:`~alkahest.jit`).
+
+    Parameters
+    ----------
+    expr : Expr
+        Expression to differentiate.
+    vars : list[Expr]
+        Variables; one partial derivative per entry.
+
+    Returns
+    -------
+    list[Expr]
+        ``[∂expr/∂vars[0], ∂expr/∂vars[1], …]`` (plain expressions, no step log).
+
+    See Also
+    --------
+    diff : single-variable derivative with :class:`~alkahest.DerivedResult` steps.
+    grad : JAX-style gradient of a traced Python function.
+    jacobian : matrix of partials for a vector-valued function.
+
+    Example
+    -------
+    >>> p = ExprPool(); x, y = p.symbol("x"), p.symbol("y")
+    >>> symbolic_grad(x**2 + y**2, [x, y])  # [2*x, 2*y]
+    """
+    return _native_symbolic_grad(expr, vars)
+
+
 def _coerce_expr(x):
     """Return ``x.value`` if *x* is a :class:`DerivedResult`, else *x* unchanged.
 
@@ -452,6 +488,18 @@ def _coerce_expr(x):
     if isinstance(x, DerivedResult):
         return x.value
     return x
+
+
+def _maybe_context_simplify(result):
+    """When ``context(simplify=True)`` is active, algebraically simplify *result*.
+
+    Merges the operation's derivation log with a ``context_simplify`` step and
+    any steps from :func:`simplify`.  No-op for non-:class:`DerivedResult`
+    values or when the flag is off.
+    """
+    if not simplify_enabled() or not isinstance(result, DerivedResult):
+        return result
+    return _derived_result_context_simplify(result)
 
 
 # Wrap key calculus/simplification functions so they accept DerivedResult or
@@ -483,7 +531,9 @@ def diff(expr, var):
     >>> d = diff(x**3, x)   # DerivedResult; d.value == 3*x^2
     >>> diff(d, x).value    # second derivative — passes DerivedResult directly
     """
-    return _native_diff(_coerce_expr(expr), _coerce_expr(var))
+    return _maybe_context_simplify(
+        _native_diff(_coerce_expr(expr), _coerce_expr(var))
+    )
 
 
 _native_integrate = integrate
@@ -508,7 +558,9 @@ def integrate(expr, var):
     >>> p = ExprPool(); x = p.symbol("x")
     >>> integrate(x**2, x).value   # x^3/3
     """
-    return _native_integrate(_coerce_expr(expr), _coerce_expr(var))
+    return _maybe_context_simplify(
+        _native_integrate(_coerce_expr(expr), _coerce_expr(var))
+    )
 
 
 _native_subs = subs
@@ -521,8 +573,10 @@ def subs(expr, mapping):
     ----------
     expr : Expr or DerivedResult
         Source expression.  :class:`DerivedResult` is auto-coerced to ``.value``.
-    mapping : dict[Expr, Expr]
-        Substitution map.
+    mapping : dict[Expr, Expr | DerivedResult | int | float]
+        Substitution map. Values (and keys that are symbols) may be
+        :class:`Expr`, :class:`DerivedResult`, or Python ``int``/``float``
+        (coerced into the expression pool).
 
     Returns
     -------
@@ -531,8 +585,9 @@ def subs(expr, mapping):
     Example
     -------
     >>> p = ExprPool(); x = p.symbol("x")
+    >>> subs(x**2, {x: 3})         # int values coerced — OK
     >>> r = diff(x**2, x)          # DerivedResult
-    >>> subs(r, {x: p.integer(1)}) # passes DerivedResult directly — OK
+    >>> subs(r, {x: 1})            # DerivedResult first arg — OK
     """
     return _native_subs(_coerce_expr(expr), mapping)
 
@@ -688,6 +743,80 @@ def limit(expr, var, point, dir=None):
     return _native_limit(_coerce_expr(expr), _coerce_expr(var), _coerce_expr(point), dir)
 
 
+_native_sum_indefinite = sum_indefinite
+
+
+def sum_indefinite(expr, k):
+    """Indefinite symbolic sum of *expr* with respect to index *k*."""
+    return _maybe_context_simplify(
+        _native_sum_indefinite(_coerce_expr(expr), _coerce_expr(k))
+    )
+
+
+_native_sum_definite = sum_definite
+
+
+def sum_definite(expr, k, lo, hi):
+    """Definite symbolic sum of *expr* for *k* from *lo* to *hi* (inclusive)."""
+    return _maybe_context_simplify(
+        _native_sum_definite(
+            _coerce_expr(expr),
+            _coerce_expr(k),
+            _coerce_expr(lo),
+            _coerce_expr(hi),
+        )
+    )
+
+
+_native_product_indefinite = product_indefinite
+
+
+def product_indefinite(expr, k):
+    """Indefinite symbolic product of *expr* with respect to index *k*."""
+    return _maybe_context_simplify(
+        _native_product_indefinite(_coerce_expr(expr), _coerce_expr(k))
+    )
+
+
+_native_product_definite = product_definite
+
+
+def product_definite(expr, k, lo, hi):
+    """Definite symbolic product of *expr* for *k* from *lo* to *hi* (inclusive)."""
+    return _maybe_context_simplify(
+        _native_product_definite(
+            _coerce_expr(expr),
+            _coerce_expr(k),
+            _coerce_expr(lo),
+            _coerce_expr(hi),
+        )
+    )
+
+
+_native_rsolve = rsolve
+
+
+def rsolve(equation, n, seq_name, initials=None):
+    """Solve a linear recurrence; *equation* may be :class:`DerivedResult`."""
+    return _native_rsolve(_coerce_expr(equation), _coerce_expr(n), seq_name, initials)
+
+
+_native_poly_normal = poly_normal
+
+
+def poly_normal(expr, vars):
+    """Expand and collect *expr* as a polynomial in *vars*."""
+    return _native_poly_normal(_coerce_expr(expr), [_coerce_expr(v) for v in vars])
+
+
+_native_eval_expr = eval_expr
+
+
+def eval_expr(expr, bindings):
+    """Numerically evaluate *expr*; accepts :class:`DerivedResult` as *expr*."""
+    return _native_eval_expr(_coerce_expr(expr), bindings)
+
+
 # ---------------------------------------------------------------------------
 # Groebner stubs — fallback for custom builds using --no-default-features.
 # Since 2.3.1, groebner is a default Cargo feature and all standard PyPI
@@ -802,6 +931,7 @@ __all__ = [
     "DiffError",
     "DiophantineError",
     "DiophantineSolution",
+    "Domain",
     "DomainError",
     "EgraphConfig",
     "EigenError",

--- a/python/alkahest/_context.py
+++ b/python/alkahest/_context.py
@@ -13,7 +13,7 @@ Example
 >>> with alkahest.context(pool=p, domain="real", simplify=True):
 ...     x = alkahest.symbol("x")          # domain and pool inferred
 ...     expr = x ** 2
-...     d = alkahest.diff(expr, x)        # simplify applied automatically
+...     d = alkahest.diff(expr, x)        # algebraic simplify applied to .value automatically
 """
 
 from __future__ import annotations
@@ -65,11 +65,15 @@ def context(
     pool : ExprPool, optional
         Default expression pool used by ``alkahest.symbol`` and other
         pool-aware helpers when called without an explicit ``pool`` argument.
-    domain : Domain, optional
-        Default domain for ``alkahest.symbol(name)`` calls that omit ``domain``.
+    domain : str or Domain, optional
+        Default domain for ``alkahest.symbol(name)`` calls that omit ``domain``
+        (e.g. ``"real"``, ``Domain.Integer``).
     simplify : bool
-        Reserved for future use: stored in the context and visible via
-        :func:`simplify_enabled`, but operations do not auto-simplify yet.
+        When ``True``, :func:`diff`, :func:`integrate`, :func:`sum_indefinite`,
+        :func:`sum_definite`, :func:`product_indefinite`, and
+        :func:`product_definite` post-process their :class:`DerivedResult` with
+        :func:`simplify` (see :func:`simplify_enabled`).  Explicit
+        :func:`simplify` / :func:`simplify_trig` calls are unchanged.
     precision : int, optional
         Default MPFR precision in bits for ball-arithmetic operations.
     **extra
@@ -86,16 +90,16 @@ def context(
     --------
     >>> import alkahest
     >>> p = alkahest.ExprPool()
-    >>> with alkahest.context(pool=p, domain=alkahest.Domain.Real):
+    >>> with alkahest.context(pool=p, domain="real"):
     ...     x = alkahest.symbol("x")
     ...     y = alkahest.symbol("y")
     ...     expr = x ** 2 + y ** 2
 
-    Contexts nest::
+    Contexts nest (inner keys shadow outer ones)::
 
         with alkahest.context(pool=p):
-            with alkahest.context(simplify=True):
-                # Both pool and simplify are active here.
+            with alkahest.context(domain="integer"):
+                # pool from outer context; domain overridden here.
                 ...
 
     """
@@ -133,7 +137,7 @@ def symbol(name: str, *, pool: Any = None, domain: Any = None, commutative: bool
         Symbol name.
     pool : ExprPool, optional
         Explicit pool; overrides the context pool.
-    domain : Domain, optional
+    domain : str or Domain, optional
         Explicit domain; overrides the context domain.
     commutative : bool
         When ``False``, the symbol does not commute under multiplication (V3-2).

--- a/python/alkahest/_product.py
+++ b/python/alkahest/_product.py
@@ -32,7 +32,10 @@ class Product:
         self._hi = bounds[2]
 
     def doit(self):
-        """Closed form as :class:`~alkahest.DerivedResult`; use `.value` for the `Expr`."""
+        """Closed form as :class:`~alkahest.DerivedResult`.
+
+        Use ``simplify(prod.doit()).value`` when you need a compact ``Expr``.
+        """
         import alkahest as ah
 
         return ah.product_definite(self.term, self._k, self._lo, self._hi)

--- a/python/alkahest/_transform.py
+++ b/python/alkahest/_transform.py
@@ -313,7 +313,11 @@ def grad(
     *,
     wrt: Sequence[Expr] | None = None,
 ) -> GradTracedFn:
-    """Return a new callable that computes the gradient of ``fn``.
+    """Return a new callable that computes the gradient of a :class:`TracedFn`.
+
+    This is the **JAX-style** transform applied after :func:`trace`. It is **not**
+    :func:`alkahest.symbolic_grad`, which takes an :class:`~alkahest.Expr` and a
+    list of variables and returns symbolic partial expressions.
 
     Parameters
     ----------
@@ -326,7 +330,12 @@ def grad(
     Returns
     -------
     GradTracedFn
-        A callable returning ``[∂f/∂wrt[0], ∂f/∂wrt[1], …]``.
+        Callable returning ``[∂f/∂wrt[0], ∂f/∂wrt[1], …]`` as floats at a point.
+        Compose with :func:`jit` for LLVM-backed evaluation.
+
+    See Also
+    --------
+    symbolic_grad : partial derivatives of an :class:`Expr` (no :class:`TracedFn`).
     """
     if not isinstance(fn, TracedFn):
         raise TypeError(

--- a/python/alkahest/_types.pyi
+++ b/python/alkahest/_types.pyi
@@ -12,6 +12,16 @@ class Pool:
     def __enter__(self) -> Pool: ...
     def __exit__(self, *args: object) -> None: ...
 
+class Domain:
+    """Symbol domain (structural identity of symbols in a pool)."""
+
+    Real: Domain
+    Complex: Domain
+    Integer: Domain
+    Positive: Domain
+    NonNegative: Domain
+    NonZero: Domain
+
 class DerivedResult:
     """Result of a symbolic transformation with a derivation log (Phase 4+)."""
 

--- a/tests/test_bugfixes_api.py
+++ b/tests/test_bugfixes_api.py
@@ -102,6 +102,20 @@ def test_solve_simplified_radicals():
         assert abs(alkahest.eval_expr(simp, {})) == pytest.approx(1.0)
 
 
+def test_domain_enum_export():
+    assert hasattr(alkahest, "Domain")
+    assert "Domain" in alkahest.__all__
+    assert str(alkahest.Domain.Real) == "real"
+    assert str(alkahest.Domain.Integer) == "integer"
+    p = alkahest.ExprPool()
+    x = p.symbol("x", alkahest.Domain.Integer)
+    y = p.symbol("y", "integer")
+    assert x is not None and y is not None
+    with alkahest.context(pool=p, domain=alkahest.Domain.Real):
+        z = alkahest.symbol("z")
+        assert z is not None
+
+
 def test_primary_decomposition_stable_export():
     assert hasattr(alkahest, "primary_decomposition")
     assert hasattr(alkahest, "radical")
@@ -114,3 +128,50 @@ def test_piecewise_pool_gt():
     cond = p.gt(x, p.integer(0))
     pw = alkahest.piecewise([(cond, x)], p.integer(-1) * x)
     assert pw is not None
+
+
+def test_context_simplify_invokes_postprocess(monkeypatch):
+    """context(simplify=True) runs _derived_result_context_simplify on diff."""
+    import alkahest
+
+    calls: list[object] = []
+    orig = alkahest._derived_result_context_simplify
+
+    def counting(dr):
+        calls.append(dr)
+        return orig(dr)
+
+    monkeypatch.setattr(alkahest, "_derived_result_context_simplify", counting)
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    with alkahest.context(simplify=True):
+        alkahest.diff(x**2, x)
+    assert calls
+    calls.clear()
+    alkahest.diff(x**2, x)
+    assert not calls
+
+
+def test_context_simplify_merges_step():
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    expr = x + 0
+    with alkahest.context(simplify=True):
+        r = alkahest.diff(expr, x)
+    rules = [s["rule"] for s in r.steps]
+    # When simplify changes the value, a context_simplify step is recorded.
+    if "context_simplify" in rules:
+        assert rules.index("context_simplify") >= 0
+
+
+def test_derived_result_coercion_extended():
+    """sum/product/poly_normal accept DerivedResult first args (B2)."""
+    p = alkahest.ExprPool()
+    k, n = p.symbol("k"), p.symbol("n")
+    hyper = alkahest.simplify(k * alkahest.gamma(k + p.integer(1)))
+    assert alkahest.sum_indefinite(hyper, k).steps
+    assert alkahest.sum_definite(hyper, k, p.integer(0), n).value is not None
+    dr_k = alkahest.integrate(p.integer(1), k)
+    assert alkahest.product_indefinite(dr_k, k).value is not None
+    assert alkahest.product_definite(dr_k, k, p.integer(1), n).value is not None
+    assert alkahest.poly_normal(alkahest.diff(k**2, k), [k]) is not None

--- a/tests/test_bugfixes_api.py
+++ b/tests/test_bugfixes_api.py
@@ -110,7 +110,8 @@ def test_domain_enum_export():
     p = alkahest.ExprPool()
     x = p.symbol("x", alkahest.Domain.Integer)
     y = p.symbol("y", "integer")
-    assert x is not None and y is not None
+    assert x is not None
+    assert y is not None
     with alkahest.context(pool=p, domain=alkahest.Domain.Real):
         z = alkahest.symbol("z")
         assert z is not None

--- a/uv.lock
+++ b/uv.lock
@@ -187,7 +187,7 @@ wheels = [
 
 [[package]]
 name = "alkahest"
-version = "2.4.0"
+version = "3.1.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- **Documentation alignment:** README, agent skill, and examples now match runtime behavior (Python `int`/`float` in arithmetic and `subs`; clear **`grad` vs `symbolic_grad`** table).
- **`Domain` enum:** Exported to stable Python (`alkahest.Domain.Real`, etc.); `pool.symbol` accepts enum or string.
- **`context(simplify=True)`:** Wired on Python wrappers for `diff`, `integrate`, `sum_*`, and `product_*` (merges derivation log with `context_simplify` step).
- **`DerivedResult` coercion:** Extended to `sum_*`, `product_*`, `rsolve`, `poly_normal`, and `eval_expr` via `_coerce_expr`.
- **Tests:** Expanded `tests/test_bugfixes_api.py` (Domain export, context simplify, coercion).

## Test plan

- [x] `uv run pytest tests/test_bugfixes_api.py -q` (16 passed)
- [x] `uv run pytest tests/test_v03.py -k grad -q` (10 passed)
- [ ] `cargo test --workspace` (Rust: `Domain` + `_derived_result_context_simplify`)
- [ ] `python scripts/check_api_freeze.py origin/main` (additive: `Domain` in `__all__`)


Made with [Cursor](https://cursor.com)