### PR TITLE
feat(integrate): primitive-element tower substrate for algebraic base points

### DIFF
--- a/alkahest-core/src/integrate/algebraic/alg_tower.rs
+++ b/alkahest-core/src/integrate/algebraic/alg_tower.rs
@@ -128,6 +128,9 @@ fn solve_columns(cols: &[Vec<Rational>], rhs: &[Rational], n: usize) -> Option<V
         for r in 0..n {
             if r != col && a[r][col] != 0 {
                 let f = a[r][col].clone();
+                // Two distinct rows (`a[r]` updated from `a[col]`): a range loop is
+                // the clearest way to index both without splitting the borrow.
+                #[allow(clippy::needless_range_loop)]
                 for k in col..=n {
                     let s = f.clone() * &a[col][k];
                     a[r][k] -= s;

--- a/alkahest-core/src/integrate/algebraic/alg_tower.rs
+++ b/alkahest-core/src/integrate/algebraic/alg_tower.rs
@@ -1,0 +1,195 @@
+//! Primitive element of a quadratic tower `ℚ(α)[w]/(w² − c)` — substrate for the
+//! **algebraic-base-point** logarithmic part (Risch **MC**).
+//!
+//! When the integrand `(B·y) dx` (`y² = a(x)`) has a pole at an **algebraic**
+//! base point `α` (a root of an irreducible `q` of degree `d ≥ 2`), the residue
+//! `r0 ± r1·√a(α)` lives in the tower `ℚ(α)(√a(α)) = ℚ(α)[w]/(w² − c)`,
+//! `c = a(α) ∈ ℚ(α)`, of degree `2d` over `ℚ`.  Trager's ℚ-basis criterion then
+//! needs the residues and the place coordinates expressed in **one** number
+//! field; this module builds a primitive element `θ` of that tower and re-expresses
+//! `α` and `w` (hence everything) as elements of `ℚ[θ]/M(θ)`.
+//!
+//! [`primitive_element`] returns `(M, α(θ), w(θ))` with `M` the minimal
+//! polynomial of `θ = w + λα` (degree `2d`), and `α`, `w` as `QPoly`s of degree
+//! `< 2d`.  Pure exact rational linear algebra in the tower (`ℚ(α)²` arithmetic).
+//!
+//! **Status:** this is the field-construction substrate only.  Wiring it into a
+//! `NonElementary` / `Principal` *verdict* additionally requires reducing the
+//! residue-component divisors at primes with a **Galois-consistent labeling** of
+//! the `2d` conjugate places (the conjugate-divisor reduction over a generally
+//! non-Galois field) — the genuine remaining step, not provided here.
+
+use rug::Rational;
+
+use super::super::risch::poly_rde::{degree, poly_add, poly_mul, poly_scale, trim, QPoly};
+use super::super::risch::rational_rde::poly_divrem;
+
+/// A tower element `p0(α) + p1(α)·w`, with `p0, p1 ∈ ℚ[α]/q` (`QPoly` of degree
+/// `< d`).
+type Tow = (QPoly, QPoly);
+
+/// `a mod q` over `ℚ[x]`.
+fn qmod(a: &QPoly, q: &QPoly) -> QPoly {
+    trim(poly_divrem(a, q).1)
+}
+
+/// Tower multiplication: `(u0+u1 w)(v0+v1 w) = (u0v0 + c·u1v1) + (u0v1+u1v0) w`,
+/// reduced mod `q` (and `w² = c`).
+fn tmul(u: &Tow, v: &Tow, q: &QPoly, c: &QPoly) -> Tow {
+    let p0 = qmod(
+        &poly_add(&poly_mul(&u.0, &v.0), &poly_mul(c, &poly_mul(&u.1, &v.1))),
+        q,
+    );
+    let p1 = qmod(&poly_add(&poly_mul(&u.0, &v.1), &poly_mul(&u.1, &v.0)), q);
+    (p0, p1)
+}
+
+/// Flatten a tower element to a `ℚ`-vector of length `2d` in the basis
+/// `{1, α, …, α^{d−1}, w, αw, …, α^{d−1}w}`.
+fn tflat(u: &Tow, d: usize) -> Vec<Rational> {
+    let mut v = vec![Rational::from(0); 2 * d];
+    for i in 0..d {
+        if let Some(c) = u.0.get(i) {
+            v[i] = c.clone();
+        }
+        if let Some(c) = u.1.get(i) {
+            v[d + i] = c.clone();
+        }
+    }
+    v
+}
+
+/// Build a primitive element `θ = w + λα` of `ℚ(α)[w]/(w² − c)` (`q` = minimal
+/// polynomial of `α`, monic, `deg q = d ≥ 2`; `c = a(α) ∈ ℚ[α]/q`).  Returns
+/// `(M, α_in_θ, w_in_θ)`: `M` = minimal polynomial of `θ` (monic, degree `2d`),
+/// and `α`, `w` as elements of `ℚ[t]/M` (`QPoly`s of degree `< 2d`).  `None` if
+/// no small `λ` yields a primitive element (should not happen for a genuine
+/// quadratic tower).
+pub(crate) fn primitive_element(q: &QPoly, c: &QPoly) -> Option<(QPoly, QPoly, QPoly)> {
+    let d = degree(q);
+    if d < 2 {
+        return None;
+    }
+    let d = d as usize;
+    let n = 2 * d;
+    let one: Tow = (vec![Rational::from(1)], vec![]);
+    let alpha: Tow = (vec![Rational::from(0), Rational::from(1)], vec![]); // α = x
+    let w: Tow = (vec![], vec![Rational::from(1)]);
+
+    for lambda in 0..=8i64 {
+        // θ = w + λα  ⇒  p0 = λα, p1 = 1.
+        let theta: Tow = (
+            qmod(&poly_scale(&alpha.0, &Rational::from(lambda)), q),
+            vec![Rational::from(1)],
+        );
+        // θ^0 … θ^n.
+        let mut powers: Vec<Tow> = vec![one.clone()];
+        let mut cur = one.clone();
+        for _ in 0..n {
+            cur = tmul(&cur, &theta, q, c);
+            powers.push(cur.clone());
+        }
+        // Columns = θ^0 … θ^{n−1} as ℚ^n vectors; solve θ^n = Σ mₖ θ^k.
+        let cols: Vec<Vec<Rational>> = (0..n).map(|k| tflat(&powers[k], d)).collect();
+        let Some(m) = solve_columns(&cols, &tflat(&powers[n], d), n) else {
+            continue; // singular ⇒ θ not primitive at this λ
+        };
+        // M(t) = t^n − Σ mₖ t^k.
+        let mut mm = vec![Rational::from(0); n + 1];
+        mm[n] = Rational::from(1);
+        for (k, mk) in m.iter().enumerate() {
+            mm[k] = -mk.clone();
+        }
+        let a_in = solve_columns(&cols, &tflat(&alpha, d), n)?;
+        let w_in = solve_columns(&cols, &tflat(&w, d), n)?;
+        return Some((trim(mm), trim(a_in), trim(w_in)));
+    }
+    None
+}
+
+/// Solve `A·x = rhs` over `ℚ`, where `A`'s columns are `cols` (each length `n`).
+/// `None` if `A` is singular.
+fn solve_columns(cols: &[Vec<Rational>], rhs: &[Rational], n: usize) -> Option<Vec<Rational>> {
+    // Build augmented matrix rows.
+    let mut a: Vec<Vec<Rational>> = (0..n)
+        .map(|i| {
+            let mut row: Vec<Rational> = (0..n).map(|j| cols[j][i].clone()).collect();
+            row.push(rhs[i].clone());
+            row
+        })
+        .collect();
+    for col in 0..n {
+        let piv = (col..n).find(|&r| a[r][col] != 0)?;
+        a.swap(col, piv);
+        let inv = Rational::from(1) / a[col][col].clone();
+        for v in a[col].iter_mut() {
+            *v *= &inv;
+        }
+        for r in 0..n {
+            if r != col && a[r][col] != 0 {
+                let f = a[r][col].clone();
+                for k in col..=n {
+                    let s = f.clone() * &a[col][k];
+                    a[r][k] -= s;
+                }
+            }
+        }
+    }
+    Some((0..n).map(|i| a[i][n].clone()).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+
+    /// `θ` solves its minimal polynomial, and the returned `α(θ), w(θ)` satisfy
+    /// the defining relations `α² ≡ (2 ⇐ q=x²−2)` and `w² ≡ c` in `ℚ[t]/M`.
+    fn check(q: &QPoly, c: &QPoly) {
+        let (m, a_in, w_in) = primitive_element(q, c).expect("primitive element");
+        let d = degree(q) as usize;
+        assert_eq!(degree(&m) as usize, 2 * d, "deg M = 2d");
+        // α satisfies q: q(α(θ)) ≡ 0 mod M.
+        let mut qa = QPoly::new();
+        let mut pw = vec![Rational::from(1)];
+        for qi in q {
+            if *qi != 0 {
+                qa = poly_add(&qa, &poly_scale(&pw, qi));
+            }
+            pw = qmod(&poly_mul(&pw, &a_in), &m);
+        }
+        assert!(degree(&qmod(&qa, &m)) < 0, "q(α(θ)) ≡ 0");
+        // w² ≡ c(α(θ)): evaluate c at α(θ), compare to w(θ)².
+        let mut ca = QPoly::new();
+        let mut pw2 = vec![Rational::from(1)];
+        for ci in c {
+            if *ci != 0 {
+                ca = poly_add(&ca, &poly_scale(&pw2, ci));
+            }
+            pw2 = qmod(&poly_mul(&pw2, &a_in), &m);
+        }
+        let w2 = qmod(&poly_mul(&w_in, &w_in), &m);
+        assert_eq!(trim(qmod(&ca, &m)), trim(w2), "w² ≡ c(α)");
+    }
+
+    /// Tower `ℚ(√2)[w]/(w² − √2)` = `ℚ(2^{1/4})`, degree 4.
+    #[test]
+    fn quartic_pure_radical() {
+        check(&qp(&[-2, 0, 1]), &qp(&[0, 1])); // q = x²−2, c = √2
+    }
+
+    /// `ℚ(√2)[w]/(w² − (1+√2))` — `1+√2` is not a square in `ℚ(√2)`, degree 4.
+    #[test]
+    fn quartic_nontrivial_sheet() {
+        check(&qp(&[-2, 0, 1]), &qp(&[1, 1])); // q = x²−2, c = 1+√2
+    }
+
+    /// Cubic base: `ℚ(α)[w]/(w² − α)` with `α³ = 2` (`q = x³−2`), degree 6.
+    #[test]
+    fn sextic_cubic_base() {
+        check(&qp(&[-2, 0, 0, 1]), &qp(&[0, 1])); // q = x³−2, c = α
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -1014,7 +1014,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -16,6 +16,12 @@
 //! - Trager (1984). Integration of algebraic functions. MIT PhD thesis.
 //! - Bronstein (2005). Symbolic Integration I. Springer, chs. 10–11.
 
+// Primitive-element substrate for the algebraic-base-point logarithmic part —
+// builds the quadratic tower ℚ(α)[w]/(w²−c).  Field construction only; the
+// Galois-consistent conjugate-divisor reduction that would turn it into a
+// verdict is the documented remaining step (see the module docs).
+#[allow(dead_code)]
+mod alg_tower;
 pub(super) mod decompose;
 pub mod elliptic;
 pub mod find_order;

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -67,10 +67,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }


### PR DESCRIPTION
## Summary

**Stacked on #114** (base `risch/genus2-compositum`). The first sound building block toward the **algebraic-base-point** logarithmic part — the case that's genuinely harder than the compositum.

## Why this case is the hard core

In the compositum (#114) the residues were `r0 ± r1·√d_i` with **rational** `r0, r1`, so the ℚ-basis components separated and each `√d_i`-place had a clean degree-2 (±) labeling. At an **algebraic base point** `α` (a root of an irreducible `q` of degree `d ≥ 2`), the residue `r0 ± r1·√a(α)` has `r0, r1 ∈ ℚ(α)`, so it lives in the quadratic tower `ℚ(α)[w]/(w²−c)` (`c = a(α)`) of degree `2d`, and the conjugate base points are pulled into one field with no clean labeling.

## What this PR adds (`alg_tower::primitive_element`)

Builds a primitive element `θ = w + λα` of the tower and returns `(M, α(θ), w(θ))`: the minimal polynomial `M` of `θ` (degree `2d`) and `α, w` re-expressed as elements of `ℚ[t]/M`. Pure exact rational linear algebra (`ℚ(α)²` tower arithmetic; minpoly + embeddings via Gaussian elimination over the `2d`-dim power basis).

## Verification
- `ℚ(√2)[w]/(w²−√2) = ℚ(2^{1/4})` (deg 4); `ℚ(√2)[w]/(w²−(1+√2))` (deg 4, non-square sheet); cubic base `ℚ(α)[w]/(w²−α)`, `α³=2` (deg 6). Each test checks `deg M = 2d` and that `α(θ), w(θ)` satisfy `q(α) ≡ 0` and `w² ≡ c(α)` in `ℚ[t]/M`.
- `cargo test --workspace`: **919 lib tests + all suites green**; `cargo fmt` + clippy clean.

## Honest status — substrate only, not yet a verdict

Turning this into a `NonElementary`/`Principal` decision additionally needs **Galois-action-aware reduction** of the Trager residue components at primes of `ℚ(θ)`: the components carry *algebraic* coefficients at the `2d` conjugate places, so reduction mod a prime requires the conjugate automorphisms (`π_j` as polynomials in `θ`) and the per-conjugate residue coordinates — conjugate-divisor reduction over a generally **non-Galois** number field. I rigorously confirmed there is **no labeling-free integer-coefficient shortcut** (the per-root weights are algebraic), so a sound verdict needs that machinery; shipping one without it would risk the soundness invariant. This PR lays the field-construction foundation; the conjugate-reduction module is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
