### PR TITLE
fix(py): parse domain strings via String for PyO3 3.9 wheels

### DIFF
--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -344,8 +344,8 @@ fn parse_domain_arg(ob: Option<&Bound<'_, PyAny>>) -> PyResult<Domain> {
     if let Ok(d) = ob.extract::<PyDomain>() {
         return Ok(d.into());
     }
-    if let Ok(s) = ob.extract::<&str>() {
-        return Ok(parse_domain(s));
+    if let Ok(s) = ob.extract::<String>() {
+        return Ok(parse_domain(&s));
     }
     Err(PyTypeError::new_err(
         "domain must be a str (e.g. 'real') or alkahest.Domain",


### PR DESCRIPTION
## Summary

Follow-up to #95: `parse_domain_arg` used `extract::<&str>()` which fails to compile in PyO3 extension-module wheel builds on Python 3.9 (CI wheel matrix).

Use `extract::<String>()` instead.

## Test plan

- [x] `cargo check` in `alkahest-py`
- [x] `pytest tests/test_bugfixes_api.py::test_domain_enum_export`
- [ ] Wheel workflow (py3.9 matrix)


Made with [Cursor](https://cursor.com)