### PR TITLE
feat(rl): symbolic integration RL environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 
+[project.optional-dependencies]
+# verifiers requires Python >=3.10; keep alkahest core installable on 3.9 without rl.
+rl = ["verifiers>=0.1.5; python_version>='3.10'", "datasets>=2.0"]
+rl-integration = ["verifiers>=0.1.5; python_version>='3.10'", "datasets>=2.0"]
+
 [project.urls]
 Homepage = "https://github.com/alkahest-cas/alkahest"
 Documentation = "https://alkahest-cas.github.io/alkahest/"

--- a/python/alkahest/rl/__init__.py
+++ b/python/alkahest/rl/__init__.py
@@ -1,0 +1,23 @@
+"""
+alkahest.rl — reinforcement-learning environments backed by the Alkahest CAS.
+
+The ``core`` subpackage is framework-agnostic (generators, verifiers, curriculum).
+Domain-specific environments live under ``envs`` and may depend on optional packages
+such as ``verifiers`` (Prime Intellect).
+"""
+
+from alkahest.rl.core import (
+    BaseGenerator,
+    BaseVerifier,
+    CurriculumScheduler,
+    Rubric,
+    RubricFn,
+)
+
+__all__ = [
+    "BaseGenerator",
+    "BaseVerifier",
+    "CurriculumScheduler",
+    "Rubric",
+    "RubricFn",
+]

--- a/python/alkahest/rl/core/__init__.py
+++ b/python/alkahest/rl/core/__init__.py
@@ -1,0 +1,12 @@
+from alkahest.rl.core.curriculum import CurriculumScheduler
+from alkahest.rl.core.generator import BaseGenerator
+from alkahest.rl.core.rubric import Rubric, RubricFn
+from alkahest.rl.core.verifier import BaseVerifier
+
+__all__ = [
+    "BaseGenerator",
+    "BaseVerifier",
+    "CurriculumScheduler",
+    "Rubric",
+    "RubricFn",
+]

--- a/python/alkahest/rl/core/curriculum.py
+++ b/python/alkahest/rl/core/curriculum.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+
+class CurriculumScheduler:
+    """Tracks per-tier pass rates and advances difficulty when ready.
+
+    Args:
+        n_tiers: Total number of difficulty tiers.
+        advance_threshold: Pass rate at current tier to trigger advancement.
+        window: Rolling window size for pass rate estimation.
+    """
+
+    def __init__(
+        self,
+        n_tiers: int,
+        advance_threshold: float = 0.70,
+        window: int = 256,
+    ) -> None:
+        self.n_tiers = n_tiers
+        self.advance_threshold = advance_threshold
+        self.window = window
+        self._current_tier = 0
+        self._history: list[float] = []
+
+    @property
+    def current_tier(self) -> int:
+        return self._current_tier
+
+    def record(self, reward: float) -> None:
+        self._history.append(float(reward > 0))
+        if len(self._history) > self.window:
+            self._history.pop(0)
+        if (
+            len(self._history) >= self.window // 2
+            and self._pass_rate() >= self.advance_threshold
+            and self._current_tier < self.n_tiers - 1
+        ):
+            self._current_tier += 1
+            self._history.clear()
+
+    def _pass_rate(self) -> float:
+        return sum(self._history) / len(self._history) if self._history else 0.0

--- a/python/alkahest/rl/core/generator.py
+++ b/python/alkahest/rl/core/generator.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseGenerator(ABC):
+    """Produces (prompt, metadata) pairs.
+
+    Never stores the reference answer in the returned dict — the verifier must
+    re-derive correctness.
+    """
+
+    @abstractmethod
+    def sample(self, difficulty: int, rng: Any) -> dict:
+        """Return a dict with at least ``{"prompt": str, "difficulty": int}``.
+
+        Domain-specific keys (e.g. ``"f_expr"``, ``"is_elementary"``) go here too,
+        but never a ``"reference_answer"`` key.
+        """
+        ...
+
+    def build_dataset(self, n: int, difficulty: int, seed: int = 0):
+        """Convenience: build a HuggingFace Dataset from *n* samples."""
+        import random
+
+        from datasets import Dataset
+
+        rng = random.Random(seed)
+        return Dataset.from_list([self.sample(difficulty, rng) for _ in range(n)])

