### PR TITLE
feat(integrate): conjugate-divisor reduction — algebraic-base-point verdict (FriCAS-validated)

### DIFF
--- a/alkahest-core/src/integrate/algebraic/alg_tower.rs
+++ b/alkahest-core/src/integrate/algebraic/alg_tower.rs
@@ -13,11 +13,13 @@
 //! polynomial of `θ = w + λα` (degree `2d`), and `α`, `w` as `QPoly`s of degree
 //! `< 2d`.  Pure exact rational linear algebra in the tower (`ℚ(α)²` arithmetic).
 //!
-//! **Status:** this is the field-construction substrate only.  Wiring it into a
-//! `NonElementary` / `Principal` *verdict* additionally requires reducing the
-//! residue-component divisors at primes with a **Galois-consistent labeling** of
-//! the `2d` conjugate places (the conjugate-divisor reduction over a generally
-//! non-Galois field) — the genuine remaining step, not provided here.
+//! For a **quadratic base** `q = x²−m` whose tower `K = ℚ(√m)[w]/(w²−c)` is
+//! Galois over `ℚ`, [`galois_quartic`] additionally returns the four
+//! automorphism images of `θ` (each *verified* `M(πⱼ) ≡ 0`), built from
+//! quadratic-field square roots ([`sqrt_in_quad`]) — no number-field
+//! factorization.  These give the conjugate residues and places (via
+//! [`compose_mod`]) that `genus_zero::try_alg_base_log` decomposes and reduces.
+//! A non-Galois tower (the conjugate sheet `√(c̄) ∉ K`) is declined.
 
 use rug::Rational;
 
@@ -138,6 +140,134 @@ fn solve_columns(cols: &[Vec<Rational>], rhs: &[Rational], n: usize) -> Option<V
     Some((0..n).map(|i| a[i][n].clone()).collect())
 }
 
