### PR TITLE
feat(integrate): Trager ℚ-basis logarithmic-part criterion (core)

### DIFF
--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -969,7 +969,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -27,6 +27,12 @@ mod jacobian_torsion;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;
 pub mod residues;
+// Trager ℚ-basis logarithmic-part criterion: the decomposition + per-component
+// torsion core is implemented and tested; its full consumer (collecting a
+// divisor's algebraic residues into a common number field — a compositum) is the
+// remaining glue, so the entry points are not yet called from non-test code.
+#[allow(dead_code)]
+mod trager_log;
 pub mod vanhoeij;
 
 use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -66,10 +66,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -1,0 +1,248 @@
+//! Trager's ℚ-basis criterion for the logarithmic part (Risch **MC**, the
+//! algebraic-residue case).
+//!
+//! After Hermite reduction the third-kind part `h dx` has simple poles with
+//! residues `res_P` (possibly **algebraic**).  By Liouville `∫ h dx` is
+//! elementary iff it is `Σ_j c_j log(u_j)`; Trager's criterion turns this into a
+//! finite set of **torsion** tests:
+//!
+//! 1. The residues span a finite-dimensional `ℚ`-vector space `V` (here:
+//!    elements of a number field `ℚ(θ)`).  Pick a `ℚ`-basis `ω_1,…,ω_r` of the
+//!    span and write `res_P = Σ_k λ_{P,k} ω_k` with `λ_{P,k} ∈ ℚ`.
+//! 2. For each component `k`, form the **rational-coefficient** divisor
+//!    `δ_k = Σ_P λ_{P,k}·P`.
+//! 3. `∫ h dx` is elementary **iff every `δ_k` is torsion** (a principal
+//!    multiple) in the Jacobian — decided per component by [`super::find_order`].
+//!
+//! This module implements the `ℚ`-basis decomposition ([`qbasis_decompose`]) and
+//! the per-component dispatch ([`trager_log_criterion`]) for residues given as
+//! elements of a **common** `ℚ(θ)` at **rational** places.  A non-torsion
+//! component certifies `NonElementary` (sound); all-torsion means the log part
+//! exists (`Principal`).  Getting the residues from several distinct places into
+//! a common `ℚ(θ)` (a compositum) and torsion of **non-branch algebraic** places
+//! are the remaining glue toward the fully general criterion.
+
+use rug::Rational;
+
+use super::super::risch::number_field::KElem;
+use super::super::risch::poly_rde::QPoly;
+use super::find_order::{find_order_placed, FindOrder};
+use super::residues::{PlacedResidue, Residue};
+
+/// `ℚ`-basis decomposition of residues `r_i ∈ ℚ(θ)` (each a `KElem`, i.e. a
+/// `QPoly` of degree `< dim`).  Returns `(r, coords)` where `r` is the dimension
+/// of the `ℚ`-span and `coords[i]` is the length-`r` coordinate vector of `r_i`
+/// in the chosen basis.  The basis is the set of pivot columns of the
+/// row-reduced residue matrix, so `coords[i][k] = r_i[pivot_k]` exactly.
+pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Vec<Rational>>) {
+    if dim == 0 || residues.is_empty() {
+        return (0, residues.iter().map(|_| Vec::new()).collect());
+    }
+    // Residues as ℚ-vectors of length `dim` (pad with zeros).
+    let vecs: Vec<Vec<Rational>> = residues
+        .iter()
+        .map(|r| {
+            (0..dim)
+                .map(|j| r.get(j).cloned().unwrap_or_else(|| Rational::from(0)))
+                .collect()
+        })
+        .collect();
+
+    // Row-reduce a copy to find the pivot columns (a basis of the row span).
+    let mut m = vecs.clone();
+    let nrows = m.len();
+    let mut pivots: Vec<usize> = Vec::new();
+    let mut row = 0usize;
+    for col in 0..dim {
+        if row >= nrows {
+            break;
+        }
+        let Some(sel) = (row..nrows).find(|&r| m[r][col] != 0) else {
+            continue;
+        };
+        m.swap(row, sel);
+        let piv = m[row][col].clone();
+        for v in m[row].iter_mut() {
+            *v /= &piv;
+        }
+        let pr = m[row].clone();
+        for r in 0..nrows {
+            if r != row && m[r][col] != 0 {
+                let f = m[r][col].clone();
+                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+                    *dst -= f.clone() * pv;
+                }
+            }
+        }
+        pivots.push(col);
+        row += 1;
+    }
+
+    // With the basis = pivot columns of the RREF, the coordinate of `r_i` along
+    // basis vector `k` is exactly `r_i[pivot_k]`.
+    let coords = vecs
+        .iter()
+        .map(|v| pivots.iter().map(|&p| v[p].clone()).collect())
+        .collect();
+    (pivots.len(), coords)
+}
+
+/// Trager's criterion for residues in a **common** `ℚ(θ)` at **rational** places.
+///
+/// `places` and `residues` are parallel (same length); each residue is a `KElem`
+/// in `ℚ(θ)` (`dim = deg θ`).  Decomposes the residues over `ℚ`, and for each
+/// component `k` runs [`find_order_placed`] on the rational-coefficient divisor
+/// `δ_k`.  Returns:
+/// * [`FindOrder::NonElementary`] if **any** component is non-torsion (sound);
+/// * [`FindOrder::Principal`] with the lcm of the component orders if **all** are
+///   torsion (the log part exists);
+/// * [`FindOrder::NotDecided`] if any component is undecided.
+pub(crate) fn trager_log_criterion(
+    n: usize,
+    a: &QPoly,
+    places: &[PlacedResidue],
+    residues: &[KElem],
+    dim: usize,
+) -> FindOrder {
+    if places.len() != residues.len() || places.is_empty() {
+        return FindOrder::NotDecided;
+    }
+    let (ncomp, coords) = qbasis_decompose(residues, dim);
+    if ncomp == 0 {
+        // All residues zero ⇒ no logarithmic part.
+        return FindOrder::Principal { order: 1 };
+    }
+
+    let mut lcm_order: u32 = 1;
+    for k in 0..ncomp {
+        // Component divisor δ_k: same places, residue value = coords[i][k].
+        let div_k: Vec<PlacedResidue> = places
+            .iter()
+            .zip(&coords)
+            .map(|(pl, c)| PlacedResidue {
+                residue: Residue {
+                    point: pl.residue.point.clone(),
+                    at_infinity: pl.residue.at_infinity,
+                    sheet: pl.residue.sheet,
+                    ramification: pl.residue.ramification,
+                    value: c[k].clone(),
+                },
+                y_coord: pl.y_coord.clone(),
+            })
+            .collect();
+        match find_order_placed(n, a, &div_k) {
+            FindOrder::NonElementary => return FindOrder::NonElementary,
+            FindOrder::Principal { order } => lcm_order = lcm_u32(lcm_order, order),
+            FindOrder::NotDecided => return FindOrder::NotDecided,
+        }
+    }
+    FindOrder::Principal { order: lcm_order }
+}
+
+fn lcm_u32(a: u32, b: u32) -> u32 {
+    if a == 0 || b == 0 {
+        return 0;
+    }
+    a / gcd_u32(a, b) * b
+}
+
+fn gcd_u32(mut a: u32, mut b: u32) -> u32 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+    fn ke(cs: &[i64]) -> KElem {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+    fn place(point: i64, y: i64, inf: bool) -> PlacedResidue {
+        PlacedResidue {
+            residue: Residue {
+                point: Rational::from(point),
+                at_infinity: inf,
+                sheet: 0,
+                ramification: 1,
+                value: Rational::from(0),
+            },
+            y_coord: Rational::from(y),
+        }
+    }
+
+    /// ℚ-basis decomposition of `{√2, −√2, 3}` in `ℚ(√2)` (dim 2): the span is
+    /// 2-dimensional (`{1, √2}` via pivots), with the expected coordinates.
+    #[test]
+    fn decompose_quadratic_field() {
+        // √2 = [0,1], −√2 = [0,−1], 3 = [3,0].
+        let res = [ke(&[0, 1]), ke(&[0, -1]), ke(&[3, 0])];
+        let (ncomp, coords) = qbasis_decompose(&res, 2);
+        assert_eq!(ncomp, 2); // span = ℚ·1 ⊕ ℚ·√2
+                              // Pivot columns are 0 (the `1` part) then 1 (the `√2` part):
+        assert_eq!(coords[0], vec![Rational::from(0), Rational::from(1)]); // √2
+        assert_eq!(coords[1], vec![Rational::from(0), Rational::from(-1)]); // −√2
+        assert_eq!(coords[2], vec![Rational::from(3), Rational::from(0)]); // 3
+    }
+
+    /// 1-dimensional span: `{√2, −√2}` ⇒ one component, coords `+1, −1`.
+    #[test]
+    fn decompose_one_dimensional() {
+        let res = [ke(&[0, 1]), ke(&[0, -1])];
+        let (ncomp, coords) = qbasis_decompose(&res, 2);
+        assert_eq!(ncomp, 1);
+        assert_eq!(coords[0], vec![Rational::from(1)]);
+        assert_eq!(coords[1], vec![Rational::from(-1)]);
+    }
+
+    /// Trager criterion, **NonElementary**: residues `√2` at `(3,5)` and `−√2`
+    /// at `∞` on the Mordell curve `y²=x³−2` (rank 1).  The single `√2`-component
+    /// divisor `(3,5) − ∞` maps to the infinite-order point `(3,5)` ⇒
+    /// non-torsion ⇒ `NonElementary`.
+    #[test]
+    fn criterion_nonelementary_via_component() {
+        let a = qp(&[-2, 0, 0, 1]); // x³ − 2
+        let places = [place(3, 5, false), place(0, 0, true)];
+        let residues = [ke(&[0, 1]), ke(&[0, -1])]; // √2, −√2
+        assert_eq!(
+            trager_log_criterion(2, &a, &places, &residues, 2),
+            FindOrder::NonElementary
+        );
+    }
+
+    /// Trager criterion, **all torsion**: residues `√2` at `(−1,0)` and `−√2` at
+    /// `∞` on `y²=x³+1` (ℤ/6).  The `√2`-component `(−1,0) − ∞` is the 2-torsion
+    /// point `(−1,0)` ⇒ `Principal{2}` (the log part exists).
+    #[test]
+    fn criterion_principal_via_component() {
+        let a = qp(&[1, 0, 0, 1]); // x³ + 1
+        let places = [place(-1, 0, false), place(0, 0, true)];
+        let residues = [ke(&[0, 1]), ke(&[0, -1])]; // √2, −√2
+        assert_eq!(
+            trager_log_criterion(2, &a, &places, &residues, 2),
+            FindOrder::Principal { order: 2 }
+        );
+    }
+
+    /// Genuine **two-component** all-torsion case on `y²=x³+1` (ℤ/6), residues
+    /// summing to zero (residue theorem): `(2,3)↦1`, `(−1,0)↦√2`, `∞↦−1−√2`.
+    /// The `1`-component is `(2,3)−∞` (order 6), the `√2`-component is `(−1,0)−∞`
+    /// (order 2) ⇒ both torsion ⇒ `Principal{lcm(6,2)=6}`.
+    #[test]
+    fn criterion_two_components_principal() {
+        let a = qp(&[1, 0, 0, 1]); // x³ + 1
+        let places = [place(2, 3, false), place(-1, 0, false), place(0, 0, true)];
+        let residues = [ke(&[1, 0]), ke(&[0, 1]), ke(&[-1, -1])]; // 1, √2, −1−√2
+        assert_eq!(
+            trager_log_criterion(2, &a, &places, &residues, 2),
+            FindOrder::Principal { order: 6 }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**Stacked on #109** (base `risch/findorder-alg-places`). Implements the **core of Trager's ℚ-basis criterion** for the logarithmic part with *algebraic* residues (Risch MC).

After Hermite reduction, `∫ h dx` (third-kind, residues `res_P` possibly algebraic) is elementary iff: decompose the residues over a `ℚ`-basis `ω_1,…,ω_r` of their span, write `res_P = Σ_k λ_{P,k} ω_k`; then it is elementary **iff every component divisor `δ_k = Σ_P λ_{P,k}·P` is torsion**.

## What's implemented (`algebraic/trager_log.rs`)

- **`qbasis_decompose(residues ∈ ℚ(θ), dim)`** — the dimension of the residues' `ℚ`-span and each residue's exact `ℚ`-coordinates, via row-reduction (coordinates = the residue's entries at the RREF pivot columns). Pure exact rational linear algebra.
- **`trager_log_criterion(n, a, places, residues, dim)`** — for residues in a common `ℚ(θ)` at rational places: decompose, and for each component run `find_order_placed` on the rational-coefficient divisor `δ_k`. Returns:
  - `NonElementary` if **any** component is non-torsion (sound);
  - `Principal{lcm Nₖ}` if **all** are torsion (the log part exists);
  - `NotDecided` otherwise.

## Verification
- `ℚ(√2)` decomposition: 2-dim and 1-dim spans with exact coordinates.
- Criterion → `NonElementary` via a non-torsion `√2`-component on the Mordell curve `y²=x³−2` (rank 1).
- `Principal{2}`, and a genuine **two-component** `Principal{6}` on `y²=x³+1` (ℤ/6) with residues summing to zero (residue theorem).
- `cargo test --workspace`: **911 lib tests + all suites green**; `cargo fmt` + clippy clean.

## Scope / remaining glue
The decomposition + per-component torsion is the criterion's core. The entry points are not yet called from non-test code (marked `#[allow(dead_code)]`) because the remaining glue is:
1. collecting a divisor's algebraic residues (`finite_residues_algebraic`, #108) across **distinct** places into a **common `ℚ(θ)`** (a compositum), and
2. torsion of **non-branch** algebraic places (#109 covers branch places).

With those two, this criterion decides the genus≥2 `∫B·√P` algebraic-pole curves end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
