### PR TITLE
feat(integrate): genus≥2 ∫B·√P over a compositum of quadratic sheet fields

### DIFF
--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -776,7 +776,8 @@ fn integrate_b_sqrt_high_degree(
         )),
         _ => Err(notimpl(
             "genus ≥ 2 logarithmic part with algebraic residues: not decided \
-             (torsion/undecided, or outside the single-quadratic-field scope)",
+             (torsion log not yet emittable, or an algebraic base point of \
+             degree ≥ 2 — a genuine tower)",
         )),
     }
 }
@@ -784,14 +785,18 @@ fn integrate_b_sqrt_high_degree(
 /// Trager ℚ-basis decision for `∫ (B·y) dx` on `y²=P` (deg P odd ≥ 5) when the
 /// algebraic residues live in a **single quadratic field** `ℚ(√d)` — i.e. every
 /// algebraic residue comes from a *rational* base point `α` whose sheet
-/// `√a(α)` has the same squarefree part `d`.  Collects all residues (rational
-/// and algebraic) as `ℚ(√d)` elements, with the algebraic ones at the two sheets
-/// `(α, ±√a(α))`, and runs [`trager_log_criterion_alg`].  `None` if outside this
-/// scope (an algebraic base point, or differing `d`'s — a genuine compositum).
+/// `√a(α)` is irrational.  Distinct sheets `√d₁, …, √d_k` (a **compositum** of
+/// quadratic fields) are handled too: a residue is `r0 ± r1·√d_i` (no products
+/// of distinct `√d`), so the residues span only `{1, √d₁, …, √d_k}` and the
+/// Trager ℚ-basis components **separate** — one rational `1`-component (the
+/// conjugate sheet-sums are rational) and one single-quadratic `√d_i`-component
+/// per field.  Residues are represented in that basis and fed to
+/// [`trager_log_criterion_alg`].  `None` for an algebraic *base* point
+/// (`conjugates ≠ 1`, a genuine tower) — still out of scope.
 fn try_genus2_alg_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<FindOrder> {
-    // Single-quadratic scope: every algebraic residue is over a degree-1 base
-    // (`conjugates == 1`, rational `α`) and shares one squarefree `d = sqfree a(α)`.
-    let mut common_d: Option<Integer> = None;
+    // Collect the distinct squarefree sheet discriminants `d_i`; index them so
+    // the residue basis is {1 (index 0), √d_0 (1), √d_1 (2), …}.
+    let mut d_list: Vec<Integer> = Vec::new();
     for ar in alg_res {
         if ar.conjugates != 1 || degree(&ar.minpoly) != 1 {
             return None; // algebraic base point ⇒ tower field, out of scope
@@ -802,21 +807,22 @@ fn try_genus2_alg_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<
             return None; // branch point, not a B-pole sheet
         }
         let d = squarefree_part_rat(&a_at);
-        match &common_d {
-            None => common_d = Some(d),
-            Some(d0) if *d0 == d => {}
-            _ => return None, // distinct quadratic fields ⇒ compositum, out of scope
+        if !d_list.contains(&d) {
+            d_list.push(d);
         }
     }
-    let d = common_d?;
-    let d_rat = Rational::from(d.clone());
-    let theta_min = vec![-d_rat.clone(), Rational::from(0), Rational::from(1)]; // θ² − d
+    let dim = 1 + d_list.len();
+    let d_index = |d: &Integer| d_list.iter().position(|x| x == d).unwrap();
 
-    // Rational + infinite places: residues are in ℚ ⊂ ℚ(√d) → KElem [value].
+    // Rational + infinite places: residues are rational ⇒ value at basis index 0.
     let rat_div = residue_divisor_placed(2, p, h);
     let rat_residues: Vec<KElem> = rat_div
         .iter()
-        .map(|r| vec![r.residue.value.clone()])
+        .map(|r| {
+            let mut v = vec![Rational::from(0); dim];
+            v[0] = r.residue.value.clone();
+            v
+        })
         .collect();
 
     // Algebraic places: the two sheets (α, ±√a(α)) = (α, ±k√d), a(α) = k²·d.
@@ -825,19 +831,26 @@ fn try_genus2_alg_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<
     for ar in alg_res {
         let alpha = -ar.minpoly[0].clone();
         let a_at = eval_poly_q(p, &alpha);
+        let d = squarefree_part_rat(&a_at);
+        let d_rat = Rational::from(d.clone());
+        let theta_min = vec![-d_rat.clone(), Rational::from(0), Rational::from(1)]; // θ² − d_i
         let k = rat_sqrt(&(a_at / &d_rat))?; // a(α)/d is a perfect square
         let r0 = ar.r0.first().cloned().unwrap_or_else(|| Rational::from(0));
         let r1 = ar.r1.first().cloned().unwrap_or_else(|| Rational::from(0));
+        let idx = 1 + d_index(&d);
         for sign in [Rational::from(1), Rational::from(-1)] {
             alg_places.push(AlgPlace {
                 minpoly: theta_min.clone(),
                 x_coord: vec![alpha.clone()], // x = α
                 y_coord: vec![Rational::from(0), sign.clone() * &k], // y = ±k·θ = ±√a(α)
                 coeff: Integer::from(0),      // set per-component by the criterion
-                orbit: false,                 // a single ℚ(√d) sheet (one embedding), not an orbit
+                orbit: false,                 // a single ℚ(√d_i) sheet (one embedding)
             });
-            // residue r0 ± r1·k·√d on the ± sheet.
-            alg_residues.push(vec![r0.clone(), sign.clone() * &r1 * &k]);
+            // residue r0·1 ± r1·k·√d_i: r0 at index 0, ±r1·k at index 1+d_index.
+            let mut v = vec![Rational::from(0); dim];
+            v[0] = r0.clone();
+            v[idx] = sign.clone() * &r1 * &k;
+            alg_residues.push(v);
         }
     }
 
@@ -848,7 +861,7 @@ fn try_genus2_alg_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<
         &rat_residues,
         &alg_places,
         &alg_residues,
-        2,
+        dim,
     ))
 }
 

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -1014,7 +1014,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -535,6 +535,33 @@ mod tests {
         );
     }
 
