### PR TITLE
feat(integrate): complete MC2 + MB fast-path + general Hermite reduction

### DIFF
--- a/alkahest-core/src/integrate/algebraic/find_order.rs
+++ b/alkahest-core/src/integrate/algebraic/find_order.rs
@@ -463,6 +463,19 @@ mod tests {
         assert_eq!(find_order_placed(2, &a, &div), FindOrder::NonElementary);
     }
 
+    /// Genus-2 `y²=x⁵−x`: the 2-torsion branch divisor `(0,0) − (1,0)` routes
+    /// through MC2 and is certified `Principal{2}` by the exact ℚ test.
+    #[test]
+    fn genus2_torsion_principal_via_dispatch() {
+        let a = qp(&[0, -1, 0, 0, 0, 1]);
+        assert_eq!(genus(2, &a), Some(2));
+        let div = [place(0, 0, 1, false, 2), place(1, 0, -1, false, 2)];
+        assert_eq!(
+            find_order_placed(2, &a, &div),
+            FindOrder::Principal { order: 2 }
+        );
+    }
+
     /// Genus-2 even-degree (real model) `y²=x⁶+1` stays undecided in MC2 scope.
     #[test]
     fn genus2_even_degree_not_decided() {

--- a/alkahest-core/src/integrate/algebraic/find_order.rs
+++ b/alkahest-core/src/integrate/algebraic/find_order.rs
@@ -113,7 +113,9 @@ pub(crate) fn find_order_placed(n: usize, a: &QPoly, divisor: &[PlacedResidue]) 
     match genus(n, a) {
         Some(0) => FindOrder::Principal { order: 1 },
         Some(1) => genus1(n, a, divisor).unwrap_or(FindOrder::NotDecided),
-        _ => FindOrder::NotDecided,
+        // Genus ≥ 2: reduction-mod-good-prime torsion test (MC2).
+        Some(_) => super::jacobian_torsion::find_order_genus_ge2(n, a, divisor),
+        None => FindOrder::NotDecided,
     }
 }
 
@@ -448,6 +450,25 @@ mod tests {
     fn genus1_incomplete_not_decided() {
         let a = qp(&[1, 0, 0, 1]);
         let div = [place(-1, 0, 1, false, 2)]; // sum = 1 ≠ 0
+        assert_eq!(find_order_placed(2, &a, &div), FindOrder::NotDecided);
+    }
+
+    /// Genus-2 `y²=x⁵+x+1`: the divisor `(0,1) − ∞` (Σ res = 0) routes through
+    /// the MC2 reduction-mod-good-prime test and is certified non-elementary.
+    #[test]
+    fn genus2_non_torsion_via_dispatch() {
+        let a = qp(&[1, 1, 0, 0, 0, 1]);
+        assert_eq!(genus(2, &a), Some(2));
+        let div = [place(0, 1, 1, false, 1), place(0, 0, -1, true, 1)];
+        assert_eq!(find_order_placed(2, &a, &div), FindOrder::NonElementary);
+    }
+
+    /// Genus-2 even-degree (real model) `y²=x⁶+1` stays undecided in MC2 scope.
+    #[test]
+    fn genus2_even_degree_not_decided() {
+        let a = qp(&[1, 0, 0, 0, 0, 0, 1]);
+        assert_eq!(genus(2, &a), Some(2));
+        let div = [place(0, 1, 1, false, 1), place(0, -1, -1, false, 1)];
         assert_eq!(find_order_placed(2, &a, &div), FindOrder::NotDecided);
     }
 

--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -13,12 +13,18 @@ use super::poly_utils::{
 };
 use crate::deriv::log::{DerivationLog, RewriteStep};
 use crate::integrate::engine::IntegrationError;
+use crate::integrate::risch::alg_field::{AlgElem, RatFn};
 use crate::integrate::risch::poly_rde::{
-    degree, expr_to_qpoly, poly_add, poly_deriv, poly_mul, poly_scale, qpoly_to_expr, trim, QPoly,
+    degree, expr_to_qpoly, poly_deriv, poly_scale, qpoly_to_expr, trim, QPoly,
 };
-use crate::integrate::risch::rational_rde::{poly_gcd, poly_sub};
+use crate::integrate::risch::rational_rde::{
+    expr_to_qrational, poly_div_exact, poly_divrem, poly_gcd, solve_rational_rde_generalized,
+};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use rug::Rational;
+
+use super::find_order::{find_order_placed, first_rational_root, FindOrder};
+use super::residues::residue_divisor_placed;
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -57,19 +63,7 @@ pub fn integrate_with_sqrt(
                     _ => unreachable!(),
                 }
             } else {
-                // deg P ≥ 3.  For a **polynomial** weight `B`, `∫ B·√P dx` has no
-                // finite poles, so it is elementary iff it equals `Q(x)·√P`
-                // (Liouville: `∫B√P = Q√P + c·∫dx/√P`, and `∫dx/√P` is
-                // non-elementary for squarefree deg P ≥ 3).  Solve the integral
-                // part; otherwise (with P squarefree) it is genuinely
-                // non-elementary.
-                if let Some(res) = try_integral_part_high_degree(b, p, sqrt_id, var, pool, log) {
-                    return res;
-                }
-                Err(IntegrationError::NonElementary(
-                    "integral over genus-1 (elliptic) or higher curve; no elementary antiderivative"
-                        .to_string(),
-                ))
+                integrate_b_sqrt_high_degree(b, p, sqrt_id, var, pool, log)
             }
         }
     }
@@ -672,115 +666,138 @@ fn binomial_coeff(n: u64, k: u64) -> rug::Integer {
 }
 
 // ---------------------------------------------------------------------------
-// Integral part for ∫ B(x)·√P dx with B polynomial and deg P ≥ 3
+// ∫ B(x)·√P dx for deg P ≥ 3 (genus ≥ 1) — sound decision
 //
-// `B·√P dx` has no finite poles, so by Liouville `∫ B√P = Q·√P + c·∫dx/√P`.
-// For squarefree deg P ≥ 3, `∫dx/√P` is non-elementary, hence the integral is
-// elementary iff `c = 0`, i.e. iff `Q·√P` solves it.  Differentiating,
-// `(Q√P)' = (2Q'P + QP')/(2√P) = B√P` ⟺ the polynomial identity
-//   2·Q'·P + Q·P' = 2·B·P.
-// The operator `Q ↦ 2Q'P + QP'` maps degree-k to degree k+m−1 with nonzero
-// leading coefficient `(2k+m)·lc(P)`, so the identity is solved by top-down
-// elimination; a nonzero remainder means `c ≠ 0` (non-elementary).
+// By Liouville `∫ B√P = b·√P + Σ cⱼ log uⱼ` with `b ∈ ℚ(x)`.  Two parts:
+//
+//  * **Integral part** `b·√P`: differentiating, `(b√P)' = (b' + (P'/2P)·b)·√P`,
+//    so `∫B√P = b√P` iff the rational **Risch DE** `b' + (P'/2P)·b = B` has a
+//    rational solution — solved by `solve_rational_rde_generalized`.  This is
+//    exact (verified by construction) and covers e.g. `∫(P'/2√P) = √P` and
+//    polynomial weights `∫5x⁴√(x⁵+1) = ⅔(x⁵+1)^{3/2}`.
+//
+//  * **Logarithmic part**: when the RDE has no rational solution there are
+//    residues.  Liouville ⟹ no residues ⇒ `∫B√P` is elementary iff it is an
+//    exact algebraic derivative — but the RDE just said it is not — so a
+//    **complete** empty residue divisor (with P squarefree) certifies
+//    `NonElementary`.  With residues, FIND-ORDER decides: a **non-torsion**
+//    divisor ⇒ `NonElementary`; otherwise (torsion log part) emitting it on a
+//    genus ≥ 2 curve needs Coates' construction (genus 0/1 are handled upstream
+//    by the parametrization / genus-1 capstone), so we decline.
+//
+// Soundness of the residue path requires the residue divisor to be **complete**:
+// the residues live at the poles of `B` that are *not* branch points (a pole of
+// `B` at a root of `P` is regularized by `√P`'s zero, contributing none).  So we
+// require the part of `denom(B)` coprime to `P` to split over ℚ; otherwise we
+// decline rather than risk a verdict on an incomplete divisor.
 // ---------------------------------------------------------------------------
 
