### PR TITLE
feat(integrate): end-to-end genus≥2 ∫B·√P with algebraic poles (FriCAS-validated)

### DIFF
--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -14,17 +14,22 @@ use super::poly_utils::{
 use crate::deriv::log::{DerivationLog, RewriteStep};
 use crate::integrate::engine::IntegrationError;
 use crate::integrate::risch::alg_field::{AlgElem, RatFn};
+use crate::integrate::risch::number_field::KElem;
 use crate::integrate::risch::poly_rde::{
-    degree, expr_to_qpoly, poly_deriv, poly_scale, qpoly_to_expr, trim, QPoly,
+    degree, expr_to_qpoly, poly_deriv, poly_scale, qpoly_to_expr, QPoly,
 };
 use crate::integrate::risch::rational_rde::{
-    expr_to_qrational, poly_div_exact, poly_divrem, poly_gcd, solve_rational_rde_generalized,
+    expr_to_qrational, poly_gcd, solve_rational_rde_generalized,
 };
 use crate::kernel::{ExprData, ExprId, ExprPool};
-use rug::Rational;
+use rug::{Integer, Rational};
 
-use super::find_order::{find_order_placed, first_rational_root, FindOrder};
-use super::residues::residue_divisor_placed;
+use super::find_order::{find_order_placed, FindOrder};
+use super::jacobian_torsion::AlgPlace;
+use super::residues::{
+    finite_residues_algebraic, residue_divisor_placed, residue_sum_complete, AlgResidue,
+};
+use super::trager_log::trager_log_criterion_alg;
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -726,36 +731,175 @@ fn integrate_b_sqrt_high_degree(
     if degree(&poly_gcd(&p_poly, &p_prime)) > 0 {
         return Err(notimpl("non-squarefree radicand at deg ≥ 3"));
     }
-    // Completeness: poles of B off the branch locus must be rational.
-    let b_den_coprime = strip_common_factors(&b_den, &p_poly);
-    if !splits_over_q(&b_den_coprime) {
+
+    let h: AlgElem = vec![RatFn::int(0), RatFn::new(b_num.clone(), b_den.clone())];
+
+    // Soundness gate: the residue divisor must be **complete** (residue theorem
+    // Σ res = 0, counting rational, algebraic and infinite places).  Otherwise a
+    // place is missing and no verdict is safe.
+    if residue_sum_complete(2, &p_poly, &h) != 0 {
         return Err(notimpl(
-            "B has poles at non-rational points off the branch locus; \
-             residue divisor would be incomplete",
+            "residue divisor incomplete (missing places not yet supported)",
         ));
     }
 
-    let h: AlgElem = vec![RatFn::int(0), RatFn::new(b_num.clone(), b_den.clone())];
-    let divisor = residue_divisor_placed(2, &p_poly, &h);
-    if divisor.is_empty() {
-        // No residues ⇒ no logarithmic part (Liouville); the RDE already ruled
-        // out an algebraic primitive ⇒ a nonzero first/second-kind differential
-        // on a genus ≥ 1 curve ⇒ non-elementary.
-        return Err(nonelem(
-            "∫ B·√P over a genus ≥ 1 curve with no logarithmic part and no \
-             algebraic primitive: non-elementary",
-        ));
+    let alg_res = finite_residues_algebraic(2, &p_poly, &h);
+    if alg_res.is_empty() {
+        // All residues are rational — the complete divisor is the rational one.
+        let divisor = residue_divisor_placed(2, &p_poly, &h);
+        if divisor.is_empty() {
+            // No residues anywhere ⇒ no log part; RDE ruled out an algebraic
+            // primitive ⇒ a nonzero first/second-kind differential ⇒ non-elem.
+            return Err(nonelem(
+                "∫ B·√P over a genus ≥ 1 curve with no logarithmic part and no \
+                 algebraic primitive: non-elementary",
+            ));
+        }
+        return match find_order_placed(2, &p_poly, &divisor) {
+            FindOrder::NonElementary => Err(nonelem(
+                "residue divisor is non-torsion (FIND-ORDER): no elementary log part",
+            )),
+            _ => Err(notimpl(
+                "genus ≥ 2 logarithmic part: torsion/undecided, log argument not \
+                 yet constructible (Coates)",
+            )),
+        };
     }
-    match find_order_placed(2, &p_poly, &divisor) {
-        FindOrder::NonElementary => Err(nonelem(
-            "residue divisor is non-torsion (FIND-ORDER): no elementary logarithmic part",
+
+    // Algebraic residues present (a rational pole with an irrational sheet, or an
+    // algebraic-base pole).  Decide via the Trager ℚ-basis criterion in a common
+    // quadratic field; a non-torsion component certifies non-elementary.
+    match try_genus2_alg_log(&p_poly, &h, &alg_res) {
+        Some(FindOrder::NonElementary) => Err(nonelem(
+            "Trager ℚ-basis criterion: a residue component is non-torsion ⇒ \
+             no elementary logarithmic part",
         )),
-        // Torsion / undecided: an elementary log part may exist, but constructing
-        // it on a genus ≥ 2 curve needs Coates' algorithm (not yet implemented).
         _ => Err(notimpl(
-            "genus ≥ 2 logarithmic part: residue divisor torsion/undecided, \
-             log argument not yet constructible (Coates)",
+            "genus ≥ 2 logarithmic part with algebraic residues: not decided \
+             (torsion/undecided, or outside the single-quadratic-field scope)",
         )),
+    }
+}
+
+/// Trager ℚ-basis decision for `∫ (B·y) dx` on `y²=P` (deg P odd ≥ 5) when the
+/// algebraic residues live in a **single quadratic field** `ℚ(√d)` — i.e. every
+/// algebraic residue comes from a *rational* base point `α` whose sheet
+/// `√a(α)` has the same squarefree part `d`.  Collects all residues (rational
+/// and algebraic) as `ℚ(√d)` elements, with the algebraic ones at the two sheets
+/// `(α, ±√a(α))`, and runs [`trager_log_criterion_alg`].  `None` if outside this
+/// scope (an algebraic base point, or differing `d`'s — a genuine compositum).
+fn try_genus2_alg_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<FindOrder> {
+    // Single-quadratic scope: every algebraic residue is over a degree-1 base
+    // (`conjugates == 1`, rational `α`) and shares one squarefree `d = sqfree a(α)`.
+    let mut common_d: Option<Integer> = None;
+    for ar in alg_res {
+        if ar.conjugates != 1 || degree(&ar.minpoly) != 1 {
+            return None; // algebraic base point ⇒ tower field, out of scope
+        }
+        let alpha = -ar.minpoly[0].clone(); // monic x − α
+        let a_at = eval_poly_q(p, &alpha);
+        if a_at == 0 {
+            return None; // branch point, not a B-pole sheet
+        }
+        let d = squarefree_part_rat(&a_at);
+        match &common_d {
+            None => common_d = Some(d),
+            Some(d0) if *d0 == d => {}
+            _ => return None, // distinct quadratic fields ⇒ compositum, out of scope
+        }
+    }
+    let d = common_d?;
+    let d_rat = Rational::from(d.clone());
+    let theta_min = vec![-d_rat.clone(), Rational::from(0), Rational::from(1)]; // θ² − d
+
+    // Rational + infinite places: residues are in ℚ ⊂ ℚ(√d) → KElem [value].
+    let rat_div = residue_divisor_placed(2, p, h);
+    let rat_residues: Vec<KElem> = rat_div
+        .iter()
+        .map(|r| vec![r.residue.value.clone()])
+        .collect();
+
+    // Algebraic places: the two sheets (α, ±√a(α)) = (α, ±k√d), a(α) = k²·d.
+    let mut alg_places: Vec<AlgPlace> = Vec::new();
+    let mut alg_residues: Vec<KElem> = Vec::new();
+    for ar in alg_res {
+        let alpha = -ar.minpoly[0].clone();
+        let a_at = eval_poly_q(p, &alpha);
+        let k = rat_sqrt(&(a_at / &d_rat))?; // a(α)/d is a perfect square
+        let r0 = ar.r0.first().cloned().unwrap_or_else(|| Rational::from(0));
+        let r1 = ar.r1.first().cloned().unwrap_or_else(|| Rational::from(0));
+        for sign in [Rational::from(1), Rational::from(-1)] {
+            alg_places.push(AlgPlace {
+                minpoly: theta_min.clone(),
+                x_coord: vec![alpha.clone()], // x = α
+                y_coord: vec![Rational::from(0), sign.clone() * &k], // y = ±k·θ = ±√a(α)
+                coeff: Integer::from(0),      // set per-component by the criterion
+                orbit: false,                 // a single ℚ(√d) sheet (one embedding), not an orbit
+            });
+            // residue r0 ± r1·k·√d on the ± sheet.
+            alg_residues.push(vec![r0.clone(), sign.clone() * &r1 * &k]);
+        }
+    }
+
+    Some(trager_log_criterion_alg(
+        2,
+        p,
+        &rat_div,
+        &rat_residues,
+        &alg_places,
+        &alg_residues,
+        2,
+    ))
+}
+
+/// Horner evaluation of `p ∈ ℚ[x]` at a rational point.
+fn eval_poly_q(p: &QPoly, x: &Rational) -> Rational {
+    p.iter().rev().fold(Rational::from(0), |acc, c| acc * x + c)
+}
+
+/// Squarefree part (kernel) of a rational `r ≠ 0`: the sign-carrying product of
+/// the primes dividing `r` to an odd power, as an integer (so `r / sqfree` is a
+/// perfect square).  Uses `r = (num·den)/den²`.
+fn squarefree_part_rat(r: &Rational) -> Integer {
+    let prod = r.numer().clone() * r.denom();
+    let sign = if prod < 0 {
+        Integer::from(-1)
+    } else {
+        Integer::from(1)
+    };
+    let mut m = prod.abs();
+    let mut sq = Integer::from(1);
+    let mut dd = Integer::from(2);
+    while Integer::from(&dd * &dd) <= m {
+        if m.is_divisible(&dd) {
+            let mut e = 0u32;
+            while m.is_divisible(&dd) {
+                m /= &dd;
+                e += 1;
+            }
+            if e % 2 == 1 {
+                sq *= &dd;
+            }
+        }
+        dd += 1;
+    }
+    sq *= &m; // remaining prime factor (exponent 1)
+    sq * sign
+}
+
+/// Exact rational square root, or `None` if `r` is not a perfect square in `ℚ`.
+fn rat_sqrt(r: &Rational) -> Option<Rational> {
+    if *r < 0 {
+        return None;
+    }
+    let n = r.numer().clone();
+    let d = r.denom().clone();
+    let ns = n.clone().sqrt();
+    let ds = d.clone().sqrt();
+    if Integer::from(&ns * &ns) == n && Integer::from(&ds * &ds) == d {
+        Some(Rational::from((ns, ds)))
+    } else {
+        None
     }
 }
 
@@ -767,37 +911,6 @@ fn qrational_to_expr(num: &QPoly, den: &QPoly, var: ExprId, pool: &ExprPool) -> 
     }
     let d = qpoly_to_expr(den, var, pool);
     pool.mul(vec![n, pool.pow(d, pool.integer(-1_i32))])
-}
-
-/// Divide `q` by all factors it shares with `p` (remove the gcd repeatedly), so
-/// the result is coprime to `p`.
-fn strip_common_factors(q: &QPoly, p: &QPoly) -> QPoly {
-    let mut d = trim(q.clone());
-    loop {
-        let g = poly_gcd(&d, p);
-        if degree(&g) <= 0 {
-            break;
-        }
-        d = poly_div_exact(&d, &g);
-    }
-    d
-}
-
-/// Does `poly` factor into linear factors over ℚ (all roots rational)?  Decided
-/// by repeatedly deflating rational roots (rational-root theorem is complete).
-fn splits_over_q(poly: &QPoly) -> bool {
-    let mut p = trim(poly.clone());
-    while degree(&p) >= 1 {
-        match first_rational_root(&p) {
-            Some(r) => {
-                let lin = vec![-r, Rational::from(1)];
-                let (q, _rem) = poly_divrem(&p, &lin);
-                p = trim(q);
-            }
-            None => return false,
-        }
-    }
-    true
 }
 
 fn neg_c_power(c: &rug::Integer, n: i64) -> rug::Integer {

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -1014,7 +1014,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -524,14 +524,22 @@ fn reduce_and_build(
     // (every conjugate root `t` reduces to F_p; the place is `(x_coord(t),
     // y_coord(t))`, keeping the sheet consistent across the orbit).
     for ap in alg {
-        let roots = fp_roots_split(&ap.minpoly, p)?; // None ⇒ not fully split ⇒ skip prime
+        let all_roots = fp_roots_split(&ap.minpoly, p)?; // None ⇒ not fully split ⇒ skip prime
         let k = ap.coeff.clone().abs().to_u64()?;
         if k == 0 {
             continue;
         }
         let x_fp = kelem_to_fp(&ap.x_coord, p)?;
         let y_fp = kelem_to_fp(&ap.y_coord, p)?;
-        for t in roots {
+        // Galois-orbit divisor ⇒ sum over **all** conjugate roots; a single
+        // ℚ(θ)-place ⇒ reduce via **one** embedding (the first root — a fixed
+        // choice; conjugate embeddings give the same class order).
+        let roots: &[u64] = if ap.orbit {
+            &all_roots
+        } else {
+            &all_roots[..1]
+        };
+        for &t in roots {
             let xt = fp_eval(&x_fp, t, p);
             let yt = fp_eval(&y_fp, t, p);
             let big_x = mulmod(lc, xt, p);
@@ -868,6 +876,12 @@ pub(crate) struct AlgPlace {
     pub x_coord: KElem,
     pub y_coord: KElem,
     pub coeff: Integer,
+    /// `true`: the place is a full **Galois orbit** of a *rational* divisor (sum
+    /// over all conjugate roots of `minpoly` — e.g. a branch orbit).  `false`:
+    /// the place lives in `ℚ(θ)` and the divisor is reduced via a **single
+    /// embedding** `θ ↦ one root` (e.g. a Trager residue-component place, where
+    /// distinct roots are distinct sheets with distinct coefficients).
+    pub orbit: bool,
 }
 
 pub(crate) fn find_order_genus_ge2(n: usize, a: &QPoly, divisor: &[PlacedResidue]) -> FindOrder {
@@ -954,6 +968,7 @@ pub(crate) fn find_order_genus_ge2_alg(
                     x_coord: p.x_coord.clone(),
                     y_coord: trim(p.y_coord.clone()),
                     coeff,
+                    orbit: p.orbit,
                 })
             }
         })
@@ -1307,6 +1322,7 @@ mod tests {
             x_coord: qp(&[0, 1]),     // x = θ (the root √2)
             y_coord: Vec::new(),      // branch: y = 0
             coeff: Integer::from(1),
+            orbit: true, // Galois orbit (both ±√2)
         }];
         assert_eq!(
             find_order_genus_ge2_alg(2, &a, &[], &alg),
@@ -1326,6 +1342,7 @@ mod tests {
             x_coord: qp(&[0, 1]),
             y_coord: Vec::new(),
             coeff: Integer::from(-1), // −1 at each of (±√2,0)
+            orbit: true,
         }];
         assert_eq!(
             find_order_genus_ge2_alg(2, &a, &rat, &alg),
@@ -1349,12 +1366,14 @@ mod tests {
                 x_coord: qp(&[0, 1]), // θ = √2
                 y_coord: qp(&[1, 1]), // 1 + θ
                 coeff: Integer::from(1),
+                orbit: true, // full Galois orbit of div(x²−2)
             },
             AlgPlace {
                 minpoly: qp(&[-2, 0, 1]),
                 x_coord: qp(&[0, 1]),
                 y_coord: qp(&[-1, -1]), // −(1 + θ)
                 coeff: Integer::from(1),
+                orbit: true,
             },
         ];
         assert_eq!(

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -28,10 +28,10 @@ pub(super) mod parametrize;
 pub(super) mod poly_utils;
 pub mod residues;
 // Trager ℚ-basis logarithmic-part criterion: decomposition + per-component
-// torsion over rational *and* algebraic places (`trager_log_criterion[_alg]`).
-// The remaining glue to a user-facing consumer is the engine-level
-// `∫B·√P` pipeline (Hermite → residues → collect into a common ℚ(θ) → criterion),
-// so the entry points are not yet called from non-test code.
+// torsion over rational *and* algebraic places.  `trager_log_criterion_alg` is
+// the engine consumer (via `genus_zero::integrate_b_sqrt_high_degree`); the
+// rational-only `trager_log_criterion` is its specialization, kept for reuse and
+// tests.
 #[allow(dead_code)]
 mod trager_log;
 pub mod vanhoeij;
@@ -498,6 +498,63 @@ mod tests {
         let x = pool.symbol("x", Domain::Real);
         let x5p1 = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
         let integrand = pool.pow(pool.func("sqrt", vec![x5p1]), pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
+    /// `∫ √(x⁵+x+1)/(x−2) dx` — a **genus-2** integrand with an algebraic-sheet
+    /// pole (rational base `x=2`, sheet `√a(2)=√35` irrational).  The end-to-end
+    /// consumer collects the residues into `ℚ(√35)` and the Trager ℚ-basis
+    /// criterion finds the `√35`-component `2[(2,√35)−∞]` non-torsion ⇒
+    /// `NonElementary`.  **Oracle-confirmed:** FriCAS 1.3.7 returns this integral
+    /// unevaluated (its complete Trager implementation ⇒ proven non-elementary).
+    #[test]
+    fn quintic_algebraic_pole_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            x,
+            pool.integer(1_i32),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let integrand = pool.mul(vec![
+            sq,
+            pool.pow(
+                pool.add(vec![x, pool.integer(-2_i32)]),
+                pool.integer(-1_i32),
+            ),
+        ]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
+    /// `∫ x³·√(x⁵+x+1)/(x−2) dx` — likewise non-elementary (algebraic-sheet pole,
+    /// non-torsion component); FriCAS-confirmed.
+    #[test]
+    fn quintic_algebraic_pole_weighted_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            x,
+            pool.integer(1_i32),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let integrand = pool.mul(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            sq,
+            pool.pow(
+                pool.add(vec![x, pool.integer(-2_i32)]),
+                pool.integer(-1_i32),
+            ),
+        ]);
         let res = crate::integrate::engine::integrate(integrand, x, &pool);
         assert!(
             matches!(res, Err(IntegrationError::NonElementary(_))),

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -203,6 +203,7 @@ pub(crate) fn trager_log_criterion_alg(
                 x_coord: ap.x_coord.clone(),
                 y_coord: ap.y_coord.clone(),
                 coeff: (c[k].clone() * Rational::from(l.clone())).numer().clone(),
+                orbit: ap.orbit,
             })
             .collect();
         match find_order_genus_ge2_alg(n, a, &rat_div, &alg_div) {
@@ -320,6 +321,7 @@ mod tests {
             x_coord: qp(&[0, 1]),     // θ
             y_coord: Vec::new(),      // branch
             coeff: Integer::from(0),  // (coeff is set per-component by the criterion)
+            orbit: true,              // Galois orbit of the two branch points
         }];
         let alg_residues = [ke(&[0, 1])]; // √2
         let res = trager_log_criterion_alg(

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -67,10 +67,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }


### PR DESCRIPTION
## Summary

**Stacked on #112** (base `risch/trager-alg-places`). Wires the full genus ≥ 2 logarithmic-part pipeline into the **public engine** for `∫ B(x)·√P dx` (deg P odd ≥ 5) with **algebraic-sheet poles** — the user-facing consumer of the #106–#112 stack — and fixes a place-reduction soundness subtlety found along the way.

## Pipeline (`genus_zero::integrate_b_sqrt_high_degree`)

After the rational Risch-DE integral part fails:
1. **Residue-theorem gate**: require `residue_sum_complete == 0` (the divisor is complete — no missing place), else decline.
2. If algebraic residues are present (`finite_residues_algebraic`): collect rational + algebraic residues into a common quadratic field `ℚ(√d)` (single-quadratic scope: rational base points sharing an irrational sheet `√d`) and run `trager_log_criterion_alg`. A **non-torsion component ⇒ `NonElementary`**; else decline (Coates / out of scope).
3. Otherwise (all-rational residues): the existing complete-divisor decision.

## Place-reduction fix (`AlgPlace.orbit`)

A Galois-orbit *rational* divisor (e.g. a branch orbit) must sum over **all** roots of the minpoly; a single `ℚ(θ)` place (a Trager residue component, where conjugate roots are *distinct sheets with distinct coefficients*) must reduce via a **single embedding**. The previous code summed all roots in both cases, which cancelled the two sheets of a residue component to zero (a wrong `Principal{1}` — sound but non-certifying). The new `orbit` flag distinguishes them.

## Oracle validation (FriCAS 1.3.7)

FriCAS implements the complete Trager algorithm, so an unevaluated result is a *proof* of non-elementary. Cross-checked:

| Integrand | FriCAS | Alkahest |
|---|---|---|
| `√(x⁵+x+1)/(x−2)` | unevaluated (non-elem) | `NonElementary` ✓ |
| `x³·√(x⁵+x+1)/(x−2)` | unevaluated | `NonElementary` ✓ |
| `5x⁴/(2√(x⁵+1))` | `√(x⁵+1)` (elem) | RDE → `√(x⁵+1)` ✓ |
| `1/√(x⁵+1)` | unevaluated | `NonElementary` ✓ |
| `√(x⁵+x+1)/((x−2)(x−3))` | unevaluated | `NotImplemented` (distinct fields — sound decline) |

`cargo test --workspace`: **915 lib tests + all suites green**; `cargo fmt` + clippy clean.

## Scope / remaining
Single common quadratic field for the algebraic residues (one `√d`); the general **compositum** (distinct `√d_i`, or algebraic *base* points of degree ≥ 2) declines soundly (`NotImplemented`). Emitting the elementary **log argument** for the torsion case (genus ≥ 2) still needs Coates' construction — the criterion decides, but the engine returns `NotImplemented` rather than the closed form there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