+    /// **Compositum** of quadratic sheet fields: `∫ √(x⁵+x+1)/((x−2)(x−3)) dx`
+    /// has algebraic-sheet poles at `x=2` (`√35`) and `x=3` (`√247`) — distinct
+    /// fields.  The Trager components separate (a rational `1`-component + one
+    /// `√d_i`-component each); the `√35`-component `2[(2,√35)−∞]` is non-torsion ⇒
+    /// `NonElementary`.  **FriCAS-confirmed** (returns it unevaluated).
+    #[test]
+    fn quintic_compositum_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            x,
+            pool.integer(1_i32),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let den = pool.mul(vec![
+            pool.add(vec![x, pool.integer(-2_i32)]),
+            pool.add(vec![x, pool.integer(-3_i32)]),
+        ]);
+        let integrand = pool.mul(vec![sq, pool.pow(den, pool.integer(-1_i32))]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
     /// `∫ x³·√(x⁵+x+1)/(x−2) dx` — likewise non-elementary (algebraic-sheet pole,
     /// non-torsion component); FriCAS-confirmed.
     #[test]

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -67,10 +67,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }


### PR DESCRIPTION
## Summary

**Stacked on #113** (base `risch/genus2-e2e`). Extends the genus≥2 `∫B·√P` consumer from a single quadratic sheet field `ℚ(√d)` to a **compositum** `ℚ(√d₁,…,√d_k)` — algebraic-sheet poles at distinct rational base points with *different* squarefree sheet discriminants.

## Key structural simplification

A residue at an algebraic-sheet pole is `r0 ± r1·√d_i` — it involves a *single* `√d_i`, never a product of distinct radicals. So the residues span only `{1, √d₁, …, √d_k}` (dimension `k+1`), and the Trager ℚ-basis components **separate**:
- one **rational `1`-component** (the conjugate sheet-sums `(α,√d_i)+(α,−√d_i)` are rational), and
- one **single-quadratic `√d_i`-component** per field.

So no primitive element / degree-`2^k` tower is constructed. `try_genus2_alg_log` represents residues in the `{1, √d_i}` basis; `trager_log_criterion_alg` decomposes and tests each component independently (a non-torsion component ⇒ `NonElementary`). Each component's `find_order` reduces at primes that split the involved `x²−d_i`.

## Verification (FriCAS 1.3.7)
- `∫ √(x⁵+x+1)/((x−2)(x−3))` — sheets `√35` at `x=2`, `√247` at `x=3` (distinct fields) → `NonElementary`; FriCAS returns it unevaluated (proven non-elementary). This case was `NotImplemented` before this PR.
- Single-quadratic cases (#113) unchanged — now the `k=1` special case.
- `cargo test --workspace`: **916 lib tests + all suites green**; `cargo fmt` + clippy clean.

## Remaining
Algebraic **base** points (an irreducible minpoly of degree ≥ 2 — a genuine tower `ℚ(α)(√a(α))` whose residue field needs `√`-products) still decline soundly. Emitting the closed-form **log** for a torsion component (genus ≥ 2) still needs Coates' construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
