### PR TITLE
feat(integrate): genus-1 quartics + genus-0 Euler substitution (land on main)

### DIFF
--- a/alkahest-core/src/integrate/algebraic/elliptic.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic.rs
@@ -179,14 +179,13 @@ pub fn short_weierstrass(
 /// ```
 /// then composed with [`short_weierstrass`] of `C`.  The place at `x = r`
 /// (`(r,0)`) maps to `u = ∞` = the origin `O` and must be handled by the caller.
-#[allow(clippy::type_complexity)]
-pub fn weierstrass_from_quartic(
-    q: &QPoly,
-    r: &Rational,
-) -> Option<(
-    EllipticCurve,
-    impl Fn(&Rational, &Rational) -> (Rational, Rational),
-)> {
+/// The cubic `C(u) = u³·c(r + 1/u)` (with `c = q/(x−r)`) obtained when reducing a
+/// genus-1 quartic `y² = q(x)` with rational root `r` to Weierstrass form via
+/// `u = 1/(x−r)`, `Y = y/(x−r)²`.  Returns `None` if `deg q ≠ 4` or `r` is not a
+/// root of `q`.  Shared by [`weierstrass_from_quartic`] (which composes it with
+/// [`short_weierstrass`]) and the genus-1 integrator (which needs `C`'s leading
+/// coefficients to back-translate the log argument to `(x, √q)`).
+pub(super) fn quartic_to_cubic(q: &QPoly, r: &Rational) -> Option<QPoly> {
     let q = trim(q.clone());
     if degree(&q) != 4 {
         return None;
@@ -216,6 +215,18 @@ pub fn weierstrass_from_quartic(
             pw = poly_mul_small(&pw, &lin);
         }
     }
+    Some(big_c)
+}
+
+#[allow(clippy::type_complexity)]
+pub fn weierstrass_from_quartic(
+    q: &QPoly,
+    r: &Rational,
+) -> Option<(
+    EllipticCurve,
+    impl Fn(&Rational, &Rational) -> (Rational, Rational),
+)> {
+    let big_c = quartic_to_cubic(q, r)?;
     let (e, map_c) = short_weierstrass(&big_c)?;
     let rr = r.clone();
     let map = move |x: &Rational, y: &Rational| -> (Rational, Rational) {

--- a/alkahest-core/src/integrate/algebraic/elliptic.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic.rs
@@ -238,6 +238,100 @@ pub fn weierstrass_from_quartic(
     Some((e, map))
 }
 
+/// Reduction of a genus-1 quartic `y² = q(x)` (deg 4) that has **no rational
+/// root** but a finite **rational point** `(x₀, y₀)` with `y₀ ≠ 0`, via Nagell's
+/// substitution.  Translate `x̃ = x − x₀` so the point sits at `x̃ = 0`
+/// (`q̃(0) = y₀² = p²`); then with `B = a₁/(2p)` the change of variable
+///
+/// ```text
+///   z = (y − p − B·x̃) / x̃²,   w = 2(z²−a₄)·x̃ − a₃ + 2B·z
+/// ```
+/// satisfies `w² = C(z)` for the **cubic** `C(z) = Δ(z)` below — a Weierstrass
+/// model.  `aᵢ` are the coefficients of the *translated* quartic `q̃`.  The base
+/// point's conjugate sheet `(x₀,−y₀)` maps to the cubic's point at infinity; the
+/// `+` sheet and the two places at infinity map to finite points (callers that
+/// can't place those should bail).
+#[derive(Clone, Debug)]
+pub(super) struct QuarticPointModel {
+    /// Reduced cubic `C(z)` with `w² = C(z)`.
+    pub c: QPoly,
+    /// Base-point abscissa `x₀`.
+    pub x0: Rational,
+    /// Base-point ordinate `p = y₀ ≠ 0`.
+    pub p: Rational,
+    /// `B = a₁/(2p)` of the translated quartic `q̃`.
+    pub b: Rational,
+    /// Translated-quartic coefficients used by the `z ↦ w` formula.
+    pub a3: Rational,
+    pub a4: Rational,
+}
+
+impl QuarticPointModel {
+    /// `z, w` at a finite place `(x, y)` with `x ≠ x₀`.  `None` when `x = x₀`
+    /// (the base-point fibre, where the formula divides by zero).
+    pub fn zw(&self, x: &Rational, y: &Rational) -> Option<(Rational, Rational)> {
+        let xt = x.clone() - &self.x0;
+        if xt == 0 {
+            return None;
+        }
+        let z = (y.clone() - &self.p - self.b.clone() * &xt) / (xt.clone() * &xt);
+        let w = Rational::from(2) * (z.clone() * &z - &self.a4) * &xt - self.a3.clone()
+            + Rational::from(2) * &self.b * &z;
+        Some((z, w))
+    }
+}
+
+/// Build the [`QuarticPointModel`] for `y² = q(x)` from a rational point
+/// `(x₀, y₀)`, `y₀ ≠ 0`.  Returns `None` if `q` is not degree 4 or `(x₀,y₀)` is
+/// not on the curve.
+pub(super) fn quartic_point_model(
+    q: &QPoly,
+    x0: &Rational,
+    y0: &Rational,
+) -> Option<QuarticPointModel> {
+    let q = trim(q.clone());
+    if degree(&q) != 4 || *y0 == 0 {
+        return None;
+    }
+    // Translate by x₀: q̃(x̃) = q(x̃ + x₀) = Σ q_i (x̃ + x₀)^i.
+    let mut qt = vec![Rational::from(0); 5];
+    let mut pw = vec![Rational::from(1)]; // (x̃ + x₀)^i, expanded in x̃
+    let shift = vec![x0.clone(), Rational::from(1)]; // x̃ + x₀
+    for qi in q.iter() {
+        for (j, pj) in pw.iter().enumerate() {
+            qt[j] += qi.clone() * pj;
+        }
+        pw = poly_mul_small(&pw, &shift);
+        pw.truncate(5);
+    }
+    let a0 = qt[0].clone();
+    let a1 = qt[1].clone();
+    let a2 = qt[2].clone();
+    let a3 = qt[3].clone();
+    let a4 = qt[4].clone();
+    if a0 != y0.clone() * y0 {
+        return None; // (x₀,y₀) not on the curve
+    }
+    let p = y0.clone();
+    let b = a1.clone() / (Rational::from(2) * &p);
+    // Δ(z) = −8p z³ + 4a₂ z² + (8p·a₄ − 4B·a₃) z + (a₃² − 4a₄·(a₂ − B²)).
+    let a2p = a2.clone() - b.clone() * &b;
+    let c = vec![
+        a3.clone() * &a3 - Rational::from(4) * &a4 * &a2p,
+        Rational::from(8) * &p * &a4 - Rational::from(4) * &b * &a3,
+        Rational::from(4) * &a2,
+        Rational::from(-8) * &p,
+    ];
+    Some(QuarticPointModel {
+        c,
+        x0: x0.clone(),
+        p,
+        b,
+        a3,
+        a4,
+    })
+}
+
 /// A factor of an elliptic function: the **vertical** line `x − x₀`, or the
 /// **chord/tangent** line `y − (λ·x + ν)`.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -500,6 +594,31 @@ mod tests {
         // The branch point (2,0) (a root ≠ r) maps to 2-torsion (Y=0).
         let (_, y2) = map(&r(2), &r(0));
         assert_eq!(y2, r(0));
+    }
+
+    /// Point-based quartic reduction (no rational root): y² = x⁴+x³+x²+x+1
+    /// (5th cyclotomic — no rational root) with the rational point (0,1).
+    /// Places (−1,1) and (3,11) must land on the reduced cubic's curve.
+    #[test]
+    fn quartic_point_reduction() {
+        let q = vec![r(1), r(1), r(1), r(1), r(1)];
+        let m = quartic_point_model(&q, &r(0), &r(1)).expect("point on curve");
+        assert_eq!(m.c, vec![r(-2), r(6), r(4), r(-8)]); // Δ(z) = −8z³+4z²+6z−2
+        let (e, _) = short_weierstrass(&m.c).expect("cubic");
+        let c3 = m.c[3].clone();
+        let c2 = m.c[2].clone();
+        for (xv, yv) in [(r(-1), r(1)), (r(3), r(11))] {
+            // w² = C(z).
+            let (z, w) = m.zw(&xv, &yv).expect("finite place");
+            let cz = m.c.iter().rev().fold(r(0), |acc, c| acc * &z + c);
+            assert_eq!(w.clone() * &w, cz, "w²=C(z) at x={xv}");
+            // (Z,W) = (c₃z + c₂/3, c₃w) lies on E.
+            let big_x = c3.clone() * &z + c2.clone() / r(3);
+            let big_y = c3.clone() * &w;
+            assert!(e.contains(&Point::Affine(big_x, big_y)), "on E at x={xv}");
+        }
+        // The conjugate base sheet (x₀,−y₀) divides by zero ⇒ None.
+        assert!(m.zw(&r(0), &r(-1)).is_none());
     }
 
     /// Miller log-argument construction on y²=x³+1:

--- a/alkahest-core/src/integrate/algebraic/find_order.rs
+++ b/alkahest-core/src/integrate/algebraic/find_order.rs
@@ -9,7 +9,7 @@
 //!
 //! * **genus 0** — every degree-0 divisor is principal, so `N = 1` always
 //!   (the rational-parametrization win, seen from the divisor side).
-//! * **genus 1** (`y²=cubic` or `y²=quartic` with a rational root) — **implemented**:
+//! * **genus 1** (`y²=cubic`, or `y²=quartic` with a rational point) — **implemented**:
 //!   map the residue divisor to `E(ℚ)` (Abel–Jacobi, [`super::elliptic`]) and read
 //!   off the order of its class; by **Mazur** a rational torsion point has order
 //!   ≤ 12, so this is a *complete* decision — `Principal{N}` if torsion,
@@ -18,14 +18,16 @@
 //!   search is best-effort — currently `NotDecided`.
 //!
 //! Sound: only `Principal`/`NonElementary` verdicts are asserted; anything
-//! uncertain (incomplete divisor with missing algebraic places, `y²=quartic`,
-//! genus ≥ 2) is `NotDecided`.
+//! uncertain (incomplete divisor with missing algebraic places, a quartic with
+//! no usable rational point, genus ≥ 2) is `NotDecided`.
 
 use rug::{Integer, Rational};
 
 use super::super::risch::poly_rde::{degree, poly_deriv, trim, QPoly};
 use super::super::risch::rational_rde::poly_gcd;
-use super::elliptic::{short_weierstrass, weierstrass_from_quartic, EllipticCurve, Point};
+use super::elliptic::{
+    quartic_point_model, short_weierstrass, weierstrass_from_quartic, EllipticCurve, Point,
+};
 use super::residues::{residue_sum, PlacedResidue, Residue};
 
 /// Result of FIND-ORDER on a residue divisor.
@@ -117,8 +119,9 @@ pub(crate) fn find_order_placed(n: usize, a: &QPoly, divisor: &[PlacedResidue]) 
 
 /// Genus-1 FIND-ORDER for `y² = a(x)` (cubic or quartic): map the residue divisor
 /// to `E(ℚ)` (Abel–Jacobi), then read off the order of its class.  `None` when
-/// outside scope (degree ≠ 3,4; quartic without a rational root or with a nonzero
-/// residue at infinity; or a place not on `E(ℚ)`).
+/// outside scope (degree ≠ 3,4; a quartic with a nonzero residue at infinity, a
+/// residue on the base-point fibre, or no rational point found; or a place not on
+/// `E(ℚ)`).
 fn genus1(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> Option<FindOrder> {
     if n != 2 {
         return None;
@@ -143,25 +146,51 @@ fn genus1(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> Option<FindOrder> {
                 (e, Box::new(f))
             }
             4 => {
-                // Quartic: handled only with no residue at infinity and a rational
-                // root (the place at x=root maps to O).
+                // Quartic: handled only with no residue at infinity.
                 if divisor
                     .iter()
                     .any(|r| r.residue.at_infinity && r.residue.value != 0)
                 {
                     return None;
                 }
-                let root = first_rational_root(&a)?;
-                let (e, map) = weierstrass_from_quartic(&a, &root)?;
-                let f = move |r: &PlacedResidue| -> Option<Point> {
-                    if r.residue.at_infinity || r.residue.point == root {
-                        None
-                    } else {
-                        let (x, y) = map(&r.residue.point, &r.y_coord);
-                        Some(Point::Affine(x, y))
+                if let Some(root) = first_rational_root(&a) {
+                    // Rational root: the place at x=root maps to O.
+                    let (e, map) = weierstrass_from_quartic(&a, &root)?;
+                    let f = move |r: &PlacedResidue| -> Option<Point> {
+                        if r.residue.at_infinity || r.residue.point == root {
+                            None
+                        } else {
+                            let (x, y) = map(&r.residue.point, &r.y_coord);
+                            Some(Point::Affine(x, y))
+                        }
+                    };
+                    (e, Box::new(f))
+                } else {
+                    // No rational root: reduce via a finite rational point (Nagell).
+                    // Residues on the base-point fibre `x=x₀` aren't placeable here
+                    // (one sheet ↦ O, the other ↦ a finite point) — bail for safety.
+                    let (x0, y0) = first_rational_point(&a)?;
+                    if divisor
+                        .iter()
+                        .any(|r| !r.residue.at_infinity && r.residue.point == x0)
+                    {
+                        return None;
                     }
-                };
-                (e, Box::new(f))
+                    let m = quartic_point_model(&a, &x0, &y0)?;
+                    let (e, _) = short_weierstrass(&m.c)?;
+                    let c3 = m.c[3].clone();
+                    let c2 = m.c.get(2).cloned().unwrap_or_else(|| Rational::from(0));
+                    let f = move |r: &PlacedResidue| -> Option<Point> {
+                        if r.residue.at_infinity {
+                            return None; // infinity residues are zero here
+                        }
+                        let (z, w) = m.zw(&r.residue.point, &r.y_coord)?;
+                        let big_x = c3.clone() * &z + c2.clone() / Rational::from(3);
+                        let big_y = c3.clone() * &w;
+                        Some(Point::Affine(big_x, big_y))
+                    };
+                    (e, Box::new(f))
+                }
             }
             _ => return None,
         };
@@ -211,6 +240,45 @@ fn genus1(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> Option<FindOrder> {
         // Non-torsion class ⇒ no multiple is principal ⇒ no elementary log part.
         None => FindOrder::NonElementary,
     })
+}
+
+/// A finite **rational point** `(x₀, y₀)` on `y² = q(x)` with `y₀ ≠ 0`, searched
+/// over small rationals.  Used to reduce a rational-root-free quartic to
+/// Weierstrass form (Nagell).  Best-effort: `None` if none is found in range.
+pub(super) fn first_rational_point(q: &QPoly) -> Option<(Rational, Rational)> {
+    let q = trim(q.clone());
+    if degree(&q) != 4 {
+        return None;
+    }
+    let evalq =
+        |x: &Rational| -> Rational { q.iter().rev().fold(Rational::from(0), |acc, c| acc * x + c) };
+    let sqrt_rat = |v: &Rational| -> Option<Rational> {
+        if *v < 0 {
+            return None;
+        }
+        let n = v.numer().clone();
+        let d = v.denom().clone();
+        let ns = n.clone().sqrt();
+        let ds = d.clone().sqrt();
+        if Integer::from(&ns * &ns) == n && Integer::from(&ds * &ds) == d {
+            Some(Rational::from((ns, ds)))
+        } else {
+            None
+        }
+    };
+    for dn in 1..=4i64 {
+        for nn in -8..=8i64 {
+            let x0 = Rational::from((nn, dn));
+            let v = evalq(&x0);
+            if v == 0 {
+                continue; // a root → handled by first_rational_root (want y₀ ≠ 0)
+            }
+            if let Some(y0) = sqrt_rat(&v) {
+                return Some((x0, y0));
+            }
+        }
+    }
+    None
 }
 
 /// A rational root of `p ∈ ℚ[x]` (rational-root theorem), if any.

--- a/alkahest-core/src/integrate/algebraic/find_order.rs
+++ b/alkahest-core/src/integrate/algebraic/find_order.rs
@@ -214,7 +214,7 @@ fn genus1(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> Option<FindOrder> {
 }
 
 /// A rational root of `p ∈ ℚ[x]` (rational-root theorem), if any.
-fn first_rational_root(p: &QPoly) -> Option<Rational> {
+pub(super) fn first_rational_root(p: &QPoly) -> Option<Rational> {
     let p = trim(p.clone());
     if degree(&p) < 1 {
         return None;

--- a/alkahest-core/src/integrate/algebraic/genus1_log.rs
+++ b/alkahest-core/src/integrate/algebraic/genus1_log.rs
@@ -1,7 +1,8 @@
 //! End-to-end genus-1 algebraic integration: emit the antiderivative
 //! `∫ R(x,y) dx = g + (1/N)·log(u)` (Risch **MC**, capstone).
 //!
-//! Ties the whole genus-1 stack together for `y² = a(x)` (cubic):
+//! Ties the whole genus-1 stack together for `y² = a(x)` (cubic, or quartic via
+//! a rational root or — when there is none — a finite rational point, Nagell):
 //! 1. **Hermite-on-curve** ([`super::hermite_curve`]) → algebraic part `g` plus a
 //!    third-kind remainder `h` (simple poles);
 //! 2. **residue divisor** ([`super::residues`]) of `h dx`;
@@ -19,17 +20,20 @@ use rug::{Integer, Rational};
 use super::super::risch::alg_field::AlgElem;
 use super::super::risch::poly_rde::{degree, qpoly_to_expr, rational_to_expr, trim, QPoly};
 use super::elliptic::{
-    quartic_to_cubic, short_weierstrass, weierstrass_from_quartic, EllFactor, EllipticCurve, Point,
+    quartic_point_model, quartic_to_cubic, short_weierstrass, weierstrass_from_quartic, EllFactor,
+    EllipticCurve, Point,
 };
-use super::find_order::{find_order_placed, first_rational_root, genus, FindOrder};
+use super::find_order::{
+    find_order_placed, first_rational_point, first_rational_root, genus, FindOrder,
+};
 use super::hermite_curve::hermite_reduce_radical;
 use super::residues::{residue_divisor_placed, PlacedResidue};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
-/// Integrate `∫ (integrand) dx` on the genus-1 curve `y² = a(x)` (cubic `a`),
-/// returning the symbolic antiderivative `g + (1/N)·log(u)` when it is elementary
-/// (verified `d/dx F = integrand`), else `None`.
+/// Integrate `∫ (integrand) dx` on the genus-1 curve `y² = a(x)` (cubic or
+/// quartic `a`), returning the symbolic antiderivative `g + (1/N)·log(u)` when it
+/// is elementary (verified `d/dx F = integrand`), else `None`.
 pub fn integrate_genus1_log(
     a: &QPoly,
     integrand: &AlgElem,
@@ -97,15 +101,15 @@ pub fn integrate_genus1_log(
             }
         };
         (e, Box::new(ptp), Box::new(to_expr))
-    } else {
-        // deg == 4: needs a rational root and no residue at infinity.
+    } else if let Some(root) = first_rational_root(&a) {
+        // deg == 4 with a rational root (no residue at ∞): reduce via
+        // `u = 1/(x−r)`, `Y = y/(x−r)²`; the place `x=r` and ∞ ↦ O.
         if divisor
             .iter()
             .any(|r| r.residue.at_infinity && r.residue.value != 0)
         {
             return None;
         }
-        let root = first_rational_root(&a)?;
         let (e, map) = weierstrass_from_quartic(&a, &root)?;
         let big_c = quartic_to_cubic(&a, &root)?;
         let c3 = big_c[3].clone();
@@ -141,6 +145,85 @@ pub fn integrate_genus1_log(
                         ),
                     ])
                 }
+            }
+        };
+        (e, Box::new(ptp), Box::new(to_expr))
+    } else {
+        // deg == 4, no rational root: Nagell reduction via a finite rational
+        // point `(x₀,y₀)`, `y₀≠0`.  `z = (y−p−B·x̃)/x̃²`, `w = 2(z²−a₄)x̃−a₃+2Bz`
+        // (`x̃=x−x₀`, `p=y₀`) gives `w²=C(z)`; `E = short_weierstrass(C)` with
+        // `Z = c₃z+c₂/3, W = c₃w`.  Residues on the base fibre `x=x₀` aren't
+        // placeable here, and ∞-residues must be zero — bail otherwise.
+        if divisor
+            .iter()
+            .any(|r| r.residue.at_infinity && r.residue.value != 0)
+        {
+            return None;
+        }
+        let (x0, y0) = first_rational_point(&a)?;
+        if divisor
+            .iter()
+            .any(|r| !r.residue.at_infinity && r.residue.point == x0)
+        {
+            return None;
+        }
+        let m = quartic_point_model(&a, &x0, &y0)?;
+        let (e, _) = short_weierstrass(&m.c)?;
+        let c3 = m.c[3].clone();
+        let c2 = m.c.get(2).cloned().unwrap_or_else(|| Rational::from(0));
+        let mm = m.clone();
+        let (c3p, c2p) = (c3.clone(), c2.clone());
+        let ptp = move |r: &PlacedResidue| -> Point {
+            if r.residue.at_infinity {
+                return Point::Infinity;
+            }
+            match mm.zw(&r.residue.point, &r.y_coord) {
+                Some((z, w)) => Point::Affine(
+                    c3p.clone() * &z + c2p.clone() / Rational::from(3),
+                    c3p.clone() * &w,
+                ),
+                None => Point::Infinity, // x==x₀ pre-checked out
+            }
+        };
+        let to_expr = move |f: &EllFactor| -> ExprId {
+            let xt = pool.add(vec![var, rational_to_expr(&(-m.x0.clone()), pool)]);
+            // z = (y − p − B·x̃)/x̃²
+            let z = pool.mul(vec![
+                pool.add(vec![
+                    y_sym,
+                    rational_to_expr(&(-m.p.clone()), pool),
+                    pool.mul(vec![rational_to_expr(&(-m.b.clone()), pool), xt]),
+                ]),
+                pool.pow(xt, pool.integer(-2_i32)),
+            ]);
+            // w = 2(z²−a₄)·x̃ − a₃ + 2B·z
+            let w = pool.add(vec![
+                pool.mul(vec![
+                    rational_to_expr(&Rational::from(2), pool),
+                    pool.add(vec![
+                        pool.pow(z, pool.integer(2_i32)),
+                        rational_to_expr(&(-m.a4.clone()), pool),
+                    ]),
+                    xt,
+                ]),
+                rational_to_expr(&(-m.a3.clone()), pool),
+                pool.mul(vec![rational_to_expr(&(Rational::from(2) * &m.b), pool), z]),
+            ]);
+            match f {
+                // Z − Z₀ = c₃·z + (c₂/3 − Z₀)
+                EllFactor::Vertical(z0) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&c3, pool), z]),
+                    rational_to_expr(&(c2.clone() / Rational::from(3) - z0.clone()), pool),
+                ]),
+                // W − λZ − ν = c₃·w − λc₃·z − (λc₂/3 + ν)
+                EllFactor::Line(lam, nu) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&c3, pool), w]),
+                    pool.mul(vec![rational_to_expr(&(-(lam.clone() * &c3)), pool), z]),
+                    rational_to_expr(
+                        &(-(lam.clone() * &c2 / Rational::from(3)) - nu.clone()),
+                        pool,
+                    ),
+                ]),
             }
         };
         (e, Box::new(ptp), Box::new(to_expr))
