### PR TITLE
feat(integrate): general quadratic algebraic-base-point (x²+bx+c)

### DIFF
--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -808,11 +808,47 @@ fn try_alg_base_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<Fi
         return None;
     }
     let ar = &alg_res[0];
-    let q = trim(ar.minpoly.clone());
-    // c = a(α) ∈ ℚ(α): reduce the radicand mod q.
-    let c = trim(poly_divrem(p, &q).1);
-    let r0 = &ar.r0;
-    let r1 = &ar.r1;
+    let q_raw = trim(ar.minpoly.clone());
+    if degree(&q_raw) != 2 {
+        return None;
+    }
+    // Complete the square: a general monic base `q = x²+b·x+c₀` becomes the
+    // depressed `qn = x²−m` (`m = b²/4−c₀`) under `α = β − b/2` (`β = √m`).  The
+    // tower builders (`galois_quartic`/`quartic_closure`) consume `qn`; the field
+    // elements (`c = a(α)`, `r0`, `r1`) are rewritten in the β-basis via
+    // `α = β + shift`, and each place's x-coordinate is shifted *back* by `shift`
+    // so it is the **actual** base-point coordinate on `y²=P`.  (The on-curve
+    // check in `reduce_and_build` self-verifies this — a wrong shift only declines,
+    // never mis-decides.)  When `b=0` every step below is the identity.
+    let lead = q_raw[2].clone();
+    let b = q_raw[1].clone() / &lead;
+    let c0 = q_raw[0].clone() / &lead;
+    let half_b = b / Rational::from(2);
+    let shift = -half_b.clone();
+    let m_val = half_b.clone() * &half_b - &c0; // m = b²/4 − c₀
+    let q = vec![-m_val, Rational::from(0), Rational::from(1)]; // x² − m
+                                                                // `e0 + e1·α  ↦  (e0 + e1·shift) + e1·β`   (substitute `α = β + shift`).
+    let to_beta = |e: &QPoly| -> QPoly {
+        let e0 = e.first().cloned().unwrap_or_else(|| Rational::from(0));
+        let e1 = e.get(1).cloned().unwrap_or_else(|| Rational::from(0));
+        trim(vec![e0 + e1.clone() * &shift, e1])
+    };
+    // Add the constant `shift` to a place x-coordinate (in `ℚ[θ]/M`).
+    let shift_x = |x: &QPoly| -> QPoly {
+        let mut v = x.clone();
+        if v.is_empty() {
+            v.push(shift.clone());
+        } else {
+            v[0] = v[0].clone() + &shift;
+        }
+        trim(v)
+    };
+    // c = a(α) ∈ ℚ(α): reduce the radicand mod the *raw* minpoly, then β-basis.
+    let c = to_beta(&trim(poly_divrem(p, &q_raw).1));
+    let r0_b = to_beta(&ar.r0);
+    let r1_b = to_beta(&ar.r1);
+    let r0 = &r0_b;
+    let r1 = &r1_b;
 
     // Build the conjugate orbit's places and residues in a common field — the
     // degree-4 tower K when Galois, else its degree-8 Galois closure L.
