### PR TITLE
feat(integrate): route Trager ℚ-basis criterion through algebraic places

### DIFF
--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -999,7 +999,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -27,10 +27,11 @@ mod jacobian_torsion;
 pub(super) mod parametrize;
 pub(super) mod poly_utils;
 pub mod residues;
-// Trager ℚ-basis logarithmic-part criterion: the decomposition + per-component
-// torsion core is implemented and tested; its full consumer (collecting a
-// divisor's algebraic residues into a common number field — a compositum) is the
-// remaining glue, so the entry points are not yet called from non-test code.
+// Trager ℚ-basis logarithmic-part criterion: decomposition + per-component
+// torsion over rational *and* algebraic places (`trager_log_criterion[_alg]`).
+// The remaining glue to a user-facing consumer is the engine-level
+// `∫B·√P` pipeline (Hermite → residues → collect into a common ℚ(θ) → criterion),
+// so the entry points are not yet called from non-test code.
 #[allow(dead_code)]
 mod trager_log;
 pub mod vanhoeij;

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -22,11 +22,12 @@
 //! a common `ℚ(θ)` (a compositum) and torsion of **non-branch algebraic** places
 //! are the remaining glue toward the fully general criterion.
 
-use rug::Rational;
+use rug::{Integer, Rational};
 
 use super::super::risch::number_field::KElem;
 use super::super::risch::poly_rde::QPoly;
 use super::find_order::{find_order_placed, FindOrder};
+use super::jacobian_torsion::{find_order_genus_ge2_alg, AlgPlace};
 use super::residues::{PlacedResidue, Residue};
 
 /// `ℚ`-basis decomposition of residues `r_i ∈ ℚ(θ)` (each a `KElem`, i.e. a
@@ -139,6 +140,80 @@ pub(crate) fn trager_log_criterion(
     FindOrder::Principal { order: lcm_order }
 }
 
+/// Trager's criterion with **algebraic** places: residues live in a common
+/// `ℚ(θ)` (`dim = deg θ`), attached to rational places (`rat_places`) and
+/// algebraic-place orbits (`alg_places`, see [`AlgPlace`]).  Decomposes all
+/// residues over `ℚ`; for each component the rational-coefficient divisor `δ_k`
+/// (over both place kinds) is tested by [`find_order_genus_ge2_alg`].  Returns
+/// `NonElementary` if any component is non-torsion, `Principal` (lcm of the
+/// component orders) if all are torsion, else `NotDecided`.
+///
+/// Each component's coordinates are cleared to integers (a constant rescaling
+/// that preserves torsion-ness; `find_order_genus_ge2_alg` re-primitivizes, so
+/// the reported order is that of the primitive class).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn trager_log_criterion_alg(
+    n: usize,
+    a: &QPoly,
+    rat_places: &[PlacedResidue],
+    rat_residues: &[KElem],
+    alg_places: &[AlgPlace],
+    alg_residues: &[KElem],
+    dim: usize,
+) -> FindOrder {
+    if rat_places.len() != rat_residues.len() || alg_places.len() != alg_residues.len() {
+        return FindOrder::NotDecided;
+    }
+    let nr = rat_residues.len();
+    let all_res: Vec<KElem> = rat_residues.iter().chain(alg_residues).cloned().collect();
+    if all_res.is_empty() {
+        return FindOrder::NotDecided;
+    }
+    let (ncomp, coords) = qbasis_decompose(&all_res, dim);
+    if ncomp == 0 {
+        return FindOrder::Principal { order: 1 };
+    }
+
+    let mut lcm_order: u32 = 1;
+    for k in 0..ncomp {
+        // Clear denominators of this component's coordinates to integers.
+        let mut l = Integer::from(1);
+        for c in &coords {
+            l = l.lcm(c[k].denom());
+        }
+        let rat_div: Vec<PlacedResidue> = rat_places
+            .iter()
+            .zip(&coords[..nr])
+            .map(|(pl, c)| PlacedResidue {
+                residue: Residue {
+                    point: pl.residue.point.clone(),
+                    at_infinity: pl.residue.at_infinity,
+                    sheet: pl.residue.sheet,
+                    ramification: pl.residue.ramification,
+                    value: c[k].clone() * Rational::from(l.clone()),
+                },
+                y_coord: pl.y_coord.clone(),
+            })
+            .collect();
+        let alg_div: Vec<AlgPlace> = alg_places
+            .iter()
+            .zip(&coords[nr..])
+            .map(|(ap, c)| AlgPlace {
+                minpoly: ap.minpoly.clone(),
+                x_coord: ap.x_coord.clone(),
+                y_coord: ap.y_coord.clone(),
+                coeff: (c[k].clone() * Rational::from(l.clone())).numer().clone(),
+            })
+            .collect();
+        match find_order_genus_ge2_alg(n, a, &rat_div, &alg_div) {
+            FindOrder::NonElementary => return FindOrder::NonElementary,
+            FindOrder::Principal { order } => lcm_order = lcm_u32(lcm_order, order),
+            FindOrder::NotDecided => return FindOrder::NotDecided,
+        }
+    }
+    FindOrder::Principal { order: lcm_order }
+}
+
 fn lcm_u32(a: u32, b: u32) -> u32 {
     if a == 0 || b == 0 {
         return 0;
@@ -229,6 +304,34 @@ mod tests {
             trager_log_criterion(2, &a, &places, &residues, 2),
             FindOrder::Principal { order: 2 }
         );
+    }
+
+    /// Criterion with an **algebraic place**: on the genus-2 curve
+    /// `y²=(x²−2)(x³+1)`, residues in `ℚ(√2)` — `√2` at the algebraic branch
+    /// orbit over `x²−2`, `−√2` at the rational branch point `(−1,0)`.  The
+    /// single `√2`-component divisor is branch-only ⇒ 2-torsion ⇒ `Principal`.
+    #[test]
+    fn criterion_alg_place_principal() {
+        let a = qp(&[-2, 0, 1, -2, 0, 1]); // (x²−2)(x³+1) = x⁵ − 2x³ + x² − 2
+        let rat_places = [place(-1, 0, false)]; // branch point (−1,0)
+        let rat_residues = [ke(&[0, -1])]; // −√2
+        let alg_places = [AlgPlace {
+            minpoly: qp(&[-2, 0, 1]), // x² − 2
+            x_coord: qp(&[0, 1]),     // θ
+            y_coord: Vec::new(),      // branch
+            coeff: Integer::from(0),  // (coeff is set per-component by the criterion)
+        }];
+        let alg_residues = [ke(&[0, 1])]; // √2
+        let res = trager_log_criterion_alg(
+            2,
+            &a,
+            &rat_places,
+            &rat_residues,
+            &alg_places,
+            &alg_residues,
+            2,
+        );
+        assert!(matches!(res, FindOrder::Principal { .. }), "got {res:?}");
     }
 
     /// Genuine **two-component** all-torsion case on `y²=x³+1` (ℤ/6), residues

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -67,10 +67,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }


