### PR TITLE
Risch algebraic integration: P1, M1–M2/MC0, Newton–Puiseux, van Hoeij integral basis, Hermite-on-curve

### DIFF
--- a/alkahest-core/src/integrate/algebraic/find_order.rs
+++ b/alkahest-core/src/integrate/algebraic/find_order.rs
@@ -1,0 +1,157 @@
+//! FIND-ORDER — genus-graded principality of the residue divisor (Risch **MC**).
+//!
+//! The logarithmic part of `∫ R(x,y) dx` is `Σ cⱼ log(uⱼ)`, and it exists (the
+//! integral is elementary) iff the **residue divisor** `δ = Σ res_P · P`
+//! ([`super::residues`]) is, after scaling residues to integers, a **torsion**
+//! element of the divisor class group — i.e. some `N·δ` is **principal**, with
+//! `div(uⱼ) = N·δⱼ` and the log term `(1/N) log(uⱼ)`.  FIND-ORDER decides that
+//! `N` (the *order* of the class), and is genus-graded:
+//!
+//! * **genus 0** — every degree-0 divisor is principal, so `N = 1` always
+//!   (the rational-parametrization win, seen from the divisor side).
+//! * **genus 1** — torsion over ℚ has order ≤ 12 (**Mazur**), so `N ∈ 1..=12` is
+//!   a *complete* test; the genuine elliptic frontier (Weierstrass form + point
+//!   arithmetic) — currently `NotDecided`.
+//! * **genus ≥ 2** — no uniform bound; the Weil-bound reduction-mod-good-prime
+//!   search is best-effort — currently `NotDecided`.
+//!
+//! This module provides the **genus** computation (superelliptic curves) and the
+//! genus-graded decision with **genus 0 complete** and the necessary conditions
+//! (degree-0 residue divisor; rational residues).  Sound: only `Principal`/
+//! `NonElementary` verdicts are asserted; everything uncertain is `NotDecided`.
+
+use super::super::risch::poly_rde::{degree, poly_deriv, trim, QPoly};
+use super::super::risch::rational_rde::poly_gcd;
+use super::residues::{residue_sum, Residue};
+
+/// Result of FIND-ORDER on a residue divisor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FindOrder {
+    /// `N·δ` is principal with this minimal `N` (the log part is `(1/N)·Σ log`).
+    Principal { order: u32 },
+    /// The integral is provably non-elementary (a necessary condition failed).
+    NonElementary,
+    /// Undecided within the implemented scope (e.g. genus ≥ 1 torsion, or an
+    /// incomplete divisor with missing algebraic places).
+    NotDecided,
+}
+
+/// Geometric genus of the **superelliptic** curve `yⁿ = a(x)` for **squarefree**
+/// `a` of degree `m`:
+///
+/// ```text
+///   g = ( m·n − m − n + 2 − gcd(n, m) ) / 2.
+/// ```
+///
+/// `None` when `a` is not squarefree (the singular/normal-form case is out of
+/// this bounded scope).
+pub fn genus(n: usize, a: &QPoly) -> Option<usize> {
+    let a = trim(a.clone());
+    let m = degree(&a);
+    if m < 1 || n < 2 {
+        return None;
+    }
+    // Squarefree ⟺ gcd(a, a') is constant.
+    if degree(&poly_gcd(&a, &poly_deriv(&a))) > 0 {
+        return None;
+    }
+    let (m, n) = (m as i64, n as i64);
+    let g2 = m * n - m - n + 2 - gcd_i64(n, m);
+    if g2 < 0 || g2 % 2 != 0 {
+        return None;
+    }
+    Some((g2 / 2) as usize)
+}
+
+/// Decide the order of the residue divisor's class — the FIND-ORDER step.
+///
+/// `divisor` is the residue divisor from [`super::residues::residue_divisor`].
+pub fn find_order(n: usize, a: &QPoly, divisor: &[Residue]) -> FindOrder {
+    // Necessary: a complete residue divisor has degree 0 (Σ res = 0).  A nonzero
+    // sum means places are missing (algebraic) — we cannot conclude.
+    if residue_sum(divisor) != 0 {
+        return FindOrder::NotDecided;
+    }
+    // No residues ⇒ no logarithmic part: the empty divisor is principal (N = 1).
+    if divisor.iter().all(|r| r.value == 0) {
+        return FindOrder::Principal { order: 1 };
+    }
+    match genus(n, a) {
+        // Genus 0: every degree-0 divisor is principal.
+        Some(0) => FindOrder::Principal { order: 1 },
+        // Genus ≥ 1: the torsion decision (Mazur for genus 1, Weil for ≥ 2) is
+        // the elliptic/Jacobian frontier — not yet implemented.
+        Some(_) => FindOrder::NotDecided,
+        None => FindOrder::NotDecided,
+    }
+}
+
+fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
+    a = a.abs();
+    b = b.abs();
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::risch::alg_field::RatFn;
+    use super::super::residues::residue_divisor;
+    use super::*;
+    use rug::Rational;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+
+    #[test]
+    fn genus_values() {
+        assert_eq!(genus(2, &qp(&[0, 1])), Some(0)); // y²=x         (rational)
+        assert_eq!(genus(2, &qp(&[1, 0, 0, 1])), Some(1)); // y²=x³+1 (elliptic)
+        assert_eq!(genus(2, &qp(&[0, 1, 0, 0, 1])), Some(1)); // y²=x⁴+x (genus 1)
+        assert_eq!(genus(2, &qp(&[1, 0, 0, 0, 0, 1])), Some(2)); // y²=x⁵+1 (genus 2)
+        assert_eq!(genus(3, &qp(&[0, 1])), Some(0)); // y³=x         (rational)
+        assert_eq!(genus(3, &qp(&[1, 0, 1])), Some(1)); // y³=x²+1   (genus 1)
+                                                        // Non-squarefree radicand ⇒ unknown (out of scope).
+        assert_eq!(genus(2, &qp(&[0, 0, 1])), None); // y²=x²
+    }
+
+    /// Genus-0 curve `y²=x`: the residue divisor of `∫1/((x−1)√x) dx` (residues
+    /// ±1 at x=1, res_∞=0, sum 0) is principal with order 1.
+    #[test]
+    fn genus0_principal_order_one() {
+        let a = qp(&[0, 1]);
+        let h = vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, -1, 1]))]; // y/((x−1)x)
+        let div = residue_divisor(2, &a, &h);
+        assert_eq!(find_order(2, &a, &div), FindOrder::Principal { order: 1 });
+    }
+
+    /// Exact differential (no residues) ⇒ principal order 1.
+    #[test]
+    fn empty_divisor_principal() {
+        let a = qp(&[0, 1]);
+        let h = vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 1]))]; // y/x = x^{-1/2}
+        let div = residue_divisor(2, &a, &h);
+        assert!(matches!(
+            find_order(2, &a, &div),
+            FindOrder::Principal { order: 1 }
+        ));
+    }
+
+    /// Genus-1 curve `y²=x³+1`: a nonzero residue divisor is the elliptic
+    /// frontier — `NotDecided` (sound, not a wrong verdict).
+    #[test]
+    fn genus1_not_decided() {
+        let a = qp(&[1, 0, 0, 1]); // x³+1
+                                   // h = 1/((x−2)y): a simple pole at x=2 (and conjugate sheets).
+        let h = vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[-2, 1]))];
+        let div = residue_divisor(2, &a, &h);
+        // Either the divisor is incomplete (algebraic places) or genus ≥ 1:
+        // both yield NotDecided.
+        assert_eq!(find_order(2, &a, &div), FindOrder::NotDecided);
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -1,0 +1,284 @@
+//! Hermite reduction on an algebraic curve — Risch milestone **M3 / P3**.
+//!
+//! Given an integrand `f ∈ ℚ(x)(y)` (`F(x,y)=0`), Hermite reduction writes
+//! `∫ f dx = g + ∫ h dx` where `g ∈ ℚ(x)(y)` is the **algebraic part** and `h`
+//! has only **simple poles** (a squarefree denominator over the curve — a
+//! differential of the third kind).  `∫ h dx` is then the logarithmic part (MC).
+//!
+//! For a **simple radical** `yⁿ = a(x)` the integral basis `wᵢ = yⁱ/dᵢ`
+//! diagonalizes the derivation: `wᵢ' = ωᵢ·wᵢ` with
+//! `ωᵢ = i·a'/(n·a) − dᵢ'/dᵢ ∈ ℚ(x)`.  Hermite then **decouples** into `n`
+//! independent *twisted* scalar Hermite reductions — for the operator
+//! `L = d/dx + ωᵢ` — one per basis component (Bronstein, *Symbolic Integration
+//! Tutorial* §3.2, eq 12).  The twist's pole at a branch point is handled
+//! automatically by the `V·ωᵢ` term, so this is correct including at the
+//! branch locus.
+//!
+//! Sound by construction: the result is accepted only after the exact field
+//! identity `g' + h = f` is verified, and each `h` component is checked to have a
+//! squarefree denominator.
+//!
+//! Scope: simple radical extensions (the diagonal case).  The general
+//! (non-diagonal) integral basis needs the coupled derivation matrix and is the
+//! documented follow-up — its substrate (`integral_basis`, `is_integral`) exists.
+
+use rug::Rational;
+
+use super::super::risch::alg_field::{AlgElem, AlgExtension, RatFn, RationalFunctionField};
+use super::super::risch::number_field::{mod_inverse, CoeffField};
+use super::super::risch::poly_rde::{degree, poly_deriv, poly_mul, trim, QPoly};
+use super::super::risch::rational_rde::{poly_div_exact, poly_gcd};
+use super::integral_basis::{radical_integral_basis, squarefree_factors};
+
+/// Hermite reduction of `∫ f dx` on the curve `yⁿ = a(x)`.  Returns `(g, h)` with
+/// `f = g' + h` and every component of `h` having a squarefree denominator
+/// (simple poles).  `None` if the shape is unsupported or verification fails.
+pub fn hermite_reduce_radical(
+    n: usize,
+    a: &QPoly,
+    integrand: &AlgElem,
+) -> Option<(AlgElem, AlgElem)> {
+    if n < 2 {
+        return None;
+    }
+    let f = RationalFunctionField;
+    let basis = radical_integral_basis(n, a)?;
+    let ext = AlgExtension::radical(n, a);
+
+    // dᵢ = denominator of the basis element wᵢ = yⁱ/dᵢ.
+    let d: Vec<QPoly> = (0..n)
+        .map(|i| {
+            basis[i]
+                .get(i)
+                .map(|c| c.denom().clone())
+                .unwrap_or_else(|| vec![Rational::from(1)])
+        })
+        .collect();
+
+    // Integrand in the w-basis: f = Σ fᵢ yⁱ = Σ (fᵢ·dᵢ) wᵢ  (diagonal basis change).
+    let a_prime = poly_deriv(a);
+    let mut g_w = vec![RatFn::int(0); n];
+    let mut h_w = vec![RatFn::int(0); n];
+    for i in 0..n {
+        let fi = integrand.get(i).cloned().unwrap_or_else(|| RatFn::int(0));
+        if fi.numer().is_empty() {
+            continue;
+        }
+        let coord = f.mul(&fi, &RatFn::from_poly(&d[i])); // fᵢ·dᵢ
+                                                          // ωᵢ = i·a'/(n·a) − dᵢ'/dᵢ.
+        let omega = omega_i(i, n, a, &a_prime, &d[i]);
+        let (gi, hi) = twisted_hermite(&coord, &omega)?;
+        g_w[i] = gi;
+        h_w[i] = hi;
+    }
+
+    // Back to the power basis: g = Σ gᵢ wᵢ = Σ (gᵢ/dᵢ) yⁱ.
+    let to_power = |w: &[RatFn]| -> AlgElem {
+        w.iter()
+            .enumerate()
+            .map(|(i, gi)| f.mul(gi, &RatFn::new(vec![Rational::from(1)], d[i].clone())))
+            .collect()
+    };
+    let g = to_power(&g_w);
+    let h = to_power(&h_w);
+
+    // Soundness gate 1: every h component has a squarefree denominator.
+    for hi in &h {
+        let den = hi.denom();
+        if degree(&poly_gcd(den, &poly_deriv(den))) > 0 {
+            return None;
+        }
+    }
+    // Soundness gate 2: g' + h == f exactly in the field.
+    let lhs = ext.add(&ext.derivation(&g), &h);
+    if !ext.elem_eq(&lhs, integrand) {
+        return None;
+    }
+    Some((g, h))
+}
+
+/// `ωᵢ = i·a'/(n·a) − dᵢ'/dᵢ`, the basis-derivative coefficient `wᵢ' = ωᵢ wᵢ`.
+fn omega_i(i: usize, n: usize, a: &QPoly, a_prime: &QPoly, di: &QPoly) -> RatFn {
+    let f = RationalFunctionField;
+    let scale = RatFn::new(
+        vec![Rational::from(i as i64)],
+        vec![Rational::from(n as i64)],
+    );
+    let log_a = RatFn::new(a_prime.clone(), a.clone()); // a'/a
+    let term1 = f.mul(&scale, &log_a);
+    if degree(di) < 1 {
+        return term1; // dᵢ = 1 ⇒ dᵢ'/dᵢ = 0
+    }
+    let log_d = RatFn::new(poly_deriv(di), di.clone()); // dᵢ'/dᵢ
+    f.add(&term1, &f.neg(&log_d))
+}
+
+/// Twisted scalar Hermite reduction for `L = d/dx + ω`: returns `(g, h)` with
+/// `c = L(g) + h`, `h` having a squarefree denominator.
+fn twisted_hermite(c: &RatFn, omega: &RatFn) -> Option<(RatFn, RatFn)> {
+    let f = RationalFunctionField;
+    let mut cur = c.clone();
+    let mut g = RatFn::int(0);
+    // Each step lowers one repeated factor's multiplicity by one.
+    let cap = 4 * (degree(c.denom()).max(0) as usize) + 8;
+    for _ in 0..cap {
+        let den = cur.denom().clone();
+        // Find the highest-multiplicity squarefree factor V (mult M ≥ 2).
+        let sqf = squarefree_factors(&den);
+        let Some((v, m)) = sqf
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(k, p)| *k + 1 >= 2 && degree(p) >= 1)
+            .map(|(k, p)| (p.clone(), k + 1))
+        else {
+            break; // denominator squarefree → done
+        };
+
+        // B ≡ (A/U)·inv(ωV − (M−1)V') (mod V), with U = den / V^M, A = numer(cur).
+        let vm = poly_pow(&v, m as u32);
+        let u = poly_div_exact(&den, &vm);
+        let num = cur.numer().clone();
+        let au = poly_mod(&poly_mul(&num, &mod_inverse(&u, &v)?), &v); // A/U mod V
+
+        // K = ωV − (M−1)V'  (a ℚ(x) element, regular at V), reduced mod V.
+        let v_rf = RatFn::from_poly(&v);
+        let vp_rf = RatFn::from_poly(&poly_scale(
+            &poly_deriv(&v),
+            &Rational::from((m - 1) as i64),
+        ));
+        let k_rf = f.add(&f.mul(omega, &v_rf), &f.neg(&vp_rf));
+        let k_mod = reduce_mod_v(&k_rf, &v)?;
+        let k_inv = mod_inverse(&k_mod, &v)?;
+
+        let b = poly_mod(&poly_mul(&au, &k_inv), &v);
+        if trim(b.clone()).is_empty() {
+            break; // no reduction possible at this place
+        }
+
+        // g += B / V^{M−1};  cur -= L(B/V^{M−1}).
+        let term = RatFn::new(b.clone(), poly_pow(&v, (m - 1) as u32));
+        g = f.add(&g, &term);
+        let l_term = f.add(&f.derivation(&term), &f.mul(omega, &term));
+        let next = f.add(&cur, &f.neg(&l_term));
+        // Guard against non-progress.
+        if degree(next.denom()) >= degree(cur.denom()) && next != RatFn::int(0) {
+            // The V-power should strictly drop; if not, stop to stay sound.
+            cur = next;
+            break;
+        }
+        cur = next;
+    }
+    Some((g, cur))
+}
+
+/// Reduce a `ℚ(x)` element `r = num/den` modulo `V` (requires `gcd(den, V) = 1`):
+/// `num · den⁻¹ mod V`.
+fn reduce_mod_v(r: &RatFn, v: &QPoly) -> Option<QPoly> {
+    let inv = mod_inverse(r.denom(), v)?;
+    Some(poly_mod(&poly_mul(r.numer(), &inv), v))
+}
+
+fn poly_mod(a: &QPoly, m: &QPoly) -> QPoly {
+    // Remainder of a ÷ m over ℚ[x].
+    let (_, rem) = poly_divrem(a, m);
+    rem
+}
+
+/// `a = q·b + r`, `deg r < deg b`, over `ℚ[x]`.
+fn poly_divrem(a: &QPoly, b: &QPoly) -> (QPoly, QPoly) {
+    let b = trim(b.clone());
+    let bd = degree(&b);
+    let mut r = trim(a.clone());
+    if bd < 0 {
+        return (Vec::new(), r);
+    }
+    let lc = b[bd as usize].clone();
+    let mut q = vec![Rational::from(0); (degree(&r) - bd + 1).max(0) as usize];
+    while degree(&r) >= bd && !r.is_empty() {
+        let rd = degree(&r);
+        let shift = (rd - bd) as usize;
+        let factor = r[rd as usize].clone() / &lc;
+        if (shift as i64) < q.len() as i64 {
+            q[shift] = factor.clone();
+        }
+        for (i, bc) in b.iter().enumerate() {
+            r[shift + i] -= factor.clone() * bc;
+        }
+        r = trim(r);
+    }
+    (trim(q), r)
+}
+
+fn poly_pow(p: &QPoly, e: u32) -> QPoly {
+    let mut acc = vec![Rational::from(1)];
+    for _ in 0..e {
+        acc = poly_mul(&acc, p);
+    }
+    acc
+}
+
+fn poly_scale(p: &QPoly, s: &Rational) -> QPoly {
+    p.iter().map(|c| c.clone() * s).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+    fn rf(num: &[i64], den: &[i64]) -> RatFn {
+        RatFn::new(qp(num), qp(den))
+    }
+
+    /// ∫ y/x³ dx on y² = x : fully algebraic, g = −⅔ y/x², h = 0.
+    #[test]
+    fn sqrt_double_pole_fully_reduces() {
+        // integrand y/x³ = AlgElem [0, 1/x³].
+        let integrand = vec![RatFn::int(0), rf(&[1], &[0, 0, 0, 1])];
+        let (g, h) = hermite_reduce_radical(2, &qp(&[0, 1]), &integrand).expect("reduce");
+        // h = 0.
+        assert!(h.iter().all(|c| c.numer().is_empty()));
+        // g = −⅔ y/x²  ⇒  component 1 = −2/3 / x².
+        assert_eq!(g[1], RatFn::new(qp(&[-2]), qp(&[0, 0, 3])));
+    }
+
+    /// ∫ y/((x−1)·x) dx on y²=x : already simple poles ⇒ g = 0, h = f.
+    #[test]
+    fn sqrt_simple_pole_untouched() {
+        // y/((x-1)x) = AlgElem [0, 1/((x-1)x)] ; (x-1)x = x²−x.
+        let integrand = vec![RatFn::int(0), rf(&[1], &[0, -1, 1])];
+        let (g, h) = hermite_reduce_radical(2, &qp(&[0, 1]), &integrand).expect("reduce");
+        assert!(g.iter().all(|c| c.numer().is_empty())); // g = 0
+        assert_eq!(h[1], rf(&[1], &[0, -1, 1])); // h = f
+    }
+
+    /// Mixed: ∫ y/(x²(x−1)) dx on y²=x reduces the x² pole, leaving simple poles.
+    /// Verified by the exact `g' + h = f` gate inside the reducer.
+    #[test]
+    fn sqrt_mixed_reduction() {
+        // x²(x-1) = x³ − x².
+        let integrand = vec![RatFn::int(0), rf(&[1], &[0, 0, -1, 1])];
+        let (g, h) = hermite_reduce_radical(2, &qp(&[0, 1]), &integrand).expect("reduce");
+        // h has squarefree denominator (gate) and the algebraic part is nontrivial.
+        assert!(!g.iter().all(|c| c.numer().is_empty()));
+        for hi in &h {
+            let den = hi.denom();
+            assert!(degree(&poly_gcd(den, &poly_deriv(den))) <= 0);
+        }
+    }
+
+    /// Degree-3 radical: ∫ y²/x⁴ dx on y³ = x reduces the x⁴ pole.
+    #[test]
+    fn cbrt_reduction() {
+        // y²/x⁴ = AlgElem [0, 0, 1/x⁴].
+        let integrand = vec![RatFn::int(0), RatFn::int(0), rf(&[1], &[0, 0, 0, 0, 1])];
+        let (g, h) = hermite_reduce_radical(3, &qp(&[0, 1]), &integrand).expect("reduce");
+        // y²/x⁴ = x^{2/3}/x⁴ = x^{2/3-4} ; ∫ = x^{2/3-3}/(2/3-3) = (-3/7) x^{-7/3}.
+        // x^{-7/3} = y²/x³ ⇒ g component 2 = (-3/7)/x³, h = 0.
+        assert!(h.iter().all(|c| c.numer().is_empty()));
+        assert_eq!(g[2], RatFn::new(qp(&[-3]), qp(&[0, 0, 0, 7])));
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/integral_basis.rs
+++ b/alkahest-core/src/integrate/algebraic/integral_basis.rs
@@ -1,0 +1,401 @@
+//! Integral bases of algebraic function fields `ℚ(x)(y)`, `F(x,y)=0` — Risch
+//! milestone **MB** (van Hoeij 1994) substrate.
+//!
+//! An *integral basis* `w₀, …, w_{n−1}` of `ℚ(x)(y)` over `ℚ[x]` spans the
+//! integral closure of `ℚ[x]` — exactly the functions with **no finite poles**.
+//! It is the normalizing model Trager's algebraic-integration algorithm (M3)
+//! builds Hermite reduction and residue analysis on.
+//!
+//! This module provides the verifiable, Puiseux-free **core primitives** of the
+//! computation:
+//!
+//! * [`discriminant`] — `D(x) = det[Tr(yⁱ⁺ʲ)] = Res_y(F, ∂F/∂y)` (up to sign),
+//!   computed from the trace form; its repeated factors locate the singular
+//!   places.
+//! * [`rational_singularities`] — the rational `α` with `(x−α)² | D`, the only
+//!   finite places where the naïve basis `1, y, …, y^{n−1}` can fail to be
+//!   integral.
+//! * [`is_integral`] — an **exact** integrality test: `a` is integral over `ℚ[x]`
+//!   iff its characteristic polynomial (over `ℚ(x)`) has polynomial coefficients,
+//!   computed from the traces `Tr(aᵏ)` via Newton's identities.  Sound and
+//!   complete — no truncation, no Puiseux precision bound.
+//! * [`radical_integral_basis`] — Trager's explicit basis `wᵢ = yⁱ/dᵢ` for a
+//!   simple radical `yⁿ = p(x)` (the case van Hoeij/Trager note is *immediate*),
+//!   each element verified by [`is_integral`].
+//!
+//! The general (non-radical) van Hoeij enlargement loop — which uses Puiseux
+//! expansions at each singular place to solve a linear system for the next basis
+//! element — is the documented next step; it needs Puiseux with algebraic
+//! coefficients at algebraic singular places (see `poly::puiseux`).
+
+use rug::Rational;
+
+use super::super::risch::alg_field::{AlgElem, AlgExtension, RatFn, RationalFunctionField};
+use super::super::risch::number_field::CoeffField;
+use super::super::risch::poly_rde::{degree, poly_deriv, poly_mul, trim, QPoly};
+use super::super::risch::rational_rde::{poly_div_exact, poly_gcd};
+
+/// `Tr_{L/ℚ(x)}(b)` for `b ∈ ℚ(x)(y)`: the trace of multiplication-by-`b`,
+/// `Σⱼ [b·yʲ]ⱼ` (the `yʲ`-coefficient of `b·yʲ` reduced mod `F`).
+fn trace(e: &AlgExtension, b: &AlgElem) -> RatFn {
+    let f = RationalFunctionField;
+    let n = e.degree() as usize;
+    let mut acc = f.zero();
+    let gen = e.generator();
+    let mut yj = e.from_int(1); // y^0
+    for j in 0..n {
+        let prod = e.mul(b, &yj);
+        if let Some(c) = prod.get(j) {
+            acc = f.add(&acc, c);
+        }
+        if j + 1 < n {
+            yj = e.mul(&yj, &gen);
+        }
+    }
+    acc
+}
+
+/// The discriminant `D(x) = det[Tr(yⁱ⁺ʲ)]_{0≤i,j<n}` of the power basis — equal
+/// to `Res_y(F, ∂F/∂y)` up to sign.  A `ℚ[x]` polynomial (the basis is integral).
+pub fn discriminant(f_coeffs: &[QPoly]) -> QPoly {
+    let e = AlgExtension::new(f_coeffs);
+    let n = e.degree() as usize;
+    let gen = e.generator();
+    // Powers y^0 … y^{2n−2} and their traces.
+    let ntr = 2 * n.saturating_sub(1) + 1;
+    let mut tr = vec![RatFn::int(0); ntr];
+    let mut ym = e.from_int(1);
+    for (m, slot) in tr.iter_mut().enumerate() {
+        *slot = trace(&e, &ym);
+        if m + 1 < ntr {
+            ym = e.mul(&ym, &gen);
+        }
+    }
+    // Matrix M[i][j] = Tr(y^{i+j}); det over ℚ(x).
+    let mat: Vec<Vec<RatFn>> = (0..n)
+        .map(|i| (0..n).map(|j| tr[i + j].clone()).collect())
+        .collect();
+    let det = ratfn_det(mat);
+    // det ∈ ℚ[x] (denominator 1); return its numerator.
+    debug_assert!(is_polynomial(&det));
+    trim(det.numer().clone())
+}
+
+/// The rational singular places: `α ∈ ℚ` with `(x−α)² | D` (i.e. `α` is a
+/// repeated root of the discriminant).  These are the only finite places where
+/// the naïve basis can fail integrality.  (Algebraic singular places exist too;
+/// they are out of this rational-only scope.)
+pub fn rational_singularities(disc: &QPoly) -> Vec<Rational> {
+    let disc = trim(disc.clone());
+    if degree(&disc) < 2 {
+        return Vec::new();
+    }
+    // Repeated part = gcd(D, D′); its rational roots are the repeated roots of D.
+    let g = poly_gcd(&disc, &poly_deriv(&disc));
+    rational_roots_monic(&g)
+}
+
+/// Decide whether `a ∈ ℚ(x)(y)` (given as the `yʲ`-coefficient vector over `ℚ(x)`)
+/// is integral over `ℚ[x]`.  Exact: `a` is integral iff its characteristic
+/// polynomial `Tⁿ − e₁Tⁿ⁻¹ + … ± eₙ` over `ℚ(x)` has every `eₖ ∈ ℚ[x]`.  The power
+/// sums `pₖ = Tr(aᵏ)` give the `eₖ` by Newton's identities.
+pub fn is_integral(f_coeffs: &[QPoly], a: &AlgElem) -> bool {
+    let e = AlgExtension::new(f_coeffs);
+    let f = RationalFunctionField;
+    let n = e.degree() as usize;
+    // Power sums p_k = Tr(a^k), k = 1..=n.
+    let mut p = vec![f.zero(); n + 1];
+    let mut ak = e.from_int(1);
+    for pk in p.iter_mut().take(n + 1).skip(1) {
+        ak = e.mul(&ak, a);
+        *pk = trace(&e, &ak);
+    }
+    // Newton: k·e_k = Σ_{i=1}^k (−1)^{i−1} e_{k−i} p_i,  e_0 = 1.
+    let mut ek = vec![f.zero(); n + 1];
+    ek[0] = f.one();
+    for k in 1..=n {
+        let mut acc = f.zero();
+        for i in 1..=k {
+            let term = f.mul(&ek[k - i], &p[i]);
+            if i % 2 == 1 {
+                acc = f.add(&acc, &term);
+            } else {
+                acc = f.add(&acc, &f.neg(&term));
+            }
+        }
+        // e_k = acc / k
+        let inv_k = f
+            .inv(&RatFn::int(k as i64))
+            .expect("k≠0 is invertible in ℚ(x)");
+        ek[k] = f.mul(&acc, &inv_k);
+    }
+    // Integral iff every e_k is a polynomial (denominator 1).
+    ek.iter().skip(1).all(is_polynomial)
+}
+
+/// Trager's explicit integral basis for a **simple radical** `yⁿ = p(x)`:
+/// writing `p = ∏ⱼ pⱼʲ` (squarefree form, `pⱼ` pairwise coprime, squarefree),
+/// `wᵢ = yⁱ / dᵢ` with `dᵢ = ∏ⱼ pⱼ^{⌊i·j/n⌋}`.  Returns the basis as `AlgElem`s
+/// over `ℚ[x]/(yⁿ − p)`.  Each element is checked by [`is_integral`].
+pub fn radical_integral_basis(n: usize, p: &QPoly) -> Option<Vec<AlgElem>> {
+    if n < 2 {
+        return None;
+    }
+    // F = yⁿ − p.
+    let mut f_coeffs = vec![QPoly::new(); n + 1];
+    f_coeffs[0] = trim(poly_scale(p, &Rational::from(-1)));
+    f_coeffs[n] = vec![Rational::from(1)];
+
+    // Squarefree decomposition p = ∏ pⱼ^j  (Yun).
+    let sqfree = squarefree_factors(p);
+
+    let mut basis = Vec::with_capacity(n);
+    for i in 0..n {
+        // dᵢ = ∏ⱼ pⱼ^{⌊i·j/n⌋}.
+        let mut di = vec![Rational::from(1)];
+        for (j, pj) in sqfree.iter().enumerate() {
+            let mult = (i * (j + 1)) / n; // pⱼ has multiplicity (j+1)
+            for _ in 0..mult {
+                di = poly_mul(&di, pj);
+            }
+        }
+        // wᵢ = (1/dᵢ)·yⁱ : AlgElem with component i = 1/dᵢ.
+        let mut w = vec![RatFn::int(0); i + 1];
+        w[i] = RatFn::new(vec![Rational::from(1)], di);
+        if !is_integral(&f_coeffs, &w) {
+            return None; // safety: the formula must yield integral elements
+        }
+        basis.push(w);
+    }
+    Some(basis)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn is_polynomial(r: &RatFn) -> bool {
+    let d = r.denom();
+    r.numer().is_empty() || (d.len() == 1 && d[0] == 1)
+}
+
+fn poly_scale(p: &QPoly, s: &Rational) -> QPoly {
+    p.iter().map(|c| c.clone() * s).collect()
+}
+
+/// Determinant of a square matrix over `ℚ(x)` by Gaussian elimination.
+fn ratfn_det(mut m: Vec<Vec<RatFn>>) -> RatFn {
+    let f = RationalFunctionField;
+    let n = m.len();
+    let mut det = f.one();
+    for col in 0..n {
+        // Find a pivot.
+        let Some(piv) = (col..n).find(|&r| !is_zero(&m[r][col])) else {
+            return f.zero();
+        };
+        if piv != col {
+            m.swap(piv, col);
+            det = f.neg(&det);
+        }
+        det = f.mul(&det, &m[col][col]);
+        let inv = f.inv(&m[col][col]).expect("nonzero pivot invertible");
+        for r in (col + 1)..n {
+            if is_zero(&m[r][col]) {
+                continue;
+            }
+            let factor = f.mul(&m[r][col], &inv);
+            let pivot_row = m[col].clone();
+            for (c, pv) in pivot_row.iter().enumerate().skip(col) {
+                let sub = f.mul(&factor, pv);
+                m[r][c] = f.add(&m[r][c], &f.neg(&sub));
+            }
+        }
+    }
+    det
+}
+
+fn is_zero(r: &RatFn) -> bool {
+    r.numer().is_empty()
+}
+
+/// Yun squarefree factorization of `p ∈ ℚ[x]`: returns `[p₁, p₂, …]` with
+/// `p = ∏ⱼ pⱼ^{j+1}` (each `pⱼ` squarefree, pairwise coprime; `pⱼ` may be `1`).
+fn squarefree_factors(p: &QPoly) -> Vec<QPoly> {
+    let p = trim(p.clone());
+    if degree(&p) < 1 {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let dp = poly_deriv(&p);
+    let mut a = poly_gcd(&p, &dp); // ∏ pⱼ^{j}
+    let mut b = poly_div_exact(&p, &a); // ∏ pⱼ
+    loop {
+        let c = poly_gcd(&a, &b); // ∏_{j≥current} pⱼ
+        let factor = poly_div_exact(&b, &c); // current squarefree factor
+        out.push(trim(factor));
+        if degree(&a) < 1 {
+            break;
+        }
+        a = poly_div_exact(&a, &c);
+        b = c;
+        if degree(&b) < 1 {
+            break;
+        }
+    }
+    out
+}
+
+/// Distinct rational roots of a monic-ish `ℚ[x]` polynomial via the rational
+/// root theorem.
+fn rational_roots_monic(p: &QPoly) -> Vec<Rational> {
+    use rug::Integer;
+    let p = trim(p.clone());
+    if degree(&p) < 1 {
+        return Vec::new();
+    }
+    let mut den_lcm = Integer::from(1);
+    for c in &p {
+        den_lcm = den_lcm.lcm(c.denom());
+    }
+    let ints: Vec<Integer> = p
+        .iter()
+        .map(|c| {
+            (c.clone() * Rational::from(den_lcm.clone()))
+                .numer()
+                .clone()
+        })
+        .collect();
+    // Trim leading zeros (shouldn't be any after trim) and trailing.
+    let a0 = ints[0].clone().abs();
+    let an = ints[ints.len() - 1].clone().abs();
+    let mut roots = Vec::new();
+    if ints[0] == 0 {
+        roots.push(Rational::from(0));
+    }
+    let pdiv = divisors(&a0);
+    let qdiv = divisors(&an);
+    for pn in &pdiv {
+        for qn in &qdiv {
+            for sign in [1i32, -1] {
+                let cand = Rational::from((Integer::from(sign) * pn.clone(), qn.clone()));
+                if roots.contains(&cand) {
+                    continue;
+                }
+                let mut acc = Rational::from(0);
+                for a in ints.iter().rev() {
+                    acc = acc * &cand + Rational::from(a.clone());
+                }
+                if acc == 0 {
+                    roots.push(cand);
+                }
+            }
+        }
+    }
+    roots
+}
+
+fn divisors(n: &rug::Integer) -> Vec<rug::Integer> {
+    use rug::Integer;
+    let n = n.clone().abs();
+    if n == 0 {
+        return vec![Integer::from(1)];
+    }
+    let mut ds = Vec::new();
+    let mut d = Integer::from(1);
+    while Integer::from(&d * &d) <= n {
+        if n.is_divisible(&d) {
+            ds.push(d.clone());
+            let o = n.clone() / &d;
+            if o != d {
+                ds.push(o);
+            }
+        }
+        d += 1;
+    }
+    ds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+    fn r(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    #[test]
+    fn discriminant_sqrt() {
+        // F = y² − x ⇒ disc = ±4x.
+        let d = discriminant(&[qp(&[0, -1]), qp(&[]), qp(&[1])]);
+        // 4x (sign aside): degree 1, root at 0 simple.
+        assert_eq!(degree(&d), 1);
+        assert!(
+            rational_singularities(&d).is_empty(),
+            "x=0 is a simple root"
+        );
+    }
+
+    #[test]
+    fn discriminant_cusp_singular() {
+        // F = y² − x³ ⇒ disc = ±4x³, repeated root at x=0.
+        let d = discriminant(&[qp(&[0, 0, 0, -1]), qp(&[]), qp(&[1])]);
+        assert_eq!(degree(&d), 3);
+        let s = rational_singularities(&d);
+        assert_eq!(s, vec![r(0)]);
+    }
+
+    #[test]
+    fn is_integral_examples() {
+        // F = y² − x³.
+        let f = [qp(&[0, 0, 0, -1]), qp(&[]), qp(&[1])];
+        // y is integral.
+        assert!(is_integral(&f, &vec![RatFn::int(0), RatFn::int(1)]));
+        // y/x is integral ((y/x)² = x).
+        let y_over_x = vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 1]))];
+        assert!(is_integral(&f, &y_over_x));
+        // y/x² is NOT integral ((y/x²)² = 1/x).
+        let y_over_x2 = vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 0, 1]))];
+        assert!(!is_integral(&f, &y_over_x2));
+    }
+
+    #[test]
+    fn radical_basis_sqrt_x_is_power_basis() {
+        // y² − x: radicand x squarefree ⇒ d₀=d₁=1, basis {1, y}.
+        let basis = radical_integral_basis(2, &qp(&[0, 1])).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(basis[0], vec![RatFn::int(1)]);
+        assert_eq!(basis[1], vec![RatFn::int(0), RatFn::int(1)]);
+    }
+
+    #[test]
+    fn radical_basis_y2_eq_x3() {
+        // y² = x³ : p = x³ = x²·x, squarefree factors [x, ... ]; d₁ = ⌊1·?⌋.
+        // x³ has squarefree form p₃ part; for n=2, d₁ should give y/x integral.
+        let basis = radical_integral_basis(2, &qp(&[0, 0, 0, 1])).expect("basis");
+        assert_eq!(basis.len(), 2);
+        // w₁ must be integral and equal y/x.
+        assert_eq!(
+            basis[1],
+            vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 1]))]
+        );
+    }
+
+    #[test]
+    fn radical_basis_cbrt_x_squared() {
+        // y³ = x² : the eq-11 basis is {1, y, y²/x}.  All verified integral.
+        let basis = radical_integral_basis(3, &qp(&[0, 0, 1])).expect("basis");
+        assert_eq!(basis.len(), 3);
+        // w₂ = y²/x.
+        assert_eq!(
+            basis[2],
+            vec![
+                RatFn::int(0),
+                RatFn::int(0),
+                RatFn::new(qp(&[1]), qp(&[0, 1]))
+            ]
+        );
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/integral_basis.rs
+++ b/alkahest-core/src/integrate/algebraic/integral_basis.rs
@@ -220,7 +220,7 @@ fn is_zero(r: &RatFn) -> bool {
 
 /// Yun squarefree factorization of `p ∈ ℚ[x]`: returns `[p₁, p₂, …]` with
 /// `p = ∏ⱼ pⱼ^{j+1}` (each `pⱼ` squarefree, pairwise coprime; `pⱼ` may be `1`).
-fn squarefree_factors(p: &QPoly) -> Vec<QPoly> {
+pub(super) fn squarefree_factors(p: &QPoly) -> Vec<QPoly> {
     let p = trim(p.clone());
     if degree(&p) < 1 {
         return Vec::new();

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -21,6 +21,7 @@ pub(super) mod genus_zero;
 pub mod integral_basis;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;
+pub mod vanhoeij;
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
 use crate::integrate::engine::IntegrationError;

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -17,6 +17,7 @@
 //! - Bronstein (2005). Symbolic Integration I. Springer, chs. 10–11.
 
 pub(super) mod decompose;
+pub mod find_order;
 pub(super) mod genus_zero;
 pub mod hermite_curve;
 pub mod integral_basis;

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -18,6 +18,7 @@
 
 pub(super) mod decompose;
 pub(super) mod genus_zero;
+pub mod hermite_curve;
 pub mod integral_basis;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -22,6 +22,7 @@ pub mod hermite_curve;
 pub mod integral_basis;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;
+pub mod residues;
 pub mod vanhoeij;
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -18,6 +18,7 @@
 
 pub(super) mod decompose;
 pub(super) mod genus_zero;
+pub mod integral_basis;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;
 

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -18,6 +18,7 @@
 
 pub(super) mod decompose;
 pub(super) mod genus_zero;
+pub(super) mod parametrize;
 pub(super) mod poly_utils;
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
@@ -160,6 +161,15 @@ pub fn integrate_algebraic(
     var: ExprId,
     pool: &ExprPool,
 ) -> Result<DerivedExpr<ExprId>, IntegrationError> {
+    // M2: genus-0 reduction by rational parametrization.  A single radical with a
+    // *linear* radicand `(a·x+b)^{1/n}` parametrizes as `x = (sⁿ−b)/a`, turning the
+    // integrand rational in `s` (always elementary — incl. the logarithmic part the
+    // simple-radical integral part below cannot finish).  Tried first so it fixes
+    // those cases (and their previously wrong `NonElementary`).
+    if let Some(res) = parametrize::try_parametrize_genus0(expr, var, pool) {
+        return res;
+    }
+
     // MA (Risch M0/M1): degree-≥3 simple radical `p(x)^{1/n}` over ℚ(x).  The
     // genus-0 sqrt engine below only covers degree 2; the simple-radical
     // integral part handles higher degrees (squarefree radicand).  Returns

--- a/alkahest-core/src/integrate/algebraic/parametrize.rs
+++ b/alkahest-core/src/integrate/algebraic/parametrize.rs
@@ -1,80 +1,98 @@
-//! Genus-0 reduction by rational parametrization — Risch milestone **M2**.
+//! Genus-0 reduction by rational parametrization — Risch milestones **M2 / MC0**.
 //!
-//! A single radical generator `y = (a·x + b)^{1/n}` with a **linear** radicand
-//! defines a genus-0 curve `yⁿ = a·x + b` with the trivial rational
-//! parametrization `x = (sⁿ − b)/a`, `y = s`.  Substituting `dx = (n/a)·s^{n−1} ds`
-//! turns `∫ R(x, y) dx` into `∫ R((sⁿ−b)/a, s)·(n/a)s^{n−1} ds`, an integrand that
-//! is **rational in `s`** — hence always elementary and handled by the ordinary
-//! rational/Risch engine.  Back-substituting `s = (a·x+b)^{1/n}` recovers the
-//! antiderivative.
+//! A single radical generator `y = r(x)^{1/n}` whose radicand `r` is a
+//! **linear-fractional** function `r = (a₁x+a₀)/(b₁x+b₀)` (numerator and
+//! denominator each of degree ≤ 1) defines a genus-0 curve `yⁿ = r(x)`.  Solving
+//! `sⁿ = r(x)` for `x` gives the rational parametrization
+//!
+//! ```text
+//!   x(s) = (a₀ − b₀·sⁿ) / (b₁·sⁿ − a₁),   y = s,
+//! ```
+//! and substituting `dx = x'(s) ds` turns `∫ R(x, y) dx` into an integrand that is
+//! **rational in `s`** — hence always elementary and handled by the ordinary
+//! rational/Risch engine.  Back-substituting `s = r(x)^{1/n}` recovers the
+//! antiderivative.  The pure polynomial-linear case (`b₁ = 0`, M2) — `∛x/(x+1)`,
+//! `x^{2/3}`, … — and the genuinely fractional case (MC0) — `√((1−x)/(1+x))`,
+//! `∛((x+1)/(x−1))`, … — are the same formula.
 //!
 //! This covers the cubic-and-higher radical genus-0 cases the simple-radical
-//! integral part (MA) cannot finish — e.g. `∫ ∛x/(x+1) dx`, `∫ 1/(x·∛(x+1)) dx`,
-//! `∫ ∛x/(1+∛x) dx` — including their **logarithmic part**, which MA omitted (and
-//! for which it previously returned a *wrong* `NonElementary`).
+//! integral part (MA) cannot finish, **including their logarithmic part** (which
+//! MA omitted — previously returning a *wrong* `NonElementary` for e.g.
+//! `∫ ∛x/(x+1) dx`).
 //!
-//! Scope: a single radical with radicand linear in `x` (any index `n ≥ 2`).
-//! Higher-degree radicands (`yⁿ = p(x)`, `deg p ≥ 2`) are generally higher genus
-//! and are out of scope here.  Sound by construction: the result is accepted only
-//! after a numeric `d/dx F = integrand` check.
+//! Scope: a single radical with linear-fractional radicand (any index `n ≥ 2`).
+//! Radicands with ≥ 2 distinct finite zeros/poles (`yⁿ = p(x)`, `deg ≥ 2`,
+//! non-Möbius) are generally higher genus and out of scope.  Sound by
+//! construction: the result is accepted only after a numeric `d/dx F = integrand`
+//! check.
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
 use crate::integrate::engine::IntegrationError;
-use crate::integrate::risch::poly_rde::{
-    degree, expr_to_qpoly, is_free_of_var, qpoly_to_expr, rational_to_expr,
-};
+use crate::integrate::risch::poly_rde::{degree, is_free_of_var, poly_mul, rational_to_expr, trim};
+use crate::integrate::risch::rational_rde::expr_to_qrational;
 use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
 use std::collections::HashMap;
 
-/// Try the genus-0 parametrization of a single linear-radicand radical.  Returns
-/// `None` when the integrand is not of this shape (caller falls through).
+type QPoly = Vec<rug::Rational>;
+
+/// Try the genus-0 parametrization of a single linear-fractional-radicand
+/// radical.  Returns `None` when the integrand is not of this shape (caller falls
+/// through).
 pub(super) fn try_parametrize_genus0(
     expr: ExprId,
     var: ExprId,
     pool: &ExprPool,
 ) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>> {
     let (n, radicand) = detect_single_radical(expr, var, pool)?;
-    let p = expr_to_qpoly(radicand, var, pool)?; // radicand as ℚ[x]
-    if degree(&p) != 1 {
-        return None; // only linear radicands are genus-0 by this parametrization
-    }
-    let b = p[0].clone();
-    let a = p[1].clone();
-    if a == 0 {
+    // Radicand as a reduced fraction num/den, each of degree ≤ 1.
+    let (num, den) = expr_to_qrational(radicand, var, pool)?;
+    let (num, den) = (trim(num), trim(den));
+    if degree(&num) > 1 || degree(&den) > 1 || (degree(&num) < 1 && degree(&den) < 1) {
         return None;
     }
+    let coeff = |p: &QPoly, i: usize| p.get(i).cloned().unwrap_or_else(|| rug::Rational::from(0));
+    let (a0, a1) = (coeff(&num, 0), coeff(&num, 1));
+    let (b0, b1) = (coeff(&den, 0), coeff(&den, 1));
 
-    // s = (a·x + b)^{1/n};  x = (sⁿ − b)/a;  dx = (n/a)·s^{n−1} ds.
+    // s = r(x)^{1/n};  x(s) = (a₀ − b₀·sⁿ)/(b₁·sⁿ − a₁).
     let s = pool.symbol("$param_s$", Domain::Real);
     let s_n = pool.pow(s, pool.integer(n as i32));
-    let neg_b = rational_to_expr(&(-b.clone()), pool);
-    let inv_a = rational_to_expr(&a.clone().recip(), pool);
-    let x_of_s = pool.mul(vec![pool.add(vec![s_n, neg_b]), inv_a]);
+    let lin = |c1: &rug::Rational, c0: &rug::Rational| {
+        // c1·sⁿ + c0
+        pool.add(vec![
+            pool.mul(vec![rational_to_expr(c1, pool), s_n]),
+            rational_to_expr(c0, pool),
+        ])
+    };
+    let x_num = lin(&-b0, &a0); // −b₀·sⁿ + a₀
+    let x_den = lin(&b1, &-a1.clone()); // b₁·sⁿ − a₁
+    if degree(&num) < 1 && b1 == 0 {
+        return None; // x would not depend on s
+    }
+    let x_of_s = pool.mul(vec![x_num, pool.pow(x_den, pool.integer(-1))]);
 
-    // Rewrite the integrand directly in `s`: every standalone `x` becomes `x(s)`
-    // and every power `(a·x+b)^{c/d}` of the radicand becomes `s^{c·n/d}`, so no
-    // un-reducible `(sⁿ)^{1/n}` is ever formed.  `None` if some subterm is not
-    // expressible (e.g. another, unrelated radical).
-    let core = to_s(expr, var, &p, n, s, x_of_s, pool)?;
-    let n_over_a = rational_to_expr(&(rug::Rational::from(n as i64) * a.recip()), pool);
-    let dx_ds = pool.mul(vec![n_over_a, pool.pow(s, pool.integer((n as i32) - 1))]);
+    // Rewrite the integrand directly in `s`: standalone `x → x(s)`, and every
+    // power `r(x)^{c/d}` of the radicand → `s^{c·n/d}`, so no un-reducible
+    // `(sⁿ)^{1/n}` is ever formed.
+    let core = to_s(expr, var, &num, &den, n, s, x_of_s, pool)?;
+    let dx_ds = simplify(crate::diff::diff(x_of_s, s, pool).ok()?.value, pool).value;
     let integrand_s = simplify(pool.mul(vec![core, dx_ds]), pool).value;
 
     // Integrate the rational-in-`s` integrand (always elementary), then
-    // back-substitute s = (a·x+b)^{1/n}.
+    // back-substitute s = r(x)^{1/n}.
     let f_s = match crate::integrate::engine::integrate(integrand_s, s, pool) {
         Ok(d) => d.value,
         Err(_) => return None,
     };
-    let radical_expr = pool.pow(qpoly_to_expr(&p, var, pool), pool.rational(1, n as i32));
+    let radical_expr = pool.pow(radicand, pool.rational(1, n as i32));
     let mut back = HashMap::new();
     back.insert(s, radical_expr);
     let f_x = simplify(crate::kernel::subs(f_s, &back, pool), pool).value;
 
     // Soundness gate: d/dx F = integrand numerically (where the radicand > 0).
-    if !verify_derivative(f_x, expr, var, &p, n, pool) {
+    if !verify_derivative(f_x, expr, radicand, var, pool) {
         return None;
     }
 
@@ -137,16 +155,17 @@ fn scan(expr: ExprId, var: ExprId, pool: &ExprPool, out: &mut Vec<(usize, ExprId
     }
 }
 
-/// Rewrite `expr` (rational in `x` and the single radical `(a·x+b)^{1/n}`) as a
-/// rational function of `s`, where `s = (a·x+b)^{1/n}`: standalone `x → x(s)`, and
-/// any power `(a·x+b)^{c/d}` of the radicand → `s^{c·n/d}`.  Returns `None` if a
-/// subterm is not expressible this way (a different radical, a transcendental of
-/// `x`, or a fractional power with `d ∤ c·n`).
+/// Rewrite `expr` (rational in `x` and the single radical `r(x)^{1/n}`, `r =
+/// num/den`) as a rational function of `s`, where `s = r(x)^{1/n}`: standalone
+/// `x → x(s)`, and any power `r(x)^{c/d}` of the radicand → `s^{c·n/d}`.  Returns
+/// `None` if a subterm is not expressible this way (a different radical, a
+/// transcendental of `x`, or a fractional power with `d ∤ c·n`).
 #[allow(clippy::too_many_arguments)]
 fn to_s(
     expr: ExprId,
     var: ExprId,
-    p: &[rug::Rational],
+    num: &QPoly,
+    den: &QPoly,
     n: usize,
     s: ExprId,
     x_of_s: ExprId,
@@ -158,10 +177,10 @@ fn to_s(
     if is_free_of_var(expr, var, pool) {
         return Some(expr); // constant in x (incl. other symbols / numbers)
     }
-    // `(radicand)^{c/d}` → `s^{c·n/d}` when that exponent is an integer.
+    // `r(x)^{c/d}` → `s^{c·n/d}` when `base = r` (as a fraction) and the exponent
+    // is an integer.
     let radical_power = |base: ExprId, c: i64, d: i64, pool: &ExprPool| -> Option<ExprId> {
-        let rb = expr_to_qpoly(base, var, pool)?;
-        if degree(&rb) >= 1 && trim_eq(&rb, p) && (c * n as i64) % d == 0 {
+        if same_fraction(base, num, den, var, pool) && (c * n as i64) % d == 0 {
             Some(pool.pow(s, pool.integer(((c * n as i64) / d) as i32)))
         } else {
             None
@@ -177,20 +196,20 @@ fn to_s(
         ExprData::Add(args) => {
             let v: Vec<ExprId> = args
                 .iter()
-                .map(|&a| to_s(a, var, p, n, s, x_of_s, pool))
+                .map(|&a| to_s(a, var, num, den, n, s, x_of_s, pool))
                 .collect::<Option<_>>()?;
             Some(pool.add(v))
         }
         ExprData::Mul(args) => {
             let v: Vec<ExprId> = args
                 .iter()
-                .map(|&a| to_s(a, var, p, n, s, x_of_s, pool))
+                .map(|&a| to_s(a, var, num, den, n, s, x_of_s, pool))
                 .collect::<Option<_>>()?;
             Some(pool.mul(v))
         }
         ExprData::Pow { base, exp } => match pool.get(exp) {
             ExprData::Integer(m) => {
-                let inner = to_s(base, var, p, n, s, x_of_s, pool)?;
+                let inner = to_s(base, var, num, den, n, s, x_of_s, pool)?;
                 Some(pool.pow(inner, pool.integer(m.0.to_i64()? as i32)))
             }
             ExprData::Rational(r) => {
@@ -202,34 +221,37 @@ fn to_s(
     }
 }
 
-/// Equality of two `ℚ[x]` polynomials up to trailing zeros.
-fn trim_eq(a: &[rug::Rational], b: &[rug::Rational]) -> bool {
-    let z = rug::Rational::from(0);
-    let la = a.iter().rposition(|c| *c != z).map_or(0, |i| i + 1);
-    let lb = b.iter().rposition(|c| *c != z).map_or(0, |i| i + 1);
-    la == lb && a[..la] == b[..lb]
+/// Is `base` equal, as a rational function of `x`, to the fraction `num/den`?
+/// Tested by cross-multiplication so unequal scalings are *not* matched.
+fn same_fraction(base: ExprId, num: &QPoly, den: &QPoly, var: ExprId, pool: &ExprPool) -> bool {
+    let Some((bn, bd)) = expr_to_qrational(base, var, pool) else {
+        return false;
+    };
+    // base nontrivial in x (so it really is the radicand, not a constant).
+    if degree(&trim(bn.clone())) < 1 && degree(&trim(bd.clone())) < 1 {
+        return false;
+    }
+    trim(poly_mul(&bn, den)) == trim(poly_mul(num, &bd))
 }
 
-/// Numeric `d/dx F = integrand` check at sample points where the radicand
-/// `a·x + b > 0` (so the principal real branch of the radical is well defined).
+/// Numeric `d/dx F = integrand` check at sample points where the radicand is
+/// positive (so the principal real branch of the radical is well defined).
 fn verify_derivative(
     f: ExprId,
     integrand: ExprId,
+    radicand: ExprId,
     var: ExprId,
-    p: &[rug::Rational],
-    _n: usize,
     pool: &ExprPool,
 ) -> bool {
     let Ok(df) = crate::diff::diff(f, var, pool) else {
         return false;
     };
     let ds = simplify(df.value, pool).value;
-    let a = p[1].to_f64();
-    let b = p[0].to_f64();
     let mut checked = 0;
-    for &xv in &[0.3_f64, 0.8, 1.6, 2.7, 3.9] {
-        if a * xv + b <= 1e-6 {
-            continue; // radicand not positive: skip
+    for &xv in &[0.3_f64, 0.8, 1.6, 2.7, 3.9, 5.1] {
+        match eval(radicand, var, xv, pool) {
+            Some(r) if r > 1e-6 && r.is_finite() => {}
+            _ => continue, // radicand not safely positive: skip
         }
         let (Some(lhs), Some(rhs)) = (eval(ds, var, xv, pool), eval(integrand, var, xv, pool))
         else {
@@ -276,15 +298,19 @@ mod tests {
     use super::*;
 
     fn check(build: impl Fn(&ExprPool, ExprId) -> ExprId) {
+        check_at(build, &[1.3, 2.4, 3.7]);
+    }
+
+    fn check_at(build: impl Fn(&ExprPool, ExprId) -> ExprId, samples: &[f64]) {
         let pool = ExprPool::new();
         let x = pool.symbol("x", Domain::Real);
         let f = build(&pool, x);
         let r = crate::integrate::engine::integrate(f, x, &pool);
         assert!(r.is_ok(), "expected elementary; got {r:?}");
-        // d/dx F = f at a positive sample.
+        // d/dx F = f at samples (chosen inside the radicand-positive domain).
         let g = r.unwrap().value;
         let ds = simplify(crate::diff::diff(g, x, &pool).unwrap().value, &pool).value;
-        for &xv in &[1.3_f64, 2.4, 3.7] {
+        for &xv in samples {
             let lhs = eval(ds, x, xv, &pool).unwrap();
             let rhs = eval(f, x, xv, &pool).unwrap();
             assert!(
@@ -293,6 +319,52 @@ mod tests {
                 pool.display(g)
             );
         }
+    }
+
+    /// MC0 (Möbius radicand): `∫ √((1−x)/(1+x)) dx` — genus-0 via `x = (1−s²)/(1+s²)`.
+    /// Radicand positive on `(−1, 1)`.
+    #[test]
+    fn sqrt_mobius_one_minus_x_over_one_plus_x() {
+        check_at(
+            |p, x| {
+                let num = p.add(vec![p.integer(1), p.mul(vec![p.integer(-1), x])]);
+                let den = p.add(vec![p.integer(1), x]);
+                let ratio = p.mul(vec![num, p.pow(den, p.integer(-1))]);
+                p.func("sqrt", vec![ratio])
+            },
+            &[0.2, 0.55, 0.85],
+        );
+    }
+
+    /// MC0: `∫ ∛((x+1)/(x−1)) dx` — radicand positive for `x > 1`.
+    #[test]
+    fn cbrt_mobius_x_plus_1_over_x_minus_1() {
+        check_at(
+            |p, x| {
+                let num = p.add(vec![x, p.integer(1)]);
+                let den = p.add(vec![x, p.integer(-1)]);
+                let ratio = p.mul(vec![num, p.pow(den, p.integer(-1))]);
+                p.func("cbrt", vec![ratio])
+            },
+            &[1.7, 2.6, 4.3],
+        );
+    }
+
+    /// MC0: `∫ 1/((1+x)·√((1−x)/(1+x))) dx` — a rational weight times the Möbius
+    /// radical.  Radicand positive on `(−1, 1)`.
+    #[test]
+    fn weighted_sqrt_mobius() {
+        check_at(
+            |p, x| {
+                let num = p.add(vec![p.integer(1), p.mul(vec![p.integer(-1), x])]);
+                let den = p.add(vec![p.integer(1), x]);
+                let ratio = p.mul(vec![num, p.pow(den, p.integer(-1))]);
+                let rad = p.func("sqrt", vec![ratio]);
+                let w = p.pow(p.add(vec![p.integer(1), x]), p.integer(-1));
+                p.mul(vec![w, p.pow(rad, p.integer(-1))])
+            },
+            &[0.2, 0.55, 0.85],
+        );
     }
 
     #[test]

--- a/alkahest-core/src/integrate/algebraic/parametrize.rs
+++ b/alkahest-core/src/integrate/algebraic/parametrize.rs
@@ -1,0 +1,342 @@
+//! Genus-0 reduction by rational parametrization — Risch milestone **M2**.
+//!
+//! A single radical generator `y = (a·x + b)^{1/n}` with a **linear** radicand
+//! defines a genus-0 curve `yⁿ = a·x + b` with the trivial rational
+//! parametrization `x = (sⁿ − b)/a`, `y = s`.  Substituting `dx = (n/a)·s^{n−1} ds`
+//! turns `∫ R(x, y) dx` into `∫ R((sⁿ−b)/a, s)·(n/a)s^{n−1} ds`, an integrand that
+//! is **rational in `s`** — hence always elementary and handled by the ordinary
+//! rational/Risch engine.  Back-substituting `s = (a·x+b)^{1/n}` recovers the
+//! antiderivative.
+//!
+//! This covers the cubic-and-higher radical genus-0 cases the simple-radical
+//! integral part (MA) cannot finish — e.g. `∫ ∛x/(x+1) dx`, `∫ 1/(x·∛(x+1)) dx`,
+//! `∫ ∛x/(1+∛x) dx` — including their **logarithmic part**, which MA omitted (and
+//! for which it previously returned a *wrong* `NonElementary`).
+//!
+//! Scope: a single radical with radicand linear in `x` (any index `n ≥ 2`).
+//! Higher-degree radicands (`yⁿ = p(x)`, `deg p ≥ 2`) are generally higher genus
+//! and are out of scope here.  Sound by construction: the result is accepted only
+//! after a numeric `d/dx F = integrand` check.
+
+use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
+use crate::integrate::engine::IntegrationError;
+use crate::integrate::risch::poly_rde::{
+    degree, expr_to_qpoly, is_free_of_var, qpoly_to_expr, rational_to_expr,
+};
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
+use crate::simplify::engine::simplify;
+
+use std::collections::HashMap;
+
+/// Try the genus-0 parametrization of a single linear-radicand radical.  Returns
+/// `None` when the integrand is not of this shape (caller falls through).
+pub(super) fn try_parametrize_genus0(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>> {
+    let (n, radicand) = detect_single_radical(expr, var, pool)?;
+    let p = expr_to_qpoly(radicand, var, pool)?; // radicand as ℚ[x]
+    if degree(&p) != 1 {
+        return None; // only linear radicands are genus-0 by this parametrization
+    }
+    let b = p[0].clone();
+    let a = p[1].clone();
+    if a == 0 {
+        return None;
+    }
+
+    // s = (a·x + b)^{1/n};  x = (sⁿ − b)/a;  dx = (n/a)·s^{n−1} ds.
+    let s = pool.symbol("$param_s$", Domain::Real);
+    let s_n = pool.pow(s, pool.integer(n as i32));
+    let neg_b = rational_to_expr(&(-b.clone()), pool);
+    let inv_a = rational_to_expr(&a.clone().recip(), pool);
+    let x_of_s = pool.mul(vec![pool.add(vec![s_n, neg_b]), inv_a]);
+
+    // Rewrite the integrand directly in `s`: every standalone `x` becomes `x(s)`
+    // and every power `(a·x+b)^{c/d}` of the radicand becomes `s^{c·n/d}`, so no
+    // un-reducible `(sⁿ)^{1/n}` is ever formed.  `None` if some subterm is not
+    // expressible (e.g. another, unrelated radical).
+    let core = to_s(expr, var, &p, n, s, x_of_s, pool)?;
+    let n_over_a = rational_to_expr(&(rug::Rational::from(n as i64) * a.recip()), pool);
+    let dx_ds = pool.mul(vec![n_over_a, pool.pow(s, pool.integer((n as i32) - 1))]);
+    let integrand_s = simplify(pool.mul(vec![core, dx_ds]), pool).value;
+
+    // Integrate the rational-in-`s` integrand (always elementary), then
+    // back-substitute s = (a·x+b)^{1/n}.
+    let f_s = match crate::integrate::engine::integrate(integrand_s, s, pool) {
+        Ok(d) => d.value,
+        Err(_) => return None,
+    };
+    let radical_expr = pool.pow(qpoly_to_expr(&p, var, pool), pool.rational(1, n as i32));
+    let mut back = HashMap::new();
+    back.insert(s, radical_expr);
+    let f_x = simplify(crate::kernel::subs(f_s, &back, pool), pool).value;
+
+    // Soundness gate: d/dx F = integrand numerically (where the radicand > 0).
+    if !verify_derivative(f_x, expr, var, &p, n, pool) {
+        return None;
+    }
+
+    let mut log = DerivationLog::new();
+    log.push(RewriteStep::simple(
+        "algebraic_genus0_parametrize",
+        expr,
+        f_x,
+    ));
+    Some(Ok(DerivedExpr::with_log(f_x, log)))
+}
+
+/// Find the unique `x`-dependent radical generator and return `(n, radicand)`.
+/// `None` if there is no such generator or more than one distinct one.
+fn detect_single_radical(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<(usize, ExprId)> {
+    let mut found: Vec<(usize, ExprId)> = Vec::new();
+    scan(expr, var, pool, &mut found);
+    let mut distinct: Vec<(usize, ExprId)> = Vec::new();
+    for (n, r) in found {
+        if !distinct.iter().any(|&(m, q)| m == n && q == r) {
+            distinct.push((n, r));
+        }
+    }
+    if distinct.len() == 1 {
+        Some(distinct.remove(0))
+    } else {
+        None
+    }
+}
+
+fn scan(expr: ExprId, var: ExprId, pool: &ExprPool, out: &mut Vec<(usize, ExprId)>) {
+    match pool.get(expr) {
+        ExprData::Func { ref name, ref args }
+            if name == "sqrt" && args.len() == 1 && !is_free_of_var(args[0], var, pool) =>
+        {
+            out.push((2, args[0]));
+        }
+        ExprData::Func { ref name, ref args }
+            if name == "cbrt" && args.len() == 1 && !is_free_of_var(args[0], var, pool) =>
+        {
+            out.push((3, args[0]));
+        }
+        ExprData::Pow { base, exp } => {
+            if let ExprData::Rational(r) = pool.get(exp) {
+                if let Some(den) = r.0.denom().to_i64() {
+                    if den >= 2 && !is_free_of_var(base, var, pool) {
+                        out.push((den as usize, base));
+                        return;
+                    }
+                }
+            }
+            scan(base, var, pool, out);
+        }
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for &a in &args {
+                scan(a, var, pool, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite `expr` (rational in `x` and the single radical `(a·x+b)^{1/n}`) as a
+/// rational function of `s`, where `s = (a·x+b)^{1/n}`: standalone `x → x(s)`, and
+/// any power `(a·x+b)^{c/d}` of the radicand → `s^{c·n/d}`.  Returns `None` if a
+/// subterm is not expressible this way (a different radical, a transcendental of
+/// `x`, or a fractional power with `d ∤ c·n`).
+#[allow(clippy::too_many_arguments)]
+fn to_s(
+    expr: ExprId,
+    var: ExprId,
+    p: &[rug::Rational],
+    n: usize,
+    s: ExprId,
+    x_of_s: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    if expr == var {
+        return Some(x_of_s);
+    }
+    if is_free_of_var(expr, var, pool) {
+        return Some(expr); // constant in x (incl. other symbols / numbers)
+    }
+    // `(radicand)^{c/d}` → `s^{c·n/d}` when that exponent is an integer.
+    let radical_power = |base: ExprId, c: i64, d: i64, pool: &ExprPool| -> Option<ExprId> {
+        let rb = expr_to_qpoly(base, var, pool)?;
+        if degree(&rb) >= 1 && trim_eq(&rb, p) && (c * n as i64) % d == 0 {
+            Some(pool.pow(s, pool.integer(((c * n as i64) / d) as i32)))
+        } else {
+            None
+        }
+    };
+    match pool.get(expr) {
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            radical_power(args[0], 1, 2, pool)
+        }
+        ExprData::Func { ref name, ref args } if name == "cbrt" && args.len() == 1 => {
+            radical_power(args[0], 1, 3, pool)
+        }
+        ExprData::Add(args) => {
+            let v: Vec<ExprId> = args
+                .iter()
+                .map(|&a| to_s(a, var, p, n, s, x_of_s, pool))
+                .collect::<Option<_>>()?;
+            Some(pool.add(v))
+        }
+        ExprData::Mul(args) => {
+            let v: Vec<ExprId> = args
+                .iter()
+                .map(|&a| to_s(a, var, p, n, s, x_of_s, pool))
+                .collect::<Option<_>>()?;
+            Some(pool.mul(v))
+        }
+        ExprData::Pow { base, exp } => match pool.get(exp) {
+            ExprData::Integer(m) => {
+                let inner = to_s(base, var, p, n, s, x_of_s, pool)?;
+                Some(pool.pow(inner, pool.integer(m.0.to_i64()? as i32)))
+            }
+            ExprData::Rational(r) => {
+                radical_power(base, r.0.numer().to_i64()?, r.0.denom().to_i64()?, pool)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Equality of two `ℚ[x]` polynomials up to trailing zeros.
+fn trim_eq(a: &[rug::Rational], b: &[rug::Rational]) -> bool {
+    let z = rug::Rational::from(0);
+    let la = a.iter().rposition(|c| *c != z).map_or(0, |i| i + 1);
+    let lb = b.iter().rposition(|c| *c != z).map_or(0, |i| i + 1);
+    la == lb && a[..la] == b[..lb]
+}
+
+/// Numeric `d/dx F = integrand` check at sample points where the radicand
+/// `a·x + b > 0` (so the principal real branch of the radical is well defined).
+fn verify_derivative(
+    f: ExprId,
+    integrand: ExprId,
+    var: ExprId,
+    p: &[rug::Rational],
+    _n: usize,
+    pool: &ExprPool,
+) -> bool {
+    let Ok(df) = crate::diff::diff(f, var, pool) else {
+        return false;
+    };
+    let ds = simplify(df.value, pool).value;
+    let a = p[1].to_f64();
+    let b = p[0].to_f64();
+    let mut checked = 0;
+    for &xv in &[0.3_f64, 0.8, 1.6, 2.7, 3.9] {
+        if a * xv + b <= 1e-6 {
+            continue; // radicand not positive: skip
+        }
+        let (Some(lhs), Some(rhs)) = (eval(ds, var, xv, pool), eval(integrand, var, xv, pool))
+        else {
+            return false;
+        };
+        if !lhs.is_finite() || !rhs.is_finite() || (lhs - rhs).abs() > 1e-6 * (1.0 + rhs.abs()) {
+            return false;
+        }
+        checked += 1;
+    }
+    checked >= 2
+}
+
+fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> Option<f64> {
+    if expr == x {
+        return Some(xv);
+    }
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some(n.0.to_f64()),
+        ExprData::Rational(r) => Some(r.0.to_f64()),
+        ExprData::Add(args) => args
+            .iter()
+            .try_fold(0.0, |s, &a| Some(s + eval(a, x, xv, pool)?)),
+        ExprData::Mul(args) => args
+            .iter()
+            .try_fold(1.0, |s, &a| Some(s * eval(a, x, xv, pool)?)),
+        ExprData::Pow { base, exp } => Some(eval(base, x, xv, pool)?.powf(eval(exp, x, xv, pool)?)),
+        ExprData::Func { ref name, ref args } if args.len() == 1 => {
+            let a = eval(args[0], x, xv, pool)?;
+            match name.as_str() {
+                "exp" => Some(a.exp()),
+                "log" => Some(a.ln()),
+                "sqrt" => Some(a.sqrt()),
+                "cbrt" => Some(a.cbrt()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(build: impl Fn(&ExprPool, ExprId) -> ExprId) {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let f = build(&pool, x);
+        let r = crate::integrate::engine::integrate(f, x, &pool);
+        assert!(r.is_ok(), "expected elementary; got {r:?}");
+        // d/dx F = f at a positive sample.
+        let g = r.unwrap().value;
+        let ds = simplify(crate::diff::diff(g, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[1.3_f64, 2.4, 3.7] {
+            let lhs = eval(ds, x, xv, &pool).unwrap();
+            let rhs = eval(f, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, f = {rhs}\n  F = {}",
+                pool.display(g)
+            );
+        }
+    }
+
+    #[test]
+    fn cbrt_x_over_x_plus_1() {
+        // ∫ ∛x/(x+1) dx — elementary (was wrongly NonElementary before M2).
+        check(|p, x| {
+            let num = p.func("cbrt", vec![x]);
+            let den = p.add(vec![x, p.integer(1)]);
+            p.mul(vec![num, p.pow(den, p.integer(-1))])
+        });
+    }
+
+    #[test]
+    fn one_over_x_cbrt_x_plus_1() {
+        // ∫ 1/(x·∛(x+1)) dx.
+        check(|p, x| {
+            let xp1 = p.add(vec![x, p.integer(1)]);
+            let cb = p.func("cbrt", vec![xp1]);
+            p.pow(p.mul(vec![x, cb]), p.integer(-1))
+        });
+    }
+
+    #[test]
+    fn cbrt_x_over_one_plus_cbrt_x() {
+        // ∫ ∛x/(1+∛x) dx.
+        check(|p, x| {
+            let cb = p.func("cbrt", vec![x]);
+            let den = p.add(vec![p.integer(1), cb]);
+            p.mul(vec![cb, p.pow(den, p.integer(-1))])
+        });
+    }
+
+    #[test]
+    fn x_two_thirds() {
+        // ∫ x^(2/3) dx = (3/5) x^(5/3).
+        check(|p, x| p.pow(x, p.rational(2, 3)));
+    }
+
+    #[test]
+    fn fifth_root_of_linear() {
+        // ∫ (2x+1)^(1/5) dx = (5/12)(2x+1)^(6/5).
+        check(|p, x| {
+            let lin = p.add(vec![p.mul(vec![p.integer(2), x]), p.integer(1)]);
+            p.pow(lin, p.rational(1, 5))
+        });
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/residues.rs
+++ b/alkahest-core/src/integrate/algebraic/residues.rs
@@ -1,0 +1,246 @@
+//! Residues of a differential on an algebraic curve — the foundation of the
+//! **logarithmic part / FIND-ORDER** (Risch milestone **MC**).
+//!
+//! After Hermite reduction (`hermite_curve`) the remaining integrand `h` is a
+//! differential of the **third kind** (only simple poles).  Its integral is
+//! `∫ h dx = Σ cⱼ log(uⱼ)`, and the `cⱼ` are governed by the **residues** of
+//! `h dx` at the places of the curve: the residue divisor `δ = Σ res_P · P` must
+//! be (a torsion multiple of) a principal divisor for the integral to be
+//! elementary.
+//!
+//! At a place over `x = α` with ramification `e` and uniformizer `t`
+//! (`x − α = t^e`, `dx = e·t^{e−1} dt`), the residue is
+//!
+//! ```text
+//!   res_P(h dx) = [t^{-1}](h · e t^{e−1}) = e · [t^{-e}]( h along the branch ).
+//! ```
+//!
+//! computed from the Puiseux expansion at `α` via the Laurent-`t` substitution
+//! shared with [`super::vanhoeij`].  The **residue theorem** `Σ_P res_P = 0`
+//! (over *all* places, including infinity) is the soundness check.
+//!
+//! Scope: residues at **rational** finite places with rational branches (poles of
+//! `h` and branch points).  Algebraic places and the place at infinity are the
+//! follow-up; together with FIND-ORDER (genus-graded principality) they complete
+//! MC.
+
+use rug::{Integer, Rational};
+use std::collections::BTreeSet;
+
+use super::super::risch::alg_field::AlgElem;
+use super::super::risch::poly_rde::{degree, trim, QPoly};
+use super::vanhoeij::{branch_ts, elem_ts};
+use crate::poly::puiseux::puiseux_at;
+
+/// A residue at a place over a rational point `x = α`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Residue {
+    /// The base point `α` of the place.
+    pub point: Rational,
+    /// Index of the Puiseux sheet at `α` (distinguishes places over the same `α`).
+    pub sheet: usize,
+    /// Ramification index of the place.
+    pub ramification: u64,
+    /// The residue `res_P(h dx)`.
+    pub value: Rational,
+}
+
+/// Residues of the differential `h dx` at all **rational finite places** of the
+/// curve `yⁿ = a(x)` — the poles of `h` and the branch points (roots of `a`).
+/// Places with zero residue are omitted.
+///
+/// (Algebraic places and the place at infinity are out of this rational-only
+/// scope; for fully ramified rational curves the finite residues already sum to
+/// `−res_∞`.)
+pub fn finite_residues(n: usize, a: &QPoly, h: &AlgElem) -> Vec<Residue> {
+    if n < 2 {
+        return Vec::new();
+    }
+    let monos = curve_monomials(n, a);
+
+    // Candidate base points: rational roots of `a` (branch points) and of every
+    // coordinate denominator of `h` (finite poles).
+    let mut cands: BTreeSet<Rational> = BTreeSet::new();
+    for r in rational_roots(a) {
+        cands.insert(r);
+    }
+    for c in h {
+        for r in rational_roots(c.denom()) {
+            cands.insert(r);
+        }
+    }
+
+    let mut out = Vec::new();
+    for alpha in cands {
+        // Enough Puiseux terms to resolve the simple poles of h's coordinates.
+        let prec = (h
+            .iter()
+            .map(|c| degree(c.denom()).max(0))
+            .max()
+            .unwrap_or(0)
+            + n as i64
+            + 3) as u32;
+        for (sheet, br) in puiseux_at(&monos, &alpha, prec).iter().enumerate() {
+            let e = br.ramification as i64;
+            let u = 2 * e + 4;
+            let series = elem_ts(h, &alpha, e, u, &branch_ts(br));
+            let coeff = series
+                .get(&(-e))
+                .cloned()
+                .unwrap_or_else(|| Rational::from(0));
+            let value = Rational::from(e) * coeff;
+            if value != 0 {
+                out.push(Residue {
+                    point: alpha.clone(),
+                    sheet,
+                    ramification: br.ramification,
+                    value,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Monomials `(i, j, coeff)` of `F = yⁿ − a(x)`.
+fn curve_monomials(n: usize, a: &QPoly) -> Vec<(u32, u32, Rational)> {
+    let mut m = vec![(0u32, n as u32, Rational::from(1))]; // yⁿ
+    for (i, c) in a.iter().enumerate() {
+        if *c != 0 {
+            m.push((i as u32, 0, -c.clone())); // −a_i x^i
+        }
+    }
+    m
+}
+
+/// Distinct rational roots of `p ∈ ℚ[x]` via the rational-root theorem.
+fn rational_roots(p: &QPoly) -> Vec<Rational> {
+    let p = trim(p.clone());
+    if degree(&p) < 1 {
+        return Vec::new();
+    }
+    let lo = p.iter().position(|c| *c != 0).unwrap_or(0);
+    let mut roots = Vec::new();
+    if lo > 0 {
+        roots.push(Rational::from(0));
+    }
+    let psi = &p[lo..];
+    if psi.len() <= 1 {
+        return roots;
+    }
+    let mut den_lcm = Integer::from(1);
+    for c in psi {
+        den_lcm = den_lcm.lcm(c.denom());
+    }
+    let ints: Vec<Integer> = psi
+        .iter()
+        .map(|c| {
+            (c.clone() * Rational::from(den_lcm.clone()))
+                .numer()
+                .clone()
+        })
+        .collect();
+    let a0 = ints[0].clone().abs();
+    let an = ints[ints.len() - 1].clone().abs();
+    for pn in divisors(&a0) {
+        for qn in &divisors(&an) {
+            for sign in [1i32, -1] {
+                let cand = Rational::from((Integer::from(sign) * pn.clone(), qn.clone()));
+                if roots.contains(&cand) {
+                    continue;
+                }
+                let mut acc = Rational::from(0);
+                for c in ints.iter().rev() {
+                    acc = acc * &cand + Rational::from(c.clone());
+                }
+                if acc == 0 {
+                    roots.push(cand);
+                }
+            }
+        }
+    }
+    roots
+}
+
+fn divisors(n: &Integer) -> Vec<Integer> {
+    let n = n.clone().abs();
+    if n == 0 {
+        return vec![Integer::from(1)];
+    }
+    let mut ds = Vec::new();
+    let mut d = Integer::from(1);
+    while Integer::from(&d * &d) <= n {
+        if n.is_divisible(&d) {
+            ds.push(d.clone());
+            let o = n.clone() / &d;
+            if o != d {
+                ds.push(o);
+            }
+        }
+        d += 1;
+    }
+    ds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::risch::alg_field::RatFn;
+    use super::*;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+    fn rf(num: &[i64], den: &[i64]) -> RatFn {
+        RatFn::new(qp(num), qp(den))
+    }
+    fn r(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    /// h dx = du/u with u = (y−1)/(y+1) on y²=x:
+    /// `∫ 1/((x−1)√x) dx = log((√x−1)/(√x+1))`.
+    /// Residues: +1 and −1 at the two sheets over x=1; total 0.
+    #[test]
+    fn log_differential_residues() {
+        // h = 1/((x−1)√x) = y/((x−1)x) = AlgElem [0, 1/(x²−x)].
+        let h = vec![RatFn::int(0), rf(&[1], &[0, -1, 1])];
+        let res = finite_residues(2, &qp(&[0, 1]), &h);
+        // Two nonzero residues at x=1.
+        let mut at1: Vec<Rational> = res
+            .iter()
+            .filter(|r| r.point == r_one())
+            .map(|r| r.value.clone())
+            .collect();
+        at1.sort();
+        assert_eq!(at1, vec![r(-1), r(1)]);
+        // Residue theorem (finite places): sum is 0 here (no residue at ∞).
+        let total: Rational = res.iter().fold(r(0), |s, x| s + &x.value);
+        assert_eq!(total, r(0));
+    }
+
+    fn r_one() -> Rational {
+        Rational::from(1)
+    }
+
+    /// h dx = x^{-1/2} dx = d(2√x): no residues (exact, no log part).
+    #[test]
+    fn exact_differential_no_residues() {
+        // h = 1/√x = y/x = AlgElem [0, 1/x].
+        let h = vec![RatFn::int(0), rf(&[1], &[0, 1])];
+        let res = finite_residues(2, &qp(&[0, 1]), &h);
+        assert!(res.is_empty(), "expected no residues; got {res:?}");
+    }
+
+    /// A single simple pole away from the branch locus: y/(x−2) on y²=x,
+    /// i.e. √x/(x−2).  The two sheets ±√2 over x=2 carry opposite residues.
+    #[test]
+    fn simple_pole_off_branch() {
+        // h = y/(x−2) = AlgElem [0, 1/(x−2)].
+        let h = vec![RatFn::int(0), rf(&[1], &[-2, 1])];
+        let res = finite_residues(2, &qp(&[0, 1]), &h);
+        // x=2 is not a rational branch point and √2 ∉ ℚ ⇒ no *rational* sheets
+        // there; the residues live at an algebraic place (out of scope) — so the
+        // rational-place result is empty, soundly (not a wrong value).
+        assert!(res.iter().all(|r| r.value != 0));
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/residues.rs
+++ b/alkahest-core/src/integrate/algebraic/residues.rs
@@ -19,25 +19,30 @@
 //! shared with [`super::vanhoeij`].  The **residue theorem** `Σ_P res_P = 0`
 //! (over *all* places, including infinity) is the soundness check.
 //!
-//! Scope: residues at **rational** finite places with rational branches (poles of
-//! `h` and branch points).  Algebraic places and the place at infinity are the
-//! follow-up; together with FIND-ORDER (genus-graded principality) they complete
-//! MC.
+//! [`finite_residues`] handles the rational finite places (poles of `h`, branch
+//! points); [`residues_at_infinity`] handles the places over `∞` (via the
+//! `w = 1/y`, `z = 1/x` curve `ã(z)wⁿ − zᵐ = 0`); [`residue_divisor`] combines
+//! them.  Scope: rational branches; **algebraic** finite/infinite places are the
+//! remaining gap (build on `puiseux_at_zero_algebraic`).  Together with FIND-ORDER
+//! (genus-graded principality) these complete MC.
 
 use rug::{Integer, Rational};
 use std::collections::BTreeSet;
 
 use super::super::risch::alg_field::AlgElem;
 use super::super::risch::poly_rde::{degree, trim, QPoly};
-use super::vanhoeij::{branch_ts, elem_ts};
-use crate::poly::puiseux::puiseux_at;
+use super::vanhoeij::{branch_ts, elem_ts, ts_add, ts_inv, ts_mul, ts_pow, TS};
+use crate::poly::puiseux::{puiseux_at, puiseux_at_zero, PuiseuxSeries};
 
-/// A residue at a place over a rational point `x = α`.
+/// A residue at a place of the curve.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Residue {
-    /// The base point `α` of the place.
+    /// The base point `α` (ignored when `at_infinity`).
     pub point: Rational,
-    /// Index of the Puiseux sheet at `α` (distinguishes places over the same `α`).
+    /// `true` for a place over `x = ∞`.
+    pub at_infinity: bool,
+    /// Index of the Puiseux sheet at the place's base (distinguishes places over
+    /// the same `α` or over `∞`).
     pub sheet: usize,
     /// Ramification index of the place.
     pub ramification: u64,
@@ -92,6 +97,7 @@ pub fn finite_residues(n: usize, a: &QPoly, h: &AlgElem) -> Vec<Residue> {
             if value != 0 {
                 out.push(Residue {
                     point: alpha.clone(),
+                    at_infinity: false,
                     sheet,
                     ramification: br.ramification,
                     value,
@@ -100,6 +106,121 @@ pub fn finite_residues(n: usize, a: &QPoly, h: &AlgElem) -> Vec<Residue> {
         }
     }
     out
+}
+
+/// Puiseux branches at **infinity** of `yⁿ = a(x)`, returned as the `w = 1/y`
+/// branches (series in `z = 1/x`) of the curve `ã(z)·wⁿ − zᵐ = 0`, where
+/// `m = deg a` and `ã(z) = zᵐ·a(1/z)` is the reversed radicand (`ã(0) ≠ 0`).
+/// The actual branch is `y = 1/w`, `x = 1/z`.
+pub fn puiseux_at_infinity(n: usize, a: &QPoly, prec: u32) -> Vec<PuiseuxSeries> {
+    let a = trim(a.clone());
+    let m = degree(&a);
+    if m < 0 {
+        return Vec::new();
+    }
+    let m = m as usize;
+    // ã(z) = Σᵢ a_i z^{m−i}  (reversed).
+    let mut monos: Vec<(u32, u32, Rational)> = Vec::new();
+    for (i, ai) in a.iter().enumerate() {
+        if *ai != 0 {
+            monos.push(((m - i) as u32, n as u32, ai.clone())); // ã_k wⁿ
+        }
+    }
+    monos.push((m as u32, 0, Rational::from(-1))); // − zᵐ
+    puiseux_at_zero(&monos, prec)
+}
+
+/// Residues of `h dx` at the places over **infinity** of `yⁿ = a(x)`.
+///
+/// At a place over `∞` with ramification `e` (uniformizer `t`, `z = 1/x = tᵉ`,
+/// `x = t^{−e}`, `dx = −e·t^{−e−1} dt`), the residue is
+/// `res = [t^{-1}](h dx) = −e·[tᵉ](h along the branch)`.
+pub fn residues_at_infinity(n: usize, a: &QPoly, h: &AlgElem) -> Vec<Residue> {
+    let m = degree(&trim(a.clone())).max(0) as usize;
+    let dmax = h
+        .iter()
+        .map(|c| degree(c.numer()).max(degree(c.denom())).max(0))
+        .max()
+        .unwrap_or(0);
+    let prec = (dmax + (n as i64) + (m as i64) + 4) as u32;
+    let mut out = Vec::new();
+    for (sheet, w_branch) in puiseux_at_infinity(n, a, prec).iter().enumerate() {
+        let e = w_branch.ramification as i64;
+        let u = 2 * e + 2 * (m as i64) * e + 8;
+        // y = 1/w  as a t-series; w from the branch (z = tᵉ).
+        let w_ts = branch_ts(w_branch);
+        let Some(y_ts) = ts_inv(&w_ts, u) else {
+            continue;
+        };
+        let h_ts = elem_at_infinity(h, e, u, &y_ts);
+        let coeff = h_ts.get(&e).cloned().unwrap_or_else(|| Rational::from(0));
+        let value = -Rational::from(e) * coeff;
+        if value != 0 {
+            out.push(Residue {
+                point: Rational::from(0),
+                at_infinity: true,
+                sheet,
+                ramification: w_branch.ramification,
+                value,
+            });
+        }
+    }
+    out
+}
+
+/// Series of `h = Σⱼ hⱼ(x) yʲ` along an infinite place: `x = t^{−e}`, `y = y_ts(t)`.
+fn elem_at_infinity(h: &AlgElem, e: i64, u: i64, y_ts: &TS) -> TS {
+    let mut acc = TS::new();
+    for (j, coeff) in h.iter().enumerate() {
+        if coeff.numer().is_empty() {
+            continue;
+        }
+        let cj = ratfn_at_infinity(coeff, e, u);
+        let yj = ts_pow(y_ts, j as u32, u);
+        acc = ts_add(&acc, &ts_mul(&cj, &yj, u));
+    }
+    acc
+}
+
+/// `r(t^{−e})` for `r ∈ ℚ(x)`, as a Laurent `t`-series truncated to exps `< u`.
+fn ratfn_at_infinity(r: &crate::integrate::risch::alg_field::RatFn, e: i64, u: i64) -> TS {
+    let num = poly_at_infinity(r.numer(), e, u);
+    let den = poly_at_infinity(r.denom(), e, u);
+    match ts_inv(&den, u) {
+        Some(inv) => ts_mul(&num, &inv, u),
+        None => TS::new(),
+    }
+}
+
+/// `p(t^{−e})` for `p ∈ ℚ[x]`: `Σᵢ p_i t^{−e·i}`.
+fn poly_at_infinity(p: &QPoly, e: i64, u: i64) -> TS {
+    let mut ts = TS::new();
+    for (i, pi) in p.iter().enumerate() {
+        if *pi != 0 {
+            let exp = -e * i as i64;
+            if exp < u {
+                *ts.entry(exp).or_insert_with(|| Rational::from(0)) += pi;
+            }
+        }
+    }
+    ts.retain(|_, c| *c != 0);
+    ts
+}
+
+/// The full **residue divisor** of `h dx` on `yⁿ = a(x)`: residues at all
+/// rational finite places **and** at the places over infinity.  The integral
+/// `∫ h dx` is elementary iff this divisor is (a torsion multiple of) a principal
+/// divisor — the FIND-ORDER decision.  `residue_sum(&divisor)` should be `0`
+/// (residue theorem) when every place was captured.
+pub fn residue_divisor(n: usize, a: &QPoly, h: &AlgElem) -> Vec<Residue> {
+    let mut d = finite_residues(n, a, h);
+    d.extend(residues_at_infinity(n, a, h));
+    d
+}
+
+/// Sum of the residue values (should be `0` over a complete set of places).
+pub fn residue_sum(divisor: &[Residue]) -> Rational {
+    divisor.iter().fold(Rational::from(0), |s, r| s + &r.value)
 }
 
 /// Monomials `(i, j, coeff)` of `F = yⁿ − a(x)`.
@@ -220,6 +341,37 @@ mod tests {
 
     fn r_one() -> Rational {
         Rational::from(1)
+    }
+
+    /// Residues at infinity: `∫ dx/√(x²+1) = log(x+√(x²+1))`.  At ∞ the curve
+    /// `y²=x²+1` has two unramified places (`y ~ ±x`); `du/u` with `u=x+y` has
+    /// residues `−1` and `+1` there.
+    #[test]
+    fn infinity_residues() {
+        // h = 1/y = y/(x²+1) = AlgElem [0, 1/(x²+1)].
+        let h = vec![RatFn::int(0), rf(&[1], &[1, 0, 1])];
+        let res = super::residues_at_infinity(2, &qp(&[1, 0, 1]), &h);
+        let mut vals: Vec<Rational> = res.iter().map(|r| r.value.clone()).collect();
+        vals.sort();
+        assert_eq!(vals, vec![r(-1), r(1)]);
+        // No rational finite poles (y=0 ⇒ x²=−1, algebraic) ⇒ finite is empty.
+        assert!(finite_residues(2, &qp(&[1, 0, 1]), &h).is_empty());
+    }
+
+    /// Residue theorem across finite + infinite places: for `y²=x`,
+    /// `h = 1/((x−1)√x)`, the finite residues (±1) and `res_∞ = 0` sum to 0.
+    #[test]
+    fn residue_theorem_finite_plus_infinity() {
+        let a = qp(&[0, 1]);
+        let h = vec![RatFn::int(0), rf(&[1], &[0, -1, 1])]; // y/((x−1)x)
+        let mut total = r(0);
+        for r0 in finite_residues(2, &a, &h) {
+            total += &r0.value;
+        }
+        for r0 in super::residues_at_infinity(2, &a, &h) {
+            total += &r0.value;
+        }
+        assert_eq!(total, r(0));
     }
 
     /// h dx = x^{-1/2} dx = d(2√x): no residues (exact, no log part).

--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -31,8 +31,8 @@ use super::integral_basis::{discriminant, is_integral, rational_singularities};
 use crate::poly::puiseux::{puiseux_at, PuiseuxSeries};
 
 /// A Laurent series in the place uniformizer `t = (x−α)^{1/e}` (integer
-/// `t`-exponents), truncated.
-type TS = BTreeMap<i64, Rational>;
+/// `t`-exponents), truncated.  Shared with [`super::residues`].
+pub(super) type TS = BTreeMap<i64, Rational>;
 
 /// Compute an integral basis `b₀, …, b_{n−1}` of `ℚ(x)(y)` over `ℚ[x]` for the
 /// monic minimal polynomial `F = Σ f_coeffs[j] yʲ`.  Returns the basis as
@@ -157,7 +157,7 @@ fn try_enlarge(
 // Laurent-series-in-t arithmetic (over ℚ)
 // ---------------------------------------------------------------------------
 
-fn branch_ts(s: &PuiseuxSeries) -> TS {
+pub(super) fn branch_ts(s: &PuiseuxSeries) -> TS {
     let e = s.ramification as i64;
     let mut ts = TS::new();
     for (exp, c) in &s.terms {
@@ -172,7 +172,7 @@ fn branch_ts(s: &PuiseuxSeries) -> TS {
 }
 
 /// Series of `b = Σⱼ bⱼ(x) yʲ` along a branch `y = bts(t)`, `x = α + t^e`.
-fn elem_ts(b: &AlgElem, alpha: &Rational, e: i64, u: i64, bts: &TS) -> TS {
+pub(super) fn elem_ts(b: &AlgElem, alpha: &Rational, e: i64, u: i64, bts: &TS) -> TS {
     let mut acc = TS::new();
     for (j, coeff) in b.iter().enumerate() {
         if coeff.numer().is_empty() {

--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -219,7 +219,7 @@ fn poly_ts(p: &QPoly, alpha: &Rational, e: i64, u: i64) -> TS {
     ts
 }
 
-fn ts_add(a: &TS, b: &TS) -> TS {
+pub(super) fn ts_add(a: &TS, b: &TS) -> TS {
     let mut r = a.clone();
     for (k, c) in b {
         *r.entry(*k).or_insert_with(|| Rational::from(0)) += c;
@@ -228,7 +228,7 @@ fn ts_add(a: &TS, b: &TS) -> TS {
     r
 }
 
-fn ts_mul(a: &TS, b: &TS, u: i64) -> TS {
+pub(super) fn ts_mul(a: &TS, b: &TS, u: i64) -> TS {
     let mut r = TS::new();
     for (ka, ca) in a {
         for (kb, cb) in b {
@@ -242,7 +242,7 @@ fn ts_mul(a: &TS, b: &TS, u: i64) -> TS {
     r
 }
 
-fn ts_pow(a: &TS, m: u32, u: i64) -> TS {
+pub(super) fn ts_pow(a: &TS, m: u32, u: i64) -> TS {
     let mut acc = TS::new();
     acc.insert(0, Rational::from(1));
     for _ in 0..m {
@@ -252,7 +252,7 @@ fn ts_pow(a: &TS, m: u32, u: i64) -> TS {
 }
 
 /// Inverse of a Laurent series, truncated to exponents `< u`.
-fn ts_inv(s: &TS, u: i64) -> Option<TS> {
+pub(super) fn ts_inv(s: &TS, u: i64) -> Option<TS> {
     let (&v0, c0) = s.iter().next()?; // lowest exponent
     let inv_c0 = Rational::from(1) / c0.clone();
     let kmax = (u + v0).max(1);

--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -1,0 +1,458 @@
+//! van Hoeij integral-basis **enlargement loop** (MB) — builds a global integral
+//! basis of `ℚ(x)(y)`, `F(x,y)=0`, from the power basis by repeatedly dividing
+//! out singular places.
+//!
+//! Following van Hoeij (1994 §2): start `b₀ = 1`; for `d = 1 … n−1`, set the
+//! initial `b_d = y·b_{d−1}` (degree `d`) and enlarge it as long as some
+//! `a = (a₀b₀ + ⋯ + a_{d−1}b_{d−1} + b_d)/(x−α)` is integral, where `α` is a
+//! singular place (`(x−α)² | disc`).  The coefficients `aᵢ ∈ ℚ` are found by
+//! substituting the Puiseux expansions at `α` into `a` and requiring every
+//! **negative-power** coefficient (in the place's uniformizer) to vanish — a
+//! `ℚ`-linear system.  Each proposed enlargement is then **gated by the exact
+//! [`is_integral`] test**, so the result is sound regardless of Puiseux
+//! truncation: a wrong proposal is rejected, never accepted.
+//!
+//! Scope: enlargements are proposed only at **rational** singular places, using
+//! their rational Puiseux sheets.  Sheets with algebraic coefficients are simply
+//! absent from the linear system, so a proposal there is under-constrained and
+//! `is_integral` rejects it — the basis may then be non-maximal at such a place,
+//! but is **never incorrect**.  Produces correct integral bases for radical
+//! curves and rational-branch curves such as the nodal cubic `y² = x³ + x²`
+//! (`{1, y/x}`).  Algebraic singular places (and algebraic sheets) are the
+//! follow-up, building on `puiseux_at_zero_algebraic`.
+
+use rug::{Integer, Rational};
+use std::collections::BTreeMap;
+
+use super::super::risch::alg_field::{AlgElem, AlgExtension, RatFn, RationalFunctionField};
+use super::super::risch::number_field::CoeffField;
+use super::super::risch::poly_rde::{degree, QPoly};
+use super::integral_basis::{discriminant, is_integral, rational_singularities};
+use crate::poly::puiseux::{puiseux_at, PuiseuxSeries};
+
+/// A Laurent series in the place uniformizer `t = (x−α)^{1/e}` (integer
+/// `t`-exponents), truncated.
+type TS = BTreeMap<i64, Rational>;
+
+/// Compute an integral basis `b₀, …, b_{n−1}` of `ℚ(x)(y)` over `ℚ[x]` for the
+/// monic minimal polynomial `F = Σ f_coeffs[j] yʲ`.  Returns the basis as
+/// `AlgElem`s (each verified integral), or `None` on failure.
+///
+/// Maximal when every singular place is rational with rational branches;
+/// otherwise an integral (possibly non-maximal) basis — see the module docs.
+pub fn integral_basis(f_coeffs: &[QPoly]) -> Option<Vec<AlgElem>> {
+    let ext = AlgExtension::new(f_coeffs);
+    let n = ext.degree() as usize;
+    if n < 1 {
+        return None;
+    }
+    let monos = to_monomials(f_coeffs);
+    let disc = discriminant(f_coeffs);
+    let sing = rational_singularities(&disc);
+
+    let mut b: Vec<AlgElem> = vec![ext.from_int(1)]; // b₀ = 1
+    for d in 1..n {
+        let mut bd = ext.mul(&b[d - 1], &ext.generator()); // y·b_{d−1}
+                                                           // Each real enlargement drops the discriminant by (x−α)²; bound the work.
+        let cap = (degree(&disc).max(0) as usize + 2) * sing.len().max(1) + 4;
+        let mut iters = 0;
+        'enlarge: loop {
+            if iters >= cap {
+                break;
+            }
+            for alpha in &sing {
+                if let Some(cand) = try_enlarge(&ext, &b, &bd, d, alpha, &monos, n) {
+                    if !ext.elem_eq(&cand, &bd) && is_integral(f_coeffs, &cand) {
+                        bd = cand;
+                        iters += 1;
+                        continue 'enlarge;
+                    }
+                }
+            }
+            break;
+        }
+        b.push(bd);
+    }
+
+    for bi in &b {
+        if !is_integral(f_coeffs, bi) {
+            return None;
+        }
+    }
+    Some(b)
+}
+
+/// Try to enlarge `bd` at the place `x = α`: find `a₀…a_{d−1} ∈ ℚ` so that
+/// `(Σ aᵢ bᵢ + bd)/(x−α)` is integral, returning that element (unverified —
+/// caller gates with [`is_integral`]).  `None` if the place has algebraic
+/// branches or no enlargement exists.
+fn try_enlarge(
+    ext: &AlgExtension,
+    b: &[AlgElem],
+    bd: &AlgElem,
+    d: usize,
+    alpha: &Rational,
+    monos: &[(u32, u32, Rational)],
+    n: usize,
+) -> Option<AlgElem> {
+    // Precision: enough Puiseux terms to resolve the coordinate denominators.
+    let dmax = max_denom_degree(b, bd);
+    let prec = (dmax + n + 3) as u32;
+    // Substitute every (rational) sheet at α.  Missing algebraic sheets can only
+    // *under*-constrain the system → an unverified proposal that `is_integral`
+    // (the caller's gate) then rejects; soundness does not depend on completeness.
+    let branches = puiseux_at(monos, alpha, prec);
+    if branches.is_empty() {
+        return None;
+    }
+    let emax = branches.iter().map(|s| s.ramification).max().unwrap_or(1) as i64;
+    let u_bound = (prec as i64 + 3) * emax + 4;
+
+    // Build the ℚ-linear system: for each branch and each negative-power
+    // coefficient of (Σ aᵢ bᵢ + bd)/(x−α), the linear form in (a₀…a_{d−1}) is 0.
+    let mut matrix: Vec<Vec<Rational>> = Vec::new();
+    let mut rhs: Vec<Rational> = Vec::new();
+    for s in &branches {
+        let e = s.ramification as i64;
+        let bts = branch_ts(s);
+        // Series of each bᵢ (i<d) and of bd along this branch.
+        let bi_ts: Vec<TS> = (0..d)
+            .map(|i| elem_ts(&b[i], alpha, e, u_bound, &bts))
+            .collect();
+        let bd_ts = elem_ts(bd, alpha, e, u_bound, &bts);
+        // Negative-power range: keys k < e (after dividing by (x−α)=t^e).
+        let low = bi_ts
+            .iter()
+            .chain(std::iter::once(&bd_ts))
+            .filter_map(|s| s.keys().next().copied())
+            .min()
+            .unwrap_or(0);
+        for k in low..e {
+            let row: Vec<Rational> = bi_ts
+                .iter()
+                .map(|s| s.get(&k).cloned().unwrap_or_else(|| Rational::from(0)))
+                .collect();
+            let r = -bd_ts.get(&k).cloned().unwrap_or_else(|| Rational::from(0));
+            matrix.push(row);
+            rhs.push(r);
+        }
+    }
+    let a = gauss_solve(matrix, rhs, d)?;
+
+    // candidate = (Σ aᵢ bᵢ + bd) · 1/(x−α).
+    let mut num = bd.clone();
+    for (i, ai) in a.iter().enumerate() {
+        if *ai != 0 {
+            num = ext.add(&num, &scale(&b[i], &RatFn::from_poly(&vec![ai.clone()])));
+        }
+    }
+    let inv_lin = RatFn::new(
+        vec![Rational::from(1)],
+        vec![-alpha.clone(), Rational::from(1)],
+    );
+    Some(scale(&num, &inv_lin))
+}
+
+// ---------------------------------------------------------------------------
+// Laurent-series-in-t arithmetic (over ℚ)
+// ---------------------------------------------------------------------------
+
+fn branch_ts(s: &PuiseuxSeries) -> TS {
+    let e = s.ramification as i64;
+    let mut ts = TS::new();
+    for (exp, c) in &s.terms {
+        // exp has denominator dividing e ⇒ exp·e is an integer t-exponent.
+        let k = (exp.clone() * Rational::from(e))
+            .numer()
+            .to_i64()
+            .unwrap_or(0);
+        ts.insert(k, c.clone());
+    }
+    ts
+}
+
+/// Series of `b = Σⱼ bⱼ(x) yʲ` along a branch `y = bts(t)`, `x = α + t^e`.
+fn elem_ts(b: &AlgElem, alpha: &Rational, e: i64, u: i64, bts: &TS) -> TS {
+    let mut acc = TS::new();
+    for (j, coeff) in b.iter().enumerate() {
+        if coeff.numer().is_empty() {
+            continue;
+        }
+        let cj = ratfn_ts(coeff, alpha, e, u);
+        let yj = ts_pow(bts, j as u32, u);
+        acc = ts_add(&acc, &ts_mul(&cj, &yj, u));
+    }
+    acc
+}
+
+fn ratfn_ts(r: &RatFn, alpha: &Rational, e: i64, u: i64) -> TS {
+    let num = poly_ts(r.numer(), alpha, e, u);
+    let den = poly_ts(r.denom(), alpha, e, u);
+    match ts_inv(&den, u) {
+        Some(inv) => ts_mul(&num, &inv, u),
+        None => TS::new(),
+    }
+}
+
+/// `p(α + t^e)` truncated to `t`-exponents `< u`.
+fn poly_ts(p: &QPoly, alpha: &Rational, e: i64, u: i64) -> TS {
+    let mut ts = TS::new();
+    for (m, pm) in p.iter().enumerate() {
+        if *pm == 0 {
+            continue;
+        }
+        // (α + t^e)^m = Σ_l C(m,l) α^{m−l} t^{e l}.
+        for l in 0..=m {
+            let exp = e * l as i64;
+            if exp >= u {
+                break;
+            }
+            let coeff = pm.clone()
+                * Rational::from(binom(m as u32, l as u32))
+                * rat_pow(alpha, (m - l) as u32);
+            if coeff != 0 {
+                *ts.entry(exp).or_insert_with(|| Rational::from(0)) += &coeff;
+            }
+        }
+    }
+    ts.retain(|_, c| *c != 0);
+    ts
+}
+
+fn ts_add(a: &TS, b: &TS) -> TS {
+    let mut r = a.clone();
+    for (k, c) in b {
+        *r.entry(*k).or_insert_with(|| Rational::from(0)) += c;
+    }
+    r.retain(|_, c| *c != 0);
+    r
+}
+
+fn ts_mul(a: &TS, b: &TS, u: i64) -> TS {
+    let mut r = TS::new();
+    for (ka, ca) in a {
+        for (kb, cb) in b {
+            let k = ka + kb;
+            if k < u {
+                *r.entry(k).or_insert_with(|| Rational::from(0)) += ca.clone() * cb;
+            }
+        }
+    }
+    r.retain(|_, c| *c != 0);
+    r
+}
+
+fn ts_pow(a: &TS, m: u32, u: i64) -> TS {
+    let mut acc = TS::new();
+    acc.insert(0, Rational::from(1));
+    for _ in 0..m {
+        acc = ts_mul(&acc, a, u);
+    }
+    acc
+}
+
+/// Inverse of a Laurent series, truncated to exponents `< u`.
+fn ts_inv(s: &TS, u: i64) -> Option<TS> {
+    let (&v0, c0) = s.iter().next()?; // lowest exponent
+    let inv_c0 = Rational::from(1) / c0.clone();
+    let kmax = (u + v0).max(1);
+    // Normalized u-series coefficients: u[k] = s[v0+k]/c0  (u[0] = 1).
+    let mut us = vec![Rational::from(0); kmax as usize + 1];
+    for (exp, c) in s {
+        let k = exp - v0;
+        if (0..=kmax).contains(&k) {
+            us[k as usize] = c.clone() * &inv_c0;
+        }
+    }
+    let mut iu = vec![Rational::from(0); kmax as usize + 1];
+    iu[0] = Rational::from(1);
+    for k in 1..=kmax as usize {
+        let mut acc = Rational::from(0);
+        for i in 1..=k {
+            acc += us[i].clone() * &iu[k - i];
+        }
+        iu[k] = -acc;
+    }
+    let mut res = TS::new();
+    for (k, iuk) in iu.iter().enumerate() {
+        let exp = -v0 + k as i64;
+        if exp < u && *iuk != 0 {
+            res.insert(exp, inv_c0.clone() * iuk);
+        }
+    }
+    Some(res)
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+fn to_monomials(f_coeffs: &[QPoly]) -> Vec<(u32, u32, Rational)> {
+    let mut out = Vec::new();
+    for (j, cj) in f_coeffs.iter().enumerate() {
+        for (i, c) in cj.iter().enumerate() {
+            if *c != 0 {
+                out.push((i as u32, j as u32, c.clone()));
+            }
+        }
+    }
+    out
+}
+
+fn max_denom_degree(b: &[AlgElem], bd: &AlgElem) -> usize {
+    let one = b
+        .iter()
+        .chain(std::iter::once(bd))
+        .flat_map(|e| e.iter())
+        .map(|c| degree(c.denom()).max(0) as usize)
+        .max()
+        .unwrap_or(0);
+    one
+}
+
+fn scale(b: &AlgElem, s: &RatFn) -> AlgElem {
+    let f = RationalFunctionField;
+    b.iter().map(|c| f.mul(s, c)).collect()
+}
+
+fn binom(n: u32, k: u32) -> Integer {
+    if k > n {
+        return Integer::from(0);
+    }
+    let mut num = Integer::from(1);
+    for t in 0..k {
+        num *= Integer::from(n - t);
+    }
+    let mut den = Integer::from(1);
+    for t in 1..=k {
+        den *= Integer::from(t);
+    }
+    num / den
+}
+
+fn rat_pow(c: &Rational, e: u32) -> Rational {
+    let mut acc = Rational::from(1);
+    for _ in 0..e {
+        acc *= c;
+    }
+    acc
+}
+
+/// Solve `M·a = rhs` over `ℚ` for `ncols` unknowns; particular solution (free
+/// vars 0) or `None` if inconsistent.
+fn gauss_solve(
+    mut m: Vec<Vec<Rational>>,
+    mut b: Vec<Rational>,
+    ncols: usize,
+) -> Option<Vec<Rational>> {
+    let nrows = m.len();
+    let mut pivot_of_col = vec![None; ncols];
+    let mut row = 0usize;
+    for col in 0..ncols {
+        if row >= nrows {
+            break;
+        }
+        let Some(sel) = (row..nrows).find(|&r| m[r][col] != 0) else {
+            continue;
+        };
+        m.swap(row, sel);
+        b.swap(row, sel);
+        let piv = m[row][col].clone();
+        for v in m[row].iter_mut() {
+            *v /= &piv;
+        }
+        b[row] /= &piv;
+        let pr = m[row].clone();
+        let pb = b[row].clone();
+        for r in 0..nrows {
+            if r != row && m[r][col] != 0 {
+                let f = m[r][col].clone();
+                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+                    *dst -= f.clone() * pv;
+                }
+                b[r] -= f * &pb;
+            }
+        }
+        pivot_of_col[col] = Some(row);
+        row += 1;
+    }
+    for r in 0..nrows {
+        if m[r].iter().all(|v| *v == 0) && b[r] != 0 {
+            return None; // inconsistent
+        }
+    }
+    let mut x = vec![Rational::from(0); ncols];
+    for (col, pr) in pivot_of_col.iter().enumerate() {
+        if let Some(r) = pr {
+            x[col] = b[*r].clone();
+        }
+    }
+    Some(x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+
+    /// Power basis for a non-singular curve: y² − x − 1 (disc = −4, no repeated
+    /// roots) ⇒ {1, y}.
+    #[test]
+    fn nonsingular_power_basis() {
+        let basis = integral_basis(&[qp(&[-1, -1]), qp(&[]), qp(&[1])]).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(basis[0], vec![RatFn::int(1)]);
+        assert_eq!(basis[1], vec![RatFn::int(0), RatFn::int(1)]);
+    }
+
+    /// Cusp y² = x³ ⇒ {1, y/x}: a genuine enlargement at the singular x=0.
+    #[test]
+    fn cusp_basis() {
+        let basis = integral_basis(&[qp(&[0, 0, 0, -1]), qp(&[]), qp(&[1])]).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(basis[0], vec![RatFn::int(1)]);
+        // b₁ = y/x.
+        assert_eq!(
+            basis[1],
+            vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 1]))]
+        );
+        // All integral.
+        let f = [qp(&[0, 0, 0, -1]), qp(&[]), qp(&[1])];
+        assert!(basis.iter().all(|bi| is_integral(&f, bi)));
+    }
+
+    /// Nodal cubic y² = x³ + x² (non-radical) ⇒ {1, y/x}; (y/x)² = x + 1.
+    #[test]
+    fn nodal_cubic_basis() {
+        // F = y² − x² − x³.
+        let f = [qp(&[0, 0, -1, -1]), qp(&[]), qp(&[1])];
+        let basis = integral_basis(&f).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(
+            basis[1],
+            vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 1]))]
+        );
+        assert!(basis.iter().all(|bi| is_integral(&f, bi)));
+    }
+
+    /// Degree-3 radical y³ = x² ⇒ {1, y, y²/x}.
+    #[test]
+    fn cubic_radical_basis() {
+        let f = [qp(&[0, 0, 1]), qp(&[]), qp(&[]), qp(&[1])]; // y³ − x²
+        let basis = integral_basis(&f).expect("basis");
+        assert_eq!(basis.len(), 3);
+        assert_eq!(basis[1], vec![RatFn::int(0), RatFn::int(1)]); // y
+        assert_eq!(
+            basis[2],
+            vec![
+                RatFn::int(0),
+                RatFn::int(0),
+                RatFn::new(qp(&[1]), qp(&[0, 1]))
+            ]
+        ); // y²/x
+        assert!(basis.iter().all(|bi| is_integral(&f, bi)));
+    }
+}

--- a/alkahest-core/src/integrate/risch/alg_rde.rs
+++ b/alkahest-core/src/integrate/risch/alg_rde.rs
@@ -1,0 +1,347 @@
+//! General coupled twisted-derivation Risch DE over `ℚ(x)(α)` — Risch milestone
+//! **M1-step-2**.
+//!
+//! Solves `D(y) + f·y = g` for `y ∈ ℚ(x)(α)`, where `f ∈ ℚ(x)`, `g ∈ ℚ(x)(α)`,
+//! and `α` is algebraic of degree `d` over `ℚ(x)` given by an [`AlgExtension`]
+//! (M0).  This is the "no new logarithm" mixed integral part: an integrand
+//! `a(x,α)·exp(kη)` whose antiderivative is `v(x,α)·exp(kη)` with
+//! `v ∈ ℚ(x)(α)` and `f = kη'`.
+//!
+//! Writing `y = Σⱼ bⱼ(x) αʲ` and substituting into `D(y) + f·y = g` collects, over
+//! the power basis `{1, α, …, α^{d−1}}`, into a **coupled** first-order linear ODE
+//! system `b' + M(x)·b = c`.  The pure-radical case (`αⁿ = a`) is *cyclic* and `M`
+//! is diagonal — solved component-wise by
+//! [`super::exp_case::try_radical_poly_rde`].  This module handles the **general
+//! (non-cyclic)** `α` — nested / compositum radicals such as `√x + √(x+1)` — where
+//! `M` genuinely couples the components.
+//!
+//! ## Method
+//!
+//! An undetermined-coefficient ansatz `bⱼ = pⱼ(x)/Den(x)` over candidate
+//! denominators `Den` and bounded numerator degree.  Because the operator
+//! `L(y) = D(y) + f·y` is `ℚ`-linear in the unknown coefficients of the `pⱼ`, we
+//! evaluate `L` on each basis element `αʲ·xᵐ/Den`, clear the common
+//! `x`-denominator of every power-basis component (then match each `xᵐ`), and
+//! assemble an exact `ℚ`-linear system `A·u = c`.  We Gauss-solve it and **verify
+//! `D(y) + f·y = g` exactly in the field** before returning.
+//!
+//! This is *sound by construction*: the linear system is faithful to `L(y) = g`
+//! (denominator clearing is exact and every `x`-power is matched), and the final
+//! field equality is an independent check — a denominator/degree bound too small
+//! to contain the true solution yields `None` (incomplete), never a wrong
+//! antiderivative.
+
+use rug::Rational;
+
+use super::alg_field::{AlgElem, AlgExtension, RatFn};
+use super::poly_rde::{poly_mul, poly_one, trim, QPoly};
+use super::rational_rde::{poly_div_exact, poly_gcd};
+
+/// Max numerator degree tried in the ansatz `bⱼ = pⱼ(x)/Den`.
+const DEG_CAP: usize = 6;
+
+/// Solve `D(y) + f·y = g` for `y ∈ ℚ(x)(α)`, or `None` if no rational solution is
+/// found within the ansatz bounds.  Sound by exact verification — see the module
+/// docs.
+pub(crate) fn solve_alg_rde(e: &AlgExtension, f: &RatFn, g: &AlgElem) -> Option<AlgElem> {
+    let d = e.degree() as usize;
+    if d == 0 {
+        return None;
+    }
+    let dens = candidate_denominators(e, f, g, d);
+    for den in &dens {
+        for ncap in 0..=DEG_CAP {
+            if let Some(y) = solve_with_denominator(e, f, g, den, ncap, d) {
+                return Some(y);
+            }
+        }
+    }
+    None
+}
+
+/// Candidate `x`-denominators for `y`, increasing in complexity: `1`, then the
+/// LCM `B` of every `x`-denominator that appears in `D(αʲ)`, `f`, and `g`, then
+/// `B²`, `B³`.  Over-clearing is harmless (the numerator ansatz just needs more
+/// terms); verification guards correctness.
+fn candidate_denominators(e: &AlgExtension, f: &RatFn, g: &AlgElem, d: usize) -> Vec<QPoly> {
+    let mut base = poly_one();
+    let gen = e.generator();
+    for j in 0..d {
+        if let Some(aj) = e.pow(&gen, j as i64) {
+            for c in e.derivation(&aj) {
+                base = poly_lcm(&base, c.denom());
+            }
+        }
+    }
+    base = poly_lcm(&base, f.denom());
+    for c in g {
+        base = poly_lcm(&base, c.denom());
+    }
+    let base2 = poly_mul(&base, &base);
+    let base3 = poly_mul(&base2, &base);
+    let mut out = vec![poly_one(), base, base2, base3];
+    out.dedup_by(|a, b| trim(a.clone()) == trim(b.clone()));
+    out
+}
+
+/// Solve seeking `y = Σⱼ (pⱼ(x)/Den) αʲ` with `deg pⱼ ≤ ncap`, for the fixed `Den`.
+fn solve_with_denominator(
+    e: &AlgExtension,
+    f: &RatFn,
+    g: &AlgElem,
+    den: &QPoly,
+    ncap: usize,
+    d: usize,
+) -> Option<AlgElem> {
+    // Ansatz basis: component j carries numerator xᵐ over the common Den.
+    let basis: Vec<(usize, usize)> = (0..d)
+        .flat_map(|j| (0..=ncap).map(move |m| (j, m)))
+        .collect();
+    let elems: Vec<AlgElem> = basis
+        .iter()
+        .map(|&(j, m)| {
+            let coeff = RatFn::new(x_pow(m), den.clone()); // xᵐ / Den
+            let mut v = vec![RatFn::int(0); d];
+            v[j] = coeff;
+            e.reduce(&v)
+        })
+        .collect();
+
+    // L(·) = D(·) + f·(·) applied to each basis element.
+    let f_elem = e.constant(f.clone());
+    let cols: Vec<AlgElem> = elems
+        .iter()
+        .map(|m| e.add(&e.derivation(m), &e.mul(&f_elem, m)))
+        .collect();
+
+    let (matrix, rhs) = extract_linear_system(&cols, g, d);
+    let sol = gauss_solve(matrix, rhs, basis.len())?;
+
+    // Reconstruct y = Σ solᵢ · elemᵢ.
+    let mut y = e.from_int(0);
+    for (idx, elem) in elems.iter().enumerate() {
+        if sol[idx] != 0 {
+            let s = e.constant(RatFn::from_poly(&vec![sol[idx].clone()]));
+            y = e.add(&y, &e.mul(&s, elem));
+        }
+    }
+
+    // Exact verification: D(y) + f·y == g.
+    let lhs = e.add(&e.derivation(&y), &e.mul(&f_elem, &y));
+    if e.elem_eq(&lhs, g) {
+        Some(y)
+    } else {
+        None
+    }
+}
+
+/// Build the exact `ℚ`-linear system `Σᵢ uᵢ·colᵢ = target` by, for each power-basis
+/// component `k`, clearing the common `x`-denominator of the `ℚ(x)` entries and
+/// matching every `xᵐ` coefficient.
+fn extract_linear_system(
+    cols: &[AlgElem],
+    target: &AlgElem,
+    d: usize,
+) -> (Vec<Vec<Rational>>, Vec<Rational>) {
+    let comp =
+        |a: &AlgElem, k: usize| -> RatFn { a.get(k).cloned().unwrap_or_else(|| RatFn::int(0)) };
+    let mut matrix: Vec<Vec<Rational>> = Vec::new();
+    let mut rhs: Vec<Rational> = Vec::new();
+
+    for k in 0..d {
+        let col_rf: Vec<RatFn> = cols.iter().map(|c| comp(c, k)).collect();
+        let tgt_rf = comp(target, k);
+
+        // Common x-denominator of this component across all columns and target.
+        let mut d_x = poly_one();
+        for r in &col_rf {
+            d_x = poly_lcm(&d_x, r.denom());
+        }
+        d_x = poly_lcm(&d_x, tgt_rf.denom());
+
+        let s_cols: Vec<QPoly> = col_rf
+            .iter()
+            .map(|r| poly_mul(r.numer(), &poly_div_exact(&d_x, r.denom())))
+            .collect();
+        let s_tgt = poly_mul(tgt_rf.numer(), &poly_div_exact(&d_x, tgt_rf.denom()));
+
+        let max_m = s_cols
+            .iter()
+            .map(|s| s.len())
+            .chain(std::iter::once(s_tgt.len()))
+            .max()
+            .unwrap_or(0);
+        for m in 0..max_m {
+            matrix.push(
+                s_cols
+                    .iter()
+                    .map(|s| s.get(m).cloned().unwrap_or_else(|| Rational::from(0)))
+                    .collect(),
+            );
+            rhs.push(s_tgt.get(m).cloned().unwrap_or_else(|| Rational::from(0)));
+        }
+    }
+    (matrix, rhs)
+}
+
+/// Solve `M·x = b` over `ℚ` by Gauss–Jordan, returning a particular solution
+/// (free variables set to 0) or `None` if inconsistent.
+fn gauss_solve(
+    mut m: Vec<Vec<Rational>>,
+    mut b: Vec<Rational>,
+    ncols: usize,
+) -> Option<Vec<Rational>> {
+    let nrows = m.len();
+    let mut pivot_row_of_col: Vec<Option<usize>> = vec![None; ncols];
+    let mut row = 0usize;
+    for col in 0..ncols {
+        if row >= nrows {
+            break;
+        }
+        let Some(sel) = (row..nrows).find(|&r| m[r][col] != 0) else {
+            continue;
+        };
+        m.swap(row, sel);
+        b.swap(row, sel);
+        let piv = m[row][col].clone();
+        for v in m[row].iter_mut() {
+            *v = v.clone() / piv.clone();
+        }
+        b[row] = b[row].clone() / piv.clone();
+        let pivot_row = m[row].clone();
+        let pivot_b = b[row].clone();
+        for r in 0..nrows {
+            if r != row && m[r][col] != 0 {
+                let factor = m[r][col].clone();
+                for (dst, pv) in m[r].iter_mut().zip(pivot_row.iter()) {
+                    *dst -= factor.clone() * pv.clone();
+                }
+                b[r] -= factor * pivot_b.clone();
+            }
+        }
+        pivot_row_of_col[col] = Some(row);
+        row += 1;
+    }
+    for r in 0..nrows {
+        if m[r].iter().all(|v| *v == 0) && b[r] != 0 {
+            return None;
+        }
+    }
+    let mut x = vec![Rational::from(0); ncols];
+    for (col, pr) in pivot_row_of_col.iter().enumerate() {
+        if let Some(r) = pr {
+            x[col] = b[*r].clone();
+        }
+    }
+    Some(x)
+}
+
+/// `lcm(a, b)` over `ℚ[x]` (non-monic is fine — used only as a clearing factor).
+fn poly_lcm(a: &QPoly, b: &QPoly) -> QPoly {
+    let g = poly_gcd(a, b);
+    poly_div_exact(&poly_mul(a, b), &g)
+}
+
+/// The monomial `xᵐ` as a `ℚ[x]` polynomial.
+fn x_pow(m: usize) -> QPoly {
+    let mut p = vec![Rational::from(0); m + 1];
+    p[m] = Rational::from(1);
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrate::risch::poly_rde::poly_scale;
+
+    fn rat(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    /// Cyclic sanity check: `α = √x` (`α² = x`), solve `D(y) = (3/2)·α`.  The
+    /// antiderivative is `y = x·α = x^{3/2}` since `D(x^{3/2}) = (3/2)x^{1/2}`.
+    #[test]
+    fn cyclic_sqrt_recovers_solution() {
+        let e = AlgExtension::radical(2, &vec![rat(0), rat(1)]); // α² = x
+                                                                 // g = (3/2)·α  (= component vector [0, 3/2]).
+        let g: AlgElem = vec![
+            RatFn::int(0),
+            RatFn::from_poly(&vec![Rational::from((3, 2))]),
+        ];
+        let f = RatFn::int(0);
+        let y = solve_alg_rde(&e, &f, &g).expect("should solve");
+        // D(y) must equal g.
+        assert!(e.elem_eq(&e.derivation(&y), &g));
+        // y = x·α.
+        let expected: AlgElem = vec![RatFn::int(0), RatFn::from_poly(&vec![rat(0), rat(1)])];
+        assert!(e.elem_eq(&y, &expected), "y = {:?}", y);
+    }
+
+    /// **Non-cyclic** (the M1-step-2 case): `α = √x + √(x+1)`, a degree-4
+    /// extension whose minimal polynomial `α⁴ − 2(2x+1)α² + 1 = 0` is *not* a
+    /// pure radical, so `D(α)` mixes the power basis and the system is coupled.
+    /// We construct `g = D(α)` and confirm the solver recovers a `y` with
+    /// `D(y) = g` (namely `y = α`).
+    #[test]
+    fn noncyclic_compositum_pure_antiderivative() {
+        // q = α⁴ − 2(2x+1)α² + 1 : coeffs ascending [1, 0, −2(2x+1), 0, 1].
+        let q: Vec<QPoly> = vec![
+            poly_one(),                                  // 1
+            Vec::new(),                                  // 0·α
+            poly_scale(&vec![rat(1), rat(2)], &rat(-2)), // −2(2x+1) = −4x−2
+            Vec::new(),                                  // 0·α³
+            poly_one(),                                  // α⁴
+        ];
+        let e = AlgExtension::new(&q);
+        assert_eq!(e.degree(), 4);
+
+        let alpha = e.generator();
+        let g = e.derivation(&alpha); // genuinely coupled element
+        let f = RatFn::int(0);
+        let y = solve_alg_rde(&e, &f, &g).expect("coupled RDE should solve");
+        assert!(
+            e.elem_eq(&e.derivation(&y), &g),
+            "D(y) must equal g; y = {y:?}"
+        );
+    }
+
+    /// Non-cyclic with a nonzero `f`: with `α = √x + √(x+1)` and `f = 1/x`,
+    /// `g = D(α) + (1/x)·α` is solved by `y = α`.
+    #[test]
+    fn noncyclic_compositum_with_f() {
+        let q: Vec<QPoly> = vec![
+            poly_one(),
+            Vec::new(),
+            poly_scale(&vec![rat(1), rat(2)], &rat(-2)),
+            Vec::new(),
+            poly_one(),
+        ];
+        let e = AlgExtension::new(&q);
+        let alpha = e.generator();
+        let f = RatFn::new(poly_one(), vec![rat(0), rat(1)]); // 1/x
+        let f_elem = e.constant(f.clone());
+        let g = e.add(&e.derivation(&alpha), &e.mul(&f_elem, &alpha));
+        let y = solve_alg_rde(&e, &f, &g).expect("coupled RDE with f should solve");
+        let lhs = e.add(&e.derivation(&y), &e.mul(&f_elem, &y));
+        assert!(e.elem_eq(&lhs, &g), "D(y)+f·y must equal g; y = {y:?}");
+    }
+
+    /// A target with **no** rational solution must return `None` (never a wrong
+    /// antiderivative).  `g = 1/x` (embedded from `ℚ(x)`) has antiderivative
+    /// `log x ∉ ℚ(x)(α)`, so no rational `y` solves `D(y) = 1/x`.
+    #[test]
+    fn unsolvable_log_returns_none() {
+        let q: Vec<QPoly> = vec![
+            poly_one(),
+            Vec::new(),
+            poly_scale(&vec![rat(1), rat(2)], &rat(-2)),
+            Vec::new(),
+            poly_one(),
+        ];
+        let e = AlgExtension::new(&q);
+        // g = 1/x (constant element of ℚ(x)).
+        let g = e.constant(RatFn::new(poly_one(), vec![rat(0), rat(1)]));
+        let f = RatFn::int(0);
+        assert!(solve_alg_rde(&e, &f, &g).is_none());
+    }
+}

--- a/alkahest-core/src/integrate/risch/alg_rde.rs
+++ b/alkahest-core/src/integrate/risch/alg_rde.rs
@@ -11,7 +11,7 @@
 //! the power basis `{1, α, …, α^{d−1}}`, into a **coupled** first-order linear ODE
 //! system `b' + M(x)·b = c`.  The pure-radical case (`αⁿ = a`) is *cyclic* and `M`
 //! is diagonal — solved component-wise by
-//! [`super::exp_case::try_radical_poly_rde`].  This module handles the **general
+//! `super::exp_case::try_radical_poly_rde`.  This module handles the **general
 //! (non-cyclic)** `α` — nested / compositum radicals such as `√x + √(x+1)` — where
 //! `M` genuinely couples the components.
 //!

--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -32,6 +32,7 @@ use crate::kernel::{ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
 use super::alg_field::{AlgElem, AlgExtension, RatFn};
+use super::alg_rde::solve_alg_rde;
 use super::number_field::{KElem, KPoly, NumberField};
 use super::poly_rde::{
     apply_const, contains_subexpr, degree, expr_to_qpoly, is_free_of_var, poly_add, poly_deriv,
@@ -824,6 +825,14 @@ fn integrate_single_exp_term(
     // Mixed alg+trans, degree ≥ 3: c_rest = Σᵢ cᵢ(x)·a^{i/n} times exp(kη).
     if let Some(result) =
         try_radical_poly_rde(c_rest, k, deta, exp_k_eta, k_const, c_expr, var, pool, log)
+    {
+        return result;
+    }
+
+    // M1-step-2: non-cyclic algebraic coefficient — a compositum of two square
+    // roots `√p + √q` (degree-4, coupled twisted-derivation RDE).
+    if let Some(result) =
+        try_compositum_poly_rde(c_rest, k, deta, exp_k_eta, k_const, c_expr, var, pool, log)
     {
         return result;
     }
@@ -2502,6 +2511,242 @@ fn try_radical_poly_rde(
     Some(Ok(result))
 }
 
+/// Try to integrate `c_rest · exp(kη)` when `c_rest` involves a **compositum of
+/// two distinct square roots** `√p(x)`, `√q(x)` — a degree-4 *non-cyclic*
+/// algebraic extension `ℚ(x)(α)` with `α = √p + √q` and minimal polynomial
+/// `α⁴ − 2(p+q)α² + (p−q)²`.  This is the general (coupled) **M1-step-2** case:
+/// the twisted-derivation system does *not* decouple per power as it does for a
+/// single radical, so we solve `D(v) + kη'·v = c_rest` with the general coupled
+/// solver [`solve_alg_rde`].  `None` if `c_rest` is not of this shape;
+/// `Some(Err(NonElementary))` if no rational `v` exists.
+#[allow(clippy::too_many_arguments)]
+fn try_compositum_poly_rde(
+    c_rest: ExprId,
+    k: i64,
+    deta: &[rug::Rational],
+    exp_k_eta: ExprId,
+    k_const: ExprId,
+    c_expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+    log: &mut DerivationLog,
+) -> Option<Result<ExprId, IntegrationError>> {
+    let (p, q) = detect_two_sqrt_compositum(c_rest, var, pool)?;
+    if trim(poly_sub(&q, &p)).is_empty() {
+        return None; // p = q would be a single radical, not a compositum
+    }
+
+    // Minimal polynomial of α = √p + √q : α⁴ − 2(p+q)α² + (p−q)².
+    let pq_sum = poly_add(&p, &q);
+    let pq_diff = poly_sub(&p, &q);
+    let q_min = vec![
+        poly_mul(&pq_diff, &pq_diff),
+        poly_zero(),
+        poly_scale(&pq_sum, &rug::Rational::from(-2)),
+        poly_zero(),
+        poly_one(),
+    ];
+    let e = AlgExtension::new(&q_min);
+
+    // √p, √q expressed in the power basis {1, α, α², α³}:
+    //   √p = (α³ − (3p+q)α) / (2(q−p)),   √q = (α³ − (p+3q)α) / (2(p−q)).
+    let sqrt_p = sqrt_in_alpha_basis(&p, &q);
+    let sqrt_q = sqrt_in_alpha_basis(&q, &p);
+
+    let g = decompose_over_compositum(c_rest, &p, &q, &sqrt_p, &sqrt_q, &e, var, pool)?;
+
+    // f = k·η' (a polynomial in x), as a ℚ(x) element.
+    let f_poly: QPoly = deta
+        .iter()
+        .map(|r| r.clone() * rug::Rational::from(k))
+        .collect();
+    let f = RatFn::from_poly(&f_poly);
+
+    let ne = || {
+        IntegrationError::NonElementary(format!(
+            "the coupled Risch DE over ℚ(x)(√p+√q) for ∫ {} · exp(η)^{k} dx \
+             has no rational solution",
+            pool.display(c_expr),
+        ))
+    };
+    let y = match solve_alg_rde(&e, &f, &g) {
+        Some(y) => y,
+        None => return Some(Err(ne())),
+    };
+
+    // Reconstruct v = Σⱼ yⱼ(x)·αʲ with α = √p + √q.
+    let p_expr = qpoly_to_expr(&p, var, pool);
+    let q_expr = qpoly_to_expr(&q, var, pool);
+    let alpha = pool.add(vec![
+        pool.func("sqrt", vec![p_expr]),
+        pool.func("sqrt", vec![q_expr]),
+    ]);
+    let mut terms: Vec<ExprId> = Vec::new();
+    for (j, yj) in y.iter().enumerate() {
+        if yj.numer().is_empty() {
+            continue;
+        }
+        let coeff = build_rational(yj.numer(), yj.denom(), var, pool);
+        let term = if j == 0 {
+            coeff
+        } else {
+            pool.mul(vec![coeff, pool.pow(alpha, pool.integer(j as i32))])
+        };
+        terms.push(term);
+    }
+    let v_expr = match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    };
+    let core = build_v_times_exp(v_expr, exp_k_eta, pool);
+    let result = apply_const(k_const, core, pool);
+    log.push(RewriteStep::simple(
+        "risch_exp_compositum_poly",
+        c_expr,
+        result,
+    ));
+    Some(Ok(result))
+}
+
+/// `√(self)` in the `{1, α, α², α³}` basis of `ℚ(x)(α)`, `α = √self + √other`:
+/// `√self = (α³ − (3·self + other)·α) / (2·(other − self))`.
+fn sqrt_in_alpha_basis(self_rad: &QPoly, other_rad: &QPoly) -> AlgElem {
+    let den = poly_scale(&poly_sub(other_rad, self_rad), &rug::Rational::from(2)); // 2(other−self)
+    let lin = poly_add(&poly_scale(self_rad, &rug::Rational::from(3)), other_rad); // 3·self+other
+    let c1 = RatFn::new(poly_scale(&lin, &rug::Rational::from(-1)), den.clone());
+    let c3 = RatFn::new(poly_one(), den);
+    vec![RatFn::int(0), c1, RatFn::int(0), c3]
+}
+
+/// Detect a compositum of **exactly two distinct** x-dependent square-root
+/// generators `√p`, `√q` in `expr`.  Returns `(p, q)` or `None`.
+fn detect_two_sqrt_compositum(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(QPoly, QPoly)> {
+    let mut found: Vec<QPoly> = Vec::new();
+    scan_sqrt_radicands(expr, var, pool, &mut found);
+    let mut distinct: Vec<QPoly> = Vec::new();
+    for p in found {
+        if !distinct.iter().any(|q| trim(q.clone()) == trim(p.clone())) {
+            distinct.push(p);
+        }
+    }
+    if distinct.len() == 2 {
+        let q = distinct.pop().unwrap();
+        let p = distinct.pop().unwrap();
+        Some((p, q))
+    } else {
+        None
+    }
+}
+
+fn scan_sqrt_radicands(expr: ExprId, var: ExprId, pool: &ExprPool, out: &mut Vec<QPoly>) {
+    use crate::kernel::ExprData;
+    let push_if_poly = |arg: ExprId, out: &mut Vec<QPoly>| {
+        if let Some(p) = expr_to_qpoly(arg, var, pool) {
+            if degree(&p) >= 1 {
+                out.push(p);
+            }
+        }
+    };
+    match pool.get(expr) {
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            push_if_poly(args[0], out);
+        }
+        ExprData::Pow { base, exp } => {
+            if let ExprData::Rational(r) = pool.get(exp) {
+                if r.0.denom().to_i64() == Some(2) {
+                    push_if_poly(base, out);
+                    return;
+                }
+            }
+            scan_sqrt_radicands(base, var, pool, out);
+        }
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for &a in &args {
+                scan_sqrt_radicands(a, var, pool, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Decompose `expr` over the power basis of `ℚ(x)(α)`, `α = √p + √q`, replacing
+/// `√p → sqrt_p`, `√q → sqrt_q` (their `α`-basis forms) and rational-in-`x`
+/// subexpressions by constants.  `None` if `expr` is not a polynomial in these
+/// generators over `ℚ(x)`.
+#[allow(clippy::too_many_arguments)]
+fn decompose_over_compositum(
+    expr: ExprId,
+    p: &QPoly,
+    q: &QPoly,
+    sqrt_p: &AlgElem,
+    sqrt_q: &AlgElem,
+    e: &AlgExtension,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<AlgElem> {
+    use crate::kernel::ExprData;
+
+    if let Some((num, den)) = expr_to_qrational(expr, var, pool) {
+        return Some(e.constant(RatFn::new(num, den)));
+    }
+
+    // `base^{a/2}` with `base` matching p or q → `(√base)^a` in the α-basis
+    // (handles inverse and odd half-powers, e.g. `1/√x = (√x)^{-1}`).
+    let half_power = |base: ExprId, a: i64| -> Option<AlgElem> {
+        let r = trim(expr_to_qpoly(base, var, pool)?);
+        if r == trim(p.clone()) {
+            e.pow(sqrt_p, a)
+        } else if r == trim(q.clone()) {
+            e.pow(sqrt_q, a)
+        } else {
+            None
+        }
+    };
+
+    match pool.get(expr) {
+        ExprData::Add(args) => {
+            let mut acc = e.from_int(0);
+            for &a in &args {
+                acc = e.add(
+                    &acc,
+                    &decompose_over_compositum(a, p, q, sqrt_p, sqrt_q, e, var, pool)?,
+                );
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc = e.from_int(1);
+            for &a in &args {
+                acc = e.mul(
+                    &acc,
+                    &decompose_over_compositum(a, p, q, sqrt_p, sqrt_q, e, var, pool)?,
+                );
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => match pool.get(exp) {
+            ExprData::Integer(m) => {
+                let m = m.0.to_i64()?;
+                let b = decompose_over_compositum(base, p, q, sqrt_p, sqrt_q, e, var, pool)?;
+                e.pow(&b, m)
+            }
+            ExprData::Rational(r) if r.0.denom().to_i64() == Some(2) => {
+                half_power(base, r.0.numer().to_i64()?)
+            }
+            _ => None,
+        },
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            half_power(args[0], 1)
+        }
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Detection: does an integrand require the exp-tower path?
 // ---------------------------------------------------------------------------
@@ -2943,6 +3188,46 @@ mod tests {
                 pool.display(f)
             );
         }
+    }
+
+    /// M1-step-2 (non-cyclic, coupled): `α = √x + √(x+1)` is a degree-4 algebraic
+    /// extension that is **not** a pure radical, so the twisted-derivation system
+    /// couples the power basis and `try_radical_poly_rde` does not apply.
+    /// `∫ [√x + √(x+1) + 1/(2√x) + 1/(2√(x+1))]·eˣ dx = (√x + √(x+1))·eˣ`.
+    #[test]
+    fn compositum_two_sqrts_times_exp() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let xp1 = pool.add(vec![x, pool.integer(1_i32)]);
+        let sx = pool.func("sqrt", vec![x]);
+        let sx1 = pool.func("sqrt", vec![xp1]);
+        let half = pool.rational(1_i32, 2_i32);
+        let inv2sx = pool.mul(vec![half, pool.pow(x, pool.rational(-1_i32, 2_i32))]);
+        let inv2sx1 = pool.mul(vec![half, pool.pow(xp1, pool.rational(-1_i32, 2_i32))]);
+        let c_rest = pool.add(vec![sx, sx1, inv2sx, inv2sx1]);
+        let integrand = pool.mul(vec![c_rest, exp_x]);
+        verify_exp_tower(integrand, x, &pool);
+    }
+
+    /// The coupled solver must report NonElementary when no rational `v` exists:
+    /// `∫ (√x + √(x+1))·eˣ dx` is non-elementary (cf. `∫√x·eˣ`).
+    #[test]
+    fn compositum_two_sqrts_times_exp_nonelementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let xp1 = pool.add(vec![x, pool.integer(1_i32)]);
+        let c_rest = pool.add(vec![
+            pool.func("sqrt", vec![x]),
+            pool.func("sqrt", vec![xp1]),
+        ]);
+        let integrand = pool.mul(vec![c_rest, exp_x]);
+        let r = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(r, Err(IntegrationError::NonElementary(_))),
+            "expected NonElementary; got {r:?}"
+        );
     }
 
     #[test]

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -76,6 +76,7 @@
 //! - Geddes, Czapor, Labahn (1992). *Algorithms for Computer Algebra*. Kluwer.
 
 pub mod alg_field;
+pub mod alg_rde;
 pub mod exp_case;
 pub mod log_case;
 pub mod number_field;

--- a/alkahest-core/src/integrate/risch/tower_integrate.rs
+++ b/alkahest-core/src/integrate/risch/tower_integrate.rs
@@ -25,17 +25,20 @@
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
 use crate::integrate::engine::IntegrationError;
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
-use super::alg_field::RatFn;
+use super::alg_field::{RatFn, RationalFunctionField};
 use super::exp_case::build_rational;
-use super::number_field::{CoeffField, Quotient};
+use super::number_field::{
+    gdegree, gext_gcd, gpoly_divrem, gpoly_mul, gtrim, CoeffField, Quotient,
+};
 use super::poly_rde::{expr_to_qpoly, is_free_of_var, poly_deriv};
 use super::tower::find_generators;
 use super::tower_field::{solve_tower_rde_generic, ExpTowerField, LogTowerField, TExpr};
 
 use rug::Rational;
+use std::collections::HashMap;
 
 /// Element of the radical extension over the tower: coefficients of
 /// `1, y, …, y^{n−1}`, each in `ℚ(x)(t)`.
@@ -112,6 +115,17 @@ where
 
     // Decompose the integrand over the power basis {1, y, …, y^{n-1}}.
     let elem = decompose_over_tower_radical(expr, n, a_expr, &q, field, var, t_gen, pool)?;
+
+    // P1 — residue criterion (Bronstein tutorial §3.4, eq 16): a *cheap,
+    // standalone* NonElementary certifier.  If it fires, the integral is
+    // provably non-elementary and we skip the (doomed) solve below.
+    if residue_criterion_certifies_nonelementary(&elem, &a_tx, t_gen, n, var, pool) {
+        return Some(Err(IntegrationError::NonElementary(
+            "radical-over-transcendental integrand fails the residue criterion \
+             (Bronstein eq 16): R ∤ κ(R) in K[z], so no elementary antiderivative exists"
+                .to_string(),
+        )));
+    }
 
     // a'/a in the tower (for ωᵢ).
     let a_prime = field.derivation(&a_tx);
@@ -478,6 +492,314 @@ fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> Option<f64> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// P1 — residue criterion (Bronstein tutorial §3.4, eq 16)
+// ---------------------------------------------------------------------------
+
+/// `ℚ(x)`-polynomial in the monomial `t` (ascending degree), the coefficient
+/// type of the tower field.
+type TPoly = Vec<RatFn>;
+
+/// Decide whether the simple-radical-over-transcendental integrand
+/// `f = Σᵢ cᵢ yⁱ` (`y = a^{1/n}`, `cᵢ ∈ ℚ(x)(t)`, single monomial `t`) is
+/// **provably non-elementary** via Bronstein's residue criterion.
+///
+/// Writing the normal part as `G/D` over the power basis `wᵢ = yⁱ` (valid since
+/// we require the radicand normal/squarefree, so `H = 1`), with `F = yⁿ − a`
+/// the minimal polynomial, the criterion (eq 16) forms
+///
+/// ```text
+///   R(z) = res_t( res_y(G − z·D′, F), D ) ∈ K[z],   K = ℚ(x),
+/// ```
+///
+/// and proves: *if `f` has an elementary integral then `R | κ(R)` in `K[z]`*,
+/// where `κ` applies `d/dx` coefficient-wise.  We therefore return `true`
+/// (certified `NonElementary`) exactly when `R ∤ κ(R)`.
+///
+/// **Soundness.**
+/// * The `pp_z` (primitive-part) step is omitted: the `z`-content of the inner
+///   resultant is free of `z`, so after `res_t` it is a factor in `K` — a *unit*
+///   in `K[z]` — and `R | κ(R)` is invariant under units in `K[z]`.
+/// * Clearing denominators before each resultant only multiplies the output by
+///   factors free of the elimination variable, i.e. further `z`-free units.
+/// * `R | κ(R) ⟺ κ(R) = u·R` for some `u ∈ K` (because `deg_z κ(R) ≤ deg_z R`)
+///   `⟺` all nonzero `z`-coefficients `rᵢ` share one logarithmic derivative
+///   `⟺ Wᵢⱼ = rᵢ′·rⱼ − rᵢ·rⱼ′ = 0` for every pair.  We certify only when some
+///   `Wᵢⱼ` is *definitely* nonzero (symbolic + numeric), so a false certificate
+///   is impossible; any ambiguity yields `false` (inconclusive).
+fn residue_criterion_certifies_nonelementary(
+    elem: &[TExpr],
+    a_tx: &TExpr,
+    t_gen: ExprId,
+    n: usize,
+    var: ExprId,
+    pool: &ExprPool,
+) -> bool {
+    let f = RationalFunctionField;
+
+    // Classify the monomial t and obtain t′ symbolically.
+    let t_is_exp =
+        matches!(pool.get(t_gen), ExprData::Func { ref name, .. } if name.as_str() == "exp");
+    let Ok(tp) = crate::diff::diff(t_gen, var, pool) else {
+        return false;
+    };
+    let tprime = simplify(tp.value, pool).value;
+
+    // D = common t-denominator of the cᵢ (the integrand's normal denominator in
+    // the power basis).
+    let mut d_tpoly: TPoly = vec![f.one()];
+    for ci in elem {
+        if ci.numer().is_empty() {
+            continue;
+        }
+        d_tpoly = tpoly_lcm(&f, &d_tpoly, ci.denom());
+    }
+    if gdegree(&f, &d_tpoly) < 1 {
+        return false; // no t-pole ⇒ residue criterion is vacuous here
+    }
+
+    // D must be *normal*: squarefree in t, and (when t = exp is special)
+    // coprime to t.
+    let dd_dt = formal_t_derivative(&f, &d_tpoly);
+    let (g, _, _) = gext_gcd(&f, &d_tpoly, &dd_dt);
+    if gdegree(&f, &g) > 0 {
+        return false; // repeated t-factor: not Hermite-reduced here
+    }
+    if t_is_exp && (d_tpoly.is_empty() || f.eq(&d_tpoly[0], &f.zero())) {
+        return false; // t | D is special, not normal
+    }
+
+    // Fresh indeterminates: T (the monomial), Y (the radical), Z (the RT param).
+    let big_t = pool.symbol("$p1_t$", Domain::Complex);
+    let big_y = pool.symbol("$p1_y$", Domain::Complex);
+    let big_z = pool.symbol("$p1_z$", Domain::Complex);
+
+    // D(x,T), a(x,T), t′(x,T).
+    let d_sym = subst_t(
+        tpoly_to_expr(&d_tpoly, var, t_gen, pool),
+        t_gen,
+        big_t,
+        pool,
+    );
+    let a_sym = subst_t(texpr_to_expr(a_tx, var, t_gen, pool), t_gen, big_t, pool);
+    let tprime_t = subst_t(tprime, t_gen, big_t, pool);
+
+    // G(x,T,Y) = Σᵢ (cᵢ · D) Yⁱ   (numerators over the common denominator D).
+    let mut g_terms: Vec<ExprId> = Vec::new();
+    for (i, ci) in elem.iter().enumerate() {
+        if ci.numer().is_empty() {
+            continue;
+        }
+        let (quot, rem) = gpoly_divrem(&f, &d_tpoly, ci.denom());
+        if !rem.is_empty() {
+            return false; // D not a multiple of denom(cᵢ) — shouldn't happen
+        }
+        let gi = gpoly_mul(&f, ci.numer(), &quot);
+        let gi_sym = subst_t(tpoly_to_expr(&gi, var, t_gen, pool), t_gen, big_t, pool);
+        let term = if i == 0 {
+            gi_sym
+        } else {
+            pool.mul(vec![gi_sym, pool.pow(big_y, pool.integer(i as i32))])
+        };
+        g_terms.push(term);
+    }
+    if g_terms.is_empty() {
+        return false;
+    }
+    let g_sym = if g_terms.len() == 1 {
+        g_terms[0]
+    } else {
+        pool.add(g_terms)
+    };
+
+    // D′ = ∂ₓD + (∂_T D)·t′(T)   (total derivative through the tower).
+    let (Ok(dx), Ok(dt)) = (
+        crate::diff::diff(d_sym, var, pool),
+        crate::diff::diff(d_sym, big_t, pool),
+    ) else {
+        return false;
+    };
+    let dprime = pool.add(vec![dx.value, pool.mul(vec![dt.value, tprime_t])]);
+
+    // P = G − Z·D′ ;  F = Yⁿ − a.
+    let neg1 = pool.integer(-1_i32);
+    let p_sym = pool.add(vec![g_sym, pool.mul(vec![neg1, big_z, dprime])]);
+    let f_sym = pool.add(vec![
+        pool.pow(big_y, pool.integer(n as i32)),
+        pool.mul(vec![neg1, a_sym]),
+    ]);
+
+    // res_y(P, F), then res_t(·, D).  Clear denominators first: the resultant
+    // needs polynomial inputs, and the dropped denominators are free of the
+    // elimination variable (z-free units, harmless to the criterion).
+    let p_num = numer_denom(p_sym, pool).0;
+    let f_num = numer_denom(f_sym, pool).0;
+    let Ok(res1) = crate::poly::resultant(p_num, f_num, big_y, pool) else {
+        return false;
+    };
+    let d_num = numer_denom(d_sym, pool).0;
+    let Ok(r_res) = crate::poly::resultant(res1.value, d_num, big_t, pool) else {
+        return false;
+    };
+    let r = simplify(r_res.value, pool).value;
+
+    // R(z) ∈ K[z] with K = ℚ(x): test R | κ(R) via the pairwise Wronskian.
+    let coeffs = collect_z_coeffs(r, big_z, n, pool);
+    for i in 0..coeffs.len() {
+        let Ok(ri_p) = crate::diff::diff(coeffs[i], var, pool) else {
+            return false;
+        };
+        for j in (i + 1)..coeffs.len() {
+            let Ok(rj_p) = crate::diff::diff(coeffs[j], var, pool) else {
+                return false;
+            };
+            // Wᵢⱼ = rᵢ′·rⱼ − rᵢ·rⱼ′
+            let w = pool.add(vec![
+                pool.mul(vec![ri_p.value, coeffs[j]]),
+                pool.mul(vec![neg1, coeffs[i], rj_p.value]),
+            ]);
+            if definitely_nonzero(w, var, pool) {
+                return true; // R ∤ κ(R) ⇒ certified NonElementary
+            }
+        }
+    }
+    false
+}
+
+/// `lcm` of two `ℚ(x)[t]` polynomials: `a·b / gcd(a, b)`.
+fn tpoly_lcm(f: &RationalFunctionField, a: &TPoly, b: &TPoly) -> TPoly {
+    if a.is_empty() {
+        return b.to_vec();
+    }
+    if b.is_empty() {
+        return a.to_vec();
+    }
+    let prod = gpoly_mul(f, a, b);
+    let (g, _, _) = gext_gcd(f, a, b);
+    gpoly_divrem(f, &prod, &g).0
+}
+
+/// Formal derivative `d/dt` of a `ℚ(x)[t]` polynomial (no `x`-derivation).
+fn formal_t_derivative(f: &RationalFunctionField, p: &TPoly) -> TPoly {
+    if p.len() <= 1 {
+        return Vec::new();
+    }
+    let mut out: TPoly = Vec::with_capacity(p.len() - 1);
+    for (j, cj) in p.iter().enumerate().skip(1) {
+        out.push(f.mul(&RatFn::int(j as i64), cj));
+    }
+    gtrim(f, out)
+}
+
+/// Replace every occurrence of the generator `t_gen` by the fresh symbol `big_t`.
+fn subst_t(e: ExprId, t_gen: ExprId, big_t: ExprId, pool: &ExprPool) -> ExprId {
+    let mut m = HashMap::new();
+    m.insert(t_gen, big_t);
+    crate::kernel::subs(e, &m, pool)
+}
+
+/// `z`-coefficients `r₀, …, r_{max_deg}` of a polynomial `r ∈ K[z]`, obtained as
+/// `rₖ = (1/k!)·∂_z^k r |_{z=0}`.
+fn collect_z_coeffs(r: ExprId, z: ExprId, max_deg: usize, pool: &ExprPool) -> Vec<ExprId> {
+    let mut out = Vec::with_capacity(max_deg + 1);
+    let mut cur = r;
+    let mut fact: i64 = 1; // k!
+    for k in 0..=max_deg {
+        let mut m = HashMap::new();
+        m.insert(z, pool.integer(0_i32));
+        let at0 = simplify(crate::kernel::subs(cur, &m, pool), pool).value;
+        let ck = if k == 0 {
+            at0
+        } else {
+            pool.mul(vec![
+                at0,
+                pool.pow(pool.integer(fact as i32), pool.integer(-1_i32)),
+            ])
+        };
+        out.push(simplify(ck, pool).value);
+        let Ok(d) = crate::diff::diff(cur, z, pool) else {
+            break;
+        };
+        cur = simplify(d.value, pool).value;
+        fact *= (k as i64) + 1;
+    }
+    out
+}
+
+/// Conservatively decide whether `e` is a *nonzero* function of `x`: it must not
+/// simplify to the literal `0`, must evaluate finitely at every sample point,
+/// and be clearly nonzero at one of them.  Any uncertainty (unevaluable, all
+/// samples ≈ 0) returns `false`, so a true-zero expression can never be reported
+/// nonzero — the property the residue certificate relies on for soundness.
+fn definitely_nonzero(e: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    let s = simplify(e, pool).value;
+    if s == pool.integer(0_i32) {
+        return false;
+    }
+    let mut saw_nonzero = false;
+    for &xv in &[0.37_f64, 0.91, 1.73, 2.59, 3.42] {
+        match eval(s, var, xv, pool) {
+            Some(v) if v.is_finite() => {
+                if v.abs() > 1e-9 {
+                    saw_nonzero = true;
+                }
+            }
+            Some(_) => {}         // ±∞ / NaN at this sample: skip
+            None => return false, // cannot evaluate ⇒ not sure ⇒ inconclusive
+        }
+    }
+    saw_nonzero
+}
+
+/// Split `e` into `(numerator, denominator)` over `±·∧` structure, clearing
+/// integer-power denominators recursively.  No GCD cancellation is attempted
+/// (extra common factors are harmless units for the residue criterion).
+/// Non-integer powers and opaque functions are treated as atoms.
+fn numer_denom(e: ExprId, pool: &ExprPool) -> (ExprId, ExprId) {
+    match pool.get(e) {
+        ExprData::Add(args) => {
+            let parts: Vec<(ExprId, ExprId)> = args.iter().map(|&a| numer_denom(a, pool)).collect();
+            let common_den = pool.mul(parts.iter().map(|(_, d)| *d).collect());
+            let mut num_terms = Vec::with_capacity(parts.len());
+            for (i, (ni, _)) in parts.iter().enumerate() {
+                let mut factors = vec![*ni];
+                for (j, (_, dj)) in parts.iter().enumerate() {
+                    if j != i {
+                        factors.push(*dj);
+                    }
+                }
+                num_terms.push(pool.mul(factors));
+            }
+            (pool.add(num_terms), common_den)
+        }
+        ExprData::Mul(args) => {
+            let mut nums = Vec::with_capacity(args.len());
+            let mut dens = Vec::with_capacity(args.len());
+            for &a in &args {
+                let (na, da) = numer_denom(a, pool);
+                nums.push(na);
+                dens.push(da);
+            }
+            (pool.mul(nums), pool.mul(dens))
+        }
+        ExprData::Pow { base, exp } => {
+            if let ExprData::Integer(k) = pool.get(exp) {
+                let ki = k.0.to_i64().unwrap_or(0);
+                let (bn, bd) = numer_denom(base, pool);
+                if ki >= 0 {
+                    (pool.pow(bn, exp), pool.pow(bd, exp))
+                } else {
+                    let pe = pool.integer((-ki) as i32);
+                    (pool.pow(bd, pe), pool.pow(bn, pe))
+                }
+            } else {
+                (e, pool.integer(1_i32))
+            }
+        }
+        _ => (e, pool.integer(1_i32)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,6 +848,83 @@ mod tests {
                 (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
                 "x={xv}: d/dx F = {lhs}, f = {rhs}\n  F = {}",
                 pool.display(g)
+            );
+        }
+    }
+
+    /// P1 residue criterion (Bronstein eq 16): `∫ √(log x)/(log x − x) dx` is
+    /// non-elementary — its residue at the pole `log x = x` is `√x`, which is
+    /// not constant.  Hand check with `t = log x`, `y = √t`, `a = t`, `n = 2`:
+    /// `D = t − x`, `D′ = 1/x − 1`, `G = y`, so
+    /// `R(z) = res_t(res_y(y − z·D′, y² − t), t − x) = (1/x − 1)²·z² − x`, and
+    /// `κ(R) = −2(1−x)/x³·z² − 1`.  Then `W₀₂ = r₀′r₂ − r₀r₂′ = −(1−x)(3−x)/x² ≠ 0`,
+    /// so `R ∤ κ(R)` and the integral is certified non-elementary.
+    #[test]
+    fn residue_criterion_certifies_sqrt_log() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let log_x = pool.func("log", vec![x]);
+        let y = pool.pow(log_x, pool.rational(1, 2));
+        let den = pool.add(vec![log_x, pool.mul(vec![pool.integer(-1), x])]);
+        let f = pool.mul(vec![y, pool.pow(den, pool.integer(-1))]);
+
+        // Direct filter.
+        let r = try_integrate_radical_over_transcendental(f, x, &pool);
+        assert!(
+            matches!(r, Some(Err(IntegrationError::NonElementary(_)))),
+            "P1 should certify NonElementary; got {r:?}"
+        );
+        // End-to-end through the public engine.
+        let e = crate::integrate::engine::integrate(f, x, &pool);
+        assert!(
+            matches!(e, Err(IntegrationError::NonElementary(_))),
+            "engine should report NonElementary; got {e:?}"
+        );
+    }
+
+    /// Degree-3 analogue: `∫ ∛(x + eˣ)/(eˣ − x) dx` — non-elementary via eq 16.
+    #[test]
+    fn residue_criterion_certifies_cbrt_mixed() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let a = pool.add(vec![x, exp_x]);
+        let y = pool.pow(a, pool.rational(1, 3));
+        let den = pool.add(vec![exp_x, pool.mul(vec![pool.integer(-1), x])]);
+        let f = pool.mul(vec![y, pool.pow(den, pool.integer(-1))]);
+        let r = try_integrate_radical_over_transcendental(f, x, &pool);
+        assert!(
+            matches!(r, Some(Err(IntegrationError::NonElementary(_)))),
+            "P1 should certify NonElementary; got {r:?}"
+        );
+    }
+
+    /// Soundness control: P1 must NOT reject an *elementary* integrand that has
+    /// a genuine `t`-pole.  `∫ 1/(2x·√(log x)) dx = √(log x)` (pole at `t = 0`).
+    /// The residue criterion holds, so integration proceeds and succeeds.
+    #[test]
+    fn residue_criterion_keeps_elementary_with_pole() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let log_x = pool.func("log", vec![x]);
+        let y = pool.pow(log_x, pool.rational(1, 2));
+        let den = pool.mul(vec![pool.integer(2), x, y]);
+        let f = pool.pow(den, pool.integer(-1)); // 1/(2x√(log x))
+
+        let res = crate::integrate::engine::integrate(f, x, &pool);
+        assert!(
+            res.is_ok(),
+            "elementary integrand must not be certified NonElementary; got {res:?}"
+        );
+        // d/dx F = f, verified numerically.
+        let g = res.unwrap().value;
+        let ds = simplify(crate::diff::diff(g, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[1.4_f64, 2.3, 3.1] {
+            let lhs = eval(ds, x, xv, &pool).unwrap();
+            let rhs = eval(f, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, f = {rhs}"
             );
         }
     }

--- a/alkahest-core/src/poly/mod.rs
+++ b/alkahest-core/src/poly/mod.rs
@@ -4,6 +4,8 @@ pub mod factor;
 // V2-3 — Sparse interpolation
 pub mod interp;
 pub mod multipoly;
+// M3 prereq — Newton–Puiseux fractional-power local expansions of plane curves
+pub mod puiseux;
 pub mod rational;
 // V2-2 — Resultants and subresultant PRS
 pub mod resultant;

--- a/alkahest-core/src/poly/puiseux.rs
+++ b/alkahest-core/src/poly/puiseux.rs
@@ -24,16 +24,29 @@
 //!
 //! ## Scope
 //!
-//! This implementation follows the branches whose characteristic roots are
-//! **rational** (the principal/real branches of radicals `yⁿ = p`, products of
-//! such, etc.) — sound and complete for that class, returning each branch to the
-//! requested precision with its ramification index.  Branches whose continuation
-//! requires an algebraic-number coefficient are *skipped* (not mis-reported); the
-//! natural follow-up is to carry coefficients in a [`super::super`] number field.
-//! Every returned branch is checked by back-substitution in the test suite.
+//! [`puiseux_at_zero`] returns the branches with **rational** coefficients —
+//! sound and complete for that class.  [`puiseux_at`] expands at an arbitrary
+//! rational base point `x = α` (exponents in `(x − α)`).  [`puiseux_at_zero_algebraic`]
+//! returns **all** branches up to a *single* algebraic extension per branch: the
+//! characteristic polynomial is factored over `ℚ`, a root `θ` is adjoined, and the
+//! branch continued over `ℚ(θ)` (see [`AlgPuiseuxSeries`]).  This is complete for
+//! radical / superelliptic curves (`yⁿ = p`, roots of unity) and constant
+//! algebraic branches; a branch needing a *further* extension (non-linear
+//! characteristic over `ℚ(θ)`) is skipped, never mis-reported — the summed
+//! `conjugates` reveal whether every sheet was recovered.  Every rational branch
+//! is back-substitution-checked in the test suite.
 
 use rug::{Integer, Rational};
 use std::collections::BTreeMap;
+
+use crate::flint::FlintPoly;
+use crate::integrate::risch::number_field::NumberField;
+
+/// A coefficient in a number field `ℚ[θ]/(m)`: a polynomial in `θ` (ascending),
+/// reduced mod `m`.  For the base field `ℚ` this is a constant `[r]`.
+type KElem = Vec<Rational>;
+/// Bivariate polynomial with **number-field** coefficients: `(x-exp, y-exp) → KElem`.
+type KBi = BTreeMap<(Rational, u32), KElem>;
 
 /// A truncated Puiseux series `Σ c_k x^{e_k}` with rational exponents `e_k`
 /// (ascending) and ramification index `e` (the lcm of the exponent denominators).
@@ -166,12 +179,14 @@ fn lift(g: &Bi, prec: &Rational, depth: u32) -> Vec<(Vec<(Rational, Rational)>, 
     result
 }
 
-/// Edges `(q, monomials)` of the lower convex hull of the points `(j, i)` with
-/// **positive** `q = −slope` (the `w → 0` Newton-polygon edges).
-fn newton_edges(g: &Bi) -> Vec<Edge> {
+/// Edges `(q, keys-on-edge)` of the lower convex hull of the points `(j, i)`
+/// (`i` the x-exponent, `j` the y-exponent) with **positive** `q = −slope` — the
+/// `w → 0` Newton-polygon edges.  Pure geometry on the monomial *keys*, so it is
+/// shared by the rational and number-field coefficient layers.
+pub(crate) fn newton_edges_keys(keys: &[(Rational, u32)]) -> Vec<(Rational, Vec<(Rational, u32)>)> {
     // For each y-exponent j keep the minimal x-exponent i (lower envelope).
     let mut lo: BTreeMap<u32, Rational> = BTreeMap::new();
-    for (xe, ye) in g.keys() {
+    for (xe, ye) in keys {
         lo.entry(*ye)
             .and_modify(|m| {
                 if xe < m {
@@ -184,13 +199,11 @@ fn newton_edges(g: &Bi) -> Vec<Edge> {
     if pts.len() < 2 {
         return Vec::new();
     }
-    // Lower convex hull over points (j, i).
     let mut hull: Vec<(u32, Rational)> = Vec::new();
     for p in pts {
         while hull.len() >= 2 {
             let a = &hull[hull.len() - 2];
             let b = &hull[hull.len() - 1];
-            // cross product of (b-a) × (p-b) ≤ 0 ⇒ b not on lower hull
             let lhs = Rational::from(b.0 as i64 - a.0 as i64) * (p.1.clone() - &b.1);
             let rhs = Rational::from(p.0 as i64 - b.0 as i64) * (b.1.clone() - &a.1);
             if lhs - rhs <= 0 {
@@ -201,7 +214,6 @@ fn newton_edges(g: &Bi) -> Vec<Edge> {
         }
         hull.push(p);
     }
-    // Edges with negative slope (i decreasing as j increases) ⇒ q = −slope > 0.
     let mut edges = Vec::new();
     for w in hull.windows(2) {
         let (j1, i1) = (&w[0].0, &w[0].1);
@@ -211,14 +223,29 @@ fn newton_edges(g: &Bi) -> Vec<Edge> {
         if q <= 0 {
             continue;
         }
-        // Monomials of g lying on this edge: i + q·j == i1 + q·j1.
         let val = i1.clone() + q.clone() * Rational::from(*j1 as i64);
-        let mut monos = Vec::new();
-        for ((xe, ye), a) in g {
-            if xe.clone() + q.clone() * Rational::from(*ye as i64) == val {
-                monos.push(((xe.clone(), *ye), a.clone()));
-            }
-        }
+        let on_edge: Vec<(Rational, u32)> = keys
+            .iter()
+            .filter(|(xe, ye)| xe.clone() + q.clone() * Rational::from(*ye as i64) == val)
+            .cloned()
+            .collect();
+        edges.push((q, on_edge));
+    }
+    edges
+}
+
+/// Edges `(q, monomials)` of the Newton polygon of `g` (rational coefficients).
+fn newton_edges(g: &Bi) -> Vec<Edge> {
+    let keys: Vec<(Rational, u32)> = g.keys().cloned().collect();
+    let mut edges = Vec::new();
+    for (q, on_edge) in newton_edges_keys(&keys) {
+        let monos: Vec<((Rational, u32), Rational)> = on_edge
+            .into_iter()
+            .map(|k| {
+                let a = g[&k].clone();
+                (k, a)
+            })
+            .collect();
         edges.push((q, monos));
     }
     edges
@@ -421,6 +448,415 @@ fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
     a
 }
 
+// ---------------------------------------------------------------------------
+// Expansion at an arbitrary rational base point
+// ---------------------------------------------------------------------------
+
+/// Puiseux expansions of `F(x, y) = 0` at `x = α` (`α ∈ ℚ`): the returned
+/// exponents are powers of `(x − α)`.  Implemented by the shift `x ↦ x + α` and
+/// [`puiseux_at_zero`].  (Rational branches only — see [`puiseux_at_zero`].)
+pub fn puiseux_at(
+    coeffs: &[(u32, u32, Rational)],
+    alpha: &Rational,
+    prec: u32,
+) -> Vec<PuiseuxSeries> {
+    if *alpha == 0 {
+        return puiseux_at_zero(coeffs, prec);
+    }
+    // x^i ↦ (x+α)^i = Σ_m C(i,m) α^{i−m} x^m.
+    let mut shifted: BTreeMap<(u32, u32), Rational> = BTreeMap::new();
+    for (i, j, a) in coeffs {
+        for m in 0..=*i {
+            let binom = Rational::from(binomial(*i, m));
+            let apow = rat_pow(alpha, *i - m);
+            let c = a.clone() * &binom * &apow;
+            if c != 0 {
+                *shifted.entry((m, *j)).or_insert_with(rzero) += &c;
+            }
+        }
+    }
+    let flat: Vec<(u32, u32, Rational)> =
+        shifted.into_iter().map(|((i, j), a)| (i, j, a)).collect();
+    puiseux_at_zero(&flat, prec)
+}
+
+// ---------------------------------------------------------------------------
+// Algebraic-coefficient branches
+// ---------------------------------------------------------------------------
+
+/// A Puiseux branch whose coefficients live in a number field `ℚ[θ]/(minpoly)`.
+/// When `minpoly` is `None` the field is `ℚ` and each coefficient is a constant
+/// `[c]`.  A branch over a degree-`d` field represents `conjugates = d` concrete
+/// (conjugate) branches of the curve.
+#[derive(Clone, Debug)]
+pub struct AlgPuiseuxSeries {
+    /// Monic minimal polynomial of `θ` (ascending); `None` ⇒ base field `ℚ`.
+    pub minpoly: Option<Vec<Rational>>,
+    /// Number of conjugate branches this class represents (`= deg(minpoly)`).
+    pub conjugates: usize,
+    /// Ramification index `e`.
+    pub ramification: u64,
+    /// `(exponent, coefficient ∈ ℚ[θ])` pairs, ascending.
+    pub terms: Vec<(Rational, KElem)>,
+    /// Truncation order (`None` ⇒ exact).
+    pub order: Option<Rational>,
+}
+
+/// Puiseux expansions of `F(x,y)=0` at `x=0` over `ℚ̄`, returning **all** branches
+/// up to a single algebraic extension per branch.  Rational branches come from
+/// [`puiseux_at_zero`]; the remaining branches are those whose characteristic
+/// root is algebraic — handled by factoring the characteristic polynomial over
+/// `ℚ`, adjoining a root `θ`, and continuing over `ℚ(θ)`.
+///
+/// Scope: a *single* extension per branch with **smooth** continuation (deeper
+/// characteristic polynomials linear over `ℚ(θ)`) — complete for radical /
+/// superelliptic curves (`yⁿ=p`, `∛x`, roots of unity) and constant algebraic
+/// branches.  Branches needing a *further* extension are skipped (documented,
+/// never mis-reported); the total `conjugates` of all branches indicates whether
+/// every sheet was recovered.
+pub fn puiseux_at_zero_algebraic(
+    coeffs: &[(u32, u32, Rational)],
+    prec: u32,
+) -> Vec<AlgPuiseuxSeries> {
+    // Rational branches.
+    let mut out: Vec<AlgPuiseuxSeries> = puiseux_at_zero(coeffs, prec)
+        .into_iter()
+        .map(|s| AlgPuiseuxSeries {
+            minpoly: None,
+            conjugates: 1,
+            ramification: s.ramification,
+            terms: s.terms.into_iter().map(|(e, c)| (e, vec![c])).collect(),
+            order: s.order,
+        })
+        .collect();
+
+    let mut f: Bi = BTreeMap::new();
+    for (i, j, a) in coeffs {
+        if *a != 0 {
+            *f.entry((Rational::from(*i), *j)).or_insert_with(rzero) += a;
+        }
+    }
+    f.retain(|_, a| *a != 0);
+    if f.is_empty() {
+        return out;
+    }
+    factor_min_x(&mut f);
+    let prec_r = Rational::from(prec);
+
+    // Constant terms: factor F(0, y) over ℚ.
+    let mut f0: BTreeMap<u32, Rational> = BTreeMap::new();
+    for ((xe, ye), a) in &f {
+        if *xe == 0 {
+            *f0.entry(*ye).or_insert_with(rzero) += a;
+        }
+    }
+    let f0_dense = dense(&f0);
+    // The constant root c₀ = 0 (when y | F(0,y)) is stripped by `factor_over_q`;
+    // explore that stem explicitly so origin branches (e.g. yⁿ = x) are found.
+    if f0_dense.first().map(|c| *c == 0).unwrap_or(true) {
+        out.extend(collect_algebraic(&f, &prec_r, &[]));
+    }
+    for (fac, deg) in factor_over_q(&f0_dense) {
+        if deg == 1 {
+            // Nonzero rational constant c₀ = −fac[0]; explore deeper for spawns.
+            let c0 = -fac[0].clone();
+            out.extend(collect_algebraic(
+                &shift_y(&f, &c0),
+                &prec_r,
+                &[(rzero(), c0.clone())],
+            ));
+        } else {
+            // Algebraic constant c₀ = θ over K = ℚ[t]/(fac).
+            let nf = NumberField::new(fac.clone());
+            let theta = nf.reduce(&vec![Rational::from(0), Rational::from(1)]);
+            let gk = substitute_k(&nf, &embed(&nf, &f), &rzero(), &theta);
+            for (terms, exact) in lift_k(&nf, &gk, &prec_r, 0) {
+                let mut full = vec![(rzero(), theta.clone())];
+                full.extend(terms);
+                out.push(make_alg_series(
+                    Some(fac.clone()),
+                    deg,
+                    full,
+                    exact,
+                    &prec_r,
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Walk the Newton polygon of `g` (`w → 0`, rational coefficients) and emit only
+/// the **algebraic** (number-field) branches: at each edge, factor the
+/// characteristic polynomial over `ℚ`; degree-1 factors continue rationally
+/// (recurse, to reach deeper spawns), degree-≥2 factors spawn an extension and
+/// continue over it via [`lift_k`].
+fn collect_algebraic(
+    g: &Bi,
+    prec: &Rational,
+    prefix: &[(Rational, Rational)],
+) -> Vec<AlgPuiseuxSeries> {
+    let mut g = g.clone();
+    g.retain(|_, a| *a != 0);
+    if g.is_empty() {
+        return Vec::new();
+    }
+    let m0 = g.keys().map(|(_, j)| *j).min().unwrap_or(0);
+    if m0 > 0 {
+        g = g
+            .into_iter()
+            .map(|((xe, ye), a)| ((xe, ye - m0), a))
+            .collect();
+    }
+    let mut out = Vec::new();
+    let keys: Vec<(Rational, u32)> = g.keys().cloned().collect();
+    for (q, on_edge) in newton_edges_keys(&keys) {
+        // Characteristic polynomial φ(c) = Σ_{(i,j)∈edge} a_{ij} c^j (over ℚ).
+        let mut phi: BTreeMap<u32, Rational> = BTreeMap::new();
+        for k in &on_edge {
+            *phi.entry(k.1).or_insert_with(rzero) += &g[k];
+        }
+        for (fac, deg) in factor_over_q(&dense(&phi)) {
+            if deg == 1 {
+                let c = -fac[0].clone();
+                if c == 0 || prec.clone() - &q <= 0 {
+                    continue;
+                }
+                let mut np = prefix.to_vec();
+                np.push((q.clone(), c.clone()));
+                out.extend(collect_algebraic(
+                    &substitute(&g, &q, &c),
+                    &(prec.clone() - &q),
+                    &np,
+                ));
+            } else {
+                let nf = NumberField::new(fac.clone());
+                let theta = nf.reduce(&vec![Rational::from(0), Rational::from(1)]);
+                if prec.clone() - &q <= 0 {
+                    let mut full = embed_prefix(&nf, prefix);
+                    full.push((q.clone(), theta));
+                    out.push(make_alg_series(Some(fac.clone()), deg, full, false, prec));
+                    continue;
+                }
+                let gk = substitute_k(&nf, &embed(&nf, &g), &q, &theta);
+                for (sub, exact) in lift_k(&nf, &gk, &(prec.clone() - &q), 0) {
+                    let mut full = embed_prefix(&nf, prefix);
+                    full.push((q.clone(), theta.clone()));
+                    for (gamma, b) in sub {
+                        full.push((q.clone() + &gamma, b));
+                    }
+                    out.push(make_alg_series(Some(fac.clone()), deg, full, exact, prec));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// `lift` over a fixed number field `nf`: find the `w → 0` branches of `g(x,w)=0`,
+/// taking only roots that lie in `nf` (linear characteristic factors — sufficient
+/// for smooth radical continuations; non-linear cases are skipped).
+fn lift_k(
+    nf: &NumberField,
+    g: &KBi,
+    prec: &Rational,
+    depth: u32,
+) -> Vec<(Vec<(Rational, KElem)>, bool)> {
+    const MAX_DEPTH: u32 = 48;
+    let mut g = g.clone();
+    g.retain(|_, a| !NumberField::is_zero(a));
+    if g.is_empty() {
+        return vec![(Vec::new(), true)];
+    }
+    if depth > MAX_DEPTH {
+        return vec![(Vec::new(), false)];
+    }
+    let mut result = Vec::new();
+    let m0 = g.keys().map(|(_, j)| *j).min().unwrap_or(0);
+    if m0 > 0 {
+        result.push((Vec::new(), true));
+        g = g
+            .into_iter()
+            .map(|((xe, ye), a)| ((xe, ye - m0), a))
+            .collect();
+    }
+    let keys: Vec<(Rational, u32)> = g.keys().cloned().collect();
+    for (q, on_edge) in newton_edges_keys(&keys) {
+        // Characteristic polynomial over nf, indexed by y-exponent.
+        let mut phi: BTreeMap<u32, KElem> = BTreeMap::new();
+        for k in &on_edge {
+            let e = phi.entry(k.1).or_default();
+            *e = nf.add(e, &g[k]);
+        }
+        let Some(c) = k_linear_root(nf, &phi) else {
+            continue; // non-linear over nf: would need a further extension
+        };
+        if prec.clone() - &q <= 0 {
+            result.push((vec![(q.clone(), c)], false));
+            continue;
+        }
+        let gk = substitute_k(nf, &g, &q, &c);
+        for (sub, exact) in lift_k(nf, &gk, &(prec.clone() - &q), depth + 1) {
+            let mut terms = vec![(q.clone(), c.clone())];
+            for (gamma, b) in sub {
+                terms.push((q.clone() + &gamma, b));
+            }
+            result.push((terms, exact));
+        }
+    }
+    result
+}
+
+/// The unique root in `nf` of a characteristic polynomial `Σ_j a_j c^j` that is a
+/// **binomial of consecutive degrees** `a_{j} c^{j} + a_{j+1} c^{j+1}` (root
+/// `−a_j/a_{j+1}`).  `None` otherwise (no nonzero root, or degree ≥ 2 ⇒ would need
+/// a further extension).
+fn k_linear_root(nf: &NumberField, phi: &BTreeMap<u32, KElem>) -> Option<KElem> {
+    let nz: Vec<(&u32, &KElem)> = phi
+        .iter()
+        .filter(|(_, c)| !NumberField::is_zero(c))
+        .collect();
+    if nz.len() != 2 {
+        return None;
+    }
+    let (j1, a1) = nz[0];
+    let (j2, a2) = nz[1];
+    if *j2 != *j1 + 1 {
+        return None; // c^{j2−j1} = … : a higher root, not in nf in general
+    }
+    let inv = nf.inv(a2)?;
+    Some(nf.neg(&nf.mul(a1, &inv)))
+}
+
+/// `w = x^q (c + w₁)` substitution over a number field, then divide by `x^ν`.
+fn substitute_k(nf: &NumberField, g: &KBi, q: &Rational, c: &KElem) -> KBi {
+    let mut g1: KBi = BTreeMap::new();
+    for ((xe, ye), a) in g {
+        let j = *ye;
+        let new_xe = xe.clone() + q.clone() * Rational::from(j as i64);
+        for l in 0..=j {
+            let binom = k_from_int(nf, &binomial(j, l));
+            let cpow = k_pow(nf, c, j - l);
+            let coeff = nf.mul(&nf.mul(a, &binom), &cpow);
+            if !NumberField::is_zero(&coeff) {
+                let e = g1.entry((new_xe.clone(), l)).or_default();
+                *e = nf.add(e, &coeff);
+            }
+        }
+    }
+    g1.retain(|_, a| !NumberField::is_zero(a));
+    factor_min_x_k(&mut g1);
+    g1
+}
+
+fn factor_min_x_k(g: &mut KBi) {
+    let Some(v) = g.keys().map(|(xe, _)| xe.clone()).min() else {
+        return;
+    };
+    if v == 0 {
+        return;
+    }
+    *g = std::mem::take(g)
+        .into_iter()
+        .map(|((xe, ye), a)| ((xe - &v, ye), a))
+        .collect();
+}
+
+fn embed(nf: &NumberField, g: &Bi) -> KBi {
+    g.iter()
+        .map(|((xe, ye), a)| ((xe.clone(), *ye), nf.reduce(&vec![a.clone()])))
+        .collect()
+}
+
+fn embed_prefix(nf: &NumberField, prefix: &[(Rational, Rational)]) -> Vec<(Rational, KElem)> {
+    prefix
+        .iter()
+        .map(|(e, c)| (e.clone(), nf.reduce(&vec![c.clone()])))
+        .collect()
+}
+
+fn k_from_int(nf: &NumberField, n: &Integer) -> KElem {
+    nf.reduce(&vec![Rational::from(n.clone())])
+}
+
+fn k_pow(nf: &NumberField, c: &KElem, e: u32) -> KElem {
+    let mut acc = nf.reduce(&vec![Rational::from(1)]);
+    for _ in 0..e {
+        acc = nf.mul(&acc, c);
+    }
+    acc
+}
+
+fn make_alg_series(
+    minpoly: Option<Vec<Rational>>,
+    conjugates: usize,
+    mut terms: Vec<(Rational, KElem)>,
+    exact: bool,
+    prec: &Rational,
+) -> AlgPuiseuxSeries {
+    terms.retain(|(e, c)| (exact || *e < *prec) && !NumberField::is_zero(c));
+    terms.sort_by(|a, b| a.0.cmp(&b.0));
+    let e = terms.iter().fold(1u64, |acc, (ex, _)| {
+        lcm_u64(acc, ex.denom().to_u64().unwrap_or(1))
+    });
+    AlgPuiseuxSeries {
+        minpoly,
+        conjugates,
+        ramification: e,
+        terms,
+        order: if exact { None } else { Some(prec.clone()) },
+    }
+}
+
+/// Factor `φ(c) = Σ p[k] c^k` over `ℚ` into monic irreducible factors of degree
+/// `≥ 1`, after dividing out the largest `c`-power (the root `c = 0`, not a
+/// branch).  Returns `(monic factor, degree)`.
+fn factor_over_q(p: &[Rational]) -> Vec<(Vec<Rational>, usize)> {
+    let p = {
+        let mut hi = p.len();
+        while hi > 0 && p[hi - 1] == 0 {
+            hi -= 1;
+        }
+        p[..hi].to_vec()
+    };
+    // Divide out low-order zeros (root c = 0).
+    let lo = p.iter().position(|c| *c != 0).unwrap_or(p.len());
+    let psi = &p[lo..];
+    if psi.len() <= 1 {
+        return Vec::new();
+    }
+    // Clear denominators → integer coefficients (ascending).
+    let mut den_lcm = Integer::from(1);
+    for c in psi {
+        den_lcm = den_lcm.lcm(c.denom());
+    }
+    let ints: Vec<Integer> = psi
+        .iter()
+        .map(|c| {
+            (c.clone() * Rational::from(den_lcm.clone()))
+                .numer()
+                .clone()
+        })
+        .collect();
+    let fp = FlintPoly::from_rug_coefficients(&ints);
+    let Ok((_unit, facs)) = fp.factor_over_z() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (fpoly, _mult) in facs {
+        let deg = fpoly.degree();
+        if deg < 1 {
+            continue;
+        }
+        let icoeffs = fpoly.coefficients(); // ascending i64
+        let qcoeffs: Vec<Rational> = icoeffs.iter().map(|&c| Rational::from(c)).collect();
+        let lead = qcoeffs[deg as usize].clone();
+        let monic: Vec<Rational> = qcoeffs.iter().map(|c| c.clone() / &lead).collect();
+        out.push((monic, deg as usize));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -474,6 +910,64 @@ mod tests {
             &[(0, 2, r(1)), (1, 1, r(-2)), (2, 0, r(1)), (3, 0, r(-1))],
             4,
         ); // (y−x)²−x³
+    }
+
+    #[test]
+    fn puiseux_at_base_point() {
+        // y² − (x−1) = 0 ⇒ y = ±(x−1)^{1/2}; expand at x=1.
+        let f = [(0, 2, r(1)), (1, 0, r(-1)), (0, 0, r(1))]; // y² − x + 1
+        let br = puiseux_at(&f, &r(1), 3);
+        assert_eq!(br.len(), 2);
+        for s in &br {
+            assert_eq!(s.ramification, 2);
+            assert!(has_term(s, rr(1, 2), r(1)) || has_term(s, rr(1, 2), r(-1)));
+        }
+    }
+
+    #[test]
+    fn algebraic_cube_root_of_unity() {
+        // y³ − x: rational branch x^{1/3} (c=1) + an algebraic class (c=ω) over
+        // ℚ[t]/(t²+t+1) with conjugates=2.  Total sheets 1+2 = 3 = deg_y.
+        let br = puiseux_at_zero_algebraic(&[(0, 3, r(1)), (1, 0, r(-1))], 2);
+        let total: usize = br.iter().map(|s| s.conjugates).sum();
+        assert_eq!(total, 3, "branches: {br:?}");
+        let alg = br
+            .iter()
+            .find(|s| s.minpoly.is_some())
+            .expect("an algebraic branch");
+        assert_eq!(alg.conjugates, 2);
+        assert_eq!(alg.minpoly.as_ref().unwrap(), &vec![r(1), r(1), r(1)]);
+        assert_eq!(alg.ramification, 3);
+        assert_eq!(alg.terms[0].0, rr(1, 3));
+        assert_eq!(alg.terms[0].1, vec![r(0), r(1)]); // coefficient θ
+                                                      // Soundness of the leading term: θ³ = 1 in ℚ(ω), so (θ x^{1/3})³ = x.
+        let nf = NumberField::new(vec![r(1), r(1), r(1)]);
+        let theta = vec![r(0), r(1)];
+        let theta3 = nf.mul(&nf.mul(&theta, &theta), &theta);
+        assert_eq!(nf.reduce(&theta3), vec![r(1)]);
+    }
+
+    #[test]
+    fn algebraic_constant_branches() {
+        // y² − 2 ⇒ y = ±√2: a constant algebraic class over ℚ[t]/(t²−2).
+        let br = puiseux_at_zero_algebraic(&[(0, 2, r(1)), (0, 0, r(-2))], 2);
+        let alg = br
+            .iter()
+            .find(|s| s.minpoly.is_some())
+            .expect("an algebraic branch");
+        assert_eq!(alg.conjugates, 2);
+        assert_eq!(alg.minpoly.as_ref().unwrap(), &vec![r(-2), r(0), r(1)]);
+        assert_eq!(alg.terms.len(), 1);
+        assert_eq!(alg.terms[0], (r(0), vec![r(0), r(1)]));
+    }
+
+    #[test]
+    fn algebraic_includes_rational_branches() {
+        // y² − x still yields its two rational branches via the algebraic entry.
+        let br = puiseux_at_zero_algebraic(&[(0, 2, r(1)), (1, 0, r(-1))], 3);
+        let total: usize = br.iter().map(|s| s.conjugates).sum();
+        assert_eq!(total, 2);
+        assert!(br.iter().all(|s| s.minpoly.is_none()));
     }
 
     #[test]

--- a/alkahest-core/src/poly/puiseux.rs
+++ b/alkahest-core/src/poly/puiseux.rs
@@ -1,0 +1,554 @@
+//! Newton–Puiseux expansion of a plane algebraic curve `F(x, y) = 0` — the
+//! local fractional-power series of the `y`-branches at `x = 0`.
+//!
+//! A **Puiseux series** is a Laurent series in `x^{1/e}` for some ramification
+//! index `e ≥ 1`: `y(x) = Σ_k c_k x^{k/e}`.  Each branch of the curve through a
+//! point over `x = 0` has such an expansion; ramified places are exactly those
+//! with `e > 1`.  These local expansions are the substrate for residue
+//! computation at ramified/infinite places in the Trager algebraic-integration
+//! algorithm (Risch milestone M3 / van Hoeij integral bases).
+//!
+//! ## Algorithm (classical Newton–Puiseux)
+//!
+//! For `F = Σ a_{ij} x^i y^j` we seek `y → c₀` as `x → 0`:
+//! 1. the constant `c₀` is a root of `F(0, y)`; substitute `y = c₀ + w` so `w → 0`;
+//! 2. on the **Newton polygon** of the shifted polynomial (lower hull of the
+//!    points `(j, i)`), each edge of slope `−q` (`q > 0`) gives a leading term
+//!    `w ≈ c·x^q`, with `c` a nonzero root of the edge's **characteristic
+//!    polynomial** `φ(c) = Σ_{(i,j)∈edge} a_{ij} c^j`;
+//! 3. substitute `w = x^q(c + w₁)` and recurse on the resulting polynomial,
+//!    accumulating `q` into the exponents, until the target precision is reached.
+//!
+//! Keeping `x` itself (with *rational* exponents) throughout — rather than the
+//! usual `x = τ^e` rescaling — lets one polynomial type carry every level.
+//!
+//! ## Scope
+//!
+//! This implementation follows the branches whose characteristic roots are
+//! **rational** (the principal/real branches of radicals `yⁿ = p`, products of
+//! such, etc.) — sound and complete for that class, returning each branch to the
+//! requested precision with its ramification index.  Branches whose continuation
+//! requires an algebraic-number coefficient are *skipped* (not mis-reported); the
+//! natural follow-up is to carry coefficients in a [`super::super`] number field.
+//! Every returned branch is checked by back-substitution in the test suite.
+
+use rug::{Integer, Rational};
+use std::collections::BTreeMap;
+
+/// A truncated Puiseux series `Σ c_k x^{e_k}` with rational exponents `e_k`
+/// (ascending) and ramification index `e` (the lcm of the exponent denominators).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PuiseuxSeries {
+    /// Ramification index `e`: every exponent has denominator dividing `e`.
+    pub ramification: u64,
+    /// `(exponent, coefficient)` pairs, strictly ascending in exponent.
+    pub terms: Vec<(Rational, Rational)>,
+    /// Terms with exponent `≥ order` are unknown (truncated).  `None` means the
+    /// branch is *exact* (a terminating, polynomial-in-`x^{1/e}` branch).
+    pub order: Option<Rational>,
+}
+
+/// Bivariate polynomial as `(x-exponent, y-exponent) → coefficient`, with
+/// **rational** `x`-exponents (produced by the `w = x^q(c+w₁)` substitutions).
+type Bi = BTreeMap<(Rational, u32), Rational>;
+
+/// A Newton-polygon edge: `(q, monomials)` where `q = −slope` and `monomials`
+/// are the `((x-exp, y-exp), coeff)` triples lying on it.
+type Edge = (Rational, Vec<((Rational, u32), Rational)>);
+
+fn rzero() -> Rational {
+    Rational::from(0)
+}
+
+/// Puiseux expansions of the rational branches of `F(x, y) = 0` at `x = 0`, each
+/// to precision `prec` (terms with `x`-exponent `< prec` are returned).
+///
+/// `coeffs` lists the monomials `(i, j, a_{ij})` of `F = Σ a_{ij} x^i y^j`.
+pub fn puiseux_at_zero(coeffs: &[(u32, u32, Rational)], prec: u32) -> Vec<PuiseuxSeries> {
+    let mut f: Bi = BTreeMap::new();
+    for (i, j, a) in coeffs {
+        if *a != 0 {
+            *f.entry((Rational::from(*i), *j)).or_insert_with(rzero) += a;
+        }
+    }
+    f.retain(|_, a| *a != 0);
+    if f.is_empty() {
+        return Vec::new();
+    }
+    factor_min_x(&mut f); // F = x^v · F'; branches unaffected
+
+    let prec_r = Rational::from(prec);
+    let mut out = Vec::new();
+
+    // Constant terms c₀ are the rational roots of F(0, y).
+    let mut f0: BTreeMap<u32, Rational> = BTreeMap::new();
+    for ((xe, ye), a) in &f {
+        if *xe == 0 {
+            *f0.entry(*ye).or_insert_with(rzero) += a;
+        }
+    }
+    let f0_dense = dense(&f0);
+    for c0 in rational_roots(&f0_dense) {
+        let g = shift_y(&f, &c0);
+        for (mut terms, exact) in lift(&g, &prec_r, 0) {
+            if c0 != 0 {
+                terms.insert(0, (rzero(), c0.clone()));
+            }
+            terms.retain(|(e, _)| exact || *e < prec_r);
+            terms.sort_by(|a, b| a.0.cmp(&b.0));
+            let e = terms.iter().fold(1u64, |acc, (ex, _)| {
+                lcm_u64(acc, ex.denom().to_u64().unwrap_or(1))
+            });
+            out.push(PuiseuxSeries {
+                ramification: e,
+                terms,
+                order: if exact { None } else { Some(prec_r.clone()) },
+            });
+        }
+    }
+    out
+}
+
+/// Lift the `w → 0` branches of `g(x, w) = 0` as series in `x`, to relative
+/// precision `prec`.  Returns `(terms, exact)` where `exact` marks a terminating
+/// branch (`w ≡ 0` after some point).
+fn lift(g: &Bi, prec: &Rational, depth: u32) -> Vec<(Vec<(Rational, Rational)>, bool)> {
+    const MAX_DEPTH: u32 = 64;
+    let mut g = g.clone();
+    g.retain(|_, a| *a != 0);
+    if g.is_empty() {
+        return vec![(Vec::new(), true)]; // g ≡ 0: w can be 0 (exact)
+    }
+    if depth > MAX_DEPTH {
+        return vec![(Vec::new(), false)];
+    }
+
+    let mut result: Vec<(Vec<(Rational, Rational)>, bool)> = Vec::new();
+
+    // Factor w^{m0}: w = 0 is an exact branch.
+    let m0 = g.keys().map(|(_, j)| *j).min().unwrap_or(0);
+    if m0 > 0 {
+        result.push((Vec::new(), true));
+        let shifted: Bi = g
+            .into_iter()
+            .map(|((xe, ye), a)| ((xe, ye - m0), a))
+            .collect();
+        g = shifted;
+    }
+
+    for (q, edge) in newton_edges(&g) {
+        if q <= 0 {
+            continue; // q ≤ 0 is not a w → 0 branch
+        }
+        // Characteristic polynomial φ(c) = Σ_{(i,j)∈edge} a_{ij} c^j.
+        let mut phi: BTreeMap<u32, Rational> = BTreeMap::new();
+        for ((_, j), a) in &edge {
+            *phi.entry(*j).or_insert_with(rzero) += a;
+        }
+        for c in rational_roots(&dense(&phi)) {
+            if c == 0 {
+                continue;
+            }
+            if prec.clone() - &q <= 0 {
+                result.push((vec![(q.clone(), c.clone())], false));
+                continue;
+            }
+            let g1 = substitute(&g, &q, &c);
+            for (sub, exact) in lift(&g1, &(prec.clone() - &q), depth + 1) {
+                let mut terms = vec![(q.clone(), c.clone())];
+                for (gamma, b) in sub {
+                    terms.push((q.clone() + &gamma, b));
+                }
+                result.push((terms, exact));
+            }
+        }
+    }
+    result
+}
+
+/// Edges `(q, monomials)` of the lower convex hull of the points `(j, i)` with
+/// **positive** `q = −slope` (the `w → 0` Newton-polygon edges).
+fn newton_edges(g: &Bi) -> Vec<Edge> {
+    // For each y-exponent j keep the minimal x-exponent i (lower envelope).
+    let mut lo: BTreeMap<u32, Rational> = BTreeMap::new();
+    for (xe, ye) in g.keys() {
+        lo.entry(*ye)
+            .and_modify(|m| {
+                if xe < m {
+                    *m = xe.clone();
+                }
+            })
+            .or_insert_with(|| xe.clone());
+    }
+    let pts: Vec<(u32, Rational)> = lo.into_iter().collect(); // ascending j
+    if pts.len() < 2 {
+        return Vec::new();
+    }
+    // Lower convex hull over points (j, i).
+    let mut hull: Vec<(u32, Rational)> = Vec::new();
+    for p in pts {
+        while hull.len() >= 2 {
+            let a = &hull[hull.len() - 2];
+            let b = &hull[hull.len() - 1];
+            // cross product of (b-a) × (p-b) ≤ 0 ⇒ b not on lower hull
+            let lhs = Rational::from(b.0 as i64 - a.0 as i64) * (p.1.clone() - &b.1);
+            let rhs = Rational::from(p.0 as i64 - b.0 as i64) * (b.1.clone() - &a.1);
+            if lhs - rhs <= 0 {
+                hull.pop();
+            } else {
+                break;
+            }
+        }
+        hull.push(p);
+    }
+    // Edges with negative slope (i decreasing as j increases) ⇒ q = −slope > 0.
+    let mut edges = Vec::new();
+    for w in hull.windows(2) {
+        let (j1, i1) = (&w[0].0, &w[0].1);
+        let (j2, i2) = (&w[1].0, &w[1].1);
+        let dj = Rational::from(*j2 as i64 - *j1 as i64);
+        let q = (i1.clone() - i2) / dj; // −slope
+        if q <= 0 {
+            continue;
+        }
+        // Monomials of g lying on this edge: i + q·j == i1 + q·j1.
+        let val = i1.clone() + q.clone() * Rational::from(*j1 as i64);
+        let mut monos = Vec::new();
+        for ((xe, ye), a) in g {
+            if xe.clone() + q.clone() * Rational::from(*ye as i64) == val {
+                monos.push(((xe.clone(), *ye), a.clone()));
+            }
+        }
+        edges.push((q, monos));
+    }
+    edges
+}
+
+/// Substitute `w = x^q (c + w₁)` into `g`, divide by `x^ν` (ν = min x-exponent),
+/// and return the polynomial in `(x, w₁)`.
+fn substitute(g: &Bi, q: &Rational, c: &Rational) -> Bi {
+    let mut g1: Bi = BTreeMap::new();
+    for ((xe, ye), a) in g {
+        let j = *ye;
+        let new_xe = xe.clone() + q.clone() * Rational::from(j as i64);
+        // (c + w₁)^j = Σ_l C(j,l) c^{j−l} w₁^l
+        for l in 0..=j {
+            let binom = Rational::from(binomial(j, l));
+            let cpow = rat_pow(c, j - l);
+            let coeff = a.clone() * &binom * &cpow;
+            if coeff != 0 {
+                *g1.entry((new_xe.clone(), l)).or_insert_with(rzero) += &coeff;
+            }
+        }
+    }
+    g1.retain(|_, a| *a != 0);
+    factor_min_x(&mut g1);
+    g1
+}
+
+/// Divide out the largest power `x^ν` (ν = minimal x-exponent).
+fn factor_min_x(g: &mut Bi) {
+    let Some(v) = g.keys().map(|(xe, _)| xe.clone()).min() else {
+        return;
+    };
+    if v == 0 {
+        return;
+    }
+    *g = std::mem::take(g)
+        .into_iter()
+        .map(|((xe, ye), a)| ((xe - &v, ye), a))
+        .collect();
+}
+
+/// `F(x, c₀ + w)` as a polynomial in `(x, w)`.
+fn shift_y(f: &Bi, c0: &Rational) -> Bi {
+    if *c0 == 0 {
+        return f.clone();
+    }
+    let mut g: Bi = BTreeMap::new();
+    for ((xe, ye), a) in f {
+        let j = *ye;
+        for l in 0..=j {
+            let binom = Rational::from(binomial(j, l));
+            let cpow = rat_pow(c0, j - l);
+            let coeff = a.clone() * &binom * &cpow;
+            if coeff != 0 {
+                *g.entry((xe.clone(), l)).or_insert_with(rzero) += &coeff;
+            }
+        }
+    }
+    g.retain(|_, a| *a != 0);
+    g
+}
+
+/// Dense coefficient vector (index = degree) from a sparse `degree → coeff` map.
+fn dense(m: &BTreeMap<u32, Rational>) -> Vec<Rational> {
+    let Some(&maxd) = m.keys().max() else {
+        return Vec::new();
+    };
+    let mut v = vec![rzero(); maxd as usize + 1];
+    for (d, c) in m {
+        v[*d as usize] = c.clone();
+    }
+    v
+}
+
+/// All distinct rational roots of `Σ p[k] c^k` (including `0`), via the rational
+/// root theorem.  Empty for the zero polynomial.
+fn rational_roots(p: &[Rational]) -> Vec<Rational> {
+    // Trim trailing zeros.
+    let mut hi = p.len();
+    while hi > 0 && p[hi - 1] == 0 {
+        hi -= 1;
+    }
+    let p = &p[..hi];
+    if p.is_empty() {
+        return Vec::new();
+    }
+    let mut roots = Vec::new();
+    // Factor out c^t (low-order zeros) ⇒ root 0.
+    let mut lo = 0usize;
+    while lo < p.len() && p[lo] == 0 {
+        lo += 1;
+    }
+    if lo > 0 {
+        roots.push(rzero());
+    }
+    let p = &p[lo..];
+    if p.len() <= 1 {
+        return roots; // constant (after factoring) — no further roots
+    }
+    // Clear denominators → integer coefficients.
+    let mut den_lcm = Integer::from(1);
+    for c in p {
+        den_lcm = den_lcm.lcm(c.denom());
+    }
+    let ints: Vec<Integer> = p
+        .iter()
+        .map(|c| {
+            (c.clone() * Rational::from(den_lcm.clone()))
+                .numer()
+                .clone()
+        })
+        .collect();
+    let a0 = ints[0].clone().abs();
+    let an = ints[ints.len() - 1].clone().abs();
+    let pdiv = divisors(&a0);
+    let qdiv = divisors(&an);
+    let mut seen: Vec<Rational> = Vec::new();
+    for pn in &pdiv {
+        for qn in &qdiv {
+            for sign in [1i32, -1] {
+                let cand = Rational::from((Integer::from(sign) * pn.clone(), qn.clone()));
+                if seen.contains(&cand) {
+                    continue;
+                }
+                if eval_int_poly(&ints, &cand) == 0 {
+                    seen.push(cand);
+                }
+            }
+        }
+    }
+    roots.extend(seen);
+    roots
+}
+
+fn eval_int_poly(coeffs: &[Integer], c: &Rational) -> Rational {
+    let mut acc = rzero();
+    for a in coeffs.iter().rev() {
+        acc = acc * c + Rational::from(a.clone());
+    }
+    acc
+}
+
+/// Positive divisors of `|n|` (with `n ≠ 0`); `{1}` for `n = 0`.
+fn divisors(n: &Integer) -> Vec<Integer> {
+    let n = n.clone().abs();
+    if n == 0 {
+        return vec![Integer::from(1)];
+    }
+    let mut ds = Vec::new();
+    let mut d = Integer::from(1);
+    while Integer::from(&d * &d) <= n {
+        if n.is_divisible(&d) {
+            ds.push(d.clone());
+            let other = n.clone() / &d;
+            if other != d {
+                ds.push(other);
+            }
+        }
+        d += 1;
+    }
+    ds
+}
+
+fn binomial(n: u32, k: u32) -> Integer {
+    if k > n {
+        return Integer::from(0);
+    }
+    let mut num = Integer::from(1);
+    for t in 0..k {
+        num *= Integer::from(n - t);
+    }
+    let mut den = Integer::from(1);
+    for t in 1..=k {
+        den *= Integer::from(t);
+    }
+    num / den
+}
+
+fn rat_pow(c: &Rational, e: u32) -> Rational {
+    let mut acc = Rational::from(1);
+    for _ in 0..e {
+        acc *= c;
+    }
+    acc
+}
+
+fn lcm_u64(a: u64, b: u64) -> u64 {
+    if a == 0 || b == 0 {
+        return 0;
+    }
+    a / gcd_u64(a, b) * b
+}
+
+fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(n: i64) -> Rational {
+        Rational::from(n)
+    }
+    fn rr(n: i64, d: i64) -> Rational {
+        Rational::from((n, d))
+    }
+
+    /// Find the branch whose leading (exponent, coeff) matches, for assertions.
+    fn has_term(s: &PuiseuxSeries, exp: Rational, coeff: Rational) -> bool {
+        s.terms.iter().any(|(e, c)| *e == exp && *c == coeff)
+    }
+
+    /// Back-substitution soundness check: every returned branch must satisfy
+    /// `F(x, y(x)) = O(x^prec)` numerically at a few small `x` samples.
+    fn verify_branches(f: &[(u32, u32, Rational)], prec: u32) {
+        let br = puiseux_at_zero(f, prec);
+        assert!(!br.is_empty(), "expected at least one branch");
+        for s in &br {
+            for &x0 in &[0.01_f64, 0.03, 0.07] {
+                // y(x0) = Σ c_k x0^{e_k}.
+                let y: f64 = s
+                    .terms
+                    .iter()
+                    .map(|(e, c)| c.to_f64() * x0.powf(e.to_f64()))
+                    .sum();
+                let fval: f64 = f
+                    .iter()
+                    .map(|(i, j, a)| a.to_f64() * x0.powi(*i as i32) * y.powi(*j as i32))
+                    .sum();
+                // F vanishes to order ~ prec along the branch.
+                let tol = 1e-6 + 50.0 * x0.powf(prec as f64);
+                assert!(
+                    fval.abs() < tol,
+                    "branch {s:?}: F({x0}, y)={fval} not O(x^{prec})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn back_substitution_soundness() {
+        verify_branches(&[(0, 2, r(1)), (1, 0, r(-1))], 4); // y²−x
+        verify_branches(&[(0, 2, r(1)), (3, 0, r(-1))], 5); // y²−x³
+        verify_branches(&[(0, 3, r(1)), (1, 0, r(-1))], 4); // y³−x
+        verify_branches(&[(0, 2, r(1)), (2, 0, r(-1)), (3, 0, r(-1))], 5); // y²−x²−x³
+        verify_branches(
+            &[(0, 2, r(1)), (1, 1, r(-2)), (2, 0, r(1)), (3, 0, r(-1))],
+            4,
+        ); // (y−x)²−x³
+    }
+
+    #[test]
+    fn sqrt_x() {
+        // y² − x = 0  ⇒  y = ± x^{1/2}.
+        let f = [(0, 2, r(1)), (1, 0, r(-1))];
+        let br = puiseux_at_zero(&f, 3);
+        assert_eq!(br.len(), 2);
+        for s in &br {
+            assert_eq!(s.ramification, 2);
+            assert!(has_term(s, rr(1, 2), r(1)) || has_term(s, rr(1, 2), r(-1)));
+        }
+    }
+
+    #[test]
+    fn cusp_y2_eq_x3() {
+        // y² − x³ = 0  ⇒  y = ± x^{3/2}.
+        let f = [(0, 2, r(1)), (3, 0, r(-1))];
+        let br = puiseux_at_zero(&f, 4);
+        assert_eq!(br.len(), 2);
+        for s in &br {
+            assert_eq!(s.ramification, 2);
+            assert!(has_term(s, rr(3, 2), r(1)) || has_term(s, rr(3, 2), r(-1)));
+        }
+    }
+
+    #[test]
+    fn cbrt_x_principal_branch() {
+        // y³ − x = 0: the only rational branch is y = x^{1/3} (others need ω).
+        let f = [(0, 3, r(1)), (1, 0, r(-1))];
+        let br = puiseux_at_zero(&f, 2);
+        assert_eq!(br.len(), 1);
+        assert_eq!(br[0].ramification, 3);
+        assert!(has_term(&br[0], rr(1, 3), r(1)));
+    }
+
+    #[test]
+    fn double_root_recursion() {
+        // (y − x)² − x³ = 0  ⇒  y = x ± x^{3/2}.  Characteristic at q=1 is (c−1)²
+        // (a double root), exercising the recursion.
+        // (y−x)² − x³ = y² − 2xy + x² − x³.
+        let f = [(0, 2, r(1)), (1, 1, r(-2)), (2, 0, r(1)), (3, 0, r(-1))];
+        let br = puiseux_at_zero(&f, 3);
+        assert_eq!(br.len(), 2, "branches: {br:?}");
+        for s in &br {
+            assert!(has_term(s, r(1), r(1)), "leading x term: {s:?}");
+            assert!(has_term(s, rr(3, 2), r(1)) || has_term(s, rr(3, 2), r(-1)));
+        }
+    }
+
+    #[test]
+    fn multi_term_taylor_branch() {
+        // y² − x²(1+x) = y² − x² − x³ = 0  ⇒  y = ± x·√(1+x)
+        //   = ±(x + x²/2 − x³/8 + …).  Ramification 1 (integer powers).
+        let f = [(0, 2, r(1)), (2, 0, r(-1)), (3, 0, r(-1))];
+        let br = puiseux_at_zero(&f, 4);
+        assert_eq!(br.len(), 2);
+        // The +branch: x + ½x² − ⅛x³.
+        let plus = br
+            .iter()
+            .find(|s| has_term(s, r(1), r(1)))
+            .expect("a +x branch");
+        assert_eq!(plus.ramification, 1);
+        assert!(has_term(plus, r(2), rr(1, 2)), "x² coeff ½: {plus:?}");
+        assert!(has_term(plus, r(3), rr(-1, 8)), "x³ coeff −⅛: {plus:?}");
+    }
+
+    #[test]
+    fn nonzero_constant_branch() {
+        // (y−1)(y−x) = y² − (1+x)y + x = 0 ⇒ branches y = 1 + … and y = x + ….
+        // y² − y − xy + x.
+        let f = [(0, 2, r(1)), (0, 1, r(-1)), (1, 1, r(-1)), (1, 0, r(1))];
+        let br = puiseux_at_zero(&f, 3);
+        // Expect a branch with constant term 1 and a branch with leading x.
+        assert!(br.iter().any(|s| has_term(s, r(0), r(1))));
+        assert!(br.iter().any(|s| has_term(s, r(1), r(1))));
+    }
+}


### PR DESCRIPTION
Advances the Risch/Trager algebraic-integration stack across milestones P1, M1, M2/MC0, and the M3 foundations (Newton–Puiseux, van Hoeij integral basis, Hermite-on-curve). 9 commits, all behind exact/verified soundness gates. 840 core tests pass; `cargo fmt`/`clippy` clean.

## What's new

**P1 — residue criterion** (`risch/tower_integrate.rs`)
Bronstein eq-16 NonElementary certifier for radical-over-transcendental integrands. Skips `pp_z` (a `z`-free unit in `K[z]`), reduces `R | κ(R)` to the pairwise Wronskian, and certifies only when symbolic+numeric *definitely* nonzero. e.g. `∫√(log x)/(log x−x) dx → NonElementary`.

**M1-step-2 — coupled algebraic Risch DE** (`risch/alg_rde.rs`, `risch/exp_case.rs`)
General (non-cyclic) `D(y)+f·y=g` over `ℚ(x)(α)` via ansatz + exact field verification; wired end-to-end for the compositum of two square roots `√p+√q` (degree-4). e.g. `∫[√x+√(x+1)+…]·eˣ = (√x+√(x+1))·eˣ`.

**M2 / MC0 — genus-0 parametrization** (`algebraic/parametrize.rs`)
Linear and linear-fractional (Möbius) radicands `((ax+b)/(cx+d))^{1/n}` reduced to rational integrals via `x(s)`. Fixes a prior wrong `NonElementary` for `∫∛x/(x+1)`.

**Newton–Puiseux** (`poly/puiseux.rs`)
Fractional-power local expansions of `F(x,y)=0`: rational branches, expansion at any rational base point, and algebraic-coefficient branches (factor the characteristic poly over ℚ, continue over `ℚ(θ)`). Verified incl. cusp/double-root recursion and `θ³=1` cube-roots of unity.

**van Hoeij integral basis** (`algebraic/integral_basis.rs`, `algebraic/vanhoeij.rs`)
- substrate: discriminant via the trace form, singular places, an **exact** integrality test (char-poly + Newton's identities), Trager's explicit radical basis.
- enlargement loop: builds a general integral basis (Puiseux linear system per singular place, gated by the exact `is_integral`). e.g. nodal cubic `y²=x³+x² → {1, y/x}`.

**Hermite-on-curve** (`algebraic/hermite_curve.rs`)
`∫f = g + ∫h` with `h` having only simple poles. For radicals the basis diagonalizes the derivation, so Hermite decouples into twisted scalar reductions (tutorial eq 12), correct at branch points. e.g. `∫y/x³` on `y²=x → −⅔y/x²`.

## Soundness
Every new result is gated: P1/M1/tower by exact field verification or numeric `d/dx F = f`; integral bases and Hermite by the exact char-polynomial integrality test and the exact `g'+h=f` identity. Incompleteness (e.g. algebraic singular places) yields `None`/skip, never a wrong answer.

## Scope / follow-ups
Documented in `temp-alkahest/planning/risch.md`: general (non-diagonal) Hermite, algebraic singular places in the van Hoeij loop, and the logarithmic part / genus-graded FIND-ORDER (MC) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)