@@ -837,7 +873,7 @@ fn try_alg_base_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<Fi
                 rj.resize(dim, Rational::from(0));
                 places.push(AlgPlace {
                     minpoly: m.clone(),
-                    x_coord: super::alg_tower::compose_mod(&a_in, pi, &m),
+                    x_coord: shift_x(&super::alg_tower::compose_mod(&a_in, pi, &m)),
                     y_coord: super::alg_tower::compose_mod(&w_in, pi, &m),
                     coeff: Integer::from(0),
                     orbit: false,
@@ -892,7 +928,7 @@ fn try_alg_base_log(p: &QPoly, h: &AlgElem, alg_res: &[AlgResidue]) -> Option<Fi
             for (x, y, res) in entries {
                 places.push(AlgPlace {
                     minpoly: ml.clone(),
-                    x_coord: x,
+                    x_coord: shift_x(&x),
                     y_coord: y,
                     coeff: Integer::from(0),
                     orbit: false,

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -645,6 +645,70 @@ mod tests {
         );
     }
 
+    /// **General quadratic base** `x²+b·x+c₀` (Galois): the `x→x+1` translate of
+    /// `∫√(x⁵−4x+3)/(x²−2)` is `∫√(x⁵+5x⁴+10x³+10x²+x)/(x²+2x−1) dx` — the base is
+    /// now `x²+2x−1` (`b=2≠0`).  Completing the square (`α=β−1`, `m=b²/4−c₀=2`)
+    /// reduces it to the depressed `x²−2`, recovering the same Galois residue field
+    /// `ℚ(√2,√3)`.  A translation cannot change elementarity, so this must stay
+    /// `NonElementary`.
+    #[test]
+    fn quintic_general_quadratic_base_galois_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // x⁵ + 5x⁴ + 10x³ + 10x² + x  (= (x+1)⁵ − 4(x+1) + 3).
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            pool.mul(vec![pool.integer(5_i32), pool.pow(x, pool.integer(4_i32))]),
+            pool.mul(vec![pool.integer(10_i32), pool.pow(x, pool.integer(3_i32))]),
+            pool.mul(vec![pool.integer(10_i32), pool.pow(x, pool.integer(2_i32))]),
+            x,
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        // x² + 2x − 1  (= (x+1)² − 2).
+        let den = pool.add(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.mul(vec![pool.integer(2_i32), x]),
+            pool.integer(-1_i32),
+        ]);
+        let integrand = pool.mul(vec![sq, pool.pow(den, pool.integer(-1_i32))]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
+    /// **General quadratic base** (non-Galois): the `x→x+1` translate of
+    /// `∫√(x⁵+x+1)/(x²−2)` is `∫√(x⁵+5x⁴+10x³+10x²+6x+3)/(x²+2x−1) dx` — base
+    /// `x²+2x−1` (`b=2`), depressing to `x²−2` with the same non-Galois closure
+    /// `K(7i)`.  Must remain `NonElementary` (a pure translation).
+    #[test]
+    fn quintic_general_quadratic_base_non_galois_non_elementary() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // x⁵ + 5x⁴ + 10x³ + 10x² + 6x + 3  (= (x+1)⁵ + (x+1) + 1).
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(5_i32)),
+            pool.mul(vec![pool.integer(5_i32), pool.pow(x, pool.integer(4_i32))]),
+            pool.mul(vec![pool.integer(10_i32), pool.pow(x, pool.integer(3_i32))]),
+            pool.mul(vec![pool.integer(10_i32), pool.pow(x, pool.integer(2_i32))]),
+            pool.mul(vec![pool.integer(6_i32), x]),
+            pool.integer(3_i32),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let den = pool.add(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.mul(vec![pool.integer(2_i32), x]),
+            pool.integer(-1_i32),
+        ]);
+        let integrand = pool.mul(vec![sq, pool.pow(den, pool.integer(-1_i32))]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "got {res:?}"
+        );
+    }
+
     /// `∫ dx/√(x³+1)` is a first-kind elliptic integral — non-elementary; the
     /// public engine must still report `NonElementary` (the capstone's verify gate
     /// declines, falling through to the genus-≥1 shortcut).


### PR DESCRIPTION
## Summary

Generalizes the algebraic-base-point logarithmic decision from the depressed base `q=x²−m` to **any** irreducible quadratic `q=x²+b·x+c₀` (`b≠0`) — the next gap after the Galois (#116) and non-Galois (#117) quartic cases.

### How

`try_alg_base_log` **completes the square**: under `α=β−b/2` (`β=√m`, `m=b²/4−c₀`) the base becomes the depressed `qn=x²−m` consumed by the tower builders. All field elements (`c=a(α)`, `r0`, `r1`) are rewritten in the β-basis via `α=β+shift`, and each conjugate place's x-coordinate is shifted **back** by `shift` so it is the actual base-point coordinate on `y²=P`. The on-curve check in `reduce_and_build` (`Y²=F(X)`) self-verifies the shift — a wrong shift only declines, never mis-decides. When `b=0` every step is the identity, so existing depressed-base behaviour is unchanged.

Both the Galois and non-Galois closures now accept general quadratic bases.

### Validation (translation invariance)

A pure translation `x→x+1` cannot change elementarity:
- `∫√(x⁵+5x⁴+10x³+10x²+x)/(x²+2x−1)` (Galois translate of `∫√(x⁵−4x+3)/(x²−2)`) → `NonElementary` ✓
- `∫√(x⁵+5x⁴+10x³+10x²+6x+3)/(x²+2x−1)` (non-Galois translate of `∫√(x⁵+x+1)/(x²−2)`) → `NonElementary` ✓

`cargo fmt`, `cargo clippy --all-targets` (clean), `cargo test --workspace` (926 + suites) all green.

> Stacked on `risch/alg-base-non-galois-quartic` (#117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)