### PR TITLE
feat(integrate): non-Galois quartic algebraic-base-point verdict

### DIFF
--- a/alkahest-core/src/integrate/algebraic/alg_tower.rs
+++ b/alkahest-core/src/integrate/algebraic/alg_tower.rs
@@ -19,7 +19,11 @@
 //! quadratic-field square roots ([`sqrt_in_quad`]) — no number-field
 //! factorization.  These give the conjugate residues and places (via
 //! [`compose_mod`]) that `genus_zero::try_alg_base_log` decomposes and reduces.
-//! A non-Galois tower (the conjugate sheet `√(c̄) ∉ K`) is declined.
+//! When the tower is **non-Galois** (the conjugate sheet `√(c̄) ∉ K`),
+//! [`quartic_closure`] builds the degree-8 Galois closure `L = K(√(N(c)))` — a
+//! single *rational* radical, since `N(c) = c·c̄ ∈ ℚ` — and returns `α, w` and
+//! `v = √(c̄) = √(N(c))·w⁻¹` as elements of `L`, each defining relation verified
+//! in `L`, for the explicit four-place orbit construction.
 
 use rug::Rational;
 
@@ -130,6 +134,9 @@ fn solve_columns(cols: &[Vec<Rational>], rhs: &[Rational], n: usize) -> Option<V
         for r in 0..n {
             if r != col && a[r][col] != 0 {
                 let f = a[r][col].clone();
+                // Two distinct rows (`a[r]` updated from `a[col]`): a range loop is
+                // the clearest way to index both without splitting the borrow.
+                #[allow(clippy::needless_range_loop)]
                 for k in col..=n {
                     let s = f.clone() * &a[col][k];
                     a[r][k] -= s;
@@ -264,6 +271,65 @@ fn eval_mod(f: &QPoly, beta: &QPoly, m: &QPoly) -> QPoly {
     compose_mod(f, beta, m)
 }
 
+/// For a **quadratic** base `q = x²−m` with a **non-Galois** tower
+/// `K = ℚ(√m)[w]/(w²−c)`, build the degree-8 Galois closure
+/// `L = K(√(N(c)))` and return `(M_L, α, w, v)` — the minimal polynomial of a
+/// primitive element of `L` (degree 8) and the coordinates `α = √m`, `w = √c`,
+/// `v = √(c̄)` as elements of `ℚ[Θ]/M_L`.
+///
+/// The closure works because `√c · √(c̄) = √(c·c̄) = √(N(c))` with `N(c) ∈ ℚ`, so
+/// `L = K(√(N(c)))` is `K` adjoined a single **rational** square root — itself a
+/// quadratic tower over `K` (reusing [`primitive_element`]) — and
+/// `v = √(c̄) = √(N(c)) · w⁻¹` in `L`.  `None` if `q ≠ x²−m`, `N(c)=0`, or `L`
+/// does not have degree 8 (i.e. `K` was already Galois — use [`galois_quartic`]).
+pub(crate) fn quartic_closure(q: &QPoly, c: &QPoly) -> Option<(QPoly, QPoly, QPoly, QPoly)> {
+    use super::super::risch::number_field::mod_inverse;
+    if degree(q) != 2 || q.get(1).map(|x| *x != 0).unwrap_or(false) {
+        return None;
+    }
+    let m = -q[0].clone();
+    let (mm, a_in, w_in) = primitive_element(q, c)?; // K = ℚ[θ]/M, degree 4
+    if degree(&mm) != 4 {
+        return None;
+    }
+    let u = c.first().cloned().unwrap_or_else(|| Rational::from(0));
+    let vc = c.get(1).cloned().unwrap_or_else(|| Rational::from(0));
+    let dprime = u.clone() * &u - vc.clone() * &vc * &m; // N(c) = u² − v²m ∈ ℚ
+    if dprime == 0 {
+        return None;
+    }
+    // L = K[s]/(s² − D'):  base field K (minpoly M), radicand the constant D'.
+    let (ml, theta_in, s_in) = primitive_element(&mm, &vec![dprime])?;
+    if degree(&ml) != 8 {
+        return None; // √D' ∈ K ⇒ K already Galois
+    }
+    // Re-express α, w, w⁻¹ (from K) in ℚ[Θ]/M_L, and v = s · w⁻¹.
+    let alpha_l = compose_mod(&a_in, &theta_in, &ml);
+    let w_l = compose_mod(&w_in, &theta_in, &ml);
+    let w_inv_k = mod_inverse(&w_in, &mm)?; // w⁻¹ in K
+    let w_inv_l = compose_mod(&w_inv_k, &theta_in, &ml);
+    let v_l = qmod(&poly_mul(&s_in, &w_inv_l), &ml); // v = √(c̄) = √(N(c))·w⁻¹
+
+    // Verify the defining relations the four orbit places rely on, *in L*:
+    //   α² ≡ m,   w² ≡ c(α) = u+vc·α,   v² ≡ c̄(α) = u−vc·α.
+    // Sound by construction — decline (None) rather than risk a wrong divisor.
+    let sq = |x: &QPoly| qmod(&poly_mul(x, x), &ml);
+    let c_at = |sgn: i64| {
+        // u + sgn·vc·α  in ℚ[Θ]/M_L
+        poly_add(
+            &vec![u.clone()],
+            &poly_scale(&alpha_l, &(vc.clone() * Rational::from(sgn))),
+        )
+    };
+    let alpha2_ok = degree(&qmod(&poly_sub_q(&sq(&alpha_l), &vec![m.clone()]), &ml)) < 0;
+    let w2_ok = degree(&qmod(&poly_sub_q(&sq(&w_l), &c_at(1)), &ml)) < 0;
+    let v2_ok = degree(&qmod(&poly_sub_q(&sq(&v_l), &c_at(-1)), &ml)) < 0;
+    if !(alpha2_ok && w2_ok && v2_ok) {
+        return None;
+    }
+    Some((ml, alpha_l, w_l, v_l))
+}
+
 fn poly_sub_q(a: &QPoly, b: &QPoly) -> QPoly {
     poly_add(a, &poly_scale(b, &Rational::from(-1)))
 }
@@ -337,5 +403,30 @@ mod tests {
     #[test]
     fn non_galois_quartic_declines() {
         assert!(galois_quartic(&qp(&[-2, 0, 1]), &qp(&[1, 5])).is_none());
+    }
+
+    /// `quartic_closure` builds the degree-8 Galois closure of the non-Galois
+    /// tower `ℚ(√2, √(1+5√2))`: `N(c)=(1+5√2)(1−5√2)=−49`, `L=K(√(−49))`.  The
+    /// returned `α, w, v` must satisfy `α²=2`, `w²=c=1+5√2`, `v²=c̄=1−5√2` in `L`.
+    #[test]
+    fn quartic_closure_non_galois() {
+        let q = qp(&[-2, 0, 1]);
+        let c = qp(&[1, 5]); // 1 + 5√2
+        let (ml, alpha, w, v) = quartic_closure(&q, &c).expect("degree-8 closure");
+        assert_eq!(degree(&ml), 8);
+        let sq = |x: &QPoly| qmod(&poly_mul(x, x), &ml);
+        // α² = 2.
+        assert_eq!(trim(sq(&alpha)), qp(&[2]));
+        // w² = 1 + 5α  and  v² = 1 − 5α  (c and its conjugate at −α).
+        let c_at = |sgn: i64| {
+            qmod(
+                &poly_add(&qp(&[1]), &poly_scale(&alpha, &Rational::from(5 * sgn))),
+                &ml,
+            )
+        };
+        assert_eq!(trim(sq(&w)), trim(c_at(1)));
+        assert_eq!(trim(sq(&v)), trim(c_at(-1)));
+        // And it really is non-Galois (galois_quartic declines on the same input).
+        assert!(galois_quartic(&q, &c).is_none());
     }
 }

--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -797,6 +797,11 @@ fn integrate_b_sqrt_high_degree(
 /// with [`trager_log_criterion_alg`] (reducing at primes that split `M`).  `None`
 /// outside this scope (non-`x²−m` base, non-Galois `K`, more than one algebraic
 /// orbit, or base degree ≥ 3).
+/// `a mod m` over `ℚ[x]`.
+fn qmod_l(a: &QPoly, m: &QPoly) -> QPoly {
+    trim(poly_divrem(a, m).1)
+}
+
 fn try_alg_base_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<FindOrder> {
     // Exactly one algebraic orbit, a quadratic base (conjugates == 2).
     if alg_res.len() != 1 || alg_res[0].conjugates != 2 || degree(&alg_res[0].minpoly) != 2 {
@@ -806,41 +811,98 @@ fn try_alg_base_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<Fi
     let q = trim(ar.minpoly.clone());
     // c = a(α) ∈ ℚ(α): reduce the radicand mod q.
     let c = trim(poly_divrem(p, &q).1);
-    let (m, a_in, w_in, autos) = super::alg_tower::galois_quartic(&q, &c)?;
-
-    // ρ = r0(α) + r1(α)·w in ℚ[θ]/M.
     let r0 = &ar.r0;
     let r1 = &ar.r1;
-    let rho = poly_add(
-        &super::alg_tower::compose_mod(r0, &a_in, &m),
-        &poly_divrem(
-            &poly_mul(&super::alg_tower::compose_mod(r1, &a_in, &m), &w_in),
-            &m,
-        )
-        .1,
-    );
-    let rho = trim(poly_divrem(&rho, &m).1);
-    let dim = (degree(&m).max(0) as usize).max(1); // = 4
 
-    // Conjugate residues ρⱼ = σⱼ(ρ) and conjugate places (A(πⱼ), W(πⱼ)).
-    let mut alg_places: Vec<AlgPlace> = Vec::new();
-    let mut alg_residues: Vec<KElem> = Vec::new();
-    for pi in &autos {
-        let rho_j = super::alg_tower::compose_mod(&rho, pi, &m);
-        let xj = super::alg_tower::compose_mod(&a_in, pi, &m);
-        let yj = super::alg_tower::compose_mod(&w_in, pi, &m);
-        alg_places.push(AlgPlace {
-            minpoly: m.clone(),
-            x_coord: xj,
-            y_coord: yj,
-            coeff: Integer::from(0),
-            orbit: false, // a single ℚ(θ) place (one embedding per prime)
-        });
-        // residue as a length-`dim` vector (pad).
-        let mut v = rho_j;
-        v.resize(dim, Rational::from(0));
-        alg_residues.push(v);
-    }
+    // Build the conjugate orbit's places and residues in a common field — the
+    // degree-4 tower K when Galois, else its degree-8 Galois closure L.
+    let (alg_places, alg_residues, dim) =
+        if let Some((m, a_in, w_in, autos)) = super::alg_tower::galois_quartic(&q, &c) {
+            // Galois: ρ = r0(α)+r1(α)w in ℚ[θ]/M; orbit = {σⱼ(ρ), σⱼ(P₀)}.
+            let dim = (degree(&m).max(0) as usize).max(1); // = 4
+            let rho = qmod_l(
+                &poly_add(
+                    &super::alg_tower::compose_mod(r0, &a_in, &m),
+                    &qmod_l(
+                        &poly_mul(&super::alg_tower::compose_mod(r1, &a_in, &m), &w_in),
+                        &m,
+                    ),
+                ),
+                &m,
+            );
+            let mut places = Vec::new();
+            let mut residues = Vec::new();
+            for pi in &autos {
+                let mut rj = super::alg_tower::compose_mod(&rho, pi, &m);
+                rj.resize(dim, Rational::from(0));
+                places.push(AlgPlace {
+                    minpoly: m.clone(),
+                    x_coord: super::alg_tower::compose_mod(&a_in, pi, &m),
+                    y_coord: super::alg_tower::compose_mod(&w_in, pi, &m),
+                    coeff: Integer::from(0),
+                    orbit: false,
+                });
+                residues.push(rj);
+            }
+            (places, residues, dim)
+        } else {
+            // Non-Galois: work in the degree-8 closure L = K(√(N(c))).  Build the
+            // four orbit places (±α, ±√c), (±α, ±√c̄) and residues explicitly.
+            let (ml, alpha, w, v) = super::alg_tower::quartic_closure(&q, &c)?;
+            let dim = (degree(&ml).max(0) as usize).max(1); // = 8
+            let neg_alpha = poly_scale(&alpha, &Rational::from(-1));
+            let lin = |coef: &QPoly, a: &QPoly| {
+                qmod_l(
+                    &poly_add(
+                        &vec![coef.first().cloned().unwrap_or_else(|| Rational::from(0))],
+                        &poly_scale(
+                            a,
+                            &coef.get(1).cloned().unwrap_or_else(|| Rational::from(0)),
+                        ),
+                    ),
+                    &ml,
+                )
+            };
+            let r0a = lin(r0, &alpha);
+            let r1a = lin(r1, &alpha);
+            let r0n = lin(r0, &neg_alpha);
+            let r1n = lin(r1, &neg_alpha);
+            let mulm = |x: &QPoly, y: &QPoly| qmod_l(&poly_mul(x, y), &ml);
+            let sub = |a: &QPoly, b: &QPoly| poly_add(a, &poly_scale(b, &Rational::from(-1)));
+            let entries: [(QPoly, QPoly, QPoly); 4] = [
+                (alpha.clone(), w.clone(), poly_add(&r0a, &mulm(&r1a, &w))),
+                (
+                    alpha.clone(),
+                    poly_scale(&w, &Rational::from(-1)),
+                    sub(&r0a, &mulm(&r1a, &w)),
+                ),
+                (
+                    neg_alpha.clone(),
+                    v.clone(),
+                    poly_add(&r0n, &mulm(&r1n, &v)),
+                ),
+                (
+                    neg_alpha.clone(),
+                    poly_scale(&v, &Rational::from(-1)),
+                    sub(&r0n, &mulm(&r1n, &v)),
+                ),
+            ];
+            let mut places = Vec::new();
+            let mut residues = Vec::new();
+            for (x, y, res) in entries {
+                places.push(AlgPlace {
+                    minpoly: ml.clone(),
+                    x_coord: x,
+                    y_coord: y,
+                    coeff: Integer::from(0),
+                    orbit: false,
+                });
+                let mut rv = trim(res);
+                rv.resize(dim, Rational::from(0));
+                residues.push(rv);
+            }
+            (places, residues, dim)
+        };
 
     // Rational + infinite places carry rational residues (basis index 0).
     let rat_div = residue_divisor_placed(2, p, h);

--- a/alkahest-core/src/integrate/algebraic/hermite_curve.rs
+++ b/alkahest-core/src/integrate/algebraic/hermite_curve.rs
@@ -256,25 +256,25 @@ fn to_w_coords(basis: &[AlgElem], elem: &AlgElem, n: usize) -> Option<Vec<RatFn>
             row
         })
         .collect();
-    // Gaussian elimination over ℚ(x).
-    let mut piv_row = 0;
+    // Gaussian elimination over ℚ(x).  The pivot row equals `col` at every step.
     for col in 0..n {
-        let sel = (piv_row..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
-        m.swap(piv_row, sel);
-        let inv = f.inv(&m[piv_row][col])?;
-        for v in m[piv_row].iter_mut() {
+        let sel = (col..n).find(|&r| !f.eq(&m[r][col], &f.zero()))?;
+        m.swap(col, sel);
+        let inv = f.inv(&m[col][col])?;
+        for v in m[col].iter_mut() {
             *v = f.mul(v, &inv);
         }
         for r in 0..n {
-            if r != piv_row && !f.eq(&m[r][col], &f.zero()) {
+            if r != col && !f.eq(&m[r][col], &f.zero()) {
                 let factor = m[r][col].clone();
+                // Two distinct rows (`m[r]` updated from `m[col]`): range loop.
+                #[allow(clippy::needless_range_loop)]
                 for c in 0..=n {
-                    let sub = f.mul(&factor, &m[piv_row][c].clone());
+                    let sub = f.mul(&factor, &m[col][c].clone());
                     m[r][c] = f.sub(&m[r][c], &sub);
                 }
             }
         }
-        piv_row += 1;
     }
     Some((0..n).map(|i| m[i][n].clone()).collect())
 }

--- a/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
+++ b/alkahest-core/src/integrate/algebraic/jacobian_torsion.rs
@@ -1014,7 +1014,7 @@ fn rational_root_off_support(a: &QPoly, places: &[Place]) -> Option<Rational> {
     let support: Vec<Rational> = places.iter().map(|p| p.x.clone()).collect();
     let mut poly = trim(a.clone());
     while let Some(r) = super::find_order::first_rational_root(&poly) {
-        if !support.iter().any(|s| *s == r) {
+        if !support.contains(&r) {
             return Some(r);
         }
         // Deflate by (x − r) and look for the next rational root.

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -618,11 +618,16 @@ mod tests {
         );
     }
 
-    /// A **non-Galois** algebraic base (`∫ √(x⁵+x+1)/(x²−2)`, `a(√2)=1+5√2`, the
-    /// conjugate sheet not in the tower) is soundly declined (`NotImplemented`),
-    /// never wrongly `NonElementary`.
+    /// A **non-Galois** algebraic base: `∫ √(x⁵+x+1)/(x²−2) dx` has a pole at the
+    /// irrational base `x=±√2` with `a(√2)=1+5√2`, so `N(c)=(1+5√2)(1−5√2)=−49`
+    /// and the residue field `ℚ(√2,√(1+5√2))` is *not* Galois — its closure
+    /// `L=K(√(−49))=K(7i)` has degree 8.  The conjugate-divisor reduction builds
+    /// `L` (each defining relation `α²=2, w²=c, v²=c̄` verified in `L`), forms the
+    /// four orbit places/residues, decomposes over ℚ, and finds a non-torsion
+    /// component ⇒ `NonElementary`.  (FriCAS times out on this degree-8 problem; the
+    /// verdict rests on the verified-by-construction closure + Trager torsion test.)
     #[test]
-    fn quintic_algebraic_base_non_galois_declines() {
+    fn quintic_algebraic_base_non_galois_non_elementary() {
         let pool = ExprPool::new();
         let x = pool.symbol("x", Domain::Real);
         let p = pool.add(vec![
@@ -635,7 +640,7 @@ mod tests {
         let integrand = pool.mul(vec![sq, pool.pow(den, pool.integer(-1_i32))]);
         let res = crate::integrate::engine::integrate(integrand, x, &pool);
         assert!(
-            matches!(res, Err(IntegrationError::NotImplemented(_))),
+            matches!(res, Err(IntegrationError::NonElementary(_))),
             "got {res:?}"
         );
     }

--- a/alkahest-core/src/integrate/algebraic/trager_log.rs
+++ b/alkahest-core/src/integrate/algebraic/trager_log.rs
@@ -67,10 +67,10 @@ pub(crate) fn qbasis_decompose(residues: &[KElem], dim: usize) -> (usize, Vec<Ve
             *v /= &piv;
         }
         let pr = m[row].clone();
-        for r in 0..nrows {
-            if r != row && m[r][col] != 0 {
-                let f = m[r][col].clone();
-                for (dst, pv) in m[r].iter_mut().zip(pr.iter()) {
+        for (r, row_vec) in m.iter_mut().enumerate().take(nrows) {
+            if r != row && row_vec[col] != 0 {
+                let f = row_vec[col].clone();
+                for (dst, pv) in row_vec.iter_mut().zip(pr.iter()) {
                     *dst -= f.clone() * pv;
                 }
             }


### PR DESCRIPTION
## Summary

Decides `∫B·√P` at a **quadratic algebraic base point** `q=x²−m` whose sheet tower `K=ℚ(√m,√c)` is **non-Galois** (the conjugate sheet `√c̄ ∉ K`) — the last gap for quadratic bases (the Galois case landed in #116).

### How

- **`alg_tower::quartic_closure(q,c)`** builds the degree-8 Galois closure `L=K(√(N(c)))`. Key reduction: `N(c)=c·c̄ ∈ ℚ`, so `L` adjoins a single *rational* square root — itself a quadratic tower over `K` (reusing `primitive_element`) — and `v=√c̄=√(N(c))·w⁻¹` in `L`. Each defining relation (`α²=m, w²=c, v²=c̄`) is **verified in `L`** before returning; on failure it declines (`None`) rather than risk a wrong divisor — preserving the soundness invariant.
- **`genus_zero::try_alg_base_log`** now dispatches Galois (`galois_quartic` automorphism path) vs non-Galois (`quartic_closure`), forming the four orbit places `(±α,±√c),(±α,±√c̄)` and residues explicitly and running the same **Trager ℚ-basis torsion criterion**; a non-torsion component ⇒ `NonElementary`.

### Validation

`∫√(x⁵+x+1)/(x²−2) → NonElementary` (`N(c)=−49`, `L=K(7i)`). FriCAS 1.3.7 **times out** on this degree-8 problem, so the verdict rests on the verified-by-construction closure plus the complete Trager torsion test. New unit test `quartic_closure_non_galois` checks the closure relations directly; engine test renamed `quintic_algebraic_base_non_galois_non_elementary`.

Also fixes pre-existing clippy `-D warnings` lints in the stack (`needless_range_loop` / `explicit_counter_loop` / `manual_contains` across `alg_tower`, `hermite_curve`, `jacobian_torsion`, `trager_log`) so CI is green.

`cargo fmt`, `cargo clippy --all-targets` (clean), and `cargo test --workspace` (923 + suites passing) all green.

> Stacked on `risch/alg-base-conjugate-reduction` (#116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)