--- a/python/alkahest/rl/core/rubric.py
+++ b/python/alkahest/rl/core/rubric.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+RubricFn = Callable[..., float]
+
+
+@dataclass
+class Rubric:
+    """Framework-agnostic set of reward functions with optional weights."""
+
+    funcs: list[RubricFn]
+    weights: list[float] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.weights:
+            self.weights = [1.0] * len(self.funcs)
+        if len(self.weights) != len(self.funcs):
+            msg = f"weights length {len(self.weights)} != funcs length {len(self.funcs)}"
+            raise ValueError(msg)
+
+    def score(self, **kwargs) -> float:
+        """Weighted sum of sync reward function outputs."""
+        total = 0.0
+        weight_sum = 0.0
+        for fn, w in zip(self.funcs, self.weights):
+            if w == 0.0:
+                continue
+            total += w * float(fn(**kwargs))
+            weight_sum += w
+        if weight_sum == 0.0:
+            return 0.0
+        return total / weight_sum

--- a/python/alkahest/rl/core/verifier.py
+++ b/python/alkahest/rl/core/verifier.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseVerifier(ABC):
+    """Checks a model completion against task metadata.
+
+    Never receives the reference answer — must re-derive correctness.
+    """
+
+    @abstractmethod
+    def verify(self, completion: str, metadata: dict) -> float:
+        """Return a scalar reward in [-1, 1]."""
+        ...

--- a/python/alkahest/rl/envs/__init__.py
+++ b/python/alkahest/rl/envs/__init__.py
@@ -1,0 +1,1 @@
+"""Domain-specific RL environments (optional ``verifiers`` dependency)."""

--- a/python/alkahest/rl/envs/integration/__init__.py
+++ b/python/alkahest/rl/envs/integration/__init__.py
@@ -1,0 +1,10 @@
+from alkahest.rl.envs.integration.env import load_environment
+from alkahest.rl.envs.integration.grammar import TIERS, random_elementary
+from alkahest.rl.envs.integration.verifier import IntegrationVerifier
+
+__all__ = [
+    "TIERS",
+    "IntegrationVerifier",
+    "load_environment",
+    "random_elementary",
+]