### PR DESCRIPTION
## Summary

**Stacked on #111** (base `risch/findorder-nonbranch`). **Glue piece 1**: connects the Trager ℚ-basis criterion (#110) to the algebraic-place torsion test (#111), so the per-component divisors may be supported on **algebraic places**.

## What's new

`trager_log_criterion_alg(n, a, rat_places, rat_residues, alg_places, alg_residues, dim)`:
- decomposes **all** residues (rational + algebraic, in a common `ℚ(θ)`) over `ℚ` (`qbasis_decompose`);
- for each component builds the rational-coefficient divisor `δ_k` over **both** rational places and algebraic-place orbits (`AlgPlace`), and tests it with `find_order_genus_ge2_alg` (#111);
- `NonElementary` if any component is non-torsion, `Principal{lcm Nₖ}` if all torsion, else `NotDecided`.

Each component's coordinates are cleared to integers (a constant rescaling that preserves torsion-ness; `find_order_genus_ge2_alg` re-primitivizes, so reported orders are exact).

## Verification
- Residues in `ℚ(√2)`: `√2` at an algebraic branch orbit (over `x²−2`) and `−√2` at the rational branch point `(−1,0)` on `y²=(x²−2)(x³+1)` ⇒ the single `√2`-component is branch-only ⇒ `Principal`.
- (plus #110's rational-place criterion tests and the `qbasis_decompose` tests.)
- `cargo test --workspace`: **913 lib tests + all suites green**; `cargo fmt` + clippy clean.

## Status of the MC stack
With #106–#112 the genus≥2 logarithmic-part machinery is now end-to-end at the **component level**: Hermite (general + lazy) → residues (rational + algebraic) → ℚ-basis decomposition → per-component torsion over rational, branch, and non-branch algebraic places.

The one remaining glue to a **user-facing** consumer is the engine-level `∫B·√P` pipeline (Hermite → residues → collect into a common `ℚ(θ)` → this criterion), whose end-to-end testing needs known-answer algebraic-pole integrands — documented as the final step in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
