### PR TITLE
docs(rl): RL guide, README, and Environments Hub manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ A high-performance computer algebra system for Python built for both humans and 
 pip install alkahest
 ```
 
+**RL environments** (symbolic integration tasks for Prime Intellect / veRL): Python **≥ 3.10** required.
+
+```bash
+pip install "alkahest[rl]"
+```
+
+See [Reinforcement learning](#reinforcement-learning) and the [RL guide](docs/mdbook/src/rl.md).
+
 For an isolated environment (recommended when juggling versions or building from source):
 
 ```bash
@@ -592,6 +600,37 @@ Every top-level operation returns a `DerivedResult` with:
 - `.value` — the result expression
 - `.steps` — derivation log (list of rewrite rules applied)
 - `.certificate` — Lean 4 proof term, when available
+
+---
+
+## Reinforcement learning
+
+`alkahest.rl` exposes **verifiable RL environments** backed by the CAS. The core layer
+(`alkahest.rl.core`) is trainer-agnostic; domain environments live under
+`alkahest.rl.envs.*` and optionally integrate with [Prime Intellect Verifiers](https://github.com/PrimeIntellect-ai/verifiers).
+
+```bash
+pip install "alkahest[rl]"   # Python ≥ 3.10; adds verifiers + datasets
+```
+
+```python
+from alkahest.rl.envs.integration import IntegrationVerifier, load_environment
+
+verifier = IntegrationVerifier()
+# reward = verifier.verify(model_output, {"f_expr": f, "is_elementary": True, "pool": pool})
+
+env = load_environment(difficulty_tier=0, n_train=1000, n_eval=100, adaptive=True)
+```
+
+| Component | Description |
+|-----------|-------------|
+| `IntegrationVerifier` | Layered check: symbolic diff → e-graph → interval spot checks; rewards honest refusal on NonElementary integrands |
+| `load_environment()` | Returns a `verifiers.SingleTurnEnv` with Risch-tier curriculum |
+| `recipes/verl_integration_reward.py` | Drop-in reward for [veRL](https://github.com/volcengine/verl) |
+
+**Environments Hub:** after merging and a PyPI release, publish from
+`python/alkahest/rl/envs/integration/` with `prime env push`. Full checklist in the
+[RL guide](docs/mdbook/src/rl.md#hub-checklist).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -628,8 +628,8 @@ env = load_environment(difficulty_tier=0, n_train=1000, n_eval=100, adaptive=Tru
 | `load_environment()` | Returns a `verifiers.SingleTurnEnv` with Risch-tier curriculum |
 | `recipes/verl_integration_reward.py` | Drop-in reward for [veRL](https://github.com/volcengine/verl) |
 
-**Environments Hub:** after merging and a PyPI release, publish from
-`python/alkahest/rl/envs/integration/` with `prime env push`. Full checklist in the
+**Environments Hub:** publish from `python/alkahest/rl/envs/integration/` with
+`prime env push` (requires `alkahest>=3.2.0` on PyPI). Full checklist in the
 [RL guide](docs/mdbook/src/rl.md#hub-checklist).
 
 ---

--- a/docs/features.md
+++ b/docs/features.md
@@ -174,6 +174,18 @@ Current stable feature surface.
 - Nightly CI runs with `--competitors` flag
 - Agent benchmark suite: 17 tasks across 6 categories comparing alkahest, SymPy, and Mathematica skill guides
 
+## Reinforcement learning (`alkahest.rl`)
+
+Optional Python extra: `pip install "alkahest[rl]"` (Python ≥ 3.10; pulls `verifiers` + `datasets`).
+
+- **Core** (`alkahest.rl.core`): `BaseGenerator`, `BaseVerifier`, `Rubric`, `CurriculumScheduler` — framework-agnostic
+- **Integration env** (`alkahest.rl.envs.integration`): Risch-tier task grammar, layered `IntegrationVerifier` (simplify → e-graph → interval spot checks), Prime Intellect `load_environment()` entry point
+- Hard-negative NonElementary samples train honest refusal; curriculum scheduler advances tiers on pass rate
+- veRL recipe: `recipes/verl_integration_reward.py`
+- Environments Hub manifest: `python/alkahest/rl/envs/integration/` (`prime env push`)
+
+See the [RL guide](./mdbook/src/rl.md) for install, API, and Hub publishing steps.
+
 ## Planned
 
 - AMD ROCm / `amdgcn` GPU codegen (hardware-blocked)

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [ODE and DAE modeling](./ode-dae.md)
 - [Polynomial system solving](./solving.md)
 - [Interoperability](./interop.md)
+- [Reinforcement learning](./rl.md)
 - [Derivation logs](./derivations.md)
 - [Lean certificates](./lean-certs.md)
 - [Error handling](./errors.md)

--- a/docs/mdbook/src/getting-started.md
+++ b/docs/mdbook/src/getting-started.md
@@ -51,6 +51,19 @@ macOS and Windows `+jit` / `+full` wheels are **not** produced in CI yet; use [b
 
 **Roadmap:** a small PEP 503 **extras index** URL hosting only `+jit` / `+full` wheels (PyTorch-style `--extra-index-url`). Until then, use PyPI for the default wheel or direct URLs / asset downloads from Releases.
 
+### Optional: RL environments (`alkahest[rl]`)
+
+Reinforcement-learning environments (symbolic integration, Prime Intellect Hub) are an
+optional extra. Requires **Python ≥ 3.10** (`verifiers` does not support 3.9).
+
+```bash
+pip install "alkahest[rl]"
+```
+
+This adds `verifiers` and `datasets`. Environment code ships in the main wheel under
+`alkahest.rl`. See the [RL guide](./rl.md) for API details, veRL integration, and
+[Environments Hub publishing](./rl.md#hub-checklist).
+
 ### From source
 
 For optional Cargo features (`jit`, `parallel`, `cuda`, …), GPU/NVPTX, or development, build the PyO3 extension with [maturin](https://github.com/PyO3/maturin). The `groebner` and `egraph` features are default and included automatically.

--- a/docs/mdbook/src/intro.md
+++ b/docs/mdbook/src/intro.md
@@ -2,7 +2,7 @@
 
 Alkahest is a high-performance computer algebra system with a Rust core and Python API.
 
-**Install:** `pip install alkahest` from [PyPI](https://pypi.org/project/alkahest/) (**Python 3.9–3.13**). Default wheels include vendored egglog (`egraph`) and the Gröbner solver (`groebner`) — `alkahest.solve` and related APIs work out of the box. LLVM JIT, Cranelift, and `parallel` are omitted; Linux **`linux_x86_64`** **`+jit`** / **`+full`** wheels (JIT and parallel) ship on [GitHub Releases](https://github.com/alkahest-cas/alkahest/releases). The [Getting started](./getting-started.md) chapter has full install notes (venv, `LD_LIBRARY_PATH`, building from source).
+**Install:** `pip install alkahest` from [PyPI](https://pypi.org/project/alkahest/) (**Python 3.9–3.13**). Optional RL environments: `pip install "alkahest[rl]"` (**Python ≥ 3.10**). Default wheels include vendored egglog (`egraph`) and the Gröbner solver (`groebner`) — `alkahest.solve` and related APIs work out of the box. LLVM JIT, Cranelift, and `parallel` are omitted; Linux **`linux_x86_64`** **`+jit`** / **`+full`** wheels (JIT and parallel) ship on [GitHub Releases](https://github.com/alkahest-cas/alkahest/releases). The [Getting started](./getting-started.md) chapter has full install notes (venv, `LD_LIBRARY_PATH`, building from source). See [Reinforcement learning](./rl.md) for verifiable RL environments.
 
 ## What it is
 

--- a/docs/mdbook/src/rl.md
+++ b/docs/mdbook/src/rl.md
@@ -132,9 +132,9 @@ prime eval run alkahest-cas/symbolic-integration -m <model>
 
 ### Hub checklist
 
-1. **Merge and release Alkahest on PyPI** — the Hub package depends on
-   `alkahest>=…` containing `alkahest.rl`. Until that release ships, install from
-   source or a dev wheel when testing locally.
+1. **Alkahest on PyPI** — the Hub package depends on `alkahest>=3.2.0` (includes
+   `alkahest.rl`). For local development before PyPI catches up, use `maturin develop`
+   or a release wheel from GitHub.
 
 2. **Install the Prime CLI** and log in:
    ```bash

--- a/docs/mdbook/src/rl.md
+++ b/docs/mdbook/src/rl.md
@@ -1,0 +1,175 @@
+# Reinforcement learning environments
+
+`alkahest.rl` turns the Alkahest CAS into **verifiable RL environments**: generators
+produce tasks, verifiers re-derive correctness (never storing reference answers in
+dataset rows), and optional curriculum schedulers advance Risch difficulty tiers.
+
+The package has two layers:
+
+| Layer | Path | Dependencies |
+|-------|------|--------------|
+| **Core** | `alkahest.rl.core` | Alkahest only — usable from veRL, TRL, OpenRLHF, custom loops |
+| **Environments** | `alkahest.rl.envs.*` | Core + optional [`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) (Prime Intellect) |
+
+## Install
+
+The RL stack is an **optional extra** on the main PyPI package. It requires **Python
+≥ 3.10** because `verifiers` does not support 3.9.
+
+```bash
+pip install "alkahest[rl]"
+```
+
+This pulls `verifiers` and `datasets`. The integration environment itself ships
+inside the `alkahest` wheel — no separate install is required for local use.
+
+From source (development):
+
+```bash
+maturin develop --manifest-path alkahest-py/Cargo.toml --release --features egraph
+pip install "verifiers>=0.1.5" datasets
+```
+
+Build with the `egraph` feature when possible: the integration verifier uses
+e-graph simplification as its second verification layer and falls back gracefully
+when it is unavailable.
+
+## Quick start — symbolic integration
+
+```python
+from alkahest.rl.envs.integration import IntegrationVerifier, load_environment
+
+# Standalone verifier (any trainer)
+verifier = IntegrationVerifier()
+reward = verifier.verify(
+    "x^2",
+    {"f_expr": pool_expr, "is_elementary": True, "pool": pool},
+)
+
+# Prime Intellect verifiers environment (after pip install "alkahest[rl]")
+env = load_environment(
+    difficulty_tier=0,
+    n_train=1000,
+    n_eval=100,
+    hard_negative_fraction=0.25,
+    adaptive=True,
+)
+# env.curriculum.record(reward)  # inside your training loop
+```
+
+Dataset rows store a parseable **`f_str`** integrand (not live `Expr` objects) so
+HuggingFace / Arrow serialization works. The async reward function reconstructs
+expressions at scoring time.
+
+### Risch tiers
+
+| Tier | Grammar | Status |
+|------|---------|--------|
+| 0 | Rational polynomials | Implemented |
+| 1 | exp / log towers | Implemented |
+| 2 | ℚ(√d) coefficients | Implemented |
+| 3 | Rational exponents | Planned |
+| 4 | Nested towers | Planned |
+
+Hard negatives (`hard_negative_fraction`) inject integrands certified
+**NonElementary** (e.g. `exp(x²)`, `sin(x)/x`) so models learn to refuse honestly.
+
+## Core API
+
+### `BaseGenerator`
+
+Produces `(prompt, metadata)` dicts. **Never** include a `reference_answer` key.
+
+### `BaseVerifier`
+
+```python
+def verify(self, completion: str, metadata: dict) -> float:
+    """Return reward in [-1, 1]."""
+```
+
+### `CurriculumScheduler`
+
+Tracks rolling pass rate at the current tier; advances when `advance_threshold`
+(default 0.70) is met over a sliding window (default 256 rewards).
+
+### `Rubric`
+
+Framework-agnostic weighted reward functions (`Rubric.score(**kwargs)`). Prime
+Intellect's `vf.Rubric` is used inside `load_environment()` for Hub compatibility.
+
+## veRL adapter
+
+```python
+from recipes.verl_integration_reward import compute_score
+
+# ground_truth = row dict from the integration dataset builder
+score = compute_score(solution_str, ground_truth)
+```
+
+Pass `compute_score` to veRL's `reward_fn` config. The `ground_truth` dict should
+include at least `f_str`, `is_elementary`, and fields the verifier expects after
+reconstruction (see `IntegrationVerifier.verify`).
+
+## Adding a new domain
+
+1. Create `python/alkahest/rl/envs/<domain>/` mirroring `integration/`.
+2. Subclass `BaseGenerator` — emit unsolved tasks + metadata, no reference answer.
+3. Subclass `BaseVerifier` — check the model output with Alkahest primitives.
+4. Add `load_environment()` returning `vf.SingleTurnEnv` (optional `verifiers` import).
+5. Add a Hub `pyproject.toml` + `README.md` if publishing independently.
+
+## Publishing to the Prime Intellect Environments Hub
+
+The integration environment includes Hub metadata at
+`python/alkahest/rl/envs/integration/`. See [Hub checklist](#hub-checklist) below.
+
+After install, users run:
+
+```bash
+prime env install alkahest-cas/symbolic-integration   # org/name after publish
+prime eval run alkahest-cas/symbolic-integration -m <model>
+```
+
+### Hub checklist
+
+1. **Merge and release Alkahest on PyPI** — the Hub package depends on
+   `alkahest>=…` containing `alkahest.rl`. Until that release ships, install from
+   source or a dev wheel when testing locally.
+
+2. **Install the Prime CLI** and log in:
+   ```bash
+   uv tool install prime
+   prime login
+   ```
+
+3. **Smoke-test locally** from the Hub package directory:
+   ```bash
+   cd python/alkahest/rl/envs/integration
+   pip install -e .                    # pulls verifiers + alkahest + datasets
+   python -c "from alkahest.rl.envs.integration.env import load_environment; load_environment(n_train=4, n_eval=2)"
+   ```
+
+4. **Push to the Hub** (from the same directory):
+   ```bash
+   prime env push
+   # or: prime env push --team alkahest-cas --auto-bump
+   ```
+   Hub CI validates the package, `load_environment()` entrypoint, and dependencies.
+
+5. **Run a Hub eval** against a hosted model:
+   ```bash
+   prime eval run alkahest-cas/symbolic-integration -m gpt-4.1-mini
+   ```
+
+6. **Iterate** — bump `version` in `pyproject.toml` (or use `--auto-bump`) for each
+   publish; tag releases in git when verifier tiers or reward logic change.
+
+### Monorepo note
+
+Implementation code lives in the main `alkahest` package; the Hub directory is a
+**thin installable manifest** that pins dependencies and declares the
+`[tool.verifiers]` entrypoint. This avoids duplicating environment code while still
+letting `prime env install` resolve everything from PyPI.
+
+Further reading: [Prime Intellect — Create & Upload Environment](https://docs.primeintellect.ai/tutorials-environments/create),
+[Verifiers Environments Hub](https://primeintellect-ai-verifiers.mintlify.app/integrations/environments-hub).

--- a/python/alkahest/rl/envs/integration/README.md
+++ b/python/alkahest/rl/envs/integration/README.md
@@ -1,0 +1,67 @@
+# alkahest-symbolic-integration
+
+Symbolic integration RL environment backed by Alkahest's Risch integrator.
+
+Models receive an integrand `f(x)` and must return an elementary antiderivative
+`F(x)` with `dF/dx = f`, or the exact phrase **"no elementary form"** when Risch
+certifies non-elementarity.
+
+## Install
+
+Requires **Python ≥ 3.10**.
+
+```bash
+pip install alkahest-symbolic-integration
+```
+
+This installs `alkahest`, `verifiers`, and `datasets`.
+
+## Usage
+
+```python
+from alkahest.rl.envs.integration.env import load_environment
+
+env = load_environment(
+    difficulty_tier=0,
+    n_train=50_000,
+    n_eval=2_000,
+    hard_negative_fraction=0.25,
+    adaptive=True,
+)
+
+# Prime Intellect CLI
+# prime eval run alkahest-cas/symbolic-integration -m <model>
+```
+
+## Configuration
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `difficulty_tier` | `0` | Starting Risch grammar tier (0 = rationals) |
+| `hard_negative_fraction` | `0.25` | Fraction of NonElementary integrands |
+| `n_train` / `n_eval` | `50_000` / `2_000` | Dataset sizes |
+| `seed` | `42` | RNG seed |
+| `adaptive` | `True` | Attach `CurriculumScheduler` on `env.curriculum` |
+
+## Reward
+
+`IntegrationVerifier` scores completions in `[-1, 1]`:
+
+- **+1.0** — correct antiderivative (symbolic diff check, optional e-graph, interval spot checks)
+- **+0.9** — numerically consistent but not symbolically confirmed
+- **+1.0** — honest refusal on a NonElementary integrand
+- **−0.2** — unnecessary refusal on an elementary integrand
+- **−0.5** — hallucinated antiderivative on NonElementary
+- **0.0** — unparseable or wrong
+
+## Development
+
+Source code lives in the main [Alkahest](https://github.com/alkahest-cas/alkahest)
+repository under `python/alkahest/rl/`. This directory is the **Environments Hub**
+publish root.
+
+```bash
+cd python/alkahest/rl/envs/integration
+pip install -e .
+prime env push --auto-bump
+```

--- a/python/alkahest/rl/envs/integration/pyproject.toml
+++ b/python/alkahest/rl/envs/integration/pyproject.toml
@@ -2,12 +2,25 @@
 name = "alkahest-symbolic-integration"
 version = "0.1.0"
 description = "Symbolic integration RL environment backed by the Risch algorithm"
+readme = "README.md"
+requires-python = ">=3.10"
 dependencies = [
     "verifiers>=0.1.5",
     "alkahest>=3.2.0",
     "datasets>=2.0",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["README.md"]
+
 [tool.verifiers]
 tags = ["math", "reasoning", "single-turn", "train", "eval", "symbolic"]
 entrypoint = "alkahest.rl.envs.integration.env:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 20
+rollouts_per_example = 3


### PR DESCRIPTION
## Summary

- Add mdbook [RL guide](docs/mdbook/src/rl.md): install (`alkahest[rl]`), API, tiers, veRL, Prime Intellect Hub checklist
- Update README (install blurb + Reinforcement learning section), getting-started, intro, features, mdbook SUMMARY
- Complete Hub publish manifest: `python/alkahest/rl/envs/integration/README.md`, hatchling `pyproject.toml`, `[tool.verifiers.eval]` defaults
- Pin Hub dependency to `alkahest>=3.2.0` (matches v3.2.0 release)

Cherry-picked from `feat/alkahest-rl` (commit `af7c10f`), which was omitted when PR #100 merged.

## Test plan

- [ ] Docs site build (mdbook) includes new RL chapter
- [ ] Links in README resolve on GitHub
- [ ] `cd python/alkahest/rl/envs/integration && pip install -e .` (smoke, optional)


Made with [Cursor](https://cursor.com)