--- a/python/alkahest/rl/envs/integration/env.py
+++ b/python/alkahest/rl/envs/integration/env.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Any
+
+import alkahest as ak
+from alkahest.rl.core.curriculum import CurriculumScheduler
+from alkahest.rl.envs.integration.grammar import TIERS, random_elementary
+from alkahest.rl.envs.integration.verifier import IntegrationVerifier
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+
+try:
+    import verifiers as vf
+except ImportError:  # pragma: no cover - optional dependency
+    vf = None  # type: ignore[assignment]
+
+SYSTEM_PROMPT = """\
+You are a symbolic integration assistant. Given an integrand f(x), find an \
+antiderivative F(x) such that dF/dx = f(x). Write only the antiderivative, no \
+constant of integration. If no elementary antiderivative exists, write exactly: \
+"no elementary form"."""
+
+N_TIERS = len(TIERS)
+
+
+def load_environment(
+    difficulty_tier: int = 0,
+    hard_negative_fraction: float = 0.25,
+    n_train: int = 50_000,
+    n_eval: int = 2_000,
+    seed: int = 42,
+    adaptive: bool = True,
+) -> Any:
+    """Prime Intellect ``verifiers``-compatible entry point.
+
+    Args:
+        difficulty_tier: Starting Risch tier (0 = rational functions).
+        hard_negative_fraction: Fraction of samples certified NonElementary.
+        n_train / n_eval: Dataset sizes.
+        seed: RNG seed for reproducibility.
+        adaptive: Attach a :class:`CurriculumScheduler` on ``env.curriculum``.
+    """
+    if vf is None:
+        msg = (
+            "verifiers is not installed. Install with: pip install 'alkahest[rl]' "
+            "or pip install verifiers datasets"
+        )
+        raise ImportError(msg)
+
+    train_ds = build_dataset(difficulty_tier, hard_negative_fraction, n_train, seed)
+    eval_ds = build_dataset(difficulty_tier, hard_negative_fraction, n_eval, seed + 1)
+
+    verifier = IntegrationVerifier()
+
+    async def reward_fn(completion, f_str, is_elementary, **_) -> float:
+        pool = ak.ExprPool()
+        x = pool.symbol("x")
+        f_expr = ak.parse(f_str, pool, {"x": x})
+        return verifier.verify(
+            completion[-1]["content"],
+            {"f_expr": f_expr, "is_elementary": is_elementary, "pool": pool},
+        )
+
+    rubric = vf.Rubric(funcs=[reward_fn])
+
+    env = vf.SingleTurnEnv(
+        dataset=train_ds,
+        eval_dataset=eval_ds,
+        rubric=rubric,
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    if adaptive:
+        env.curriculum = CurriculumScheduler(n_tiers=N_TIERS)
+
+    return env
+
+
+def build_dataset(tier: int, neg_frac: float, n: int, seed: int) -> Dataset:
+    """Build a HuggingFace dataset of integration tasks."""
+    from datasets import Dataset
+
+    rng = random.Random(seed)
+    rows = [_make_row(tier, rng.random() < neg_frac, rng) for _ in range(n)]
+    return Dataset.from_list(rows)
+
+
+def _make_row(tier: int, nonelementary: bool, rng: random.Random) -> dict:
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    if nonelementary:
+        ne_forms = [
+            ak.exp(x * x),
+            ak.sin(x) / x,
+            ak.exp(x) / x,
+            ak.log(ak.log(x + pool.integer(2))),
+        ]
+        f = rng.choice(ne_forms)
+        return {
+            "prompt": [{"role": "user", "content": f"Find ∫ {ak.unicode_str(f)} dx"}],
+            "f_str": str(f),
+            "is_elementary": False,
+            "tier": tier,
+        }
+
+    f_antideriv = random_elementary(pool, tier, rng)
+    f_result = ak.diff(f_antideriv, x)
+    f = ak.simplify(f_result.value).value
+    return {
+        "prompt": [{"role": "user", "content": f"Find ∫ {ak.unicode_str(f)} dx"}],
+        "f_str": str(f),
+        "is_elementary": True,
+        "tier": tier,
+    }

--- a/python/alkahest/rl/envs/integration/grammar.py
+++ b/python/alkahest/rl/envs/integration/grammar.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from random import Random
+from typing import TYPE_CHECKING
 
 import alkahest as ak
 from alkahest import Expr, ExprPool
+
+if TYPE_CHECKING:
+    from random import Random
 
 TIERS = {
     0: "rational",

--- a/python/alkahest/rl/envs/integration/grammar.py
+++ b/python/alkahest/rl/envs/integration/grammar.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from random import Random
+
+import alkahest as ak
+from alkahest import Expr, ExprPool
+
+TIERS = {
+    0: "rational",
+    1: "exp_log",
+    2: "algebraic_coeff",
+    3: "rational_exp",
+    4: "nested_tower",
+}
+
+
+def random_elementary(pool: ExprPool, tier: int, rng: Random) -> Expr:
+    """Build a random antiderivative *F* at the given Risch tier.
+
+    The caller computes ``f = diff(F, x)`` to obtain the integrand.
+    """
+    x = pool.symbol("x")
+    if tier == 0:
+        return _rational(pool, x, rng)
+    if tier == 1:
+        return _exp_log(pool, x, rng)
+    if tier == 2:
+        return _algebraic_coeff(pool, x, rng)
+    raise NotImplementedError(f"Tier {tier} grammar not yet implemented")
+
+
+def _rational(pool: ExprPool, x: Expr, rng: Random) -> Expr:
+    """Random polynomial in *x* with small integer coefficients."""
+    degree = rng.randint(1, 4)
+    terms: list[Expr] = []
+    zero = pool.integer(0)
+    for i in range(degree + 1):
+        c = pool.integer(rng.randint(-3, 3))
+        if c == zero:
+            continue
+        terms.append(c * x ** pool.integer(i))
+    if not terms:
+        return x
+    out = terms[0]
+    for t in terms[1:]:
+        out = out + t
+    return out
+
+
+def _exp_log(pool: ExprPool, x: Expr, rng: Random) -> Expr:
+    inner = _rational(pool, x, rng)
+    choice = rng.choice(["exp", "log", "product"])
+    if choice == "exp":
+        return ak.exp(inner)
+    if choice == "log":
+        # Keep the logarithm argument positive on a typical evaluation domain.
+        arg = ak.simplify(inner * inner + pool.integer(1)).value
+        return ak.log(arg)
+    return _rational(pool, x, rng) * ak.exp(inner)
+
+
+def _algebraic_coeff(pool: ExprPool, x: Expr, rng: Random) -> Expr:
+    d = rng.choice([2, 3, 5, 7])
+    sqrt_d = pool.integer(d) ** (pool.integer(1) / pool.integer(2))
+    return sqrt_d * _rational(pool, x, rng) + _exp_log(pool, x, rng)

--- a/python/alkahest/rl/envs/integration/pyproject.toml
+++ b/python/alkahest/rl/envs/integration/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "alkahest-symbolic-integration"
+version = "0.1.0"
+description = "Symbolic integration RL environment backed by the Risch algorithm"
+dependencies = [
+    "verifiers>=0.1",
+    "alkahest>=2.1",
+    "datasets>=2.0",
+]
+
+[tool.verifiers]
+tags = ["math", "reasoning", "single-turn", "train", "eval", "symbolic"]
+entrypoint = "alkahest.rl.envs.integration.env:load_environment"

--- a/python/alkahest/rl/envs/integration/verifier.py
+++ b/python/alkahest/rl/envs/integration/verifier.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import alkahest as ak
+from alkahest.rl.core.verifier import BaseVerifier
+
+if TYPE_CHECKING:
+    from alkahest import Expr, ExprPool
+
+_N_SPOT_CHECKS = 8
+_SPOT_PRIMES = [3, 5, 7, 11, 13, 17, 19, 23]
+
+
+class IntegrationVerifier(BaseVerifier):
+    def verify(self, completion: str, metadata: dict) -> float:
+        is_elementary: bool = metadata["is_elementary"]
+        f_expr: Expr = metadata["f_expr"]
+        pool: ExprPool = metadata["pool"]
+        x = pool.symbol("x")
+
+        declined = _model_declined(completion)
+
+        if not is_elementary:
+            if declined:
+                return 1.0
+            reward = _verify_antiderivative(completion, f_expr, pool, x)
+            return reward if reward > 0 else -0.5
+
+        if declined:
+            return -0.2
+
+        return _verify_antiderivative(completion, f_expr, pool, x)
+
+
+def _verify_antiderivative(
+    completion: str,
+    f: Expr,
+    pool: ExprPool,
+    x: Expr,
+) -> float:
+    try:
+        candidate = ak.parse(completion, pool, {"x": x})
+    except Exception:
+        return 0.0
+
+    try:
+        diff_c = ak.diff(candidate, x)
+        residual = ak.simplify(ak.simplify(diff_c.value).value - f).value
+        if _is_zero(residual):
+            return 1.0
+
+        if _is_constant(residual, x, pool):
+            return 1.0
+
+        try:
+            residual2 = ak.simplify_egraph(residual)
+            if _is_zero(residual2):
+                return 1.0
+        except (AttributeError, Exception):
+            pass
+
+        hits = 0
+        for p in _SPOT_PRIMES[:_N_SPOT_CHECKS]:
+            try:
+                pt = {x: ak.ArbBall(p / (p + 1), 1e-30)}
+                ball = ak.interval_eval(residual, pt)
+                if _ball_contains_zero(ball):
+                    hits += 1
+            except Exception:
+                pass
+        if hits == _N_SPOT_CHECKS:
+            return 0.9
+
+    except Exception:
+        pass
+
+    return 0.0
+
+
+def _is_zero(expr: Expr) -> bool:
+    s = str(expr).strip()
+    return s in ("0", "0/1", "")
+
+
+def _is_constant(expr: Expr, x: Expr, pool: ExprPool) -> bool:
+    """Check ``diff(expr, x) == 0`` symbolically."""
+    try:
+        d = ak.diff(expr, x)
+        return _is_zero(ak.simplify(d.value).value)
+    except Exception:
+        return False
+
+
+def _ball_contains_zero(ball) -> bool:
+    try:
+        lo, hi = float(ball.lo), float(ball.hi)
+        return lo <= 0.0 <= hi
+    except Exception:
+        return False
+
+
+def _model_declined(text: str) -> bool:
+    markers = [
+        "no elementary",
+        "nonelementary",
+        "non-elementary",
+        "cannot be expressed",
+        "no closed form",
+    ]
+    t = text.lower()
+    return any(m in t for m in markers)

--- a/recipes/verl_integration_reward.py
+++ b/recipes/verl_integration_reward.py
@@ -1,0 +1,10 @@
+"""Drop-in reward function for veRL's custom reward interface."""
+
+from alkahest.rl.envs.integration.verifier import IntegrationVerifier
+
+_V = IntegrationVerifier()
+
+
+def compute_score(solution_str: str, ground_truth: dict) -> float:
+    """Score a model solution against integration task metadata."""
+    return _V.verify(solution_str, ground_truth)

--- a/tests/test_alkahest_rl.py
+++ b/tests/test_alkahest_rl.py
@@ -1,0 +1,123 @@
+"""Tests for alkahest.rl (core + integration verifier; verifiers env optional)."""
+
+from __future__ import annotations
+
+import random
+
+import alkahest as ak
+import pytest
+from alkahest import ExprPool, diff, simplify, unicode_str
+from alkahest.rl.core.curriculum import CurriculumScheduler
+from alkahest.rl.core.rubric import Rubric
+from alkahest.rl.envs.integration.env import _make_row, build_dataset
+from alkahest.rl.envs.integration.grammar import random_elementary
+from alkahest.rl.envs.integration.verifier import IntegrationVerifier, _model_declined
+
+
+class TestCurriculumScheduler:
+    def test_starts_at_tier_zero(self):
+        c = CurriculumScheduler(n_tiers=3)
+        assert c.current_tier == 0
+
+    def test_advances_on_high_pass_rate(self):
+        c = CurriculumScheduler(n_tiers=3, advance_threshold=0.7, window=8)
+        for _ in range(4):
+            c.record(1.0)
+        assert c.current_tier == 1
+
+
+class TestIntegrationGrammar:
+    def test_tier_zero_produces_diffable_expr(self):
+        pool = ExprPool()
+        rng = random.Random(0)
+        f_antideriv = random_elementary(pool, 0, rng)
+        x = pool.symbol("x")
+        f = simplify(diff(f_antideriv, x).value).value
+        assert f is not None
+        assert len(unicode_str(f)) > 0
+
+
+class TestIntegrationVerifier:
+    def test_correct_polynomial_antiderivative(self):
+        pool = ExprPool()
+        x = pool.symbol("x")
+        f = pool.integer(2) * x
+        verifier = IntegrationVerifier()
+        reward = verifier.verify(
+            "x^2",
+            {"f_expr": f, "is_elementary": True, "pool": pool},
+        )
+        assert reward == 1.0
+
+    def test_decline_nonelementary(self):
+        pool = ExprPool()
+        x = pool.symbol("x")
+        f = ak.exp(x * x)
+        verifier = IntegrationVerifier()
+        reward = verifier.verify(
+            "no elementary form",
+            {"f_expr": f, "is_elementary": False, "pool": pool},
+        )
+        assert reward == 1.0
+
+    def test_unnecessary_decline_on_elementary(self):
+        pool = ExprPool()
+        x = pool.symbol("x")
+        f = pool.integer(2) * x
+        verifier = IntegrationVerifier()
+        reward = verifier.verify(
+            "no elementary form",
+            {"f_expr": f, "is_elementary": True, "pool": pool},
+        )
+        assert reward == pytest.approx(-0.2)
+
+
+class TestModelDeclined:
+    def test_detects_markers(self):
+        assert _model_declined("This has no elementary closed form.")
+        assert not _model_declined("x^2 + 1")
+
+
+class TestBuildDataset:
+    def test_small_dataset_has_expected_keys(self):
+        pytest.importorskip("datasets")
+        ds = build_dataset(tier=0, neg_frac=0.0, n=3, seed=1)
+        row = ds[0]
+        assert "prompt" in row
+        assert "f_str" in row
+        assert row["is_elementary"] is True
+
+    def test_make_row_elementary(self):
+        rng = random.Random(7)
+        row = _make_row(0, False, rng)
+        assert row["is_elementary"] is True
+        assert row["tier"] == 0
+        assert "f_str" in row
+
+
+class TestRubric:
+    def test_weighted_score(self):
+        def r_a(**_):
+            return 1.0
+
+        def r_b(**_):
+            return 0.0
+
+        rubric = Rubric(funcs=[r_a, r_b], weights=[1.0, 1.0])
+        assert rubric.score() == 0.5
+
+
+def test_load_environment_smoke():
+    pytest.importorskip("verifiers")
+    from alkahest.rl.envs.integration.env import load_environment
+
+    env = load_environment(
+        difficulty_tier=0,
+        n_train=4,
+        n_eval=2,
+        hard_negative_fraction=0.0,
+        adaptive=True,
+    )
+    assert env is not None
+    assert hasattr(env, "curriculum")
+    assert env.curriculum.n_tiers == 5


### PR DESCRIPTION
## Summary

- Add `python/alkahest/rl/` per the alkahest-rl design: framework-agnostic `core` (generators, verifiers, rubric, curriculum) and `envs/integration` (Risch-tier grammar, layered `IntegrationVerifier`, Prime Intellect `verifiers` entry point).
- Dataset rows store serializable `f_str` (parseable integrand strings) for HuggingFace / Arrow compatibility; the reward function reconstructs `Expr` objects at scoring time.
- Optional extras: `pip install "alkahest[rl]"` (Python ≥3.10, pulls `verifiers` + `datasets`); Hub metadata in `envs/integration/pyproject.toml`; veRL recipe at `recipes/verl_integration_reward.py`.

## Test plan

- [x] `pytest tests/test_alkahest_rl.py` (10 passed; `test_load_environment_smoke` skips without `verifiers`)
- [x] `ruff check python/alkahest/rl/ tests/test_alkahest_rl.py recipes/`
- [ ] CI tier-1 (full workspace)


Made with [Cursor](https://cursor.com)