+/// `f(g) mod M` — compose polynomials, reduced mod `M` (Horner).
+pub(crate) fn compose_mod(f: &QPoly, g: &QPoly, m: &QPoly) -> QPoly {
+    let mut acc: QPoly = Vec::new();
+    for fi in f.iter().rev() {
+        acc = qmod(&poly_mul(&acc, g), m);
+        if *fi != 0 {
+            acc = poly_add(&acc, &vec![fi.clone()]);
+        }
+    }
+    qmod(&acc, m)
+}
+
+/// Exact rational square root, or `None`.
+fn rat_sqrt(r: &Rational) -> Option<Rational> {
+    if *r < 0 {
+        return None;
+    }
+    let (n, d) = (r.numer().clone(), r.denom().clone());
+    let (ns, ds) = (n.clone().sqrt(), d.clone().sqrt());
+    if rug::Integer::from(&ns * &ns) == n && rug::Integer::from(&ds * &ds) == d {
+        Some(Rational::from((ns, ds)))
+    } else {
+        None
+    }
+}
+
+/// Square root of `u + v√m` in `ℚ(√m)`, as `[a, b]` (`= a + b√m`), or `None` if
+/// it is not a square there.
+fn sqrt_in_quad(u: &Rational, v: &Rational, m: &Rational) -> Option<[Rational; 2]> {
+    let zero = Rational::from(0);
+    if *v == 0 {
+        if let Some(a) = rat_sqrt(u) {
+            return Some([a, zero]);
+        }
+        if let Some(b) = rat_sqrt(&(u.clone() / m)) {
+            return Some([zero, b]);
+        }
+        return None;
+    }
+    let disc = u.clone() * u - v.clone() * v * m; // u² − v²m, must be a square
+    let s = rat_sqrt(&disc)?;
+    for sg in [Rational::from(1), Rational::from(-1)] {
+        let a2 = (u.clone() + sg * &s) / Rational::from(2);
+        if let Some(a) = rat_sqrt(&a2) {
+            if a != 0 {
+                let b = v.clone() / (Rational::from(2) * &a);
+                return Some([a, b]);
+            }
+        }
+    }
+    None
+}
+
+/// For a **quadratic** base `q = x² − m` and sheet radicand `c = a(α) ∈ ℚ(α)`
+/// (`α = √m`), build the degree-4 field `K = ℚ(√m)[w]/(w²−c)` and, **when it is
+/// Galois over ℚ**, its four automorphism images of `θ` (as `QPoly`s mod `M`).
+/// Returns `(M, α(θ), w(θ), [π₀=θ, π₁, π₂, π₃])`.  `None` if `q` is not `x²−m`,
+/// `K` is not degree 4, or `K/ℚ` is not Galois (the conjugate sheet `√(c̄)` is
+/// not in `K`) — all sound declines.  Every returned `πⱼ` is **verified**
+/// (`M(πⱼ) ≡ 0 (mod M)`), so the result is correct by construction.
+pub(crate) fn galois_quartic(q: &QPoly, c: &QPoly) -> Option<(QPoly, QPoly, QPoly, Vec<QPoly>)> {
+    if degree(q) != 2 || q.get(1).map(|x| *x != 0).unwrap_or(false) {
+        return None; // require q = x² − m
+    }
+    let m = -q[0].clone(); // α² = m
+    let (mm, a_in, w_in) = primitive_element(q, c)?;
+    if degree(&mm) != 4 {
+        return None;
+    }
+    let u = c.first().cloned().unwrap_or_else(|| Rational::from(0));
+    let v = c.get(1).cloned().unwrap_or_else(|| Rational::from(0));
+    // c̄ = u − v√m;  c̄/c = (u²+v²m − 2uv√m)/(u²−v²m).
+    let nrm = u.clone() * &u - v.clone() * &v * &m; // N(c)
+    if nrm == 0 {
+        return None;
+    }
+    let cbar = [u.clone(), -v.clone()];
+    let cbar_over_c = [
+        (u.clone() * &u + v.clone() * &v * &m) / &nrm,
+        Rational::from(-2) * &u * &v / &nrm,
+    ];
+
+    // w_α = √(c̄) ∈ K: either √(c̄/c)·w (g ∈ ℚ(α)) or √(c̄) ∈ ℚ(α).
+    let w_alpha: QPoly = if let Some(g) = sqrt_in_quad(&cbar_over_c[0], &cbar_over_c[1], &m) {
+        // g(α)·w  with g = g0 + g1·α.
+        let g_at = poly_add(
+            &vec![g[0].clone()],
+            &poly_scale(&a_in, &g[1]), // g1·α(θ)
+        );
+        qmod(&poly_mul(&g_at, &w_in), &mm)
+    } else if let Some(h) = sqrt_in_quad(&cbar[0], &cbar[1], &m) {
+        // √(c̄) = h0 + h1·α ∈ ℚ(α).
+        poly_add(&vec![h[0].clone()], &poly_scale(&a_in, &h[1]))
+    } else {
+        return None; // conjugate sheet not in K ⇒ not Galois
+    };
+
+    // π₀ = θ;  σ_w(θ) = θ − 2w;  σ_α(θ) = w_α + w − θ;  σ_αw(θ) = −w_α + w − θ.
+    let theta = vec![Rational::from(0), Rational::from(1)];
+    let two_w = poly_scale(&w_in, &Rational::from(2));
+    let sigma_w = qmod(&poly_sub_q(&theta, &two_w), &mm);
+    let sigma_a = qmod(&poly_sub_q(&poly_add(&w_alpha, &w_in), &theta), &mm);
+    let sigma_aw = qmod(&poly_sub_q(&poly_sub_q(&w_in, &w_alpha), &theta), &mm);
+    let autos = vec![theta, sigma_w, sigma_a, sigma_aw];
+
+    // Verify each is a genuine root of M (sound) and they are distinct.
+    for (i, pi) in autos.iter().enumerate() {
+        if degree(&eval_mod(&mm, pi, &mm)) >= 0 {
+            return None; // πᵢ not a root of M ⇒ construction invalid (not Galois)
+        }
+        for pj in autos.iter().take(i) {
+            if trim(pi.clone()) == trim(pj.clone()) {
+                return None; // repeated ⇒ fewer than 4 automorphisms
+            }
+        }
+    }
+    Some((mm, a_in, w_in, autos))
+}
+
+/// `f(β) mod M`.
+fn eval_mod(f: &QPoly, beta: &QPoly, m: &QPoly) -> QPoly {
+    compose_mod(f, beta, m)
+}
+
+fn poly_sub_q(a: &QPoly, b: &QPoly) -> QPoly {
+    poly_add(a, &poly_scale(b, &Rational::from(-1)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,5 +321,21 @@ mod tests {
     #[test]
     fn sextic_cubic_base() {
         check(&qp(&[-2, 0, 0, 1]), &qp(&[0, 1])); // q = x³−2, c = α
+    }
+
+    /// Galois quartic `ℚ(√2, √3)` (`q = x²−2`, `c = 3` rational): four
+    /// automorphisms; `M = t⁴−10t²+1` is the minimal polynomial of `√2+√3`.
+    #[test]
+    fn galois_quartic_multiquadratic() {
+        let (m, _a, _w, autos) = galois_quartic(&qp(&[-2, 0, 1]), &qp(&[3])).expect("Galois");
+        assert_eq!(m, qp(&[1, 0, -10, 0, 1])); // t⁴ − 10t² + 1
+        assert_eq!(autos.len(), 4);
+    }
+
+    /// Non-Galois quartic `ℚ(√2, √(1+5√2))` (`q = x²−2`, `c = 1+5√2`): the
+    /// conjugate sheet `√(1−5√2) ∉ K`, so `galois_quartic` declines.
+    #[test]
+    fn non_galois_quartic_declines() {
+        assert!(galois_quartic(&qp(&[-2, 0, 1]), &qp(&[1, 5])).is_none());
     }
 }

--- a/alkahest-core/src/integrate/algebraic/alg_tower.rs
+++ b/alkahest-core/src/integrate/algebraic/alg_tower.rs
@@ -130,6 +130,9 @@ fn solve_columns(cols: &[Vec<Rational>], rhs: &[Rational], n: usize) -> Option<V
         for r in 0..n {
             if r != col && a[r][col] != 0 {
                 let f = a[r][col].clone();
+                // Two distinct rows (`a[r]` updated from `a[col]`): a range loop is
+                // the clearest way to index both without splitting the borrow.
+                #[allow(clippy::needless_range_loop)]
                 for k in col..=n {
                     let s = f.clone() * &a[col][k];
                     a[r][k] -= s;

--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -16,10 +16,10 @@ use crate::integrate::engine::IntegrationError;
 use crate::integrate::risch::alg_field::{AlgElem, RatFn};
 use crate::integrate::risch::number_field::KElem;
 use crate::integrate::risch::poly_rde::{
-    degree, expr_to_qpoly, poly_deriv, poly_scale, qpoly_to_expr, QPoly,
+    degree, expr_to_qpoly, poly_add, poly_deriv, poly_mul, poly_scale, qpoly_to_expr, trim, QPoly,
 };
 use crate::integrate::risch::rational_rde::{
-    expr_to_qrational, poly_gcd, solve_rational_rde_generalized,
+    expr_to_qrational, poly_divrem, poly_gcd, solve_rational_rde_generalized,
 };
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use rug::{Integer, Rational};
@@ -766,20 +766,102 @@ fn integrate_b_sqrt_high_degree(
         };
     }
 
-    // Algebraic residues present (a rational pole with an irrational sheet, or an
-    // algebraic-base pole).  Decide via the Trager ℚ-basis criterion in a common
-    // quadratic field; a non-torsion component certifies non-elementary.
-    match try_genus2_alg_log(&p_poly, &h, &alg_res) {
+    // Algebraic residues present.  Two routes through the Trager ℚ-basis
+    // criterion: rational base points with irrational sheets (a compositum of
+    // quadratic *sheet* fields) via `try_genus2_alg_log`; a quadratic *base*
+    // point (degree-4 tower ℚ(√m,√c)) via `try_alg_base_log`.
+    let verdict = if alg_res.iter().all(|r| r.conjugates == 1) {
+        try_genus2_alg_log(&p_poly, &h, &alg_res)
+    } else {
+        try_alg_base_log(&p_poly, &h, &alg_res)
+    };
+    match verdict {
         Some(FindOrder::NonElementary) => Err(nonelem(
             "Trager ℚ-basis criterion: a residue component is non-torsion ⇒ \
              no elementary logarithmic part",
         )),
         _ => Err(notimpl(
             "genus ≥ 2 logarithmic part with algebraic residues: not decided \
-             (torsion log not yet emittable, or an algebraic base point of \
-             degree ≥ 2 — a genuine tower)",
+             (torsion log not yet emittable, or out of the handled scope — \
+             non-Galois tower / base degree ≥ 3)",
         )),
     }
+}
+
+/// Trager ℚ-basis decision for a single **quadratic algebraic base point**: the
+/// pole denominator has an irreducible factor `q = x²−m`, the residue
+/// `r0 ± r1·√a(α)` (`r0,r1 ∈ ℚ(α)=ℚ(√m)`) living in the degree-4 tower
+/// `K = ℚ(√m)[w]/(w²−c)`, `c = a(α)`.  When `K/ℚ` is Galois
+/// ([`super::alg_tower::galois_quartic`]) the four conjugate residues and places
+/// are expressed in `ℚ[θ]/M`, decomposed over `ℚ`, and each component is tested
+/// with [`trager_log_criterion_alg`] (reducing at primes that split `M`).  `None`
+/// outside this scope (non-`x²−m` base, non-Galois `K`, more than one algebraic
+/// orbit, or base degree ≥ 3).
+fn try_alg_base_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<FindOrder> {
+    // Exactly one algebraic orbit, a quadratic base (conjugates == 2).
+    if alg_res.len() != 1 || alg_res[0].conjugates != 2 || degree(&alg_res[0].minpoly) != 2 {
+        return None;
+    }
+    let ar = &alg_res[0];
+    let q = trim(ar.minpoly.clone());
+    // c = a(α) ∈ ℚ(α): reduce the radicand mod q.
+    let c = trim(poly_divrem(p, &q).1);
+    let (m, a_in, w_in, autos) = super::alg_tower::galois_quartic(&q, &c)?;
+
+    // ρ = r0(α) + r1(α)·w in ℚ[θ]/M.
+    let r0 = &ar.r0;
+    let r1 = &ar.r1;
+    let rho = poly_add(
+        &super::alg_tower::compose_mod(r0, &a_in, &m),
+        &poly_divrem(
+            &poly_mul(&super::alg_tower::compose_mod(r1, &a_in, &m), &w_in),
+            &m,
+        )
+        .1,
+    );
+    let rho = trim(poly_divrem(&rho, &m).1);
+    let dim = (degree(&m).max(0) as usize).max(1); // = 4
+
+    // Conjugate residues ρⱼ = σⱼ(ρ) and conjugate places (A(πⱼ), W(πⱼ)).
+    let mut alg_places: Vec<AlgPlace> = Vec::new();
+    let mut alg_residues: Vec<KElem> = Vec::new();
+    for pi in &autos {
+        let rho_j = super::alg_tower::compose_mod(&rho, pi, &m);
+        let xj = super::alg_tower::compose_mod(&a_in, pi, &m);
+        let yj = super::alg_tower::compose_mod(&w_in, pi, &m);
+        alg_places.push(AlgPlace {
+            minpoly: m.clone(),
+            x_coord: xj,
+            y_coord: yj,
+            coeff: Integer::from(0),
+            orbit: false, // a single ℚ(θ) place (one embedding per prime)
+        });
+        // residue as a length-`dim` vector (pad).
+        let mut v = rho_j;
+        v.resize(dim, Rational::from(0));
+        alg_residues.push(v);
+    }
+
+    // Rational + infinite places carry rational residues (basis index 0).
+    let rat_div = residue_divisor_placed(2, p, h);
+    let rat_residues: Vec<KElem> = rat_div
+        .iter()
+        .map(|r| {
+            let mut v = vec![Rational::from(0); dim];
+            v[0] = r.residue.value.clone();
+            v
+        })
+        .collect();
+
+    Some(trager_log_criterion_alg(
+        2,
+        p,
+        &rat_div,
+        &rat_residues,
+        &alg_places,
+        &alg_residues,
+        dim,
+    ))
 }
 
 /// Trager ℚ-basis decision for `∫ (B·y) dx` on `y²=P` (deg P odd ≥ 5) when the

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -1014,7 +1014,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -16,11 +16,10 @@
 //! - Trager (1984). Integration of algebraic functions. MIT PhD thesis.
 //! - Bronstein (2005). Symbolic Integration I. Springer, chs. 10–11.
 
-// Primitive-element substrate for the algebraic-base-point logarithmic part —
-// builds the quadratic tower ℚ(α)[w]/(w²−c).  Field construction only; the
-// Galois-consistent conjugate-divisor reduction that would turn it into a
-// verdict is the documented remaining step (see the module docs).
-#[allow(dead_code)]
+// Quadratic-tower field ℚ(α)[w]/(w²−c) + Galois automorphisms for the
+// algebraic-base-point logarithmic part: `primitive_element` builds the field
+// and `galois_quartic` its automorphisms, consumed by
+// `genus_zero::try_alg_base_log` (the conjugate-divisor reduction).
 mod alg_tower;
 pub(super) mod decompose;
 pub mod elliptic;
@@ -591,6 +590,52 @@ mod tests {
         let res = crate::integrate::engine::integrate(integrand, x, &pool);
         assert!(
             matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
+    /// **Algebraic base point** (degree-4 Galois tower): `∫ √(x⁵−4x+3)/(x²−2) dx`
+    /// has a pole at the irrational base `x=±√2`; since `a(√2)=3`, the residue
+    /// field is `ℚ(√2,√3)` (Galois).  The conjugate-divisor reduction builds the
+    /// four automorphisms, decomposes the conjugate residues over ℚ, and finds a
+    /// non-torsion component ⇒ `NonElementary`.  **FriCAS-confirmed**.
+    #[test]
+    fn quintic_algebraic_base_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            pool.mul(vec![pool.integer(-4_i32), x]),
+            pool.integer(3_i32),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-2_i32)]); // x²−2
+        let integrand = pool.mul(vec![sq, pool.pow(den, pool.integer(-1_i32))]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
+    /// A **non-Galois** algebraic base (`∫ √(x⁵+x+1)/(x²−2)`, `a(√2)=1+5√2`, the
+    /// conjugate sheet not in the tower) is soundly declined (`NotImplemented`),
+    /// never wrongly `NonElementary`.
+    #[test]
+    fn quintic_algebraic_base_non_galois_declines() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            x,
+            pool.integer(1_i32),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let den = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-2_i32)]);
+        let integrand = pool.mul(vec![sq, pool.pow(den, pool.integer(-1_i32))]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NotImplemented(_))),
             "got {res:?}"
         );
     }

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -67,10 +67,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }


### PR DESCRIPTION
## Summary

**Stacked on #115** (base `risch/alg-base-tower`). Turns the tower substrate (#115) into a sound `NonElementary` verdict for `∫ B·√P` with a pole at a **quadratic algebraic base point** `α` (`q = x²−m`), in the Galois case — the genuine Trager core the compositum shortcut (#114) could not reach.

Here `r0, r1 ∈ ℚ(α)`, so the residue field `ℚ(√m, √c)` (`c = a(α)`) is a degree-4 **tower with √-products**, not a separating multiquadratic — so the conjugate places must be handled in one field with a Galois-consistent embedding.

## What's new

**`alg_tower::galois_quartic(q, c)`** — builds `K = ℚ(√m)[w]/(w²−c)` and, when `K/ℚ` is Galois, its four automorphism images of `θ`. They're constructed from quadratic-field square roots (`sqrt_in_quad`, **no number-field factorization**) and each is **verified** `M(πⱼ) ≡ 0` — sound by construction. A non-Galois tower (conjugate sheet `√(c̄) ∉ K`) is declined.

**`genus_zero::try_alg_base_log`** — expresses the base residue `ρ = r0(α)+r1(α)w` in `ℚ[θ]/M`, forms the four conjugate residues `σⱼ(ρ)=ρ∘πⱼ` and conjugate places `(A∘πⱼ, W∘πⱼ)` via `compose_mod`, then runs the Trager ℚ-basis criterion: each component reduces at primes splitting `M`, with the four conjugate places sharing one embedding (`orbit=false`). A non-torsion component ⇒ `NonElementary`. Gated by the residue theorem; **only `NonElementary` is asserted** (torsion / non-Galois / base-deg ≥ 3 all decline), so no false positive is possible.

## FriCAS-1.3.7 validation
- `∫ √(x⁵−4x+3)/(x²−2)` — `a(√2)=3` ⇒ `K=ℚ(√2,√3)` Galois, `M=t⁴−10t²+1` (minpoly of √2+√3) → **`NonElementary`**, matching FriCAS (unevaluated).
- `∫ √(x⁵+x+1)/(x²−2)` — non-Galois (`a(√2)=1+5√2`) → soundly **declines** (`NotImplemented`), never wrong.
- `galois_quartic` unit-tested (Galois `t⁴−10t²+1` with 4 automorphisms; non-Galois declined).
- `cargo test --workspace`: **923 lib tests + all suites green**; `cargo fmt` + clippy clean.

## Remaining
Non-Galois quartic towers (need the Galois closure), general quadratic bases `x²+bx+c` (normalize to `x²−m`), and base degree ≥ 3 (general number-field automorphisms via Trager factorization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
