### PR TITLE
feat(integrate): lazy (different-aware) Hermite for branch-locus poles

### DIFF
--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -15,17 +15,18 @@
 //! branch locus.
 //!
 //! [`hermite_reduce_general`] handles an **arbitrary** curve `F(x,y)=0` over the
-//! van Hoeij integral basis: the leading pole cancellation is componentwise
-//! scalar (mod `V`) on the **normal part** (factors coprime to the discriminant,
-//! where `wᵢ'` is regular), with the basis-derivation mixing handled by iteration.
+//! van Hoeij integral basis.  On the **normal part** (factors coprime to the
+//! discriminant, where `wᵢ'` is regular) the leading pole cancellation is the
+//! fast componentwise scalar solve (mod `V`).  At a **branch-locus** factor
+//! (`V | disc`, where the basis derivation has a pole at `V`) it uses the
+//! `different`-aware **lazy** solve: a `ℚ`-linear system for `b`'s coordinates
+//! mod `V` derived from `U·[(M−1)V'·b − V·D(b)] ≡ −A (mod V)`.  Repeated poles
+//! at *either* locus are reduced to simple poles; a genuine simple pole at the
+//! branch locus (the lazy system inconsistent) is left in `h`.
 //!
 //! Sound by construction: every result is accepted only after the exact field
 //! identity `g' + h = f` is verified, and each `h` component is checked to have a
-//! squarefree denominator (on the normal part).
-//!
-//! Remaining follow-up: the `different`-aware ("lazy") Hermite step that also
-//! reduces **repeated poles on the branch locus** (factors dividing the
-//! discriminant), which [`hermite_reduce_general`] leaves in place.
+//! squarefree denominator (modulo the branch locus, where simple poles remain).
 
 use rug::Rational;
 