@@ -426,6 +509,124 @@ mod tests {
         let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
         let mut checked = 0;
         for &xv in &[0.7_f64, 1.3, 2.2, 3.1] {
+            let lhs = eval(df, x, xv, &pool).unwrap();
+            let rhs = eval(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}\n  F = {}",
+                pool.display(f)
+            );
+            checked += 1;
+        }
+        assert!(checked >= 2);
+    }
+
+    /// **Quartic with NO rational root** — `y² = x⁴ − x² + 1` (roots are primitive
+    /// 12th roots of unity).  Reduced via a finite rational point (Nagell): base
+    /// `(−1,1)`, and the place `(0,1)` maps to an order-4 point on `E`.  We build
+    /// an explicit curve function `w` (Miller, divisor `N(φ(0,1))−N(φ(0,−1))`)
+    /// and integrate `w'/w` — an exact `dlog`, elementary — end-to-end through the
+    /// public engine, exercising the rational-root-free quartic capstone path.
+    #[test]
+    fn quartic_no_root_elliptic_log_via_engine() {
+        use super::super::elliptic::{quartic_point_model, EllFactor, Point};
+        use super::super::find_order::first_rational_point;
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let a = qp(&[1, 0, -1, 0, 1]); // x⁴ − x² + 1
+        let (x0, y0) = first_rational_point(&a).expect("rational point");
+        let m = quartic_point_model(&a, &x0, &y0).expect("model");
+        let (e, _) = short_weierstrass(&m.c).expect("cubic");
+        let c3 = m.c[3].clone();
+        let c2 = m.c[2].clone();
+        let img = |xv: &Rational, yv: &Rational| -> Point {
+            let (z, w) = m.zw(xv, yv).unwrap();
+            Point::Affine(
+                c3.clone() * &z + c2.clone() / Rational::from(3),
+                c3.clone() * &w,
+            )
+        };
+        // Generic finite places P=(0,1), Q=(0,−1) (x≠x₀=−1); their E-images.
+        let pe = img(&Rational::from(0), &Rational::from(1));
+        let qe = img(&Rational::from(0), &Rational::from(-1));
+        let n = e
+            .order(&e.add(&pe, &e.neg(&qe)))
+            .expect("class (P)−(Q) torsion") as i64;
+        let w_e = e
+            .general_miller(&[(pe, n), (qe, -n)])
+            .expect("principal divisor");
+
+        // Pull back each factor via the Nagell change of variable.
+        let y_sym = pool.func("sqrt", vec![qpoly_to_expr(&a, x, &pool)]);
+        let factor = |f: &EllFactor| -> ExprId {
+            let xt = pool.add(vec![x, rational_to_expr(&(-m.x0.clone()), &pool)]);
+            let z = pool.mul(vec![
+                pool.add(vec![
+                    y_sym,
+                    rational_to_expr(&(-m.p.clone()), &pool),
+                    pool.mul(vec![rational_to_expr(&(-m.b.clone()), &pool), xt]),
+                ]),
+                pool.pow(xt, pool.integer(-2_i32)),
+            ]);
+            let w = pool.add(vec![
+                pool.mul(vec![
+                    rational_to_expr(&Rational::from(2), &pool),
+                    pool.add(vec![
+                        pool.pow(z, pool.integer(2_i32)),
+                        rational_to_expr(&(-m.a4.clone()), &pool),
+                    ]),
+                    xt,
+                ]),
+                rational_to_expr(&(-m.a3.clone()), &pool),
+                pool.mul(vec![
+                    rational_to_expr(&(Rational::from(2) * &m.b), &pool),
+                    z,
+                ]),
+            ]);
+            match f {
+                EllFactor::Vertical(z0) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&c3, &pool), z]),
+                    rational_to_expr(&(c2.clone() / Rational::from(3) - z0.clone()), &pool),
+                ]),
+                EllFactor::Line(lam, nu) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&c3, &pool), w]),
+                    pool.mul(vec![rational_to_expr(&(-(lam.clone() * &c3)), &pool), z]),
+                    rational_to_expr(
+                        &(-(lam.clone() * &c2 / Rational::from(3)) - nu.clone()),
+                        &pool,
+                    ),
+                ]),
+            }
+        };
+        let prod = |fs: &[EllFactor]| -> ExprId {
+            if fs.is_empty() {
+                pool.integer(1_i32)
+            } else {
+                pool.mul(fs.iter().map(|f| factor(f)).collect())
+            }
+        };
+        let w = if w_e.den.is_empty() {
+            prod(&w_e.num)
+        } else {
+            pool.mul(vec![
+                prod(&w_e.num),
+                pool.pow(prod(&w_e.den), pool.integer(-1_i32)),
+            ])
+        };
+        let integrand = simplify(
+            crate::diff::diff(pool.func("log", vec![w]), x, &pool)
+                .unwrap()
+                .value,
+            &pool,
+        )
+        .value;
+
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("rational-root-free quartic dlog must integrate");
+        let f = res.value;
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        let mut checked = 0;
+        for &xv in &[0.4_f64, 1.3, 2.2, 3.1] {
             let lhs = eval(df, x, xv, &pool).unwrap();
             let rhs = eval(integrand, x, xv, &pool).unwrap();
             assert!(

--- a/alkahest-core/src/integrate/algebraic/genus1_log.rs
+++ b/alkahest-core/src/integrate/algebraic/genus1_log.rs
@@ -18,10 +18,12 @@ use rug::{Integer, Rational};
 
 use super::super::risch::alg_field::AlgElem;
 use super::super::risch::poly_rde::{degree, qpoly_to_expr, rational_to_expr, trim, QPoly};
-use super::elliptic::{short_weierstrass, EllFactor, Point};
-use super::find_order::{find_order_placed, genus, FindOrder};
+use super::elliptic::{
+    quartic_to_cubic, short_weierstrass, weierstrass_from_quartic, EllFactor, EllipticCurve, Point,
+};
+use super::find_order::{find_order_placed, first_rational_root, genus, FindOrder};
 use super::hermite_curve::hermite_reduce_radical;
-use super::residues::residue_divisor_placed;
+use super::residues::{residue_divisor_placed, PlacedResidue};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::simplify::engine::simplify;
 
@@ -35,7 +37,8 @@ pub fn integrate_genus1_log(
     pool: &ExprPool,
 ) -> Option<ExprId> {
     let a = trim(a.clone());
-    if genus(2, &a) != Some(1) || degree(&a) != 3 {
+    let deg = degree(&a);
+    if genus(2, &a) != Some(1) || !(deg == 3 || deg == 4) {
         return None;
     }
 
@@ -49,8 +52,101 @@ pub fn integrate_genus1_log(
         return None;
     }
 
-    // 4. Abel–Jacobi image and its order; build u for the principal divisor.
-    let (e, map) = short_weierstrass(&a)?;
+    let a_expr = qpoly_to_expr(&a, var, pool);
+    let y_sym = pool.func("sqrt", vec![a_expr]);
+
+    // 4. Build the elliptic curve `E`, the place→point map onto `E`, and the
+    // back-translation of an `EllFactor` (a function on `E`) to a symbolic
+    // function in `(x, √a)`.
+    //  * Cubic `y²=a`: depressed model `X = a₃x + a₂/3, Y = a₃y`; the place ∞ ↦ O.
+    //  * Quartic `y²=a` (rational root `r`, no residue at ∞): reduce via
+    //    `u = 1/(x−r)`, `Y' = y/(x−r)²` to the cubic `C(u)` then to `E`; the
+    //    place `x=r` and the ∞-places ↦ O.  An `EllFactor` in `(X,Y)` pulls back
+    //    with `X = c₃·u + c₂/3`, `Y = c₃·y/(x−r)²` (`c₃,c₂` = `C`'s top coeffs).
+    #[allow(clippy::type_complexity)]
+    let (e, place_to_point, to_expr): (
+        EllipticCurve,
+        Box<dyn Fn(&PlacedResidue) -> Point>,
+        Box<dyn Fn(&EllFactor) -> ExprId + '_>,
+    ) = if deg == 3 {
+        let (e, map) = short_weierstrass(&a)?;
+        let a3 = a[3].clone();
+        let a2 = a.get(2).cloned().unwrap_or_else(|| Rational::from(0));
+        let ptp = move |r: &PlacedResidue| -> Point {
+            if r.residue.at_infinity {
+                Point::Infinity
+            } else {
+                let (x, y) = map(&r.residue.point, &r.y_coord);
+                Point::Affine(x, y)
+            }
+        };
+        let to_expr = move |f: &EllFactor| -> ExprId {
+            match f {
+                EllFactor::Vertical(x0) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&a3, pool), var]),
+                    rational_to_expr(&(a2.clone() / Rational::from(3) - x0.clone()), pool),
+                ]),
+                EllFactor::Line(lam, nu) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&a3, pool), y_sym]),
+                    pool.mul(vec![rational_to_expr(&(-(lam.clone() * &a3)), pool), var]),
+                    rational_to_expr(
+                        &(-(lam.clone() * &a2 / Rational::from(3)) - nu.clone()),
+                        pool,
+                    ),
+                ]),
+            }
+        };
+        (e, Box::new(ptp), Box::new(to_expr))
+    } else {
+        // deg == 4: needs a rational root and no residue at infinity.
+        if divisor
+            .iter()
+            .any(|r| r.residue.at_infinity && r.residue.value != 0)
+        {
+            return None;
+        }
+        let root = first_rational_root(&a)?;
+        let (e, map) = weierstrass_from_quartic(&a, &root)?;
+        let big_c = quartic_to_cubic(&a, &root)?;
+        let c3 = big_c[3].clone();
+        let c2 = big_c.get(2).cloned().unwrap_or_else(|| Rational::from(0));
+        let root_p = root.clone();
+        let ptp = move |r: &PlacedResidue| -> Point {
+            if r.residue.at_infinity || r.residue.point == root_p {
+                Point::Infinity
+            } else {
+                let (x, y) = map(&r.residue.point, &r.y_coord);
+                Point::Affine(x, y)
+            }
+        };
+        let neg_root = -root.clone();
+        let to_expr = move |f: &EllFactor| -> ExprId {
+            let x_minus_r = pool.add(vec![var, rational_to_expr(&neg_root, pool)]);
+            let u = pool.pow(x_minus_r, pool.integer(-1_i32));
+            match f {
+                // X − X₀ = c₃·u + (c₂/3 − X₀)
+                EllFactor::Vertical(x0) => pool.add(vec![
+                    pool.mul(vec![rational_to_expr(&c3, pool), u]),
+                    rational_to_expr(&(c2.clone() / Rational::from(3) - x0.clone()), pool),
+                ]),
+                // Y − λX − ν = c₃·y/(x−r)² − λc₃·u − (λc₂/3 + ν)
+                EllFactor::Line(lam, nu) => {
+                    let d2 = pool.pow(x_minus_r, pool.integer(-2_i32));
+                    pool.add(vec![
+                        pool.mul(vec![rational_to_expr(&c3, pool), y_sym, d2]),
+                        pool.mul(vec![rational_to_expr(&(-(lam.clone() * &c3)), pool), u]),
+                        rational_to_expr(
+                            &(-(lam.clone() * &c2 / Rational::from(3)) - nu.clone()),
+                            pool,
+                        ),
+                    ])
+                }
+            }
+        };
+        (e, Box::new(ptp), Box::new(to_expr))
+    };
+
+    // Abel–Jacobi image and its order; build u for the principal divisor.
     let mut l = Integer::from(1);
     for r in &divisor {
         l = l.lcm(r.residue.value.denom());
@@ -59,13 +155,7 @@ pub fn integrate_genus1_log(
     for r in &divisor {
         let scaled = r.residue.value.clone() * Rational::from(l.clone());
         let coeff = scaled.numer().to_i64()?;
-        let pt = if r.residue.at_infinity {
-            Point::Infinity
-        } else {
-            let (x, y) = map(&r.residue.point, &r.y_coord);
-            Point::Affine(x, y)
-        };
-        pairs.push((pt, coeff));
+        pairs.push((place_to_point(r), coeff));
     }
     let mut s = Point::Infinity;
     for (p, c) in &pairs {
@@ -83,28 +173,7 @@ pub fn integrate_genus1_log(
         .collect();
     let u_e = e.general_miller(&scaled)?;
 
-    // Back-translate u (on E, coords X = a₃x + a₂/3, Y = a₃y) to (x, √a).
-    let a3 = a[3].clone();
-    let a2 = a.get(2).cloned().unwrap_or_else(|| Rational::from(0));
-    let a_expr = qpoly_to_expr(&a, var, pool);
-    let y_sym = pool.func("sqrt", vec![a_expr]);
-    let to_expr = |f: &EllFactor| -> ExprId {
-        match f {
-            EllFactor::Vertical(x0) => pool.add(vec![
-                pool.mul(vec![rational_to_expr(&a3, pool), var]),
-                rational_to_expr(&(a2.clone() / Rational::from(3)), pool),
-                rational_to_expr(&(-x0.clone()), pool),
-            ]),
-            EllFactor::Line(lam, nu) => pool.add(vec![
-                pool.mul(vec![rational_to_expr(&a3, pool), y_sym]),
-                pool.mul(vec![rational_to_expr(&(-(lam.clone() * &a3)), pool), var]),
-                rational_to_expr(
-                    &(-(lam.clone() * &a2 / Rational::from(3)) - nu.clone()),
-                    pool,
-                ),
-            ]),
-        }
-    };
+    // Back-translate u (on E) to (x, √a).
     let product = |fs: &[EllFactor]| -> ExprId {
         if fs.is_empty() {
             pool.integer(1_i32)
@@ -288,5 +357,84 @@ mod tests {
         // 1/y = y/(x³+1).
         let integrand = vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[1, 0, 0, 1]))];
         assert!(integrate_genus1_log(&a, &integrand, x, &pool).is_none());
+    }
+
+    /// **Quartic** genus-1 curve `y² = x⁴ + x` (reduces to `Y²=u³+1` via `u=1/x`,
+    /// rational root `r=0`).  We build an *explicit* curve function `w` via Miller
+    /// (divisor `3(P)−3(−P)`, `P=(2,3)` ⇒ class order 3), pull it back to
+    /// `(x,√(x⁴+x))` with `X=1/x, Y=y/x²`, and integrate its logarithmic
+    /// derivative `w'/w` — an **exact** `dlog` (no first-kind part), hence
+    /// elementary.  The public engine must recover an antiderivative with
+    /// `d/dx F = w'/w`, exercising the degree-4 capstone path (rational root
+    /// `r=0`, both ∞-residues zero) through `integrate` → `integrate_algebraic`.
+    #[test]
+    fn quartic_elliptic_log_via_engine() {
+        use super::super::elliptic::{EllFactor, EllipticCurve, Point};
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.func(
+            "sqrt",
+            vec![pool.add(vec![pool.pow(x, pool.integer(4_i32)), x])],
+        );
+        let big_x = pool.pow(x, pool.integer(-1_i32)); // X = 1/x
+        let big_y = pool.mul(vec![y, pool.pow(x, pool.integer(-2_i32))]); // Y = y/x²
+        let factor = |f: &EllFactor| -> ExprId {
+            match f {
+                EllFactor::Vertical(x0) => {
+                    pool.add(vec![big_x, rational_to_expr(&(-x0.clone()), &pool)])
+                }
+                EllFactor::Line(lam, nu) => pool.add(vec![
+                    big_y,
+                    pool.mul(vec![rational_to_expr(&(-lam.clone()), &pool), big_x]),
+                    rational_to_expr(&(-nu.clone()), &pool),
+                ]),
+            }
+        };
+        let e = EllipticCurve::new(Rational::from(0), Rational::from(1)); // Y²=X³+1
+        let p = Point::Affine(Rational::from(2), Rational::from(3));
+        let np = Point::Affine(Rational::from(2), Rational::from(-3));
+        let w_e = e
+            .general_miller(&[(p, 3), (np, -3)])
+            .expect("order-3 class principal");
+        let prod = |fs: &[EllFactor]| -> ExprId {
+            if fs.is_empty() {
+                pool.integer(1_i32)
+            } else {
+                pool.mul(fs.iter().map(|f| factor(f)).collect())
+            }
+        };
+        let w = if w_e.den.is_empty() {
+            prod(&w_e.num)
+        } else {
+            pool.mul(vec![
+                prod(&w_e.num),
+                pool.pow(prod(&w_e.den), pool.integer(-1_i32)),
+            ])
+        };
+        // integrand = d/dx log(w) = w'/w — an exact logarithmic derivative.
+        let integrand = simplify(
+            crate::diff::diff(pool.func("log", vec![w]), x, &pool)
+                .unwrap()
+                .value,
+            &pool,
+        )
+        .value;
+
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("exact dlog on quartic genus-1 curve must integrate");
+        let f = res.value;
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        let mut checked = 0;
+        for &xv in &[0.7_f64, 1.3, 2.2, 3.1] {
+            let lhs = eval(df, x, xv, &pool).unwrap();
+            let rhs = eval(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}\n  F = {}",
+                pool.display(f)
+            );
+            checked += 1;
+        }
+        assert!(checked >= 2);
     }
 }

--- a/alkahest-core/src/integrate/algebraic/genus1_log.rs
+++ b/alkahest-core/src/integrate/algebraic/genus1_log.rs
@@ -483,7 +483,7 @@ mod tests {
             if fs.is_empty() {
                 pool.integer(1_i32)
             } else {
-                pool.mul(fs.iter().map(|f| factor(f)).collect())
+                pool.mul(fs.iter().map(&factor).collect())
             }
         };
         let w = if w_e.den.is_empty() {
@@ -602,7 +602,7 @@ mod tests {
             if fs.is_empty() {
                 pool.integer(1_i32)
             } else {
-                pool.mul(fs.iter().map(|f| factor(f)).collect())
+                pool.mul(fs.iter().map(&factor).collect())
             }
         };
         let w = if w_e.den.is_empty() {

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -187,6 +187,31 @@ pub fn integrate_algebraic(
         return res;
     }
 
+    // Standard path: decompose `A(x) + B(x)·√P` and integrate each part.  When it
+    // cannot express the integrand — e.g. a *rational* coefficient on a quadratic
+    // radical, `∫ dx/((x²−1)√(x²+1))` — fall back to the genus-0 Euler
+    // substitution, which rationalizes the whole `∫ R(x,√(quadratic)) dx`.  The
+    // decompose path is tried first so polynomial-coefficient cases keep their
+    // nicer closed forms.
+    match integrate_via_decompose(expr, var, pool) {
+        Err(IntegrationError::NotImplemented(_)) => {
+            if let Some(res) = parametrize::try_euler_quadratic(expr, var, pool) {
+                return res;
+            }
+            integrate_via_decompose(expr, var, pool)
+        }
+        other => other,
+    }
+}
+
+/// The standard algebraic path: find the single `√P` generator, decompose the
+/// integrand as `A(x) + B(x)·√P`, and integrate each part (with the genus-1
+/// capstone for `deg P ≥ 3`).
+fn integrate_via_decompose(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Result<DerivedExpr<ExprId>, IntegrationError> {
     let mut log = DerivationLog::new();
 
     // Step 1: Find the unique sqrt generator y = sqrt(P(x))

--- a/alkahest-core/src/integrate/algebraic/parametrize.rs
+++ b/alkahest-core/src/integrate/algebraic/parametrize.rs
@@ -20,10 +20,12 @@
 //! MA omitted — previously returning a *wrong* `NonElementary` for e.g.
 //! `∫ ∛x/(x+1) dx`).
 //!
-//! Scope: a single radical with linear-fractional radicand (any index `n ≥ 2`).
-//! Radicands with ≥ 2 distinct finite zeros/poles (`yⁿ = p(x)`, `deg ≥ 2`,
-//! non-Möbius) are generally higher genus and out of scope.  Sound by
-//! construction: the result is accepted only after a numeric `d/dx F = integrand`
+//! Scope ([`try_parametrize_genus0`]): a single radical with linear-fractional
+//! radicand (any index `n ≥ 2`).  Radicands `yⁿ = p(x)` of `deg ≥ 2` (non-Möbius)
+//! are generally higher genus and out of scope **except** the genus-0
+//! `√(quadratic)` case, which [`try_euler_quadratic`] handles for an arbitrary
+//! rational `R(x, √(quadratic))` via an Euler substitution.  Both are sound by
+//! construction: a result is accepted only after a numeric `d/dx F = integrand`
 //! check.
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
@@ -103,6 +105,191 @@ pub(super) fn try_parametrize_genus0(
         f_x,
     ));
     Some(Ok(DerivedExpr::with_log(f_x, log)))
+}
+
+/// Genus-0 integration of `∫ R(x, √(a x²+b x+c)) dx` with **`R` an arbitrary
+/// rational function** (not just a polynomial coefficient on the radical), via an
+/// **Euler substitution**.  A nondegenerate quadratic radicand is a genus-0
+/// conic, so a rational point gives a parameter `t` in which both `x` and
+/// `√(quad)` are rational — turning the whole integrand rational in `t` (always
+/// elementary).  Two substitutions cover the rational-point cases:
+///
+/// * `a = e²` a perfect square: `√(quad) = t − e·x`, so
+///   `x = (t²−c)/(2e·t + b)`, and `t = √(quad) + e·x`;
+/// * else `c = g²` a perfect square: `√(quad) = x·t + g`, so
+///   `x = (2g·t − b)/(a − t²)`, and `t = (√(quad) − g)/x`.
+///
+/// Returns `None` when not a single `sqrt(quadratic-over-ℚ[x])` generator, or
+/// when neither leading nor constant coefficient is a rational square (a rational
+/// point at infinity / at `x=0` is then unavailable in this bounded form).
+pub(super) fn try_euler_quadratic(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<Result<DerivedExpr<ExprId>, IntegrationError>> {
+    let (n, radicand) = detect_single_radical(expr, var, pool)?;
+    if n != 2 {
+        return None;
+    }
+    // Radicand must be a degree-2 polynomial in x over ℚ.
+    let (num, den) = expr_to_qrational(radicand, var, pool)?;
+    let (num, den) = (trim(num), trim(den));
+    if degree(&den) != 0 || degree(&num) != 2 {
+        return None;
+    }
+    let coeff = |p: &QPoly, i: usize| p.get(i).cloned().unwrap_or_else(|| rug::Rational::from(0));
+    let (c, b, a) = (coeff(&num, 0), coeff(&num, 1), coeff(&num, 2));
+    let quad = num.clone(); // a·x²+b·x+c (den is the constant 1 after normalization)
+
+    let t = pool.symbol("$euler_t$", Domain::Real);
+    let two = rug::Rational::from(2);
+    let radical = pool.func("sqrt", vec![radicand]); // √(quad) in x, for back-sub
+    let (x_of_t, sqrt_t, back_t) = if let Some(e) = sqrt_rational(&a) {
+        // x = (t²−c)/(2e·t + b);  √quad = t − e·x;  t = √quad + e·x.
+        let t2 = pool.pow(t, pool.integer(2));
+        let x_num = pool.add(vec![t2, rational_to_expr(&-c.clone(), pool)]);
+        let x_den = pool.add(vec![
+            pool.mul(vec![rational_to_expr(&(two.clone() * &e), pool), t]),
+            rational_to_expr(&b, pool),
+        ]);
+        let x_of_t = pool.mul(vec![x_num, pool.pow(x_den, pool.integer(-1))]);
+        let sqrt_t = simplify(
+            pool.add(vec![
+                t,
+                pool.mul(vec![rational_to_expr(&-e.clone(), pool), x_of_t]),
+            ]),
+            pool,
+        )
+        .value;
+        let back_t = pool.add(vec![
+            radical,
+            pool.mul(vec![rational_to_expr(&e, pool), var]),
+        ]);
+        (x_of_t, sqrt_t, back_t)
+    } else if let Some(g) = sqrt_rational(&c) {
+        // x = (2g·t − b)/(a − t²);  √quad = x·t + g;  t = (√quad − g)/x.
+        let t2 = pool.pow(t, pool.integer(2));
+        let x_num = pool.add(vec![
+            pool.mul(vec![rational_to_expr(&(two.clone() * &g), pool), t]),
+            rational_to_expr(&-b.clone(), pool),
+        ]);
+        let x_den = pool.add(vec![
+            rational_to_expr(&a, pool),
+            pool.mul(vec![rational_to_expr(&rug::Rational::from(-1), pool), t2]),
+        ]);
+        let x_of_t = pool.mul(vec![x_num, pool.pow(x_den, pool.integer(-1))]);
+        let sqrt_t = simplify(
+            pool.add(vec![pool.mul(vec![x_of_t, t]), rational_to_expr(&g, pool)]),
+            pool,
+        )
+        .value;
+        let back_t = pool.mul(vec![
+            pool.add(vec![radical, rational_to_expr(&-g.clone(), pool)]),
+            pool.pow(var, pool.integer(-1)),
+        ]);
+        (x_of_t, sqrt_t, back_t)
+    } else {
+        return None;
+    };
+
+    // Rewrite the integrand rational in `t`, multiply by dx/dt, integrate, and
+    // back-substitute `t`.
+    let core = to_t(expr, var, &quad, sqrt_t, x_of_t, pool)?;
+    let dx_dt = simplify(crate::diff::diff(x_of_t, t, pool).ok()?.value, pool).value;
+    let integrand_t = simplify(pool.mul(vec![core, dx_dt]), pool).value;
+    let f_t = match crate::integrate::engine::integrate(integrand_t, t, pool) {
+        Ok(d) => d.value,
+        Err(_) => return None,
+    };
+    let mut back = HashMap::new();
+    back.insert(t, back_t);
+    let f_x = simplify(crate::kernel::subs(f_t, &back, pool), pool).value;
+
+    if !verify_derivative(f_x, expr, radicand, var, pool) {
+        return None;
+    }
+    let mut log = DerivationLog::new();
+    log.push(RewriteStep::simple("algebraic_genus0_euler", expr, f_x));
+    Some(Ok(DerivedExpr::with_log(f_x, log)))
+}
+
+/// Rewrite `expr` (rational in `x` and `√(quad)`) as a rational function of the
+/// Euler parameter `t`: `x → x_of_t`, `√(quad) → sqrt_t` (and any half-integer
+/// power of the radicand → the matching power of `sqrt_t`).  `None` if a subterm
+/// is not expressible this way.
+fn to_t(
+    expr: ExprId,
+    var: ExprId,
+    quad: &QPoly,
+    sqrt_t: ExprId,
+    x_of_t: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    if expr == var {
+        return Some(x_of_t);
+    }
+    if is_free_of_var(expr, var, pool) {
+        return Some(expr);
+    }
+    let one = vec![rug::Rational::from(1)];
+    // `quad^{c/d}` (base ≡ radicand) → `sqrt_t^{2c/d}` when `d | 2c`.
+    let radical_power = |base: ExprId, c: i64, d: i64, pool: &ExprPool| -> Option<ExprId> {
+        if same_fraction(base, quad, &one, var, pool) && (2 * c) % d == 0 {
+            Some(pool.pow(sqrt_t, pool.integer(((2 * c) / d) as i32)))
+        } else {
+            None
+        }
+    };
+    match pool.get(expr) {
+        ExprData::Func { ref name, ref args } if name == "sqrt" && args.len() == 1 => {
+            radical_power(args[0], 1, 2, pool)
+        }
+        ExprData::Add(args) => {
+            let v: Vec<ExprId> = args
+                .iter()
+                .map(|&a| to_t(a, var, quad, sqrt_t, x_of_t, pool))
+                .collect::<Option<_>>()?;
+            Some(pool.add(v))
+        }
+        ExprData::Mul(args) => {
+            let v: Vec<ExprId> = args
+                .iter()
+                .map(|&a| to_t(a, var, quad, sqrt_t, x_of_t, pool))
+                .collect::<Option<_>>()?;
+            Some(pool.mul(v))
+        }
+        ExprData::Pow { base, exp } => match pool.get(exp) {
+            ExprData::Integer(m) => {
+                let inner = to_t(base, var, quad, sqrt_t, x_of_t, pool)?;
+                Some(pool.pow(inner, pool.integer(m.0.to_i64()? as i32)))
+            }
+            ExprData::Rational(r) => {
+                radical_power(base, r.0.numer().to_i64()?, r.0.denom().to_i64()?, pool)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// A rational square root of `v ≥ 0` (numerator and denominator both perfect
+/// squares), else `None`.
+fn sqrt_rational(v: &rug::Rational) -> Option<rug::Rational> {
+    if *v < 0 {
+        return None;
+    }
+    if *v == 0 {
+        return Some(rug::Rational::from(0));
+    }
+    let nn = v.numer().clone();
+    let dd = v.denom().clone();
+    let ns = nn.clone().sqrt();
+    let ds = dd.clone().sqrt();
+    if rug::Integer::from(&ns * &ns) == nn && rug::Integer::from(&ds * &ds) == dd {
+        Some(rug::Rational::from((ns, ds)))
+    } else {
+        None
+    }
 }
 
 /// Find the unique `x`-dependent radical generator and return `(n, radicand)`.
@@ -410,5 +597,51 @@ mod tests {
             let lin = p.add(vec![p.mul(vec![p.integer(2), x]), p.integer(1)]);
             p.pow(lin, p.rational(1, 5))
         });
+    }
+
+    /// Euler (a=1 square): `∫ dx/((x²−1)·√(x²+1))` — a *rational* coefficient on a
+    /// quadratic radical (the deg-2 sqrt engine handles only polynomial weights).
+    /// Elementary; radicand positive everywhere, avoid the poles `x=±1`.
+    #[test]
+    fn euler_rational_weight_quadratic() {
+        check_at(
+            |p, x| {
+                let q = p.add(vec![p.pow(x, p.integer(2)), p.integer(1)]);
+                let d = p.add(vec![p.pow(x, p.integer(2)), p.integer(-1)]);
+                p.mul(vec![
+                    p.pow(d, p.integer(-1)),
+                    p.pow(p.func("sqrt", vec![q]), p.integer(-1)),
+                ])
+            },
+            &[0.3, 1.7, 2.6],
+        );
+    }
+
+    /// Euler (a=1 square): `∫ dx/(x·√(x²+1))` = `log((√(x²+1)−1)/x)`-type.
+    #[test]
+    fn euler_one_over_x_sqrt_quadratic() {
+        check_at(
+            |p, x| {
+                let q = p.add(vec![p.pow(x, p.integer(2)), p.integer(1)]);
+                p.mul(vec![
+                    p.pow(x, p.integer(-1)),
+                    p.pow(p.func("sqrt", vec![q]), p.integer(-1)),
+                ])
+            },
+            &[0.6, 1.4, 3.1],
+        );
+    }
+
+    /// Euler (a=1 square, c=−1 not a square): `∫ √(x²−1)/x dx`.  Radicand positive
+    /// for `x > 1`.
+    #[test]
+    fn euler_sqrt_quadratic_over_x() {
+        check_at(
+            |p, x| {
+                let q = p.add(vec![p.pow(x, p.integer(2)), p.integer(-1)]);
+                p.mul(vec![p.func("sqrt", vec![q]), p.pow(x, p.integer(-1))])
+            },
+            &[1.4, 2.5, 3.8],
+        );
     }
 }


### PR DESCRIPTION
PR #104 was merged into its stacked base (`risch/wire-genus1-engine`), but #103 had already merged that branch into `main` at an earlier commit — so these 4 commits never reached `main`. This PR lands them directly on `main`.

## Contents (4 commits)

1. **Quartic `y²=quartic` with a rational root** — `integrate_genus1_log` extended to degree-4 (no ∞-residue) via `weierstrass_from_quartic` (`u=1/(x−r)`, `Y=y/(x−r)²`); `quartic_to_cubic` extracted for the back-translation.
2. **Quartic with NO rational root (Nagell)** — finite rational point `(x₀,y₀)`, `y₀≠0`: `z=(y−p−B·x̃)/x̃²`, `w=2(z²−a₄)x̃−a₃+2Bz` ⇒ `w²=C(z)` cubic. New `QuarticPointModel`/`quartic_point_model` and `first_rational_point`; `find_order` + `genus1_log` fall back to it.
3. **CI fix** — `clippy::redundant_closure` (`.map(|f| factor(f))` → `.map(&factor)`).
4. **Genus-0 Euler substitution** — `∫ R(x,√(quadratic)) dx` for arbitrary rational `R` (e.g. `∫dx/((x²−1)√(x²+1))`), wired as a fallback after the `A+B√P` decompose path so polynomial-weight cases keep their clean closed forms.

## Soundness
Every path ends in a numeric `d/dx F = integrand` gate — a wrong reduction yields `None`/fallthrough, never a wrong answer.

## Tests (all `d/dx F = f` verified, end-to-end through the public `integrate`)
- quartic-root and quartic-no-root via explicit Miller curve functions (`w'/w`);
- Euler: `∫dx/((x²−1)√(x²+1))`, `∫dx/(x√(x²+1))`, `∫√(x²−1)/x`;
- unit `quartic_point_reduction` (`w²=C(z)`, on-curve images).

All **879** `alkahest-cas` lib tests pass; `cargo fmt` + `clippy --all-targets` clean. (This is the same code already CI-green as #104.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)