-/// Try `∫ B·√P dx = Q·√P` for polynomial `B`, deg P ≥ 3.  Returns:
-/// * `Some(Ok(result))` — elementary, `result = Q·√P`;
-/// * `Some(Err(NonElementary))` — `B` polynomial and `P` squarefree but no `Q`
-///   exists (`c ≠ 0`), so the integral is genuinely non-elementary;
-/// * `None` — not applicable (`B` not polynomial, or `P` not squarefree), leave
-///   the decision to the caller.
-fn try_integral_part_high_degree(
+fn integrate_b_sqrt_high_degree(
     b: ExprId,
     p: ExprId,
     sqrt_id: ExprId,
     var: ExprId,
     pool: &ExprPool,
     log: &mut DerivationLog,
-) -> Option<Result<ExprId, IntegrationError>> {
-    let p_poly = expr_to_qpoly(p, var, pool)?;
-    let b_poly = expr_to_qpoly(b, var, pool)?; // `None` ⇒ B not polynomial
+) -> Result<ExprId, IntegrationError> {
+    let nonelem = |msg: &str| IntegrationError::NonElementary(msg.to_string());
+    let notimpl = |msg: &str| IntegrationError::NotImplemented(msg.to_string());
+
+    let p_poly = expr_to_qpoly(p, var, pool)
+        .ok_or_else(|| notimpl("radicand P is not a polynomial in the variable"))?;
+    let (b_num, b_den) = expr_to_qrational(b, var, pool)
+        .ok_or_else(|| notimpl("weight B is not a rational function"))?;
     if degree(&p_poly) < 3 {
-        return None;
+        return Err(notimpl("expected deg P ≥ 3 here"));
     }
-    // P must be squarefree for the NonElementary conclusion to be sound.
-    let p_sqfree = degree(&poly_gcd(&p_poly, &poly_deriv(&p_poly))) <= 0;
-    if !p_sqfree {
-        return None;
+
+    // 1. Integral part: b' + (P'/2P)·b = B  ⇒  ∫B√P = b·√P.
+    let p_prime = poly_deriv(&p_poly);
+    let two_p = poly_scale(&p_poly, &Rational::from(2));
+    if let Some((q_num, q_den)) = solve_rational_rde_generalized(&p_prime, &two_p, &b_num, &b_den) {
+        let q_expr = qrational_to_expr(&q_num, &q_den, var, pool);
+        let result = pool.mul(vec![q_expr, sqrt_id]);
+        log.push(RewriteStep::simple("alg_integral_part_sqrt", b, result));
+        return Ok(result);
     }
-    if degree(&b_poly) < 0 {
-        return None; // B = 0 handled elsewhere
+
+    // 2. No algebraic primitive — analyze the logarithmic part via residues.
+    //    Need P squarefree for the Liouville argument below.
+    if degree(&poly_gcd(&p_poly, &p_prime)) > 0 {
+        return Err(notimpl("non-squarefree radicand at deg ≥ 3"));
     }
-    match solve_integral_part(&p_poly, &b_poly) {
-        Some(q) => {
-            let q_expr = qpoly_to_expr(&q, var, pool);
-            let result = pool.mul(vec![q_expr, sqrt_id]);
-            log.push(RewriteStep::simple("alg_integral_part_sqrt", b, result));
-            Some(Ok(result))
+    // Completeness: poles of B off the branch locus must be rational.
+    let b_den_coprime = strip_common_factors(&b_den, &p_poly);
+    if !splits_over_q(&b_den_coprime) {
+        return Err(notimpl(
+            "B has poles at non-rational points off the branch locus; \
+             residue divisor would be incomplete",
+        ));
+    }
+
+    let h: AlgElem = vec![RatFn::int(0), RatFn::new(b_num.clone(), b_den.clone())];
+    let divisor = residue_divisor_placed(2, &p_poly, &h);
+    if divisor.is_empty() {
+        // No residues ⇒ no logarithmic part (Liouville); the RDE already ruled
+        // out an algebraic primitive ⇒ a nonzero first/second-kind differential
+        // on a genus ≥ 1 curve ⇒ non-elementary.
+        return Err(nonelem(
+            "∫ B·√P over a genus ≥ 1 curve with no logarithmic part and no \
+             algebraic primitive: non-elementary",
+        ));
+    }
+    match find_order_placed(2, &p_poly, &divisor) {
+        FindOrder::NonElementary => Err(nonelem(
+            "residue divisor is non-torsion (FIND-ORDER): no elementary logarithmic part",
+        )),
+        // Torsion / undecided: an elementary log part may exist, but constructing
+        // it on a genus ≥ 2 curve needs Coates' algorithm (not yet implemented).
+        _ => Err(notimpl(
+            "genus ≥ 2 logarithmic part: residue divisor torsion/undecided, \
+             log argument not yet constructible (Coates)",
+        )),
+    }
+}
+
+/// Build the expression `num(x)/den(x)`.
+fn qrational_to_expr(num: &QPoly, den: &QPoly, var: ExprId, pool: &ExprPool) -> ExprId {
+    let n = qpoly_to_expr(num, var, pool);
+    if den.len() == 1 && den.first().map(|c| *c == 1).unwrap_or(false) {
+        return n;
+    }
+    let d = qpoly_to_expr(den, var, pool);
+    pool.mul(vec![n, pool.pow(d, pool.integer(-1_i32))])
+}
+
+/// Divide `q` by all factors it shares with `p` (remove the gcd repeatedly), so
+/// the result is coprime to `p`.
+fn strip_common_factors(q: &QPoly, p: &QPoly) -> QPoly {
+    let mut d = trim(q.clone());
+    loop {
+        let g = poly_gcd(&d, p);
+        if degree(&g) <= 0 {
+            break;
         }
-        None => Some(Err(IntegrationError::NonElementary(
-            "∫ B(x)·√P with B polynomial, P squarefree of degree ≥ 3: integral \
-             part has a residual ∫dx/√P (non-elementary)"
-                .to_string(),
-        ))),
+        d = poly_div_exact(&d, &g);
     }
+    d
 }
 
-/// Solve `2·Q'·P + Q·P' = 2·B·P` for a polynomial `Q ∈ ℚ[x]`, or `None` if no
-/// polynomial solution exists.
-fn solve_integral_part(p: &QPoly, b: &QPoly) -> Option<QPoly> {
-    let m = degree(p);
-    if m < 1 {
-        return None;
-    }
-    let lc = p[m as usize].clone();
-    let p_prime = poly_deriv(p);
-    let bdeg = degree(b);
-    if bdeg < 0 {
-        return None;
-    }
-    let qdeg = bdeg + 1;
-    let mut q = vec![Rational::from(0); (qdeg + 1) as usize];
-    let mut rem = poly_scale(&poly_mul(b, p), &Rational::from(2)); // 2·B·P
-
-    for k in (0..=qdeg).rev() {
-        let d = (k + m - 1) as usize; // leading degree contributed by qₖ·xᵏ
-        let cd = rem.get(d).cloned().unwrap_or_else(|| Rational::from(0));
-        if cd == 0 {
-            continue; // qₖ = 0
+/// Does `poly` factor into linear factors over ℚ (all roots rational)?  Decided
+/// by repeatedly deflating rational roots (rational-root theorem is complete).
+fn splits_over_q(poly: &QPoly) -> bool {
+    let mut p = trim(poly.clone());
+    while degree(&p) >= 1 {
+        match first_rational_root(&p) {
+            Some(r) => {
+                let lin = vec![-r, Rational::from(1)];
+                let (q, _rem) = poly_divrem(&p, &lin);
+                p = trim(q);
+            }
+            None => return false,
         }
-        // qₖ = cd / ((2k+m)·lc(P)).
-        let factor = Rational::from(2 * k + m) * &lc;
-        let qk = cd / factor;
-        q[k as usize] = qk.clone();
-        // rem −= qₖ · L(xᵏ),  L(xᵏ) = 2k·x^{k−1}·P + xᵏ·P'.
-        let lxk = l_of_monomial(k, p, &p_prime);
-        rem = poly_sub(&rem, &poly_scale(&lxk, &qk));
     }
-
-    if degree(&trim(rem)) >= 0 {
-        return None; // nonzero remainder ⇒ no polynomial Q ⇒ c ≠ 0
-    }
-    Some(trim(q))
-}
-
-/// `L(xᵏ) = 2k·x^{k−1}·P + xᵏ·P'`.
-fn l_of_monomial(k: i64, p: &QPoly, p_prime: &QPoly) -> QPoly {
-    let xk = monomial(k);
-    let mut out = poly_mul(&xk, p_prime);
-    if k >= 1 {
-        let xk1 = monomial(k - 1);
-        let term = poly_scale(&poly_mul(&xk1, p), &Rational::from(2 * k));
-        out = poly_add(&out, &term);
-    }
-    out
-}
-
-/// The monomial `xᵏ` as a `QPoly` (`k ≥ 0`).
-fn monomial(k: i64) -> QPoly {
-    let mut v = vec![Rational::from(0); (k.max(0) + 1) as usize];
-    v[k.max(0) as usize] = Rational::from(1);
-    v
+    true
 }
 
 fn neg_c_power(c: &rug::Integer, n: i64) -> rug::Integer {

--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -1,7 +1,10 @@
 //! Integration formulas for genus-0 algebraic extensions.
 //!
 //! Handles `∫ B(x) · sqrt(P(x)) dx` when P has degree ≤ 2 (genus-0 curve).
-//! For degree ≥ 3, returns `IntegrationError::NonElementary`.
+//! For degree ≥ 3 with a **polynomial** weight `B`, the *integral part*
+//! `∫ B√P = Q·√P` is solved when it exists (Liouville), so elementary cases such
+//! as `∫ (P'/2)·√P = ⅓P^{3/2}` are returned rather than wrongly rejected;
+//! otherwise (with P squarefree) the integral is genuinely `NonElementary`.
 //!
 //! Reference: Bronstein (2005) §6.3–6.5; standard CAS table integrals.
 
@@ -10,7 +13,12 @@ use super::poly_utils::{
 };
 use crate::deriv::log::{DerivationLog, RewriteStep};
 use crate::integrate::engine::IntegrationError;
+use crate::integrate::risch::poly_rde::{
+    degree, expr_to_qpoly, poly_add, poly_deriv, poly_mul, poly_scale, qpoly_to_expr, trim, QPoly,
+};
+use crate::integrate::risch::rational_rde::{poly_gcd, poly_sub};
 use crate::kernel::{ExprData, ExprId, ExprPool};
+use rug::Rational;
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -46,12 +54,18 @@ pub fn integrate_with_sqrt(
                     0 => integrate_b_sqrt_const(b, p, sqrt_id, var, pool, log),
                     1 => integrate_b_sqrt_linear(b, p, sqrt_id, var, pool, log),
                     2 => integrate_b_sqrt_quadratic(b, p, sqrt_id, var, pool, log),
-                    _ => Err(IntegrationError::NonElementary(
-                        "integral over genus-1 (elliptic) or higher curve; no elementary antiderivative"
-                            .to_string(),
-                    )),
+                    _ => unreachable!(),
                 }
             } else {
+                // deg P ≥ 3.  For a **polynomial** weight `B`, `∫ B·√P dx` has no
+                // finite poles, so it is elementary iff it equals `Q(x)·√P`
+                // (Liouville: `∫B√P = Q√P + c·∫dx/√P`, and `∫dx/√P` is
+                // non-elementary for squarefree deg P ≥ 3).  Solve the integral
+                // part; otherwise (with P squarefree) it is genuinely
+                // non-elementary.
+                if let Some(res) = try_integral_part_high_degree(b, p, sqrt_id, var, pool, log) {
+                    return res;
+                }
                 Err(IntegrationError::NonElementary(
                     "integral over genus-1 (elliptic) or higher curve; no elementary antiderivative"
                         .to_string(),
@@ -655,6 +669,118 @@ fn binomial_coeff(n: u64, k: u64) -> rug::Integer {
         result /= rug::Integer::from(i + 1);
     }
     result
+}
+
+// ---------------------------------------------------------------------------
+// Integral part for ∫ B(x)·√P dx with B polynomial and deg P ≥ 3
+//
+// `B·√P dx` has no finite poles, so by Liouville `∫ B√P = Q·√P + c·∫dx/√P`.
+// For squarefree deg P ≥ 3, `∫dx/√P` is non-elementary, hence the integral is
+// elementary iff `c = 0`, i.e. iff `Q·√P` solves it.  Differentiating,
+// `(Q√P)' = (2Q'P + QP')/(2√P) = B√P` ⟺ the polynomial identity
+//   2·Q'·P + Q·P' = 2·B·P.
+// The operator `Q ↦ 2Q'P + QP'` maps degree-k to degree k+m−1 with nonzero
+// leading coefficient `(2k+m)·lc(P)`, so the identity is solved by top-down
+// elimination; a nonzero remainder means `c ≠ 0` (non-elementary).
+// ---------------------------------------------------------------------------
+
+/// Try `∫ B·√P dx = Q·√P` for polynomial `B`, deg P ≥ 3.  Returns:
+/// * `Some(Ok(result))` — elementary, `result = Q·√P`;
+/// * `Some(Err(NonElementary))` — `B` polynomial and `P` squarefree but no `Q`
+///   exists (`c ≠ 0`), so the integral is genuinely non-elementary;
+/// * `None` — not applicable (`B` not polynomial, or `P` not squarefree), leave
+///   the decision to the caller.
+fn try_integral_part_high_degree(
+    b: ExprId,
+    p: ExprId,
+    sqrt_id: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+    log: &mut DerivationLog,
+) -> Option<Result<ExprId, IntegrationError>> {
+    let p_poly = expr_to_qpoly(p, var, pool)?;
+    let b_poly = expr_to_qpoly(b, var, pool)?; // `None` ⇒ B not polynomial
+    if degree(&p_poly) < 3 {
+        return None;
+    }
+    // P must be squarefree for the NonElementary conclusion to be sound.
+    let p_sqfree = degree(&poly_gcd(&p_poly, &poly_deriv(&p_poly))) <= 0;
+    if !p_sqfree {
+        return None;
+    }
+    if degree(&b_poly) < 0 {
+        return None; // B = 0 handled elsewhere
+    }
+    match solve_integral_part(&p_poly, &b_poly) {
+        Some(q) => {
+            let q_expr = qpoly_to_expr(&q, var, pool);
+            let result = pool.mul(vec![q_expr, sqrt_id]);
+            log.push(RewriteStep::simple("alg_integral_part_sqrt", b, result));
+            Some(Ok(result))
+        }
+        None => Some(Err(IntegrationError::NonElementary(
+            "∫ B(x)·√P with B polynomial, P squarefree of degree ≥ 3: integral \
+             part has a residual ∫dx/√P (non-elementary)"
+                .to_string(),
+        ))),
+    }
+}
+
+/// Solve `2·Q'·P + Q·P' = 2·B·P` for a polynomial `Q ∈ ℚ[x]`, or `None` if no
+/// polynomial solution exists.
+fn solve_integral_part(p: &QPoly, b: &QPoly) -> Option<QPoly> {
+    let m = degree(p);
+    if m < 1 {
+        return None;
+    }
+    let lc = p[m as usize].clone();
+    let p_prime = poly_deriv(p);
+    let bdeg = degree(b);
+    if bdeg < 0 {
+        return None;
+    }
+    let qdeg = bdeg + 1;
+    let mut q = vec![Rational::from(0); (qdeg + 1) as usize];
+    let mut rem = poly_scale(&poly_mul(b, p), &Rational::from(2)); // 2·B·P
+
+    for k in (0..=qdeg).rev() {
+        let d = (k + m - 1) as usize; // leading degree contributed by qₖ·xᵏ
+        let cd = rem.get(d).cloned().unwrap_or_else(|| Rational::from(0));
+        if cd == 0 {
+            continue; // qₖ = 0
+        }
+        // qₖ = cd / ((2k+m)·lc(P)).
+        let factor = Rational::from(2 * k + m) * &lc;
+        let qk = cd / factor;
+        q[k as usize] = qk.clone();
+        // rem −= qₖ · L(xᵏ),  L(xᵏ) = 2k·x^{k−1}·P + xᵏ·P'.
+        let lxk = l_of_monomial(k, p, &p_prime);
+        rem = poly_sub(&rem, &poly_scale(&lxk, &qk));
+    }
+
+    if degree(&trim(rem)) >= 0 {
+        return None; // nonzero remainder ⇒ no polynomial Q ⇒ c ≠ 0
+    }
+    Some(trim(q))
+}
+
+/// `L(xᵏ) = 2k·x^{k−1}·P + xᵏ·P'`.
+fn l_of_monomial(k: i64, p: &QPoly, p_prime: &QPoly) -> QPoly {
+    let xk = monomial(k);
+    let mut out = poly_mul(&xk, p_prime);
+    if k >= 1 {
+        let xk1 = monomial(k - 1);
+        let term = poly_scale(&poly_mul(&xk1, p), &Rational::from(2 * k));
+        out = poly_add(&out, &term);
+    }
+    out
+}
+
+/// The monomial `xᵏ` as a `QPoly` (`k ≥ 0`).
+fn monomial(k: i64) -> QPoly {
+    let mut v = vec![Rational::from(0); (k.max(0) + 1) as usize];
+    v[k.max(0) as usize] = Rational::from(1);
+    v
 }
 
 fn neg_c_power(c: &rug::Integer, n: i64) -> rug::Integer {

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -235,25 +235,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -14,13 +14,18 @@
 //! automatically by the `V·ωᵢ` term, so this is correct including at the
 //! branch locus.
 //!
-//! Sound by construction: the result is accepted only after the exact field
-//! identity `g' + h = f` is verified, and each `h` component is checked to have a
-//! squarefree denominator.
+//! [`hermite_reduce_general`] handles an **arbitrary** curve `F(x,y)=0` over the
+//! van Hoeij integral basis: the leading pole cancellation is componentwise
+//! scalar (mod `V`) on the **normal part** (factors coprime to the discriminant,
+//! where `wᵢ'` is regular), with the basis-derivation mixing handled by iteration.
 //!
-//! Scope: simple radical extensions (the diagonal case).  The general
-//! (non-diagonal) integral basis needs the coupled derivation matrix and is the
-//! documented follow-up — its substrate (`integral_basis`, `is_integral`) exists.
+//! Sound by construction: every result is accepted only after the exact field
+//! identity `g' + h = f` is verified, and each `h` component is checked to have a
+//! squarefree denominator (on the normal part).
+//!
+//! Remaining follow-up: the `different`-aware ("lazy") Hermite step that also
+//! reduces **repeated poles on the branch locus** (factors dividing the
+//! discriminant), which [`hermite_reduce_general`] leaves in place.
 
 use rug::Rational;
 
@@ -28,7 +33,8 @@ use super::super::risch::alg_field::{AlgElem, AlgExtension, RatFn, RationalFunct
 use super::super::risch::number_field::{mod_inverse, CoeffField};
 use super::super::risch::poly_rde::{degree, poly_deriv, poly_mul, trim, QPoly};
 use super::super::risch::rational_rde::{poly_div_exact, poly_gcd};
-use super::integral_basis::{radical_integral_basis, squarefree_factors};
+use super::integral_basis::{discriminant, radical_integral_basis, squarefree_factors};
+use super::vanhoeij::integral_basis;
 
 /// Hermite reduction of `∫ f dx` on the curve `yⁿ = a(x)`.  Returns `(g, h)` with
 /// `f = g' + h` and every component of `h` having a squarefree denominator
@@ -95,6 +101,198 @@ pub fn hermite_reduce_radical(
         return None;
     }
     Some((g, h))
+}
+
+/// Hermite reduction of `∫ f dx` on a **general** curve `F(x,y)=0` (not
+/// necessarily a simple radical), over the van Hoeij integral basis.  Returns
+/// `(g, h)` with `f = g' + h`, `g ∈ ℚ(x)(y)` the algebraic part and `h` a
+/// differential of the **third kind** — every integral-basis coordinate of `h`
+/// has a squarefree denominator on the **normal part** (the locus coprime to the
+/// discriminant).  `None` if the basis is unavailable or a soundness gate fails.
+///
+/// Reduces the repeated factors `V` of the denominator that are **coprime to the
+/// discriminant** (where the basis derivation is regular, so `wᵢ'` has no pole at
+/// `V`).  There the leading order-`M` pole cancels **componentwise**: with
+/// `D = U·V^M`, the integral element `b = Σ bᵢ wᵢ` solving
+/// `bᵢ ≡ −Aᵢ·(U·(M−1)·V')⁻¹ (mod V)` makes `(b/V^{M−1})'` match the pole, so
+/// `f − (b/V^{M−1})'` drops one power of `V`.  The basis-mixing `wᵢ' = Σ Mᵢⱼ wⱼ`
+/// only perturbs lower orders and is handled by iteration.  Branch-locus repeated
+/// poles (factors dividing the discriminant) are left untouched — that is the
+/// `different`-aware ("lazy") Hermite step, a documented follow-up.
+///
+/// Sound by construction: accepted only after the exact field identity
+/// `g' + h = f` holds and every `h`-coordinate denominator is squarefree on the
+/// normal part.
+pub fn hermite_reduce_general(
+    f_coeffs: &[QPoly],
+    integrand: &AlgElem,
+) -> Option<(AlgElem, AlgElem)> {
+    let ext = AlgExtension::new(f_coeffs);
+    let n = ext.degree() as usize;
+    if n < 2 {
+        return None;
+    }
+    let basis = integral_basis(f_coeffs)?;
+    let disc = discriminant(f_coeffs);
+
+    let mut cur = pad(integrand, n);
+    let mut g = ext.from_int(0);
+
+    let denom_total = |e: &AlgElem| -> i64 {
+        to_w_coords(&basis, e, n)
+            .map(|cs| cs.iter().map(|c| degree(c.denom()).max(0)).sum())
+            .unwrap_or(0)
+    };
+    let cap = 4 * (denom_total(&cur) as usize) + 8;
+
+    for _ in 0..cap {
+        let coords = to_w_coords(&basis, &cur, n)?;
+        let (d_poly, a_polys) = common_denominator(&coords);
+        // Highest-multiplicity repeated factor V of the **normal part** (mult ≥ 2,
+        // coprime to the discriminant), where the basis derivation is regular.
+        let sqf = squarefree_factors(&d_poly);
+        let Some((v, m)) = sqf
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(k, p)| *k + 1 >= 2 && degree(p) >= 1 && degree(&poly_gcd(p, &disc)) <= 0)
+            .map(|(k, p)| (p.clone(), k + 1))
+        else {
+            break; // normal part squarefree → done
+        };
+
+        // s = U·(M−1)·V'  (scalar in ℚ[x]); invertible mod V.
+        let vm = poly_pow(&v, m as u32);
+        let u = poly_div_exact(&d_poly, &vm);
+        let s = poly_scale(
+            &poly_mul(&u, &poly_deriv(&v)),
+            &Rational::from((m - 1) as i64),
+        );
+        let s_inv = mod_inverse(&s, &v)?;
+
+        // bᵢ = (−Aᵢ·s⁻¹) mod V, componentwise; b = Σ bᵢ wᵢ (→ power basis).
+        let mut b_w = vec![RatFn::int(0); n];
+        for (i, ai) in a_polys.iter().enumerate() {
+            let bi = poly_mod(&poly_mul(ai, &s_inv), &v);
+            b_w[i] = RatFn::from_poly(&poly_scale(&bi, &Rational::from(-1)));
+        }
+        let b_power = w_to_power(&basis, &b_w, &ext, n);
+
+        // term = b/V^{M−1};  cur −= term';  g += term.
+        let inv_vm1 = RatFn::new(vec![Rational::from(1)], poly_pow(&v, (m - 1) as u32));
+        let term = scale_elem(&b_power, &inv_vm1);
+        if ext.elem_eq(&term, &ext.from_int(0)) {
+            break; // no progress possible at this place
+        }
+        let next = ext.sub(&cur, &ext.derivation(&term));
+        g = ext.add(&g, &term);
+        // Progress guard: the normal-part denominator must strictly drop.
+        if denom_total(&next) >= denom_total(&cur) {
+            cur = next;
+            break;
+        }
+        cur = next;
+    }
+
+    let h = cur;
+    // Gate 1: every h-coordinate denominator is squarefree on the normal part.
+    let hcoords = to_w_coords(&basis, &h, n)?;
+    for c in &hcoords {
+        let den = c.denom();
+        let g_sq = poly_gcd(den, &poly_deriv(den));
+        // Allow repeated factors only at the discriminant (branch) locus.
+        if degree(&poly_gcd(&g_sq, &disc)) < degree(&g_sq) {
+            return None;
+        }
+    }
+    // Gate 2: g' + h = f exactly in the field.
+    let lhs = ext.add(&ext.derivation(&g), &h);
+    if !ext.elem_eq(&lhs, integrand) {
+        return None;
+    }
+    Some((g, h))
+}
+
+/// Pad an `AlgElem` to length `n` with zero coordinates.
+fn pad(e: &AlgElem, n: usize) -> AlgElem {
+    let mut v = e.clone();
+    while v.len() < n {
+        v.push(RatFn::int(0));
+    }
+    v
+}
+
+/// Coordinates of `elem` in the integral basis: solve `Σ cᵢ·basisᵢ = elem` over
+/// `ℚ(x)`.  `None` if the basis matrix is singular (should not happen).
+fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>> {
+    let f = RationalFunctionField;
+    let comp = |e: &AlgElem, r: usize| e.get(r).cloned().unwrap_or_else(|| RatFn::int(0));
+    // Augmented matrix: column i = basisᵢ (coeff of yʳ in row r), last column = elem.
+    let mut m: Vec<Vec<RatFn>> = (0..n)
+        .map(|r| {
+            let mut row: Vec<RatFn> = (0..n).map(|i| comp(&basis[i], r)).collect();
+            row.push(comp(elem, r));
+            row
+        })
+        .collect();
+    // Gaussian elimination over ℚ(x).
+    let mut piv_row = 0;
+    for col in 0..n {
+        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(piv_row, sel);
+        let inv = f.inv(&m[piv_row][col])?;
+        for v in m[piv_row].iter_mut() {
+            *v = f.mul(v, &inv);
+        }
+        for r in 0..n {
+            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+                let factor = m[r][col].clone();
+                for c in 0..=n {
+                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    m[r][c] = f.sub(&m[r][c], &sub);
+                }
+            }
+        }
+        piv_row += 1;
+    }
+    Some((0..n).map(|i| m[i][n].clone()).collect())
+}
+
+/// `Σ coordsᵢ · basisᵢ` (integral basis → power basis).
+fn w_to_power(basis: &[AlgElem], coords: &[RatFn], ext: &AlgExtension, n: usize) -> AlgElem {
+    let mut acc = ext.from_int(0);
+    for i in 0..n {
+        acc = ext.add(&acc, &scale_elem(&basis[i], &coords[i]));
+    }
+    acc
+}
+
+/// Multiply every coordinate of `elem` by the scalar `s ∈ ℚ(x)`.
+fn scale_elem(elem: &AlgElem, s: &RatFn) -> AlgElem {
+    let f = RationalFunctionField;
+    elem.iter().map(|c| f.mul(s, c)).collect()
+}
+
+/// Common denominator `D` of the coordinates and the integral numerators
+/// `Aᵢ = numer(cᵢ)·(D/denom(cᵢ))`, so `cᵢ = Aᵢ/D`.
+fn common_denominator(coords: &[RatFn]) -> (QPoly, Vec<QPoly>) {
+    let mut d = vec![Rational::from(1)];
+    for c in coords {
+        d = poly_lcm(&d, c.denom());
+    }
+    let a = coords
+        .iter()
+        .map(|c| poly_mul(c.numer(), &poly_div_exact(&d, c.denom())))
+        .collect();
+    (d, a)
+}
+
+/// Least common multiple `a·b/gcd(a,b)` over `ℚ[x]`.
+fn poly_lcm(a: &QPoly, b: &QPoly) -> QPoly {
+    if degree(a) < 0 || degree(b) < 0 {
+        return vec![Rational::from(1)];
+    }
+    poly_div_exact(&poly_mul(a, b), &poly_gcd(a, b))
 }
 
 /// `ωᵢ = i·a'/(n·a) − dᵢ'/dᵢ`, the basis-derivative coefficient `wᵢ' = ωᵢ wᵢ`.
@@ -264,6 +462,63 @@ mod tests {
         let (g, h) = hermite_reduce_radical(2, &qp(&[0, 1]), &integrand).expect("reduce");
         // h has squarefree denominator (gate) and the algebraic part is nontrivial.
         assert!(!g.iter().all(|c| c.numer().is_empty()));
+        for hi in &h {
+            let den = hi.denom();
+            assert!(degree(&poly_gcd(den, &poly_deriv(den))) <= 0);
+        }
+    }
+
+    /// General (non-radical) curve `y² + y − x³ = 0` (a `y`-term ⇒ non-radical;
+    /// disc = 1+4x³ squarefree ⇒ nonsingular, basis {1, y}).  Reduce an **exact
+    /// derivative**: take `g₀ = y/(x−1)` (a simple pole off the branch locus),
+    /// `f = g₀'` has a double pole; Hermite must recover `h = 0` with `g' = f`.
+    #[test]
+    fn general_curve_exact_derivative_reduces_to_zero() {
+        // F = y² + y − x³  ⇒  coeffs [ -x³, 1, 1 ].
+        let f_coeffs = [qp(&[0, 0, 0, -1]), qp(&[1]), qp(&[1])];
+        let ext = AlgExtension::new(&f_coeffs);
+        let g0 = vec![RatFn::int(0), rf(&[1], &[-1, 1])]; // y/(x−1)
+        let f = ext.derivation(&g0);
+        let (g, h) = hermite_reduce_general(&f_coeffs, &f).expect("reduce");
+        // Exact derivative ⇒ no third-kind remainder.
+        assert!(h.iter().all(|c| c.numer().is_empty()), "h = {h:?}");
+        // g' = f.
+        assert!(ext.elem_eq(&ext.derivation(&g), &f));
+    }
+
+    /// General curve, a double pole that is **not** an exact derivative: the
+    /// reduction still lowers the pole and the `g' + h = f` gate holds with `h`
+    /// having a squarefree (normal-part) denominator.
+    #[test]
+    fn general_curve_double_pole_reduces() {
+        let f_coeffs = [qp(&[0, 0, 0, -1]), qp(&[1]), qp(&[1])]; // y²+y−x³
+        let ext = AlgExtension::new(&f_coeffs);
+        // f = y/(x−1)²  = AlgElem [0, 1/(x−1)²];  (x−1)² = x²−2x+1.
+        let f = vec![RatFn::int(0), rf(&[1], &[1, -2, 1])];
+        let (g, h) = hermite_reduce_general(&f_coeffs, &f).expect("reduce");
+        // Nontrivial algebraic part extracted.
+        assert!(!g.iter().all(|c| c.numer().is_empty()));
+        // g' + h = f exactly.
+        assert!(ext.elem_eq(&ext.add(&ext.derivation(&g), &h), &f));
+        // h denominators squarefree (x=1 is off the branch locus disc=1+4x³).
+        for hi in &h {
+            let den = hi.denom();
+            assert!(degree(&poly_gcd(den, &poly_deriv(den))) <= 0);
+        }
+    }
+
+    /// The general reducer handles a higher-degree radical curve at an
+    /// **off-branch** pole: y³ = x (disc ∝ x², branch at 0), integrand y/(x−1)²
+    /// (pole at x=1, normal).  The pole is lowered and the `g'+h=f` gate holds
+    /// with squarefree `h` — exercising the degree-3 basis derivation mixing.
+    #[test]
+    fn general_off_branch_pole_cubic_radical() {
+        let f_coeffs = [qp(&[0, -1]), qp(&[]), qp(&[]), qp(&[1])]; // y³ − x
+        let ext = AlgExtension::new(&f_coeffs);
+        let f = vec![RatFn::int(0), rf(&[1], &[1, -2, 1])]; // y/(x−1)²
+        let (g, h) = hermite_reduce_general(&f_coeffs, &f).expect("reduce");
+        assert!(!g.iter().all(|c| c.numer().is_empty()));
+        assert!(ext.elem_eq(&ext.add(&ext.derivation(&g), &h), &f));
         for hi in &h {
             let den = hi.denom();
             assert!(degree(&poly_gcd(den, &poly_deriv(den))) <= 0);

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -1,0 +1,787 @@
+//! MC2 — FIND-ORDER on genus ≥ 2 curves by reduction modulo good primes.
+//!
+//! For a hyperelliptic curve `y² = a(x)` of genus `g ≥ 2` there is **no uniform
+//! bound** on the order of a rational torsion divisor class, so the genus-1
+//! Mazur shortcut ([`super::find_order`]) does not apply.  Instead we use the
+//! classical *reduction-mod-good-prime* test (Bronstein 1990 Prop. 1.16–1.17;
+//! Davenport, *problem of torsion divisors*):
+//!
+//! 1. Reduce the curve and the residue divisor `δ` modulo several **good primes**
+//!    `p` (`p ≠ 2`, `a` stays squarefree of full degree, denominators invertible).
+//! 2. Compute the order `mₚ` of the reduced class in the finite group
+//!    `Jac(F_p)` — using Cantor's algorithm on Mumford representations.
+//! 3. **Reduction is injective on prime-to-`p` torsion** (a theorem).  Hence if
+//!    `δ` were torsion over ℚ of order `N`, then for every good prime the
+//!    `prime-to-p` part of `N` equals the `prime-to-p` part of `mₚ`.  Comparing
+//!    two good primes therefore pins every `v_ℓ(N)` and any **disagreement
+//!    certifies `δ` is non-torsion** ⇒ the integral is non-elementary.
+//!
+//! This module asserts only the *sound* half of the genus-graded decision:
+//!
+//! * [`FindOrder::NonElementary`] when the prime-to-`p` orders are provably
+//!   inconsistent (a real theorem — no false positives).
+//! * [`FindOrder::NotDecided`] otherwise (too few good primes, even-degree /
+//!   real model, or a *consistent* candidate torsion order).  Certifying the
+//!   consistent case as `Principal{N}` would additionally require constructing a
+//!   function with divisor `N·δ` (Coates' algorithm / Riemann–Roch), which is
+//!   not yet implemented for genus ≥ 2; we never claim `Principal` here.
+//!
+//! Scope: `n = 2` (hyperelliptic), `a` squarefree of **odd** degree `2g+1`
+//! (imaginary model, a single rational place at infinity).  Even degree (real
+//! model, two places at infinity) and `n > 2` fall through to `NotDecided`.
+
+use rug::{Integer, Rational};
+
+use super::super::risch::poly_rde::{degree, trim, QPoly};
+use super::find_order::FindOrder;
+use super::residues::PlacedResidue;
+
+// ===========================================================================
+// F_p scalar arithmetic
+// ===========================================================================
+
+#[inline]
+fn mulmod(a: u64, b: u64, p: u64) -> u64 {
+    ((a as u128 * b as u128) % p as u128) as u64
+}
+
+#[inline]
+fn addmod(a: u64, b: u64, p: u64) -> u64 {
+    let s = a + b;
+    if s >= p {
+        s - p
+    } else {
+        s
+    }
+}
+
+#[inline]
+fn submod(a: u64, b: u64, p: u64) -> u64 {
+    if a >= b {
+        a - b
+    } else {
+        p - (b - a)
+    }
+}
+
+fn powmod(mut base: u64, mut exp: u64, p: u64) -> u64 {
+    let mut r = 1u64 % p;
+    base %= p;
+    while exp > 0 {
+        if exp & 1 == 1 {
+            r = mulmod(r, base, p);
+        }
+        base = mulmod(base, base, p);
+        exp >>= 1;
+    }
+    r
+}
+
+/// Inverse of `a` in `F_p` (`p` prime, `a ≢ 0`).
+fn invmod(a: u64, p: u64) -> u64 {
+    powmod(a % p, p - 2, p)
+}
+
+/// Reduce a rational `r = n/d` to `F_p`; `None` if `p | d`.
+fn rat_to_fp(r: &Rational, p: u64) -> Option<u64> {
+    let pb = Integer::from(p);
+    let dm = {
+        let m = r.denom().clone() % pb.clone();
+        let m = if m < 0 { m + &pb } else { m };
+        m.to_u64().unwrap()
+    };
+    if dm == 0 {
+        return None;
+    }
+    let nm = {
+        let m = r.numer().clone() % pb.clone();
+        let m = if m < 0 { m + &pb } else { m };
+        m.to_u64().unwrap()
+    };
+    Some(mulmod(nm, invmod(dm, p), p))
+}
+
+// ===========================================================================
+// F_p[x] polynomial arithmetic — dense, little-endian (index = degree).
+// ===========================================================================
+
+type FpPoly = Vec<u64>;
+
+fn fp_trim(mut a: FpPoly) -> FpPoly {
+    while a.last() == Some(&0) {
+        a.pop();
+    }
+    a
+}
+
+/// Degree, or `None` for the zero polynomial.
+fn fp_deg(a: &[u64]) -> Option<usize> {
+    let a = fp_trim(a.to_vec());
+    if a.is_empty() {
+        None
+    } else {
+        Some(a.len() - 1)
+    }
+}
+
+fn fp_add(a: &[u64], b: &[u64], p: u64) -> FpPoly {
+    let n = a.len().max(b.len());
+    let mut r = vec![0u64; n];
+    for (i, slot) in r.iter_mut().enumerate() {
+        let av = a.get(i).copied().unwrap_or(0);
+        let bv = b.get(i).copied().unwrap_or(0);
+        *slot = addmod(av, bv, p);
+    }
+    fp_trim(r)
+}
+
+fn fp_sub(a: &[u64], b: &[u64], p: u64) -> FpPoly {
+    let n = a.len().max(b.len());
+    let mut r = vec![0u64; n];
+    for (i, slot) in r.iter_mut().enumerate() {
+        let av = a.get(i).copied().unwrap_or(0);
+        let bv = b.get(i).copied().unwrap_or(0);
+        *slot = submod(av, bv, p);
+    }
+    fp_trim(r)
+}
+
+fn fp_scale(a: &[u64], s: u64, p: u64) -> FpPoly {
+    if s == 0 {
+        return vec![];
+    }
+    fp_trim(a.iter().map(|&c| mulmod(c, s, p)).collect())
+}
+
+fn fp_mul(a: &[u64], b: &[u64], p: u64) -> FpPoly {
+    if a.is_empty() || b.is_empty() {
+        return vec![];
+    }
+    let mut r = vec![0u64; a.len() + b.len() - 1];
+    for (i, &ai) in a.iter().enumerate() {
+        if ai == 0 {
+            continue;
+        }
+        for (j, &bj) in b.iter().enumerate() {
+            r[i + j] = addmod(r[i + j], mulmod(ai, bj, p), p);
+        }
+    }
+    fp_trim(r)
+}
+
+/// Make `a` monic; returns `(monic, leading_coeff)`.  Zero polynomial returns
+/// `(zero, 0)`.
+fn fp_monic(a: &[u64], p: u64) -> (FpPoly, u64) {
+    let a = fp_trim(a.to_vec());
+    match a.last() {
+        None | Some(0) => (vec![], 0),
+        Some(&lc) => {
+            let inv = invmod(lc, p);
+            (fp_scale(&a, inv, p), lc)
+        }
+    }
+}
+
+/// `(q, r)` with `a = q·b + r`, `deg r < deg b`.  `b` must be nonzero.
+fn fp_divrem(a: &[u64], b: &[u64], p: u64) -> (FpPoly, FpPoly) {
+    let b = fp_trim(b.to_vec());
+    let bd = b.len() - 1;
+    let blc_inv = invmod(b[bd], p);
+    let mut r = fp_trim(a.to_vec());
+    if r.len() < b.len() {
+        return (vec![], r);
+    }
+    let mut q = vec![0u64; r.len() - bd];
+    while r.len() >= b.len() && !r.is_empty() {
+        let rd = r.len() - 1;
+        let coeff = mulmod(r[rd], blc_inv, p);
+        let shift = rd - bd;
+        q[shift] = coeff;
+        for (j, &bj) in b.iter().enumerate() {
+            r[shift + j] = submod(r[shift + j], mulmod(coeff, bj, p), p);
+        }
+        r = fp_trim(r);
+    }
+    (fp_trim(q), r)
+}
+
+fn fp_rem(a: &[u64], b: &[u64], p: u64) -> FpPoly {
+    fp_divrem(a, b, p).1
+}
+
+fn fp_gcd(a: &[u64], b: &[u64], p: u64) -> FpPoly {
+    let mut a = fp_trim(a.to_vec());
+    let mut b = fp_trim(b.to_vec());
+    while !b.is_empty() {
+        let r = fp_rem(&a, &b, p);
+        a = b;
+        b = r;
+    }
+    fp_monic(&a, p).0
+}
+
+/// Extended gcd: returns `(g, s, t)` with `s·a + t·b = g`, `g` monic.
+fn fp_ext_gcd(a: &[u64], b: &[u64], p: u64) -> (FpPoly, FpPoly, FpPoly) {
+    let mut r0 = fp_trim(a.to_vec());
+    let mut r1 = fp_trim(b.to_vec());
+    let mut s0 = vec![1u64];
+    let mut s1 = vec![];
+    let mut t0 = vec![];
+    let mut t1 = vec![1u64];
+    while !r1.is_empty() {
+        let (q, r) = fp_divrem(&r0, &r1, p);
+        let new_s = fp_sub(&s0, &fp_mul(&q, &s1, p), p);
+        let new_t = fp_sub(&t0, &fp_mul(&q, &t1, p), p);
+        r0 = r1;
+        r1 = r;
+        s0 = s1;
+        s1 = new_s;
+        t0 = t1;
+        t1 = new_t;
+    }
+    // Normalize g monic.
+    let (g, lc) = fp_monic(&r0, p);
+    if lc == 0 {
+        return (vec![], vec![], vec![]);
+    }
+    let inv = invmod(lc, p);
+    (g, fp_scale(&s0, inv, p), fp_scale(&t0, inv, p))
+}
+
+fn fp_eval(a: &[u64], x: u64, p: u64) -> u64 {
+    let mut acc = 0u64;
+    for &c in a.iter().rev() {
+        acc = addmod(mulmod(acc, x, p), c, p);
+    }
+    acc
+}
+
+fn fp_deriv(a: &[u64], p: u64) -> FpPoly {
+    if a.len() <= 1 {
+        return vec![];
+    }
+    let mut r = vec![0u64; a.len() - 1];
+    for (i, slot) in r.iter_mut().enumerate() {
+        let k = (i as u64 + 1) % p;
+        *slot = mulmod(a[i + 1], k, p);
+    }
+    fp_trim(r)
+}
+
+// ===========================================================================
+// Hyperelliptic Jacobian over F_p (imaginary model y² = F, F monic odd degree)
+// ===========================================================================
+
+/// A reduced divisor class in Mumford representation `(u, v)`:
+/// `u` monic with `deg u ≤ g`, `deg v < deg u`, and `u | (v² − F)`.
+/// The identity (zero class) is `(1, 0)`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Mumford {
+    u: FpPoly,
+    v: FpPoly,
+}
+
+/// Imaginary hyperelliptic curve `y² = F(x)` over `F_p`, `F` monic of degree
+/// `2g+1`.
+struct HypFp {
+    p: u64,
+    f: FpPoly,
+    g: usize,
+}
+
+impl HypFp {
+    fn identity(&self) -> Mumford {
+        Mumford {
+            u: vec![1],
+            v: vec![],
+        }
+    }
+
+    fn is_identity(d: &Mumford) -> bool {
+        fp_deg(&d.u) == Some(0)
+    }
+
+    /// The class of `(X₀, Y₀) − ∞`, i.e. `u = x − X₀`, `v = Y₀`.
+    fn point_class(&self, x0: u64, y0: u64) -> Mumford {
+        Mumford {
+            u: fp_trim(vec![submod(0, x0, self.p), 1]),
+            v: if y0 == 0 { vec![] } else { vec![y0] },
+        }
+    }
+
+    /// Inverse class `(u, −v mod u)`.
+    fn neg(&self, d: &Mumford) -> Mumford {
+        let nv = fp_sub(&[], &d.v, self.p);
+        let nv = if nv.is_empty() {
+            vec![]
+        } else {
+            fp_rem(&nv, &d.u, self.p)
+        };
+        Mumford {
+            u: d.u.clone(),
+            v: nv,
+        }
+    }
+
+    /// Cantor reduction: while `deg u > g`, replace `(u, v)` by the reduced
+    /// equivalent class.
+    fn reduce(&self, mut u: FpPoly, mut v: FpPoly) -> Mumford {
+        let p = self.p;
+        while fp_deg(&u).map(|d| d > self.g).unwrap_or(false) {
+            // u' = (F − v²) / u   (exact), then make monic
+            let v2 = fp_mul(&v, &v, p);
+            let num = fp_sub(&self.f, &v2, p);
+            let (mut up, _r) = fp_divrem(&num, &u, p);
+            up = fp_monic(&up, p).0;
+            // v' = (−v) mod u'
+            let nv = fp_sub(&[], &v, p);
+            let vp = if up.len() <= 1 {
+                vec![]
+            } else {
+                fp_rem(&nv, &up, p)
+            };
+            u = up;
+            v = vp;
+        }
+        let u = fp_monic(&u, p).0;
+        let v = if u.len() <= 1 {
+            vec![]
+        } else {
+            fp_rem(&v, &u, p)
+        };
+        Mumford { u, v }
+    }
+
+    /// Cantor composition + reduction: `d1 + d2` in `Jac(F_p)`.
+    fn add(&self, d1: &Mumford, d2: &Mumford) -> Mumford {
+        let p = self.p;
+        let (u1, v1) = (&d1.u, &d1.v);
+        let (u2, v2) = (&d2.u, &d2.v);
+
+        // d = gcd(u1, u2, v1 + v2) = e1·u1 + e2·u2 + c·(v1+v2)
+        let (g1, a1, b1) = fp_ext_gcd(u1, u2, p); // g1 = a1·u1 + b1·u2
+        let vsum = fp_add(v1, v2, p);
+        let (d, c1, c2) = fp_ext_gcd(&g1, &vsum, p); // d = c1·g1 + c2·vsum
+                                                     // s1 = c1·a1, s2 = c1·b1, s3 = c2
+        let s1 = fp_mul(&c1, &a1, p);
+        let s2 = fp_mul(&c1, &b1, p);
+        let s3 = c2;
+
+        // u = u1·u2 / d²
+        let u1u2 = fp_mul(u1, u2, p);
+        let d2sq = fp_mul(&d, &d, p);
+        let (u, _r) = fp_divrem(&u1u2, &d2sq, p);
+        let u = fp_monic(&u, p).0;
+
+        // v = (s1·u1·v2 + s2·u2·v1 + s3·(v1·v2 + F)) / d   mod u
+        let t1 = fp_mul(&fp_mul(&s1, u1, p), v2, p);
+        let t2 = fp_mul(&fp_mul(&s2, u2, p), v1, p);
+        let v1v2 = fp_mul(v1, v2, p);
+        let t3 = fp_mul(&s3, &fp_add(&v1v2, &self.f, p), p);
+        let vnum = fp_add(&fp_add(&t1, &t2, p), &t3, p);
+        let (vq, _vr) = fp_divrem(&vnum, &d, p);
+        let v = if u.len() <= 1 {
+            vec![]
+        } else {
+            fp_rem(&vq, &u, p)
+        };
+
+        self.reduce(u, v)
+    }
+
+    /// `k · D` by double-and-add (`k ≥ 0`).
+    fn mul(&self, k: u64, d: &Mumford) -> Mumford {
+        let mut acc = self.identity();
+        let mut base = d.clone();
+        let mut k = k;
+        while k > 0 {
+            if k & 1 == 1 {
+                acc = self.add(&acc, &base);
+            }
+            base = self.add(&base, &base);
+            k >>= 1;
+        }
+        acc
+    }
+
+    /// Order of the class `d` in `Jac(F_p)` (always finite — a finite group).
+    /// Bounded by the Weil ceiling `(√p + 1)^{2g}`; returns `None` if the cap is
+    /// somehow exceeded (a bad reduction we failed to filter — caller skips it).
+    fn order(&self, d: &Mumford) -> Option<u64> {
+        if Self::is_identity(d) {
+            return Some(1);
+        }
+        let bound = weil_upper_bound(self.p, self.g);
+        let mut acc = d.clone();
+        let mut k = 1u64;
+        while !Self::is_identity(&acc) {
+            acc = self.add(&acc, d);
+            k += 1;
+            if k > bound {
+                return None;
+            }
+        }
+        Some(k)
+    }
+}
+
+/// Weil upper bound `⌈(√p + 1)^{2g}⌉` on `#Jac(F_p)` (a ceiling for the search).
+fn weil_upper_bound(p: u64, g: usize) -> u64 {
+    let s = (p as f64).sqrt() + 1.0;
+    let b = s.powi(2 * g as i32).ceil();
+    if b.is_finite() && b < (u64::MAX as f64) {
+        b as u64 + 4
+    } else {
+        u64::MAX
+    }
+}
+
+// ===========================================================================
+// Reduction of the ℚ curve + divisor to F_p, and the multi-prime decision
+// ===========================================================================
+
+/// A finite place `(α, β)` of the divisor with integer multiplicity `c`.
+struct Place {
+    x: Rational,
+    y: Rational,
+    coeff: Integer,
+}
+
+/// Reduce `y² = a(x)` (monic-normalized) and the divisor `places` to `F_p`,
+/// building the reduced class.  Returns `None` if `p` is a **bad** prime for
+/// this data (so the caller tries the next prime).
+fn reduce_and_build(a: &QPoly, g: usize, places: &[Place], p: u64) -> Option<(HypFp, Mumford)> {
+    if p == 2 {
+        return None;
+    }
+    let d = degree(a) as usize;
+    // Reduce a mod p; leading coeff must survive.
+    let mut a_fp = Vec::with_capacity(d + 1);
+    for c in a.iter() {
+        a_fp.push(rat_to_fp(c, p)?);
+    }
+    let a_fp = fp_trim(a_fp);
+    if a_fp.len() != d + 1 {
+        return None; // leading coeff vanished mod p
+    }
+    let lc = a_fp[d];
+    // Monicize via X = lc·x, Y = lc^g·y:  F_k = a_k · lc^{d-1-k}.
+    let mut f: FpPoly = vec![0u64; d + 1];
+    for (k, slot) in f.iter_mut().enumerate() {
+        // F_k = a_k · lc^{d-1-k}; exponent d-1-k ∈ [−1, d−1] (k=d gives lc^{-1}).
+        let factor = if k == d {
+            invmod(lc, p)
+        } else {
+            powmod(lc, (d - 1 - k) as u64, p)
+        };
+        *slot = mulmod(a_fp[k], factor, p);
+    }
+    let f = fp_trim(f);
+    if f.len() != d + 1 || f[d] != 1 {
+        return None;
+    }
+    // Good reduction: F squarefree (gcd(F, F') constant).
+    if fp_deg(&fp_gcd(&f, &fp_deriv(&f, p), p)) != Some(0) {
+        return None;
+    }
+    let curve = HypFp { p, f, g };
+
+    // Build the class Σ cₐ·[(Xₐ, Yₐ) − ∞] with the monicizing transform.
+    let lc_g = powmod(lc, g as u64, p);
+    let mut acc = curve.identity();
+    for pl in places {
+        let xa = rat_to_fp(&pl.x, p)?;
+        let ya = rat_to_fp(&pl.y, p)?;
+        let big_x = mulmod(lc, xa, p);
+        let big_y = mulmod(lc_g, ya, p);
+        // Sanity: the reduced point must lie on the curve.
+        if mulmod(big_y, big_y, p) != fp_eval(&curve.f, big_x, p) {
+            return None;
+        }
+        let cls = curve.point_class(big_x, big_y);
+        let k = pl.coeff.clone().abs().to_u64()?;
+        if k == 0 {
+            continue;
+        }
+        let term = curve.mul(k, &cls);
+        let term = if pl.coeff < 0 { curve.neg(&term) } else { term };
+        acc = curve.add(&acc, &term);
+    }
+    Some((curve, acc))
+}
+
+/// `v_ℓ(m)` — exponent of prime `ℓ` in `m`.
+fn val(m: u64, l: u64) -> u32 {
+    let mut e = 0;
+    let mut m = m;
+    while m % l == 0 {
+        m /= l;
+        e += 1;
+    }
+    e
+}
+
+/// Distinct prime factors of `m` (trial division; `m` is bounded by a Weil
+/// ceiling, so this is cheap).
+fn prime_factors(mut m: u64) -> Vec<u64> {
+    let mut fs = Vec::new();
+    let mut d = 2u64;
+    while d * d <= m {
+        if m % d == 0 {
+            fs.push(d);
+            while m % d == 0 {
+                m /= d;
+            }
+        }
+        d += 1;
+    }
+    if m > 1 {
+        fs.push(m);
+    }
+    fs
+}
+
+/// FIND-ORDER for genus ≥ 2 hyperelliptic curves `y² = a(x)` (odd-degree
+/// squarefree `a`).  Sound: returns [`FindOrder::NonElementary`] only when the
+/// prime-to-`p` torsion orders are provably inconsistent across good primes;
+/// everything else (consistent candidate, too few primes, even degree) is
+/// [`FindOrder::NotDecided`].
+pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> FindOrder {
+    if n != 2 {
+        return FindOrder::NotDecided;
+    }
+    let a = trim(a.clone());
+    let dd = degree(&a);
+    // Imaginary model only: odd degree ⇒ a single rational place at infinity, so
+    // the infinity residue is absorbed by Σ coeff = 0 and need not be placed.
+    if dd < 5 || dd % 2 == 0 {
+        return FindOrder::NotDecided;
+    }
+    let d = dd as usize;
+    let g = (d - 1) / 2;
+
+    // Collect finite places with integer (primitive) multiplicities.
+    let finite: Vec<&PlacedResidue> = divisor.iter().filter(|r| !r.residue.at_infinity).collect();
+    if finite.is_empty() {
+        return FindOrder::NotDecided;
+    }
+    // Scale residue values to a primitive integer divisor.
+    let mut l = Integer::from(1);
+    for r in &finite {
+        l = l.lcm(r.residue.value.denom());
+    }
+    let int_coeffs: Vec<Integer> = finite
+        .iter()
+        .map(|r| {
+            (r.residue.value.clone() * Rational::from(l.clone()))
+                .numer()
+                .clone()
+        })
+        .collect();
+    let mut gg = Integer::from(0);
+    for c in &int_coeffs {
+        gg = gg.gcd(c);
+    }
+    if gg == 0 {
+        return FindOrder::NotDecided; // no logarithmic part among finite places
+    }
+    let places: Vec<Place> = finite
+        .iter()
+        .zip(&int_coeffs)
+        .filter_map(|(r, c)| {
+            let coeff = c.clone() / &gg;
+            if coeff == 0 {
+                None
+            } else {
+                Some(Place {
+                    x: r.residue.point.clone(),
+                    y: r.y_coord.clone(),
+                    coeff,
+                })
+            }
+        })
+        .collect();
+    if places.is_empty() {
+        return FindOrder::NotDecided;
+    }
+
+    // Gather (prime, order) pairs over several good primes.
+    const MAX_PRIME: u64 = 200;
+    const WANT: usize = 4;
+    let mut data: Vec<(u64, u64)> = Vec::new();
+    let mut p = 3u64;
+    while p <= MAX_PRIME && data.len() < WANT {
+        if crate::modular::is_prime(p) {
+            if let Some((curve, cls)) = reduce_and_build(&a, g, &places, p) {
+                if let Some(order) = curve.order(&cls) {
+                    data.push((p, order));
+                }
+            }
+        }
+        p += 2;
+    }
+    if data.len() < 2 {
+        return FindOrder::NotDecided; // not enough good primes to conclude
+    }
+
+    // Inconsistency test on prime-to-p torsion (sound non-torsion certificate).
+    // For each prime ℓ, every good prime pᵢ ≠ ℓ pins v_ℓ(N) = v_ℓ(mᵢ); a
+    // disagreement ⇒ no finite N ⇒ non-torsion.  Additionally, for ℓ = pᵢ the
+    // image order's ℓ-part must not exceed v_ℓ(N) (order of image divides N).
+    let mut ls: Vec<u64> = Vec::new();
+    for (_, m) in &data {
+        for f in prime_factors(*m) {
+            if !ls.contains(&f) {
+                ls.push(f);
+            }
+        }
+    }
+    for &l in &ls {
+        let witnesses: Vec<u32> = data
+            .iter()
+            .filter(|(pi, _)| *pi != l)
+            .map(|(_, m)| val(*m, l))
+            .collect();
+        if witnesses.is_empty() {
+            continue; // can't pin v_ℓ(N) without a prime ≠ ℓ
+        }
+        let v_n = witnesses[0];
+        if witnesses.iter().any(|&w| w != v_n) {
+            return FindOrder::NonElementary; // prime-to-ℓ inconsistency
+        }
+        // ℓ-part of the image order at the modulus ℓ must divide N.
+        if let Some((_, m)) = data.iter().find(|(pi, _)| *pi == l) {
+            if val(*m, l) > v_n {
+                return FindOrder::NonElementary;
+            }
+        }
+    }
+
+    // Consistent candidate torsion order: certifying it elementary needs Coates'
+    // function construction (not implemented for genus ≥ 2) — stay undecided.
+    FindOrder::NotDecided
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rug::Rational;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+
+    /// Build a monic imaginary curve over F_p directly for arithmetic tests.
+    fn curve(p: u64, f: &[u64], g: usize) -> HypFp {
+        HypFp {
+            p,
+            f: fp_trim(f.to_vec()),
+            g,
+        }
+    }
+
+    #[test]
+    fn fp_divrem_roundtrip() {
+        let p = 13;
+        let a = vec![1, 0, 0, 0, 2]; // 2x⁴ + 1
+        let b = vec![3, 1]; // x + 3
+        let (q, r) = fp_divrem(&a, &b, p);
+        // a == q·b + r
+        let back = fp_add(&fp_mul(&q, &b, p), &r, p);
+        assert_eq!(back, fp_trim(a));
+        assert!(fp_deg(&r).map(|d| d < 1).unwrap_or(true));
+    }
+
+    #[test]
+    fn ext_gcd_identity() {
+        let p = 17;
+        let a = vec![1, 0, 1]; // x²+1
+        let b = vec![2, 1]; // x+2
+        let (g, s, t) = fp_ext_gcd(&a, &b, p);
+        let lhs = fp_add(&fp_mul(&s, &a, p), &fp_mul(&t, &b, p), p);
+        assert_eq!(lhs, g);
+    }
+
+    /// `D + (−D) = O` and `order(O) = 1` on a genus-2 curve y²=x⁵+1 over F_11.
+    #[test]
+    fn neg_cancels() {
+        let c = curve(11, &[1, 0, 0, 0, 0, 1], 2); // x⁵+1
+                                                   // (0,1) is on the curve: 0+1=1.
+        let d = c.point_class(0, 1);
+        let sum = c.add(&d, &c.neg(&d));
+        assert!(HypFp::is_identity(&sum));
+        assert_eq!(c.order(&c.identity()), Some(1));
+    }
+
+    /// A finite rational point's class has the order the group assigns; the
+    /// branch-point class `(α,0)−∞` is 2-torsion (`2·D = O`, `D ≠ O`).
+    #[test]
+    fn branch_point_two_torsion() {
+        // y² = x⁵ - x = x(x-1)(x+1)(x²+1) over F_11 (genus 2). Roots 0, 1, -1.
+        // f = -x + x⁵  →  coeffs [0, -1, 0, 0, 0, 1]; over F_11, -1 = 10.
+        let c = curve(11, &[0, 10, 0, 0, 0, 1], 2);
+        let d = c.point_class(1, 0); // (1,0), a branch point
+        assert!(!HypFp::is_identity(&d));
+        let dd = c.add(&d, &d);
+        assert!(HypFp::is_identity(&dd));
+        assert_eq!(c.order(&d), Some(2));
+    }
+
+    /// Difference of two rational branch points is 2-torsion of order 2.
+    #[test]
+    fn branch_difference_order_two() {
+        let c = curve(11, &[0, 10, 0, 0, 0, 1], 2);
+        let p0 = c.point_class(0, 0);
+        let p1 = c.point_class(1, 0);
+        let diff = c.add(&p0, &c.neg(&p1)); // (0,0) - (1,0)
+        assert!(!HypFp::is_identity(&diff));
+        assert!(HypFp::is_identity(&c.add(&diff, &diff)));
+        assert_eq!(c.order(&diff), Some(2));
+    }
+
+    fn place(x: i64, y: i64, value: i64) -> PlacedResidue {
+        PlacedResidue {
+            residue: super::super::residues::Residue {
+                point: Rational::from(x),
+                at_infinity: false,
+                sheet: 0,
+                ramification: 1,
+                value: Rational::from(value),
+            },
+            y_coord: Rational::from(y),
+        }
+    }
+
+    /// Even-degree radicand (real model) is out of scope ⇒ NotDecided.
+    #[test]
+    fn even_degree_not_decided() {
+        // y² = x⁶+1 (genus 2, two places at ∞).
+        let a = qp(&[1, 0, 0, 0, 0, 0, 1]);
+        let div = [place(0, 1, 1), place(0, -1, -1)];
+        assert_eq!(find_order_genus_ge2(2, &a, &div), FindOrder::NotDecided);
+    }
+
+    /// Genus-2 `y² = x(x-1)(x+1)(x²+1) = x⁵ - x`.  The divisor
+    /// `(0,0) − (1,0)` of two rational branch points is 2-torsion ⇒ consistent
+    /// across primes ⇒ NotDecided (sound: never asserts Principal for genus ≥ 2).
+    #[test]
+    fn genus2_branch_difference_consistent_not_decided() {
+        let a = qp(&[0, -1, 0, 0, 0, 1]);
+        assert_eq!(super::super::find_order::genus(2, &a), Some(2));
+        let div = [place(0, 0, 1), place(1, 0, -1)];
+        assert_eq!(find_order_genus_ge2(2, &a, &div), FindOrder::NotDecided);
+    }
+
+    /// Genus-2 `y² = x⁵ + x + 1` with the non-torsion divisor `(0,1) − ∞`
+    /// (the infinity place is absorbed by Σ coeff = 0).  The reduced class has
+    /// orders 6, 44, 47, … at p = 5, 11, 13 — wildly inconsistent prime-to-p
+    /// parts ⇒ certified NonElementary.
+    #[test]
+    fn genus2_non_torsion_certified() {
+        // (0,1) on the curve: 0+0+1 = 1 = 1² ✓.
+        let a = qp(&[1, 1, 0, 0, 0, 1]);
+        assert_eq!(super::super::find_order::genus(2, &a), Some(2));
+        let div = [place(0, 1, 1)];
+        assert_eq!(find_order_genus_ge2(2, &a, &div), FindOrder::NonElementary);
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -16,15 +16,19 @@
 //!    two good primes therefore pins every `v_ℓ(N)` and any **disagreement
 //!    certifies `δ` is non-torsion** ⇒ the integral is non-elementary.
 //!
-//! This module asserts only the *sound* half of the genus-graded decision:
+//! The decision is **complete and sound** for this class:
 //!
-//! * [`FindOrder::NonElementary`] when the prime-to-`p` orders are provably
-//!   inconsistent (a real theorem — no false positives).
-//! * [`FindOrder::NotDecided`] otherwise (too few good primes, even-degree /
-//!   real model, or a *consistent* candidate torsion order).  Certifying the
-//!   consistent case as `Principal{N}` would additionally require constructing a
-//!   function with divisor `N·δ` (Coates' algorithm / Riemann–Roch), which is
-//!   not yet implemented for genus ≥ 2; we never claim `Principal` here.
+//! * When the prime-to-`p` orders are inconsistent across good primes, `δ` is
+//!   non-torsion (a real theorem — no false positives) ⇒ [`FindOrder::NonElementary`].
+//! * Otherwise the reconstruction pins the **exact** candidate order `N`, and an
+//!   exact Cantor computation **over ℚ** tests whether `N·δ` is principal:
+//!   principal ⇒ [`FindOrder::Principal`] (torsion of order `N`), else
+//!   non-torsion ⇒ [`FindOrder::NonElementary`].  No Coates function
+//!   construction is needed for the *decision* — only for emitting the log
+//!   argument, which the genus-1 integrator does and the (not-yet-wired)
+//!   genus ≥ 2 integrator would.
+//! * [`FindOrder::NotDecided`] only when out of scope: too few good primes, the
+//!   order exceeds a practical cap, or the curve is outside the handled class.
 //!
 //! Scope: `n = 2` (hyperelliptic), `a` squarefree of **odd** degree `2g+1`
 //! (imaginary model, a single rational place at infinity).  Even degree (real
@@ -32,7 +36,8 @@
 
 use rug::{Integer, Rational};
 
-use super::super::risch::poly_rde::{degree, trim, QPoly};
+use super::super::risch::poly_rde::{degree, poly_add, poly_mul, poly_scale, trim, QPoly};
+use super::super::risch::rational_rde::{poly_divrem, poly_monic, poly_sub};
 use super::find_order::FindOrder;
 use super::residues::PlacedResidue;
 
@@ -541,31 +546,257 @@ fn prime_factors(mut m: u64) -> Vec<u64> {
     fs
 }
 
+// ===========================================================================
+// Exact Cantor arithmetic over ℚ — for the *principality* test
+//
+// Once reduction mod good primes pins the exact candidate torsion order `N`
+// (sound, by injectivity of reduction on prime-to-p torsion), `δ` is torsion of
+// order `N` **iff** `N·δ` is principal, i.e. reduces to the identity class.  We
+// decide that exactly over ℚ with the same Cantor/Mumford machinery — no Coates
+// function construction is needed for the *decision* (only for emitting the
+// log argument, which the genus-1 integrator does and genus ≥ 2 does not yet).
+// ===========================================================================
+
+/// Extended gcd over `ℚ[x]`: `(g, s, t)` with `s·a + t·b = g`, `g` monic.
+fn q_ext_gcd(a: &QPoly, b: &QPoly) -> (QPoly, QPoly, QPoly) {
+    let mut r0 = trim(a.clone());
+    let mut r1 = trim(b.clone());
+    let mut s0 = vec![Rational::from(1)];
+    let mut s1: QPoly = vec![];
+    let mut t0: QPoly = vec![];
+    let mut t1 = vec![Rational::from(1)];
+    while degree(&r1) >= 0 {
+        let (q, r) = poly_divrem(&r0, &r1);
+        let new_s = poly_sub(&s0, &poly_mul(&q, &s1));
+        let new_t = poly_sub(&t0, &poly_mul(&q, &t1));
+        r0 = r1;
+        r1 = r;
+        s0 = s1;
+        s1 = new_s;
+        t0 = t1;
+        t1 = new_t;
+    }
+    let lc = match trim(r0.clone()).last() {
+        Some(c) => c.clone(),
+        None => return (vec![], vec![], vec![]),
+    };
+    let inv = Rational::from(1) / lc;
+    (
+        poly_scale(&trim(r0), &inv),
+        poly_scale(&s0, &inv),
+        poly_scale(&t0, &inv),
+    )
+}
+
+fn q_is_zero(p: &QPoly) -> bool {
+    degree(p) < 0
+}
+
+fn q_rem(a: &QPoly, b: &QPoly) -> QPoly {
+    poly_divrem(a, b).1
+}
+
+/// A reduced Mumford class `(u, v)` over ℚ (`u` monic, `deg v < deg u ≤ g`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MumQ {
+    u: QPoly,
+    v: QPoly,
+}
+
+/// Imaginary hyperelliptic curve `y² = F(x)` over ℚ, `F` monic of odd degree.
+struct HypQ {
+    f: QPoly,
+    g: usize,
+}
+
+impl HypQ {
+    fn identity(&self) -> MumQ {
+        MumQ {
+            u: vec![Rational::from(1)],
+            v: vec![],
+        }
+    }
+
+    fn is_identity(d: &MumQ) -> bool {
+        degree(&d.u) == 0
+    }
+
+    fn point_class(&self, x0: &Rational, y0: &Rational) -> MumQ {
+        MumQ {
+            u: trim(vec![-x0.clone(), Rational::from(1)]),
+            v: if *y0 == 0 { vec![] } else { vec![y0.clone()] },
+        }
+    }
+
+    fn neg(&self, d: &MumQ) -> MumQ {
+        let nv = poly_scale(&d.v, &Rational::from(-1));
+        let nv = if q_is_zero(&nv) {
+            vec![]
+        } else {
+            q_rem(&nv, &d.u)
+        };
+        MumQ {
+            u: d.u.clone(),
+            v: nv,
+        }
+    }
+
+    fn reduce(&self, mut u: QPoly, mut v: QPoly) -> MumQ {
+        while degree(&u) > self.g as i64 {
+            let v2 = poly_mul(&v, &v);
+            let num = poly_sub(&self.f, &v2);
+            let (mut up, _r) = poly_divrem(&num, &u);
+            up = poly_monic(&up);
+            let nv = poly_scale(&v, &Rational::from(-1));
+            let vp = if degree(&up) <= 0 {
+                vec![]
+            } else {
+                q_rem(&nv, &up)
+            };
+            u = up;
+            v = vp;
+        }
+        let u = poly_monic(&u);
+        let v = if degree(&u) <= 0 {
+            vec![]
+        } else {
+            q_rem(&v, &u)
+        };
+        MumQ { u, v }
+    }
+
+    fn add(&self, d1: &MumQ, d2: &MumQ) -> MumQ {
+        let (u1, v1) = (&d1.u, &d1.v);
+        let (u2, v2) = (&d2.u, &d2.v);
+        let (g1, a1, b1) = q_ext_gcd(u1, u2);
+        let vsum = poly_add(v1, v2);
+        let (d, c1, c2) = q_ext_gcd(&g1, &vsum);
+        let s1 = poly_mul(&c1, &a1);
+        let s2 = poly_mul(&c1, &b1);
+        let s3 = c2;
+
+        let u1u2 = poly_mul(u1, u2);
+        let d2sq = poly_mul(&d, &d);
+        let (u, _r) = poly_divrem(&u1u2, &d2sq);
+        let u = poly_monic(&u);
+
+        let t1 = poly_mul(&poly_mul(&s1, u1), v2);
+        let t2 = poly_mul(&poly_mul(&s2, u2), v1);
+        let v1v2 = poly_mul(v1, v2);
+        let t3 = poly_mul(&s3, &poly_add(&v1v2, &self.f));
+        let vnum = poly_add(&poly_add(&t1, &t2), &t3);
+        let (vq, _vr) = poly_divrem(&vnum, &d);
+        let v = if degree(&u) <= 0 {
+            vec![]
+        } else {
+            q_rem(&vq, &u)
+        };
+        self.reduce(u, v)
+    }
+
+    fn mul(&self, k: u64, d: &MumQ) -> MumQ {
+        let mut acc = self.identity();
+        let mut base = d.clone();
+        let mut k = k;
+        while k > 0 {
+            if k & 1 == 1 {
+                acc = self.add(&acc, &base);
+            }
+            base = self.add(&base, &base);
+            k >>= 1;
+        }
+        acc
+    }
+}
+
+/// Build the monic curve `F` over ℚ (`X = lc·x`, `Y = lc^g·y`) and the divisor
+/// class `Σ cₐ·[(Xₐ,Yₐ) − ∞]`, then test whether `N·δ` is principal (reduces to
+/// the identity).  `None` if a point fails to lie on the (monicized) curve
+/// (should not happen for a genuine residue divisor) or `N` overflows the cap.
+fn n_delta_is_principal(a: &QPoly, g: usize, places: &[Place], n: u64) -> Option<bool> {
+    let d = degree(a) as usize;
+    let lc = a[d].clone();
+    // F_k = a_k · lc^{d-1-k}.
+    let mut f = vec![Rational::from(0); d + 1];
+    for (k, slot) in f.iter_mut().enumerate() {
+        let e = d as i64 - 1 - k as i64;
+        *slot = a[k].clone() * pow_rat(&lc, e);
+    }
+    let f = trim(f);
+    let curve = HypQ { f, g };
+    let lc_g = pow_rat(&lc, g as i64);
+    let mut delta = curve.identity();
+    for pl in places {
+        let big_x = lc.clone() * &pl.x;
+        let big_y = lc_g.clone() * &pl.y;
+        // On-curve sanity: Y² = F(X).
+        let fx = eval_q(&curve.f, &big_x);
+        if big_y.clone() * &big_y != fx {
+            return None;
+        }
+        let cls = curve.point_class(&big_x, &big_y);
+        let k = pl.coeff.clone().abs().to_u64()?;
+        if k == 0 {
+            continue;
+        }
+        let term = curve.mul(k, &cls);
+        let term = if pl.coeff < 0 { curve.neg(&term) } else { term };
+        delta = curve.add(&delta, &term);
+    }
+    let nd = curve.mul(n, &delta);
+    Some(HypQ::is_identity(&nd))
+}
+
+/// `r^e` for a rational base and (possibly negative) integer exponent.
+fn pow_rat(r: &Rational, e: i64) -> Rational {
+    if e >= 0 {
+        let mut acc = Rational::from(1);
+        for _ in 0..e {
+            acc *= r;
+        }
+        acc
+    } else {
+        let mut acc = Rational::from(1);
+        for _ in 0..(-e) {
+            acc *= r;
+        }
+        Rational::from(1) / acc
+    }
+}
+
+fn eval_q(p: &QPoly, x: &Rational) -> Rational {
+    let mut acc = Rational::from(0);
+    for c in p.iter().rev() {
+        acc = acc * x + c;
+    }
+    acc
+}
+
 /// FIND-ORDER for genus ≥ 2 hyperelliptic curves `y² = a(x)` (odd-degree
-/// squarefree `a`).  Sound: returns [`FindOrder::NonElementary`] only when the
-/// prime-to-`p` torsion orders are provably inconsistent across good primes;
-/// everything else (consistent candidate, too few primes, even degree) is
-/// [`FindOrder::NotDecided`].
+/// squarefree `a`).  **Complete and sound** for this class: reduction mod good
+/// primes pins the exact candidate order `N` (injectivity of reduction on
+/// prime-to-`p` torsion), then an exact Cantor computation over ℚ tests whether
+/// `N·δ` is principal — giving [`FindOrder::Principal`] (torsion, order `N`) or
+/// [`FindOrder::NonElementary`] (non-torsion).  Even-degree (real) models with
+/// **no residue at infinity** are reduced to an odd model by moving a rational
+/// branch point to infinity.  [`FindOrder::NotDecided`] only when out of scope
+/// (too few good primes, `N` past the cap, an even model with a residue at ∞ or
+/// no usable rational branch point).
 pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> FindOrder {
     if n != 2 {
         return FindOrder::NotDecided;
     }
     let a = trim(a.clone());
     let dd = degree(&a);
-    // Imaginary model only: odd degree ⇒ a single rational place at infinity, so
-    // the infinity residue is absorbed by Σ coeff = 0 and need not be placed.
-    if dd < 5 || dd % 2 == 0 {
-        return FindOrder::NotDecided;
+    if dd < 5 {
+        return FindOrder::NotDecided; // genus ≥ 2 needs deg ≥ 5
     }
-    let d = dd as usize;
-    let g = (d - 1) / 2;
 
-    // Collect finite places with integer (primitive) multiplicities.
+    // Collect finite places with primitive integer multiplicities.
     let finite: Vec<&PlacedResidue> = divisor.iter().filter(|r| !r.residue.at_infinity).collect();
     if finite.is_empty() {
         return FindOrder::NotDecided;
     }
-    // Scale residue values to a primitive integer divisor.
     let mut l = Integer::from(1);
     for r in &finite {
         l = l.lcm(r.residue.value.denom());
@@ -605,6 +836,112 @@ pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue
         return FindOrder::NotDecided;
     }
 
+    if dd % 2 == 1 {
+        // Imaginary model: a single rational place at infinity, absorbed by Σ = 0.
+        decide_odd(&a, &places)
+    } else {
+        // Real model (two places at infinity).  Handle only the case with **no
+        // residue at infinity** (mirrors the genus-1 quartic path): move a
+        // rational branch point to infinity via `x = r + 1/s` to get an odd
+        // model, then decide there.  Any residue at ∞, no rational root, or a
+        // residue on the moved fibre ⇒ undecided.
+        if divisor
+            .iter()
+            .any(|r| r.residue.at_infinity && r.residue.value != 0)
+        {
+            return FindOrder::NotDecided;
+        }
+        // Pick a rational branch point **off** the divisor support to move to ∞.
+        let Some(r) = rational_root_off_support(&a, &places) else {
+            return FindOrder::NotDecided;
+        };
+        let Some((a_odd, places_odd)) = even_to_odd(&a, &r, &places) else {
+            return FindOrder::NotDecided;
+        };
+        decide_odd(&a_odd, &places_odd)
+    }
+}
+
+/// A rational root of `a` that is **not** the `x`-coordinate of any divisor
+/// place (so the moved fibre `x=r` carries no residue).  Found by deflating out
+/// each rational root in turn.
+fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
+    let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
+    let mut poly = trim(a.clone());
+    while let Some(r) = super::find_order::first_rational_root(&poly) {
+        if !support.iter().any(|s| *s == r) {
+            return Some(r);
+        }
+        // Deflate by (x − r) and look for the next rational root.
+        let lin = vec![-r.clone(), Rational::from(1)];
+        let (q, _rem) = poly_divrem(&poly, &lin);
+        poly = trim(q);
+        if degree(&poly) < 1 {
+            break;
+        }
+    }
+    None
+}
+
+/// Reduce an even-degree model `y²=a(x)` (with `a(r)=0`, `r` rational) to the
+/// odd model `ỹ²=ã(s)`, `ã(s) = sᵈ·a(r+1/s)`, mapping each finite place
+/// `(α,β) ↦ (1/(α−r), β/(α−r)^{g+1})`.  `None` if a place sits on the moved
+/// fibre `x=r` (it would go to `s=∞`).
+fn even_to_odd(a: &QPoly, r: &Rational, places: &[Place]) -> Option<(QPoly, Vec<Place>)> {
+    let d = degree(a) as usize; // 2g+2
+    let g = (d - 2) / 2;
+    // ã = reverse(a(x+r)); the constant term a(r)=0 drops the top, giving deg d-1.
+    let b = poly_shift(a, r);
+    let mut a_odd = vec![Rational::from(0); d + 1];
+    for (i, slot) in a_odd.iter_mut().enumerate() {
+        if let Some(c) = b.get(d - i) {
+            *slot = c.clone();
+        }
+    }
+    let a_odd = trim(a_odd);
+    if degree(&a_odd) != (d as i64 - 1) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(places.len());
+    for pl in places {
+        let dx = pl.x.clone() - r;
+        if dx == 0 {
+            return None; // place on the moved fibre x=r
+        }
+        let s0 = Rational::from(1) / &dx;
+        let y_new = pl.y.clone() * pow_rat(&s0, g as i64 + 1);
+        out.push(Place {
+            x: s0,
+            y: y_new,
+            coeff: pl.coeff.clone(),
+        });
+    }
+    Some((a_odd, out))
+}
+
+/// `a(x + r)` (Taylor shift).
+fn poly_shift(a: &QPoly, r: &Rational) -> QPoly {
+    let mut result: QPoly = vec![];
+    let mut xr_pow = vec![Rational::from(1)]; // (x+r)^0
+    let xr = vec![r.clone(), Rational::from(1)]; // x + r
+    for ak in a.iter() {
+        if *ak != 0 {
+            result = poly_add(&result, &poly_scale(&xr_pow, ak));
+        }
+        xr_pow = poly_mul(&xr_pow, &xr);
+    }
+    trim(result)
+}
+
+/// The decision core for an **odd-degree** imaginary model `y²=a(x)` with the
+/// already-collected primitive integer finite `places`.
+fn decide_odd(a: &QPoly, places: &[Place]) -> FindOrder {
+    let dd = degree(a);
+    if dd < 5 || dd % 2 == 0 {
+        return FindOrder::NotDecided;
+    }
+    let g = (dd as usize - 1) / 2;
+
     // Gather (prime, order) pairs over several good primes.
     const MAX_PRIME: u64 = 200;
     const WANT: usize = 4;
@@ -612,7 +949,7 @@ pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue
     let mut p = 3u64;
     while p <= MAX_PRIME && data.len() < WANT {
         if crate::modular::is_prime(p) {
-            if let Some((curve, cls)) = reduce_and_build(&a, g, &places, p) {
+            if let Some((curve, cls)) = reduce_and_build(a, g, places, p) {
                 if let Some(order) = curve.order(&cls) {
                     data.push((p, order));
                 }
@@ -636,6 +973,8 @@ pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue
             }
         }
     }
+    // Candidate order N = ∏ ℓ^{v_ℓ(N)}, with v_ℓ(N) pinned by the primes ≠ ℓ.
+    let mut big_n = Integer::from(1);
     for &l in &ls {
         let witnesses: Vec<u32> = data
             .iter()
@@ -647,7 +986,7 @@ pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue
         }
         let v_n = witnesses[0];
         if witnesses.iter().any(|&w| w != v_n) {
-            return FindOrder::NonElementary; // prime-to-ℓ inconsistency
+            return FindOrder::NonElementary; // prime-to-ℓ inconsistency ⇒ non-torsion
         }
         // ℓ-part of the image order at the modulus ℓ must divide N.
         if let Some((_, m)) = data.iter().find(|(pi, _)| *pi == l) {
@@ -655,11 +994,24 @@ pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue
                 return FindOrder::NonElementary;
             }
         }
+        for _ in 0..v_n {
+            big_n *= Integer::from(l);
+        }
     }
 
-    // Consistent candidate torsion order: certifying it elementary needs Coates'
-    // function construction (not implemented for genus ≥ 2) — stay undecided.
-    FindOrder::NotDecided
+    // The prime-to-p reconstruction is exact: *if* δ is torsion its order is
+    // exactly N.  Decide torsion-ness by testing N·δ principal exactly over ℚ.
+    let Some(n) = big_n.to_u64() else {
+        return FindOrder::NotDecided; // order past a practical cap
+    };
+    if n == 0 || n > u32::MAX as u64 {
+        return FindOrder::NotDecided;
+    }
+    match n_delta_is_principal(a, g, places, n) {
+        Some(true) => FindOrder::Principal { order: n as u32 },
+        Some(false) => FindOrder::NonElementary,
+        None => FindOrder::NotDecided,
+    }
 }
 
 #[cfg(test)]
@@ -752,24 +1104,42 @@ mod tests {
         }
     }
 
-    /// Even-degree radicand (real model) is out of scope ⇒ NotDecided.
+    /// Even-degree real model `y²=x⁶+1` with no rational branch point (roots are
+    /// complex 12th roots of unity) ⇒ NotDecided (can't move a place to ∞).
     #[test]
-    fn even_degree_not_decided() {
-        // y² = x⁶+1 (genus 2, two places at ∞).
+    fn even_degree_no_rational_root_not_decided() {
         let a = qp(&[1, 0, 0, 0, 0, 0, 1]);
         let div = [place(0, 1, 1), place(0, -1, -1)];
         assert_eq!(find_order_genus_ge2(2, &a, &div), FindOrder::NotDecided);
     }
 
-    /// Genus-2 `y² = x(x-1)(x+1)(x²+1) = x⁵ - x`.  The divisor
-    /// `(0,0) − (1,0)` of two rational branch points is 2-torsion ⇒ consistent
-    /// across primes ⇒ NotDecided (sound: never asserts Principal for genus ≥ 2).
+    /// Even-degree real model `y²=(x²−1)(x²−4)(x²−9)=x⁶−14x⁴+49x²−36` (genus 2,
+    /// rational branch points ±1,±2,±3).  The branch difference `(1,0) − (2,0)`
+    /// is 2-torsion: reduce a rational root to ∞, then the exact ℚ test gives
+    /// `Principal{2}`.
     #[test]
-    fn genus2_branch_difference_consistent_not_decided() {
+    fn even_degree_branch_difference_principal() {
+        let a = qp(&[-36, 0, 49, 0, -14, 0, 1]);
+        assert_eq!(super::super::find_order::genus(2, &a), Some(2));
+        let div = [place(1, 0, 1), place(2, 0, -1)];
+        assert_eq!(
+            find_order_genus_ge2(2, &a, &div),
+            FindOrder::Principal { order: 2 }
+        );
+    }
+
+    /// Genus-2 `y² = x(x-1)(x+1)(x²+1) = x⁵ - x`.  The divisor `(0,0) − (1,0)`
+    /// of two distinct rational branch points is 2-torsion: the exact ℚ test
+    /// confirms `2·δ` is principal ⇒ `Principal{2}`.
+    #[test]
+    fn genus2_branch_difference_principal_order_two() {
         let a = qp(&[0, -1, 0, 0, 0, 1]);
         assert_eq!(super::super::find_order::genus(2, &a), Some(2));
         let div = [place(0, 0, 1), place(1, 0, -1)];
-        assert_eq!(find_order_genus_ge2(2, &a, &div), FindOrder::NotDecided);
+        assert_eq!(
+            find_order_genus_ge2(2, &a, &div),
+            FindOrder::Principal { order: 2 }
+        );
     }
 
     /// Genus-2 `y² = x⁵ + x + 1` with the non-torsion divisor `(0,1) − ∞`

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -869,7 +869,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -23,6 +23,7 @@ pub mod genus1_log;
 pub(super) mod genus_zero;
 pub mod hermite_curve;
 pub mod integral_basis;
+mod jacobian_torsion;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;
 pub mod residues;

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -408,6 +408,51 @@ mod tests {
         assert!(checked >= 2);
     }
 
+    /// `∫ 5x⁴·√(x⁵+1) dx = ⅔(x⁵+1)^{3/2}` — a **genus-2** (deg P = 5) integrand
+    /// that is nonetheless elementary (the polynomial-`B` integral part).  This
+    /// used to be wrongly reported `NonElementary`; the integral-part solver now
+    /// returns `Q·√P`.  Verified by `d/dx F = integrand`.
+    #[test]
+    fn quintic_poly_b_integral_part_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let x5p1 = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
+        let sq = pool.func("sqrt", vec![x5p1]);
+        let integrand = pool.mul(vec![
+            pool.integer(5_i32),
+            pool.pow(x, pool.integer(4_i32)),
+            sq,
+        ]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("polynomial-B integral part is elementary");
+        let df = simplify(crate::diff::diff(res.value, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[0.3_f64, 0.8, 1.4] {
+            let lhs = eval(df, x, xv, &pool).unwrap();
+            let rhs = eval(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}"
+            );
+        }
+    }
+
+    /// `∫ x·√(x⁵+1) dx` is genuinely non-elementary (the integral-part ansatz has
+    /// no polynomial solution ⇒ a residual `∫dx/√(x⁵+1)`), and `x⁵+1` is
+    /// squarefree — so the engine soundly reports `NonElementary`.
+    #[test]
+    fn quintic_poly_b_genuinely_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let x5p1 = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
+        let sq = pool.func("sqrt", vec![x5p1]);
+        let integrand = pool.mul(vec![x, sq]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
     /// `∫ dx/√(x³+1)` is a first-kind elliptic integral — non-elementary; the
     /// public engine must still report `NonElementary` (the capstone's verify gate
     /// declines, falling through to the genus-≥1 shortcut).

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -453,6 +453,51 @@ mod tests {
         );
     }
 
+    /// **Rational** weight `B` on a genus-2 curve: `∫ 5x⁴/(2√(x⁵+1)) dx =
+    /// √(x⁵+1)` — the integral part `b·√P` (`b=1`) found via the rational Risch
+    /// DE `b' + (P'/2P)b = B`.  Previously hit the blind `NonElementary` shortcut.
+    #[test]
+    fn quintic_rational_b_integral_part_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let x5p1 = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
+        let inv_sqrt = pool.pow(pool.func("sqrt", vec![x5p1]), pool.integer(-1_i32));
+        let half = pool.pow(pool.integer(2_i32), pool.integer(-1_i32));
+        let integrand = pool.mul(vec![
+            pool.integer(5_i32),
+            pool.pow(x, pool.integer(4_i32)),
+            half,
+            inv_sqrt,
+        ]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("rational-B integral part is elementary");
+        let df = simplify(crate::diff::diff(res.value, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[0.4_f64, 0.9, 1.6] {
+            let lhs = eval(df, x, xv, &pool).unwrap();
+            let rhs = eval(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}"
+            );
+        }
+    }
+
+    /// `∫ dx/√(x⁵+1)` — genus-2 first-kind hyperelliptic: no logarithmic part
+    /// (empty residue divisor) and no algebraic primitive (Risch DE unsolvable),
+    /// so soundly `NonElementary`.
+    #[test]
+    fn quintic_first_kind_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let x5p1 = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
+        let integrand = pool.pow(pool.func("sqrt", vec![x5p1]), pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
     /// `∫ dx/√(x³+1)` is a first-kind elliptic integral — non-elementary; the
     /// public engine must still report `NonElementary` (the capstone's verify gate
     /// declines, falling through to the genus-≥1 shortcut).

--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -12,6 +12,11 @@
 //! [`is_integral`] test**, so the result is sound regardless of Puiseux
 //! truncation: a wrong proposal is rejected, never accepted.
 //!
+//! Efficiency (van Hoeij's remark): a **simple radical** `yⁿ = p(x)` skips the
+//! Puiseux enlargement loop entirely — [`integral_basis`] dispatches to Trager's
+//! explicit basis `wᵢ = yⁱ/dᵢ` ([`super::integral_basis::radical_integral_basis`]),
+//! whose only cost is a squarefree factorization of `p`.
+//!
 //! Scope: enlargements are proposed only at **rational** singular places, using
 //! their rational Puiseux sheets.  Sheets with algebraic coefficients are simply
 //! absent from the linear system, so a proposal there is under-constrained and
@@ -45,6 +50,16 @@ pub fn integral_basis(f_coeffs: &[QPoly]) -> Option<Vec<AlgElem>> {
     let n = ext.degree() as usize;
     if n < 1 {
         return None;
+    }
+    // Efficiency fast-path (van Hoeij's remark): for a **simple radical**
+    // `yⁿ = p(x)` the integral basis is Trager's explicit `wᵢ = yⁱ/dᵢ`, needing
+    // only a squarefree factorization of `p` — no Puiseux expansions or
+    // enlargement loop.  Each `wᵢ` is `is_integral`-gated inside, so this is
+    // sound; we only take it when it yields a full basis.
+    if let Some(p) = as_simple_radical(f_coeffs, n) {
+        if let Some(basis) = super::integral_basis::radical_integral_basis(n, &p) {
+            return Some(basis);
+        }
     }
     let monos = to_monomials(f_coeffs);
     let disc = discriminant(f_coeffs);
@@ -287,6 +302,28 @@ pub(super) fn ts_inv(s: &TS, u: i64) -> Option<TS> {
 // Small helpers
 // ---------------------------------------------------------------------------
 
+/// If `F = yⁿ − p(x)` is a **simple radical** (monic in `y`, only the top and
+/// constant `y`-coefficients nonzero), return `p`.  `None` otherwise.
+fn as_simple_radical(f_coeffs: &[QPoly], n: usize) -> Option<QPoly> {
+    if f_coeffs.len() != n + 1 {
+        return None;
+    }
+    // Monic leading coefficient.
+    if f_coeffs[n].len() != 1 || f_coeffs[n][0] != 1 {
+        return None;
+    }
+    // All middle coefficients (1..n) must vanish.
+    if f_coeffs[1..n].iter().any(|c| degree(c) >= 0) {
+        return None;
+    }
+    // p = −(constant coefficient); must be nonzero.
+    let p: QPoly = f_coeffs[0].iter().map(|c| -c.clone()).collect();
+    if degree(&p) < 0 {
+        return None;
+    }
+    Some(p)
+}
+
 fn to_monomials(f_coeffs: &[QPoly]) -> Vec<(u32, u32, Rational)> {
     let mut out = Vec::new();
     for (j, cj) in f_coeffs.iter().enumerate() {
@@ -436,6 +473,28 @@ mod tests {
             vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[0, 1]))]
         );
         assert!(basis.iter().all(|bi| is_integral(&f, bi)));
+    }
+
+    /// Radical fast-path: `integral_basis` on a simple radical short-circuits to
+    /// the explicit Trager basis (no Puiseux loop) and matches it.  Degree-4
+    /// radical y⁴ = x³ ⇒ {1, y, y²/x, y³/x²}.
+    #[test]
+    fn radical_fast_path_matches_explicit() {
+        let f = [qp(&[0, 0, 0, -1]), qp(&[]), qp(&[]), qp(&[]), qp(&[1])]; // y⁴ − x³
+        let via_loop = integral_basis(&f).expect("basis");
+        let explicit =
+            super::super::integral_basis::radical_integral_basis(4, &qp(&[0, 0, 0, 1])).unwrap();
+        assert_eq!(via_loop, explicit);
+        assert_eq!(via_loop.len(), 4);
+        assert_eq!(
+            via_loop[2],
+            vec![
+                RatFn::int(0),
+                RatFn::int(0),
+                RatFn::new(qp(&[1]), qp(&[0, 1]))
+            ]
+        ); // y²/x
+        assert!(via_loop.iter().all(|bi| is_integral(&f, bi)));
     }
 
     /// Degree-3 radical y³ = x² ⇒ {1, y, y²/x}.


### PR DESCRIPTION
## Summary

Completes the remaining items in the Risch roadmap's M3 chain (`temp-alkahest/planning/risch.md`): the genus ≥ 2 FIND-ORDER decision (**MC2**), the open **MB** efficiency checkbox, and the **general (non-diagonal) Hermite reduction** on algebraic curves.

## MC2 — genus ≥ 2 FIND-ORDER (complete & sound for hyperelliptic curves)

`jacobian_torsion.rs`: self-contained `F_p`/`F_p[x]` arithmetic + **Cantor's algorithm** on Mumford representations → `Jac(F_p)` group law and a class's order; the same Cantor over ℚ (exact) gives the principality test.
- Inconsistent prime-to-`p` orders across good primes ⇒ non-torsion ⇒ `NonElementary` (theorem-backed).
- Otherwise the reconstruction pins the **exact** order `N`; the exact ℚ test `N·δ ?= 0` decides `Principal{N}` vs `NonElementary`.
- Even-degree (real) models reduced to the odd model via a rational branch point (`x = r + 1/s`).

Wired into `find_order_placed`'s genus dispatch; not reachable from the public engine yet (`genus1_log` guards genus 1) → no user-facing change.

## MB — radical fast-path (van Hoeij efficiency remark)

`vanhoeij.rs`: `integral_basis` detects a simple radical `yⁿ = p(x)` and short-circuits to Trager's explicit basis `wᵢ = yⁱ/dᵢ` (only a squarefree factorization), bypassing Puiseux + the enlargement loop. `is_integral`-gated.

## General Hermite reduction on the curve (`hermite_reduce_general`)

`hermite_curve.rs`: Hermite reduction for an **arbitrary** curve `F(x,y)=0` over the van Hoeij integral basis, generalizing the radical-only path (the M3/P3 step for non-radical curves). The leading order-`M` pole cancellation is **componentwise scalar** mod `V` on the normal part (factors coprime to the discriminant); basis-derivation mixing is handled by iteration; coordinates via an exact `ℚ(x)` solve. Branch-locus repeated poles (the `different`-aware "lazy" step) are left in place — documented follow-up.

## Soundness & verification

Every path is sound by construction (exact `g'+h=f` gates, residue-theorem / injectivity arguments) — no gap can produce a wrong answer; declines (`None`/`NotDecided`) otherwise.

- MC2: `[(0,1)−∞]` on `y²=x⁵+x+1` → `NonElementary`; branch differences on `y²=x⁵−x` (odd) and `y²=(x²−1)(x²−4)(x²−9)` (even) → `Principal{2}`.
- MB: radical fast-path matches the explicit basis on `y⁴=x³`.
- Hermite: exact-derivative on non-radical `y²+y−x³` → `h=0`; off-branch double poles on `y²+y−x³` and `y³=x` reduced with `g'+h=f`, squarefree `h`.
- `cargo test --workspace`: **895 lib tests + all integration suites green, 0 failures.** `cargo fmt` + clippy clean.

## Out of scope (documented in the plan's consolidated gaps register)
Genus≥2 `Principal{N}` log-argument output (Coates/Riemann–Roch) + genus≥2 public integrator; `n > 2` superelliptic (general Jacobian arithmetic); branch-locus ("lazy") Hermite step; algebraic-base-point Puiseux (unblocks algebraic-place residues / find_order completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Robust genus ≥2 torsion/order detection via modular-reduction checks and a new Jacobian-torsion path (handles even-degree real models by conversion).
  * Fast-path for simple-radical curves to speed integral-basis computation.
  * General Hermite-reduction entry point for arbitrary plane algebraic curves.
  * Improved genus‑0 handling: attempt polynomial "integral part" solutions before declaring non-elementary.

* **Tests**
  * Added genus-2 cases and tests for radical fast-path, reduced-field Jacobian arithmetic, Hermite reduction, and genus‑0 integral-part solver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->