@@ -117,12 +118,12 @@ pub fn hermite_reduce_radical(
 /// `bᵢ ≡ −Aᵢ·(U·(M−1)·V')⁻¹ (mod V)` makes `(b/V^{M−1})'` match the pole, so
 /// `f − (b/V^{M−1})'` drops one power of `V`.  The basis-mixing `wᵢ' = Σ Mᵢⱼ wⱼ`
 /// only perturbs lower orders and is handled by iteration.  Branch-locus repeated
-/// poles (factors dividing the discriminant) are left untouched — that is the
-/// `different`-aware ("lazy") Hermite step, a documented follow-up.
+/// poles (`V | disc`) are reduced by the lazy [`lazy_solve_b`] step; a genuine
+/// simple pole there is left in `h`.
 ///
 /// Sound by construction: accepted only after the exact field identity
-/// `g' + h = f` holds and every `h`-coordinate denominator is squarefree on the
-/// normal part.
+/// `g' + h = f` holds and every `h`-coordinate denominator is squarefree away
+/// from the branch locus.
 pub fn hermite_reduce_general(
     f_coeffs: &[QPoly],
     integrand: &AlgElem,
@@ -148,45 +149,64 @@ pub fn hermite_reduce_general(
     for _ in 0..cap {
         let coords = to_w_coords(&basis, &cur, n)?;
         let (d_poly, a_polys) = common_denominator(&coords);
-        // Highest-multiplicity repeated factor V of the **normal part** (mult ≥ 2,
-        // coprime to the discriminant), where the basis derivation is regular.
         let sqf = squarefree_factors(&d_poly);
-        let Some((v, m)) = sqf
+
+        // Build the reduction term `b/V^{M−1}` for the highest-multiplicity
+        // repeated factor `V` (mult `M ≥ 2`).  Prefer a **normal-part** factor
+        // (coprime to the discriminant) — there the leading cancellation is the
+        // fast componentwise solve `bᵢ ≡ −Aᵢ·(U(M−1)V')⁻¹ (mod V)`.  Otherwise
+        // fall back to the **lazy** branch-locus solve (`V | disc`), which
+        // accounts for the basis derivation's pole at `V`.
+        let normal = sqf
             .iter()
             .enumerate()
             .rev()
             .find(|(k, p)| *k + 1 >= 2 && degree(p) >= 1 && degree(&poly_gcd(p, &disc)) <= 0)
+            .map(|(k, p)| (p.clone(), k + 1));
+
+        let term = if let Some((v, m)) = normal {
+            let vm = poly_pow(&v, m as u32);
+            let u = poly_div_exact(&d_poly, &vm);
+            let s = poly_scale(
+                &poly_mul(&u, &poly_deriv(&v)),
+                &Rational::from((m - 1) as i64),
+            );
+            let s_inv = mod_inverse(&s, &v)?;
+            let mut b_w = vec![RatFn::int(0); n];
+            for (i, ai) in a_polys.iter().enumerate() {
+                let bi = poly_mod(&poly_mul(ai, &s_inv), &v);
+                b_w[i] = RatFn::from_poly(&poly_scale(&bi, &Rational::from(-1)));
+            }
+            let b_power = w_to_power(&basis, &b_w, &ext, n);
+            let inv_vm1 = RatFn::new(vec![Rational::from(1)], poly_pow(&v, (m - 1) as u32));
+            Some(scale_elem(&b_power, &inv_vm1))
+        } else if let Some((v, m)) = sqf
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(k, p)| *k + 1 >= 2 && degree(p) >= 1)
             .map(|(k, p)| (p.clone(), k + 1))
-        else {
-            break; // normal part squarefree → done
+        {
+            // Branch-locus (`V | disc`): lazy coupled solve.
+            let vm = poly_pow(&v, m as u32);
+            let u = poly_div_exact(&d_poly, &vm);
+            lazy_solve_b(&ext, &basis, &a_polys, &u, &v, m, n).map(|b_power| {
+                let inv_vm1 = RatFn::new(vec![Rational::from(1)], poly_pow(&v, (m - 1) as u32));
+                scale_elem(&b_power, &inv_vm1)
+            })
+        } else {
+            None
         };
 
-        // s = U·(M−1)·V'  (scalar in ℚ[x]); invertible mod V.
-        let vm = poly_pow(&v, m as u32);
-        let u = poly_div_exact(&d_poly, &vm);
-        let s = poly_scale(
-            &poly_mul(&u, &poly_deriv(&v)),
-            &Rational::from((m - 1) as i64),
-        );
-        let s_inv = mod_inverse(&s, &v)?;
-
-        // bᵢ = (−Aᵢ·s⁻¹) mod V, componentwise; b = Σ bᵢ wᵢ (→ power basis).
-        let mut b_w = vec![RatFn::int(0); n];
-        for (i, ai) in a_polys.iter().enumerate() {
-            let bi = poly_mod(&poly_mul(ai, &s_inv), &v);
-            b_w[i] = RatFn::from_poly(&poly_scale(&bi, &Rational::from(-1)));
-        }
-        let b_power = w_to_power(&basis, &b_w, &ext, n);
-
-        // term = b/V^{M−1};  cur −= term';  g += term.
-        let inv_vm1 = RatFn::new(vec![Rational::from(1)], poly_pow(&v, (m - 1) as u32));
-        let term = scale_elem(&b_power, &inv_vm1);
+        let Some(term) = term else {
+            break; // squarefree denominator (or lazy solve unavailable) → done
+        };
         if ext.elem_eq(&term, &ext.from_int(0)) {
             break; // no progress possible at this place
         }
         let next = ext.sub(&cur, &ext.derivation(&term));
         g = ext.add(&g, &term);
-        // Progress guard: the normal-part denominator must strictly drop.
+        // Progress guard: the denominator must strictly drop.
         if denom_total(&next) >= denom_total(&cur) {
             cur = next;
             break;
@@ -200,7 +220,8 @@ pub fn hermite_reduce_general(
     for c in &hcoords {
         let den = c.denom();
         let g_sq = poly_gcd(den, &poly_deriv(den));
-        // Allow repeated factors only at the discriminant (branch) locus.
+        // Allow repeated factors only at the discriminant (branch) locus — these
+        // are left in place when the lazy solve cannot reduce them.
         if degree(&poly_gcd(&g_sq, &disc)) < degree(&g_sq) {
             return None;
         }
@@ -293,6 +314,151 @@ fn poly_lcm(a: &QPoly, b: &QPoly) -> QPoly {
         return vec![Rational::from(1)];
     }
     poly_div_exact(&poly_mul(a, b), &poly_gcd(a, b))
+}
+
+/// **Lazy** Hermite solve at a branch-locus factor `V` (`V | disc`, squarefree,
+/// multiplicity `M`).  Find `b = Σ bᵢ wᵢ` (`bᵢ ∈ ℚ[x]/V`) with
+/// `U·[(M−1)V'·b − V·D(b)] ≡ −A (mod V)` in the integral basis, so that
+/// `(b/V^{M−1})'` cancels the order-`M` pole even though the basis derivation
+/// `D(wᵢ)` itself has a pole at `V`.  Returns `b` in the power basis, or `None`
+/// if the (linear, over `ℚ`) system is inconsistent — i.e. the pole at `V` is a
+/// genuine simple pole that cannot be reduced.
+fn lazy_solve_b(
+    ext: &AlgExtension,
+    basis: &[AlgElem],
+    a_polys: &[QPoly],
+    u: &QPoly,
+    v: &QPoly,
+    m: usize,
+    n: usize,
+) -> Option<AlgElem> {
+    let dv = degree(v) as usize;
+    if dv < 1 {
+        return None;
+    }
+    let nunk = n * dv;
+    let mv1 = poly_scale(&poly_deriv(v), &Rational::from((m - 1) as i64)); // (M−1)V'
+    let u_rf = RatFn::from_poly(u);
+    let v_rf = RatFn::from_poly(v);
+    let mv1_rf = RatFn::from_poly(&mv1);
+
+    // Column `(i, p)` = the basis trial `b = xᵖ·wᵢ` mapped through
+    // `T(b) = U·[(M−1)V'·b − V·D(b)]`, reduced to w-coords mod V and flattened.
+    let mut cols: Vec<Vec<Rational>> = Vec::with_capacity(nunk);
+    for i in 0..n {
+        for p in 0..dv {
+            let mut b_w = vec![RatFn::int(0); n];
+            b_w[i] = RatFn::from_poly(&monomial_q(p));
+            let b_power = w_to_power(basis, &b_w, ext, n);
+            let db = ext.derivation(&b_power);
+            let v_db = scale_elem(&db, &v_rf); // V·D(b)
+            let mv1_b = scale_elem(&b_power, &mv1_rf); // (M−1)V'·b
+            let inner = ext.sub(&mv1_b, &v_db);
+            let t_elem = scale_elem(&inner, &u_rf); // U·[…]
+            let tcoords = to_w_coords(basis, &t_elem, n)?;
+            let mut col = Vec::with_capacity(nunk);
+            for c in &tcoords {
+                let r = ratfn_mod_v(c, v)?; // None ⇒ not regular at V ⇒ bail
+                for k in 0..dv {
+                    col.push(r.get(k).cloned().unwrap_or_else(|| Rational::from(0)));
+                }
+            }
+            cols.push(col);
+        }
+    }
+
+    // RHS = −A mod V (flattened over the n coordinates).
+    let mut rhs = Vec::with_capacity(nunk);
+    for j in 0..n {
+        let aj = a_polys.get(j).cloned().unwrap_or_default();
+        let r = poly_mod(&poly_scale(&aj, &Rational::from(-1)), v);
+        for k in 0..dv {
+            rhs.push(r.get(k).cloned().unwrap_or_else(|| Rational::from(0)));
+        }
+    }
+
+    // Assemble `mat·x = rhs` (rows = nunk equations, cols = nunk unknowns).
+    let mut mat = vec![vec![Rational::from(0); nunk]; nunk];
+    for (unk, col) in cols.iter().enumerate() {
+        for (eq, val) in col.iter().enumerate() {
+            mat[eq][unk] = val.clone();
+        }
+    }
+    let sol = gauss_solve_q(mat, rhs, nunk)?;
+
+    let mut b_w = vec![RatFn::int(0); n];
+    for (i, slot) in b_w.iter_mut().enumerate() {
+        let poly: QPoly = (0..dv).map(|p| sol[i * dv + p].clone()).collect();
+        *slot = RatFn::from_poly(&trim(poly));
+    }
+    Some(w_to_power(basis, &b_w, ext, n))
+}
+
+/// Reduce `r = num/den ∈ ℚ(x)` modulo `V` (requires `gcd(den, V) = 1`):
+/// `num · den⁻¹ mod V`, as a polynomial of degree `< deg V`.  `None` if `den`
+/// is not invertible mod `V` (i.e. `r` has a pole at `V`).
+fn ratfn_mod_v(r: &RatFn, v: &QPoly) -> Option<QPoly> {
+    let inv = mod_inverse(r.denom(), v)?;
+    Some(poly_mod(&poly_mul(r.numer(), &inv), v))
+}
+
+/// The monomial `xᵖ` as a `QPoly`.
+fn monomial_q(p: usize) -> QPoly {
+    let mut v = vec![Rational::from(0); p + 1];
+    v[p] = Rational::from(1);
+    v
+}
+
+/// Solve `mat·x = rhs` over `ℚ` (square `n×n`); particular solution (free vars 0)
+/// or `None` if inconsistent.
+fn gauss_solve_q(
+    mut mat: Vec<Vec<Rational>>,
+    mut rhs: Vec<Rational>,
+    n: usize,
+) -> Option<Vec<Rational>> {
+    let nrows = mat.len();
+    let mut pivot_of_col = vec![None; n];
+    let mut row = 0usize;
+    for col in 0..n {
+        if row >= nrows {
+            break;
+        }
+        let Some(sel) = (row..nrows).find(|&r| mat[r][col] != 0) else {
+            continue;
+        };
+        mat.swap(row, sel);
+        rhs.swap(row, sel);
+        let piv = mat[row][col].clone();
+        for v in mat[row].iter_mut() {
+            *v /= &piv;
+        }
+        rhs[row] /= &piv;
+        let pr = mat[row].clone();
+        let pb = rhs[row].clone();
+        for r in 0..nrows {
+            if r != row && mat[r][col] != 0 {
+                let f = mat[r][col].clone();
+                for (dst, pv) in mat[r].iter_mut().zip(pr.iter()) {
+                    *dst -= f.clone() * pv;
+                }
+                rhs[r] -= f * &pb;
+            }
+        }
+        pivot_of_col[col] = Some(row);
+        row += 1;
+    }
+    for r in 0..nrows {
+        if mat[r].iter().all(|v| *v == 0) && rhs[r] != 0 {
+            return None; // inconsistent
+        }
+    }
+    let mut x = vec![Rational::from(0); n];
+    for (col, pr) in pivot_of_col.iter().enumerate() {
+        if let Some(r) = pr {
+            x[col] = rhs[*r].clone();
+        }
+    }
+    Some(x)
 }
 
 /// `ωᵢ = i·a'/(n·a) − dᵢ'/dᵢ`, the basis-derivative coefficient `wᵢ' = ωᵢ wᵢ`.
@@ -523,6 +689,41 @@ mod tests {
             let den = hi.denom();
             assert!(degree(&poly_gcd(den, &poly_deriv(den))) <= 0);
         }
+    }
+
+    /// Lazy (branch-locus) Hermite: the **general** reducer now reduces a pole
+    /// at the branch point `x=0` (`x | disc`), matching the radical reducer.
+    /// ∫ y/x³ on y²=x ⇒ g = −⅔ y/x², h = 0.
+    #[test]
+    fn general_branch_locus_pole_reduces() {
+        let f_coeffs = [qp(&[0, -1]), qp(&[]), qp(&[1])]; // y² − x
+        let integrand = vec![RatFn::int(0), rf(&[1], &[0, 0, 0, 1])]; // y/x³
+        let (g, h) = hermite_reduce_general(&f_coeffs, &integrand).expect("reduce");
+        assert!(h.iter().all(|c| c.numer().is_empty()), "h = {h:?}");
+        assert_eq!(g[1], RatFn::new(qp(&[-2]), qp(&[0, 0, 3]))); // −⅔ y/x²
+    }
+
+    /// Lazy Hermite on a degree-3 radical at the branch locus: ∫ y²/x⁴ on y³=x
+    /// (disc ∝ x²) ⇒ g = −3/7 y²/x³, h = 0, via the general reducer.
+    #[test]
+    fn general_branch_locus_cubic_radical() {
+        let f_coeffs = [qp(&[0, -1]), qp(&[]), qp(&[]), qp(&[1])]; // y³ − x
+        let integrand = vec![RatFn::int(0), RatFn::int(0), rf(&[1], &[0, 0, 0, 0, 1])]; // y²/x⁴
+        let (g, h) = hermite_reduce_general(&f_coeffs, &integrand).expect("reduce");
+        assert!(h.iter().all(|c| c.numer().is_empty()), "h = {h:?}");
+        assert_eq!(g[2], RatFn::new(qp(&[-3]), qp(&[0, 0, 0, 7]))); // −3/7 y²/x³
+    }
+
+    /// A genuine **simple pole** at the branch locus is left in `h` (the lazy
+    /// solve is inconsistent — nothing to reduce): ∫ y/((x−1)x) on y²=x, the
+    /// branch-point part stays, `g'+h=f` holds.
+    #[test]
+    fn general_branch_simple_pole_untouched() {
+        let f_coeffs = [qp(&[0, -1]), qp(&[]), qp(&[1])]; // y² − x
+        let ext = AlgExtension::new(&f_coeffs);
+        let f = vec![RatFn::int(0), rf(&[1], &[0, -1, 1])]; // y/((x−1)x)
+        let (g, h) = hermite_reduce_general(&f_coeffs, &f).expect("reduce");
+        assert!(ext.elem_eq(&ext.add(&ext.derivation(&g), &h), &f));
     }
 
     /// Degree-3 radical: ∫ y²/x⁴ dx on y³ = x reduces the x⁴ pole.

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -869,7 +869,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.


### PR DESCRIPTION
## Summary

**Stacked on #106** (base `risch/mc2-genus2`). Completes the Hermite reduction on algebraic curves: `hermite_reduce_general` now reduces repeated poles on the **branch locus** (factors `V | disc`), the `different`-aware ("lazy") step that #106 left as a documented follow-up.

## The problem

On the normal part (factors coprime to the discriminant) the basis derivation `wᵢ'` is regular and the order-`M` pole cancels componentwise. At a **branch-locus** factor `V` (`V | disc`), `wᵢ'` itself has a pole at `V`, so the residue of `D(b)` couples the coordinates and the componentwise solve no longer applies.

## The fix (`lazy_solve_b`)

Solve the `ℚ`-linear system for `b = Σ bᵢ wᵢ` (`bᵢ ∈ ℚ[x]/V`) from

```
U·[(M−1)V'·b − V·D(b)] ≡ −A   (mod V)
```

assembled by evaluating the map on the basis trials `xᵖ·wᵢ`, reducing each coordinate mod `V` (`ratfn_mod_v`), and Gaussian-solving over `ℚ` (`gauss_solve_q`). The `V·D(b)` term captures the derivation's residue at `V` that the normal case drops. The normal-part fast path is unchanged and tried first; the lazy path is the fallback. An inconsistent system = a genuine simple pole at the branch place, correctly left in `h`.

## Soundness & verification

Same exact `g' + h = f` gate (no oracle). Verified by the **general** reducer matching the **radical** reducer at branch points:
- `∫ y/x³` on `y²=x` ⇒ `g = −⅔ y/x²`, `h = 0`;
- `∫ y²/x⁴` on `y³=x` ⇒ `g = −3/7 y²/x³`, `h = 0`;
- a branch-locus simple pole is retained in `h` with `g'+h=f`.

`cargo test --workspace`: **902 lib tests + all suites green**; `cargo fmt` + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
