### PR TITLE
feat(integrate): first-kind elliptic-integral output for genus-1 ∫dx/√(cubic|quartic)

### DIFF
--- a/alkahest-core/src/integrate/algebraic/elliptic_output.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic_output.rs
@@ -1,0 +1,537 @@
+//! First-kind elliptic-integral *output* for genus-1 radicands.
+//!
+//! When `∫ c·dx/√(P(x))` with `P` a **cubic or quartic** polynomial is
+//! genus-1 and **non-elementary**, the antiderivative is an incomplete elliptic
+//! integral of the first kind.  This module reduces that integrand to Legendre
+//! normal form and emits a closed form
+//!
+//! ```text
+//! F_cand(x) = g · EllipticF(φ(x), m)
+//! ```
+//!
+//! with `φ(x) = arcsin(S(x))` or `arccos(S(x))` for an explicit real Möbius `S`,
+//! a modulus parameter `m` (Mathematica convention `m = k²`, matching the PR1
+//! `EllipticF` primitive), and a constant `g` — all algebraic in the roots of
+//! `P`.  The reduction follows the standard case analysis of Byrd & Friedman,
+//! *Handbook of Elliptic Integrals* (§3.13x cubics, §3.14x–§3.16x quartics).
+//!
+//! # Soundness
+//!
+//! The reduction constants are **not trusted blindly**.  Every candidate is run
+//! through a numeric verification gate (`verify`): its *symbolic* `d/dx` (via
+//! the engine's `diff`, which differentiates `EllipticF` through the primitive
+//! registry — `∂φ F = 1/√(1 − m·sin²φ)`, elementary) is sampled against the
+//! integrand `c/√P` at points where `P > 0`.  The form is emitted **only** if
+//! the gate passes; otherwise the caller falls through to `NonElementary`.  An
+//! imperfect reduction constant can therefore never produce a wrong answer — it
+//! merely declines.
+
+use crate::integrate::risch::poly_rde::{expr_to_qpoly, is_free_of_var};
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::simplify::engine::simplify;
+
+/// A complex root, stored as `(re, im)`.
+type Croot = (f64, f64);
+
+/// Try to emit a first-kind `EllipticF` closed form for `∫ (a + b·√P) dx` when
+/// the integrand reduces to the pure first-kind shape `c/√P` (`a = 0`,
+/// `b = c/P` with `c` a constant) and `P` is a gate-verifiable cubic/quartic.
+///
+/// Returns the antiderivative `g·EllipticF(φ(x), m)` (numeric `g`, `m`,
+/// real-Möbius `φ`) when the verification gate passes, else `None` (caller
+/// falls through to the existing `NonElementary` path).
+pub fn try_elliptic_output(
+    a_part: ExprId,
+    b_part: ExprId,
+    p_expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    // Restrict to the *pure first kind*: `∫ c·dx/√P`.  This is `a = 0` and
+    // `b·√P = c/√P`, i.e. `b = c/P` with `c` free of `var`.
+    if !is_zero(a_part, pool) {
+        return None;
+    }
+    let bp = pool.mul(vec![b_part, p_expr]);
+    let c_expr = simplify(bp, pool).value;
+    if !is_free_of_var(c_expr, var, pool) {
+        return None;
+    }
+    let c = eval_const(c_expr, pool)?;
+    if !c.is_finite() || c == 0.0 {
+        return None;
+    }
+
+    // Parse P to rational coefficients (ascending) and get its degree.
+    let p_poly = expr_to_qpoly(p_expr, var, pool)?;
+    let coeffs: Vec<f64> = p_poly.iter().map(|r| r.to_f64()).collect();
+    let deg = coeffs.len().checked_sub(1)?;
+    if deg != 3 && deg != 4 {
+        return None;
+    }
+    let lead = *coeffs.last()?;
+    if lead == 0.0 {
+        return None;
+    }
+
+    // Find all complex roots and classify into real / complex-conjugate pairs.
+    let roots = poly_roots(&coeffs)?;
+    let (mut reals, pairs) = classify_roots(&roots);
+    reals.sort_by(|a, b| b.partial_cmp(a).unwrap()); // descending
+
+    let inv_sqrt_lead = 1.0 / lead.abs().sqrt();
+
+    // Build the candidate reduction (g, m, phi-expr) per case.
+    let cand = match (deg, reals.len(), pairs.len()) {
+        (3, 3, 0) => cubic_three_real(&reals, inv_sqrt_lead, var, pool),
+        (3, 1, 1) => cubic_one_real(reals[0], pairs[0], inv_sqrt_lead, var, pool),
+        (4, 4, 0) => quartic_four_real(&reals, inv_sqrt_lead, var, pool),
+        (4, 2, 1) => quartic_two_real(&reals, pairs[0], inv_sqrt_lead, var, pool),
+        _ => return None, // e.g. all-complex quartic: declined (falls through)
+    }?;
+    let (g, m, phi) = cand;
+
+    // F_cand = (c · g) · EllipticF(phi, m).
+    let m_expr = float_to_expr(m, pool);
+    let f = pool.func("EllipticF", vec![phi, m_expr]);
+    let coeff = float_to_expr(c * g, pool);
+    let f_cand = simplify(pool.mul(vec![coeff, f]), pool).value;
+
+    // Soundness gate: d/dx F_cand = c/√P numerically where P > 0.
+    if verify(f_cand, &coeffs, c, var, pool) {
+        Some(f_cand)
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reduction cases (Byrd & Friedman normal forms)
+// ---------------------------------------------------------------------------
+
+/// Cubic, three real roots `e1 > e2 > e3` (region `x ≥ e1`, where `P > 0` for a
+/// positive leading coefficient): `sin²φ = (e1−e3)/(x−e3)`,
+/// `m = (e2−e3)/(e1−e3)`, `g = −2/√(e1−e3)`.
+fn cubic_three_real(
+    reals: &[f64],
+    inv_sqrt_lead: f64,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(f64, f64, ExprId)> {
+    let (e1, e2, e3) = (reals[0], reals[1], reals[2]);
+    let denom = e1 - e3;
+    if denom <= 0.0 {
+        return None;
+    }
+    let g = -2.0 / denom.sqrt() * inv_sqrt_lead;
+    let m = (e2 - e3) / denom;
+    // φ = arcsin( √( (e1−e3)/(x−e3) ) )
+    let x_minus_e3 = pool.add(vec![var, float_to_expr(-e3, pool)]);
+    let ratio = pool.mul(vec![
+        float_to_expr(e1 - e3, pool),
+        pool.pow(x_minus_e3, pool.integer(-1_i32)),
+    ]);
+    let s = pool.func("sqrt", vec![ratio]);
+    let phi = pool.func("asin", vec![s]);
+    Some((g, m, phi))
+}
+
+/// Cubic, one real root `y1` and a complex pair `b1 ± i·a1` (region `x ≥ y1`):
+/// `A = √((y1−b1)² + a1²)`, `g = 1/√A`, `m = (A + (b1−y1))/(2A)`,
+/// `cos φ = (A − (x−y1))/(A + (x−y1))`.
+fn cubic_one_real(
+    y1: f64,
+    pair: Croot,
+    inv_sqrt_lead: f64,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(f64, f64, ExprId)> {
+    let (b1, a1) = pair;
+    let aa = ((y1 - b1).powi(2) + a1 * a1).sqrt();
+    if aa <= 0.0 {
+        return None;
+    }
+    let g = inv_sqrt_lead / aa.sqrt();
+    let m = (aa + (b1 - y1)) / (2.0 * aa);
+    // cos φ = (A − (x − y1)) / (A + (x − y1)); φ = arccos(...)
+    let x_minus_y1 = pool.add(vec![var, float_to_expr(-y1, pool)]);
+    let num = pool.add(vec![
+        float_to_expr(aa, pool),
+        pool.mul(vec![pool.integer(-1_i32), x_minus_y1]),
+    ]);
+    let den = pool.add(vec![float_to_expr(aa, pool), x_minus_y1]);
+    let cosphi = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+    let phi = pool.func("acos", vec![cosphi]);
+    Some((g, m, phi))
+}
+
+/// Quartic, four real roots `a > b > c > d` (region `c ≤ x ≤ b`, where `P > 0`):
+/// `sn²φ = (b−d)(x−c)/((b−c)(x−d))`, `m = (b−c)(a−d)/((a−c)(b−d))`,
+/// `g = 2/√((a−c)(b−d))`.
+fn quartic_four_real(
+    reals: &[f64],
+    inv_sqrt_lead: f64,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(f64, f64, ExprId)> {
+    let (a, b, c, d) = (reals[0], reals[1], reals[2], reals[3]);
+    let ac = a - c;
+    let bd = b - d;
+    let bc = b - c;
+    if ac <= 0.0 || bd <= 0.0 || bc <= 0.0 {
+        return None;
+    }
+    let g = 2.0 / (ac * bd).sqrt() * inv_sqrt_lead;
+    let m = bc * (a - d) / (ac * bd);
+    // sin²φ = (b−d)(x−c) / ((b−c)(x−d))
+    let x_minus_c = pool.add(vec![var, float_to_expr(-c, pool)]);
+    let x_minus_d = pool.add(vec![var, float_to_expr(-d, pool)]);
+    let num = pool.mul(vec![float_to_expr(bd, pool), x_minus_c]);
+    let den = pool.mul(vec![float_to_expr(bc, pool), x_minus_d]);
+    let ratio = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+    let s = pool.func("sqrt", vec![ratio]);
+    let phi = pool.func("asin", vec![s]);
+    Some((g, m, phi))
+}
+
+/// Quartic, two real roots `b1 > b2` and a complex pair `b3 ± i·a3`
+/// (region `b2 ≤ x ≤ b1`, where `P > 0`):
+/// `A1 = √((b1−b3)² + a3²)`, `A2 = √((b2−b3)² + a3²)`, `g = 1/√(A1·A2)`,
+/// `m = ((A1+A2)² − (b1−b2)²)/(4·A1·A2)`,
+/// `cos φ = ((b1−x)A2 − (x−b2)A1)/((b1−x)A2 + (x−b2)A1)`.
+fn quartic_two_real(
+    reals: &[f64],
+    pair: Croot,
+    inv_sqrt_lead: f64,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<(f64, f64, ExprId)> {
+    let (b1, b2) = (reals[0], reals[1]);
+    let (b3, a3) = pair;
+    let aa1 = ((b1 - b3).powi(2) + a3 * a3).sqrt();
+    let aa2 = ((b2 - b3).powi(2) + a3 * a3).sqrt();
+    if aa1 <= 0.0 || aa2 <= 0.0 {
+        return None;
+    }
+    let g = inv_sqrt_lead / (aa1 * aa2).sqrt();
+    let m = ((aa1 + aa2).powi(2) - (b1 - b2).powi(2)) / (4.0 * aa1 * aa2);
+    // cos φ = ((b1−x)A2 − (x−b2)A1) / ((b1−x)A2 + (x−b2)A1)
+    let b1_minus_x = pool.add(vec![
+        float_to_expr(b1, pool),
+        pool.mul(vec![pool.integer(-1_i32), var]),
+    ]);
+    let x_minus_b2 = pool.add(vec![var, float_to_expr(-b2, pool)]);
+    let t1 = pool.mul(vec![b1_minus_x, float_to_expr(aa2, pool)]);
+    let t2 = pool.mul(vec![x_minus_b2, float_to_expr(aa1, pool)]);
+    let num = pool.add(vec![t1, pool.mul(vec![pool.integer(-1_i32), t2])]);
+    let den = pool.add(vec![t1, t2]);
+    let cosphi = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+    let phi = pool.func("acos", vec![cosphi]);
+    Some((g, m, phi))
+}
+
+// ---------------------------------------------------------------------------
+// Verification gate
+// ---------------------------------------------------------------------------
+
+/// Numerically verify `d/dx F_cand = c/√P` at sample points where `P > 0`.
+fn verify(f_cand: ExprId, coeffs: &[f64], c: f64, var: ExprId, pool: &ExprPool) -> bool {
+    let Ok(df) = crate::diff::diff(f_cand, var, pool) else {
+        return false;
+    };
+    let ds = simplify(df.value, pool).value;
+    // Sample widely; keep only points where P > 0 and both sides are finite reals.
+    let samples = [
+        -3.5, -2.7, -1.6, -0.9, -0.4, 0.15, 0.3, 0.55, 0.7, 0.9, 1.1, 1.4, 1.9, 2.6, 3.4, 4.7,
+    ];
+    let mut checked = 0;
+    for &xv in &samples {
+        let pv = eval_poly(coeffs, xv);
+        if pv <= 1e-6 {
+            continue;
+        }
+        let rhs = c / pv.sqrt();
+        let Some(lhs) = eval(ds, var, xv, pool) else {
+            continue;
+        };
+        if !lhs.is_finite() || !rhs.is_finite() {
+            continue;
+        }
+        if (lhs - rhs).abs() > 1e-7 * (1.0 + rhs.abs()) {
+            return false;
+        }
+        checked += 1;
+    }
+    checked >= 3
+}
+
+// ---------------------------------------------------------------------------
+// Numeric helpers
+// ---------------------------------------------------------------------------
+
+fn is_zero(expr: ExprId, pool: &ExprPool) -> bool {
+    super::poly_utils::is_zero_expr(expr, pool)
+}
+
+/// Evaluate a constant (var-free) expression to `f64`.
+fn eval_const(expr: ExprId, pool: &ExprPool) -> Option<f64> {
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some(n.0.to_f64()),
+        ExprData::Rational(r) => Some(r.0.to_f64()),
+        ExprData::Add(args) => args
+            .iter()
+            .try_fold(0.0, |s, &a| Some(s + eval_const(a, pool)?)),
+        ExprData::Mul(args) => args
+            .iter()
+            .try_fold(1.0, |s, &a| Some(s * eval_const(a, pool)?)),
+        ExprData::Pow { base, exp } => Some(eval_const(base, pool)?.powf(eval_const(exp, pool)?)),
+        _ => None,
+    }
+}
+
+/// Horner evaluation of a polynomial given ascending coefficients.
+fn eval_poly(coeffs: &[f64], x: f64) -> f64 {
+    coeffs.iter().rev().fold(0.0, |acc, &c| acc * x + c)
+}
+
+/// Numeric eval supporting the elementary functions produced by `diff` of the
+/// candidate (`sin`, `cos`, `asin`, `acos`, `sqrt`; the `EllipticF` derivative
+/// is rewritten to the elementary `1/√(1−m·sin²φ)` so no special-function eval
+/// is needed).
+fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> Option<f64> {
+    if expr == x {
+        return Some(xv);
+    }
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some(n.0.to_f64()),
+        ExprData::Rational(r) => Some(r.0.to_f64()),
+        ExprData::Add(args) => args
+            .iter()
+            .try_fold(0.0, |s, &a| Some(s + eval(a, x, xv, pool)?)),
+        ExprData::Mul(args) => args
+            .iter()
+            .try_fold(1.0, |s, &a| Some(s * eval(a, x, xv, pool)?)),
+        ExprData::Pow { base, exp } => Some(eval(base, x, xv, pool)?.powf(eval(exp, x, xv, pool)?)),
+        ExprData::Func { ref name, ref args } if args.len() == 1 => {
+            let v = eval(args[0], x, xv, pool)?;
+            match name.as_str() {
+                "sin" => Some(v.sin()),
+                "cos" => Some(v.cos()),
+                "tan" => Some(v.tan()),
+                "asin" => Some(v.asin()),
+                "acos" => Some(v.acos()),
+                "atan" => Some(v.atan()),
+                "sqrt" => Some(v.sqrt()),
+                "exp" => Some(v.exp()),
+                "log" => Some(v.ln()),
+                "cbrt" => Some(v.cbrt()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Build an `ExprId` for an `f64` value as an exact rational reconstruction of
+/// the float.  Keeping the constant rational (rather than a float literal the
+/// engine has no node for) lets `simplify`/`diff` operate on it cleanly.
+fn float_to_expr(v: f64, pool: &ExprPool) -> ExprId {
+    // Exact small integers stay integer nodes.
+    if v.fract() == 0.0 && v.abs() <= i32::MAX as f64 {
+        return pool.integer(v as i32);
+    }
+    match rug::Rational::from_f64(v) {
+        Some(r) => {
+            let (num, den) = r.into_numer_denom();
+            pool.rational(num, den)
+        }
+        None => pool.integer(0_i32),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Complex root finding (Durand–Kerner) + classification
+// ---------------------------------------------------------------------------
+
+/// Find all complex roots of a polynomial with ascending real coefficients
+/// (degree 3 or 4) via Durand–Kerner iteration.
+fn poly_roots(coeffs: &[f64]) -> Option<Vec<Croot>> {
+    let n = coeffs.len() - 1;
+    if n == 0 {
+        return Some(vec![]);
+    }
+    let lead = *coeffs.last()?;
+    // Monic normalized coefficients, ascending.
+    let mono: Vec<f64> = coeffs.iter().map(|&c| c / lead).collect();
+
+    // Initial guesses: powers of the classic Durand–Kerner seed 0.4 + 0.9i.
+    let seed = (0.4_f64, 0.9_f64);
+    let mut z: Vec<Croot> = (0..n).map(|k| cpow(seed, k as i32)).collect();
+
+    for _ in 0..500 {
+        let mut max_delta = 0.0_f64;
+        for i in 0..n {
+            let num = ceval(&mono, z[i]);
+            let mut den = (1.0, 0.0);
+            for j in 0..n {
+                if i != j {
+                    den = cmul(den, csub(z[i], z[j]));
+                }
+            }
+            let delta = cdiv(num, den);
+            z[i] = csub(z[i], delta);
+            let d = (delta.0 * delta.0 + delta.1 * delta.1).sqrt();
+            if d > max_delta {
+                max_delta = d;
+            }
+        }
+        if max_delta < 1e-14 {
+            break;
+        }
+    }
+    Some(z)
+}
+
+/// Classify roots into sorted real roots and complex-conjugate pairs
+/// `(re, |im|)` (one entry per conjugate pair).
+fn classify_roots(roots: &[Croot]) -> (Vec<f64>, Vec<Croot>) {
+    let tol = 1e-7;
+    let mut reals = Vec::new();
+    let mut pairs = Vec::new();
+    let mut used = vec![false; roots.len()];
+    for i in 0..roots.len() {
+        if used[i] {
+            continue;
+        }
+        if roots[i].1.abs() < tol {
+            reals.push(roots[i].0);
+            used[i] = true;
+        } else {
+            // Find the conjugate partner.
+            let mut best = None;
+            let mut best_d = f64::INFINITY;
+            for (j, used_j) in used.iter().enumerate().skip(i + 1) {
+                if *used_j {
+                    continue;
+                }
+                let d = (roots[j].0 - roots[i].0).abs() + (roots[j].1 + roots[i].1).abs();
+                if d < best_d {
+                    best_d = d;
+                    best = Some(j);
+                }
+            }
+            if let Some(j) = best {
+                if best_d < 1e-5 {
+                    pairs.push((roots[i].0, roots[i].1.abs()));
+                    used[i] = true;
+                    used[j] = true;
+                }
+            }
+        }
+    }
+    (reals, pairs)
+}
+
+// Minimal complex arithmetic on `(re, im)` tuples.
+fn cmul(a: Croot, b: Croot) -> Croot {
+    (a.0 * b.0 - a.1 * b.1, a.0 * b.1 + a.1 * b.0)
+}
+fn csub(a: Croot, b: Croot) -> Croot {
+    (a.0 - b.0, a.1 - b.1)
+}
+fn cdiv(a: Croot, b: Croot) -> Croot {
+    let d = b.0 * b.0 + b.1 * b.1;
+    ((a.0 * b.0 + a.1 * b.1) / d, (a.1 * b.0 - a.0 * b.1) / d)
+}
+fn cpow(a: Croot, n: i32) -> Croot {
+    let mut r = (1.0, 0.0);
+    for _ in 0..n {
+        r = cmul(r, a);
+    }
+    r
+}
+/// Horner evaluation of a monic polynomial (ascending coeffs) at a complex point.
+fn ceval(mono: &[f64], z: Croot) -> Croot {
+    let mut acc = (0.0, 0.0);
+    for &c in mono.iter().rev() {
+        acc = cmul(acc, z);
+        acc.0 += c;
+    }
+    acc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    /// Assert `∫ c·dx/√P` emits an `EllipticF` form whose `d/dx` matches the
+    /// integrand at sample points; return the form's display string.
+    fn check_emits(p_expr: ExprId, var: ExprId, c: f64, pool: &ExprPool) -> Option<String> {
+        let zero = pool.integer(0_i32);
+        // b = c / P  ⇒ integrand = b·√P = c/√P.
+        let c_e = float_to_expr(c, pool);
+        let b = pool.mul(vec![c_e, pool.pow(p_expr, pool.integer(-1_i32))]);
+        let f = try_elliptic_output(zero, b, p_expr, var, pool)?;
+        let s = pool.display(f).to_string();
+        assert!(s.contains("EllipticF"), "no EllipticF in {s}");
+        Some(s)
+    }
+
+    #[test]
+    fn cubic_x3_plus_1_emits_ellipticf() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![pool.pow(x, pool.integer(3_i32)), pool.integer(1_i32)]);
+        let s = check_emits(p, x, 1.0, &pool).expect("∫dx/√(x³+1) should emit EllipticF");
+        assert!(s.contains("EllipticF"), "{s}");
+    }
+
+    #[test]
+    fn cubic_three_real_emits_ellipticf() {
+        // x³ − x = x(x−1)(x+1): three real roots.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        check_emits(p, x, 1.0, &pool).expect("∫dx/√(x³−x) should emit EllipticF");
+    }
+
+    #[test]
+    fn quartic_four_real_emits_ellipticf() {
+        // (x²−1)(x²−4) = x⁴ − 5x² + 4: four real roots ±1, ±2.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(4_i32)),
+            pool.mul(vec![pool.integer(-5_i32), pool.pow(x, pool.integer(2_i32))]),
+            pool.integer(4_i32),
+        ]);
+        check_emits(p, x, 1.0, &pool).expect("∫dx/√((x²−1)(x²−4)) should emit EllipticF");
+    }
+
+    #[test]
+    fn quartic_two_real_pair_emits_ellipticf() {
+        // 1 − x⁴ = (1−x²)(1+x²): two real roots ±1, complex pair ±i.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(4_i32))]),
+        ]);
+        check_emits(p, x, 1.0, &pool).expect("∫dx/√(1−x⁴) should emit EllipticF");
+    }
+
+    #[test]
+    fn quintic_declined() {
+        // x⁵+1 is genus-2: no degree-3/4 reduction ⇒ None (caller → NonElementary).
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
+        let zero = pool.integer(0_i32);
+        let b = pool.pow(p, pool.integer(-1_i32));
+        assert!(try_elliptic_output(zero, b, p, x, &pool).is_none());
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -23,6 +23,7 @@
 mod alg_tower;
 pub(super) mod decompose;
 pub mod elliptic;
+pub mod elliptic_output;
 pub mod find_order;
 pub mod genus1_log;
 pub(super) mod genus_zero;
@@ -276,6 +277,24 @@ fn integrate_via_decompose(
             log = log.merge(simplified.log);
             log.push(RewriteStep::simple(
                 "genus1_elliptic_log",
+                expr,
+                simplified.value,
+            ));
+            return Ok(DerivedExpr::with_log(simplified.value, log));
+        }
+
+        // PR2: first-kind elliptic-integral *output*.  When the integrand is the
+        // pure first-kind shape `∫ c·dx/√P` with `P` a genus-1 cubic/quartic that
+        // the genus-1 log capstone above proved non-elementary, emit the Legendre
+        // normal-form `c·g·EllipticF(φ(x), m)`.  Gated by numeric `d/dx F =
+        // integrand` verification inside `try_elliptic_output`, so it returns
+        // `None` (falling through to the `NonElementary` path) unless the closed
+        // form is verified — never a wrong answer.
+        if let Some(f) = elliptic_output::try_elliptic_output(a_part, b_part, p_expr, var, pool) {
+            let simplified = simplify(f, pool);
+            log = log.merge(simplified.log);
+            log.push(RewriteStep::simple(
+                "genus1_elliptic_firstkind_output",
                 expr,
                 simplified.value,
             ));
@@ -709,20 +728,159 @@ mod tests {
         );
     }
 
-    /// `∫ dx/√(x³+1)` is a first-kind elliptic integral — non-elementary; the
-    /// public engine must still report `NonElementary` (the capstone's verify gate
-    /// declines, falling through to the genus-≥1 shortcut).
+    /// `∫ dx/√(x³+1)` is a first-kind elliptic integral.  **PR2**: the genus-1
+    /// log capstone proves it non-elementary, then the first-kind elliptic-output
+    /// reduction (`elliptic_output::try_elliptic_output`) emits the Legendre
+    /// normal form `c·EllipticF(φ(x), m)`.  We assert the result contains
+    /// `EllipticF` and that its symbolic `d/dx` numerically matches the integrand
+    /// `1/√(x³+1)` where `x³+1 > 0`.  (Previously this test asserted
+    /// `NonElementary`; PR1 added the primitive, PR2 wires the output.)
     #[test]
-    fn genus1_first_kind_non_elementary_via_engine() {
+    fn genus1_first_kind_emits_ellipticf_via_engine() {
         let pool = ExprPool::new();
         let x = pool.symbol("x", Domain::Real);
         let x3p1 = pool.add(vec![pool.pow(x, pool.integer(3_i32)), pool.integer(1_i32)]);
         let sq = pool.func("sqrt", vec![x3p1]);
         let integrand = pool.pow(sq, pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("∫dx/√(x³+1) should emit a first-kind EllipticF form");
+        let f = res.value;
+        assert!(
+            pool.display(f).to_string().contains("EllipticF"),
+            "expected EllipticF in {}",
+            pool.display(f)
+        );
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        let mut checked = 0;
+        for &xv in &[0.5_f64, 1.0, 2.0, 3.0] {
+            // x³+1 > 0 for these.
+            let lhs = eval_ell(df, x, xv, &pool).unwrap();
+            let rhs = 1.0 / (xv * xv * xv + 1.0).sqrt();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}\n  F = {}",
+                pool.display(f)
+            );
+            checked += 1;
+        }
+        assert!(checked >= 3);
+    }
+
+    /// `∫ dx/√(x³−x)` (three real roots) — also reduces to a first-kind
+    /// `EllipticF` form, verified by `d/dx F = integrand` on `x > 1` (`x³−x > 0`).
+    #[test]
+    fn genus1_three_real_emits_ellipticf_via_engine() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let integrand = pool.pow(sq, pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("∫dx/√(x³−x) should emit EllipticF");
+        let f = res.value;
+        assert!(
+            pool.display(f).to_string().contains("EllipticF"),
+            "{}",
+            pool.display(f)
+        );
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[1.2_f64, 2.0, 4.0] {
+            let lhs = eval_ell(df, x, xv, &pool).unwrap();
+            let rhs = 1.0 / (xv * xv * xv - xv).sqrt();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}"
+            );
+        }
+    }
+
+    /// `∫ dx/√(1−x⁴)` (two real roots + complex pair) — first-kind quartic
+    /// reduction, verified on `|x| < 1` (`1−x⁴ > 0`).
+    #[test]
+    fn genus1_quartic_emits_ellipticf_via_engine() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // 1 − x⁴.
+        let p = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(4_i32))]),
+        ]);
+        let sq = pool.func("sqrt", vec![p]);
+        let integrand = pool.pow(sq, pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("∫dx/√(1−x⁴) should emit EllipticF");
+        let f = res.value;
+        assert!(
+            pool.display(f).to_string().contains("EllipticF"),
+            "{}",
+            pool.display(f)
+        );
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[-0.8_f64, -0.2, 0.3, 0.8] {
+            let lhs = eval_ell(df, x, xv, &pool).unwrap();
+            let rhs = 1.0 / (1.0 - xv.powi(4)).sqrt();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}"
+            );
+        }
+    }
+
+    /// `∫ dx/√(x⁵+1)` is genus-2 (quintic): no first-kind cubic/quartic
+    /// reduction applies, so the engine still soundly reports `NonElementary`.
+    #[test]
+    fn quintic_first_kind_still_non_elementary_via_engine() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![pool.pow(x, pool.integer(5_i32)), pool.integer(1_i32)]);
+        let sq = pool.func("sqrt", vec![p]);
+        let integrand = pool.pow(sq, pool.integer(-1_i32));
         let res = crate::integrate::engine::integrate(integrand, x, &pool);
         assert!(
             matches!(res, Err(IntegrationError::NonElementary(_))),
-            "∫dx/√(x³+1) must be NonElementary, got {res:?}"
+            "∫dx/√(x⁵+1) must stay NonElementary, got {res:?}"
         );
+    }
+
+    /// Numeric eval that also handles `sin`/`cos`/`asin`/`acos` so the symbolic
+    /// `d/dx` of an `EllipticF` form (which rewrites to elementary terms) can be
+    /// sampled.  Extends the `sqrt`/`log`/`exp`/`cbrt`-only `eval` above.
+    fn eval_ell(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> Option<f64> {
+        if expr == x {
+            return Some(xv);
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => Some(n.0.to_f64()),
+            ExprData::Rational(r) => Some(r.0.to_f64()),
+            ExprData::Add(args) => args
+                .iter()
+                .try_fold(0.0, |s, &a| Some(s + eval_ell(a, x, xv, pool)?)),
+            ExprData::Mul(args) => args
+                .iter()
+                .try_fold(1.0, |s, &a| Some(s * eval_ell(a, x, xv, pool)?)),
+            ExprData::Pow { base, exp } => {
+                Some(eval_ell(base, x, xv, pool)?.powf(eval_ell(exp, x, xv, pool)?))
+            }
+            ExprData::Func { ref name, ref args } if args.len() == 1 => {
+                let v = eval_ell(args[0], x, xv, pool)?;
+                match name.as_str() {
+                    "sin" => Some(v.sin()),
+                    "cos" => Some(v.cos()),
+                    "tan" => Some(v.tan()),
+                    "asin" => Some(v.asin()),
+                    "acos" => Some(v.acos()),
+                    "atan" => Some(v.atan()),
+                    "sqrt" => Some(v.sqrt()),
+                    "log" => Some(v.ln()),
+                    "exp" => Some(v.exp()),
+                    "cbrt" => Some(v.cbrt()),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
     }
 }

--- a/tests/test_elliptic_integrate.py
+++ b/tests/test_elliptic_integrate.py
@@ -1,0 +1,119 @@
+"""PR2: first-kind elliptic-integral *output* for genus-1 radicands.
+
+`∫ c·dx/√(P(x))` with `P` a cubic or quartic that is non-elementary reduces to
+an incomplete elliptic integral of the first kind in Legendre normal form,
+`c·g·EllipticF(φ(x), m)` (Mathematica `m = k²` convention).  The engine emits
+this only when its internal numeric `d/dx F = integrand` gate passes, so the
+returned form is always verifiable.
+
+Each test asserts `EllipticF` appears in the rendered antiderivative and that
+its symbolic derivative numerically matches the integrand `1/√P` at points
+where `P > 0` (so both sides are real).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from alkahest import ExprPool, diff, integrate, sqrt
+
+# The closed forms use `asin`/`acos`, which the native `eval_expr`/`interval_eval`
+# do not support; evaluate the derivative tree directly via the `node()` API.
+_UNARY = {
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "sqrt": math.sqrt,
+    "exp": math.exp,
+    "log": math.log,
+    "cbrt": lambda v: math.copysign(abs(v) ** (1.0 / 3.0), v),
+}
+
+
+def _num_eval(expr, xv):
+    """Recursively evaluate *expr* at ``x = xv`` using the node() reflection API."""
+    n = expr.node()
+    tag = n[0]
+    if tag == "symbol":
+        return xv
+    if tag == "integer":
+        return float(int(n[1]))
+    if tag == "rational":
+        return float(int(n[1])) / float(int(n[2]))
+    if tag == "add":
+        return sum(_num_eval(a, xv) for a in n[1])
+    if tag == "mul":
+        prod = 1.0
+        for a in n[1]:
+            prod *= _num_eval(a, xv)
+        return prod
+    if tag == "pow":
+        return _num_eval(n[1], xv) ** _num_eval(n[2], xv)
+    if tag == "func":
+        name, args = n[1], n[2]
+        if name in _UNARY and len(args) == 1:
+            return _UNARY[name](_num_eval(args[0], xv))
+    raise AssertionError(f"cannot evaluate node {n}")
+
+
+def _check(pool, x, integrand, p_func, sample_xs):
+    """Integrate, assert EllipticF in the result, and verify d/dx F = integrand."""
+    res = integrate(integrand, x)
+    f = res.value
+    assert "EllipticF" in str(f), f"expected EllipticF, got {f}"
+    d = diff(f, x).value
+    checked = 0
+    for xv in sample_xs:
+        pv = p_func(xv)
+        assert pv > 0, f"sample {xv} not in domain P>0"
+        lhs = _num_eval(d, xv)
+        rhs = 1.0 / math.sqrt(pv)
+        assert abs(lhs - rhs) < 1e-6 * (1.0 + abs(rhs)), (
+            f"x={xv}: d/dx F = {lhs}, integrand = {rhs}\n  F = {f}"
+        )
+        checked += 1
+    assert checked >= 3
+    return f
+
+
+def test_integral_one_over_sqrt_cubic_x3_plus_1():
+    """Headline: ∫ dx/√(x³+1) -> c·EllipticF(φ(x), m) (one real root + pair)."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    p = x**3 + pool.integer(1)
+    integrand = sqrt(p) ** -1
+    _check(pool, x, integrand, lambda v: v**3 + 1.0, [0.5, 1.0, 2.0, 3.0])
+
+
+def test_integral_one_over_sqrt_cubic_three_real():
+    """∫ dx/√(x³−x) -> EllipticF (three real roots), verified on x > 1."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    p = x**3 - x
+    integrand = sqrt(p) ** -1
+    _check(pool, x, integrand, lambda v: v**3 - v, [1.2, 2.0, 4.0])
+
+
+def test_integral_one_over_sqrt_quartic_1_minus_x4():
+    """∫ dx/√(1−x⁴) -> EllipticF (two real roots + complex pair), |x| < 1."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    p = pool.integer(1) - x**4
+    integrand = sqrt(p) ** -1
+    _check(pool, x, integrand, lambda v: 1.0 - v**4, [-0.8, -0.2, 0.3, 0.8])
+
+
+def test_quintic_first_kind_still_non_elementary():
+    """∫ dx/√(x⁵+1) is genus-2: no first-kind reduction, still non-elementary."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    p = x**5 + pool.integer(1)
+    integrand = sqrt(p) ** -1
+    with pytest.raises(Exception) as exc_info:
+        integrate(integrand, x)
+    msg = str(exc_info.value)
+    assert "E-INT-004" in msg or "elementary" in msg.lower() or "NonElementary" in msg


### PR DESCRIPTION
## Summary

PR2 of the elliptic-integral-output stack (**PR1 = #119**, which landed the `EllipticK/E/F/Pi` primitives).

When `∫ c·dx/√(P(x))` with `P` a **cubic or quartic** (genus-1) is proven non-elementary by the existing genus-1 machinery, this PR emits the closed form as an **incomplete elliptic integral of the first kind** in Legendre normal form — `c·g·EllipticF(φ(x), m)` — instead of a bare `NonElementary`.

## The reduction (`algebraic/elliptic_output.rs`)

1. Parse `P`, root-find via Durand–Kerner, classify roots into real / complex-conjugate pairs.
2. Build the Byrd & Friedman case-specific candidate (`m = k²`, matching PR1):
   - **Cubic, 1 real root + complex pair** (e.g. `x³+1`): `cos φ = (A−(x−y₁))/(A+(x−y₁))`, `m = (A+(b₁−y₁))/(2A)`, `g = 1/√A`.
   - **Cubic, 3 real roots** (e.g. `x³−x`): `sin²φ = (e₁−e₃)/(x−e₃)`, `m = (e₂−e₃)/(e₁−e₃)`, `g = −2/√(e₁−e₃)`.
   - **Quartic, 4 real roots**: B&F 254 (`sn²` Möbius).
   - **Quartic, 2 real + complex pair** (e.g. `1−x⁴`): B&F 260 (`cos φ` Möbius).
3. Leading-coefficient scaling via `1/√|a|`.

Wired as a fallback in `integrate_via_decompose`, immediately after the genus-1 log capstone, restricted to the **pure first-kind shape** (`a = 0`, `b = c/P`). Elementary integrals (which resolve earlier) are unaffected.

## Verification gate (soundness)

The reduction constants are **never trusted blindly**. Each candidate's *symbolic* `d/dx` (computed by the engine's `diff`, which differentiates `EllipticF` through the primitive registry to the **elementary** `1/√(1−m·sin²φ)`) is sampled numerically against the integrand `c/√P` at points where `P > 0`. The closed form is emitted **only if the gate passes** (tol ~1e-7, ≥3 points); otherwise it returns `None` and falls through to the existing `NonElementary` path. An imperfect reduction constant can therefore only *decline* — it can never produce a wrong answer.

All-complex-root quartics and genus≥2 radicands (e.g. `∫dx/√(x⁵+1)`) decline and stay `NonElementary`.

## What now emits `EllipticF` vs stays `NonElementary`

- ✅ `∫dx/√(x³+1)` → `c·EllipticF(arccos(…), m)` (headline; d/dx-verified)
- ✅ `∫dx/√(x³−x)`, `∫dx/√(1−x⁴)`, `∫dx/√((x²−1)(x²−4))`
- ❌ `∫dx/√(x⁵+1)` (genus 2), `∫√(x³+1)dx` (2nd/3rd kind), all-complex-root quartic — still `NonElementary`.

## Tests

- Rust: updated the test that asserted `∫dx/√(x³+1)` is `NonElementary` → now asserts the gate-verified `EllipticF` form (plus new three-real-cubic and quartic engine tests, and a guard that `∫dx/√(x⁵+1)` stays `NonElementary`); 5 module unit tests in `elliptic_output.rs`.
- Python: `tests/test_elliptic_integrate.py` — `integrate(1/sqrt(x**3+1), x)` contains `EllipticF` and its `diff` numerically matches the integrand (cubic + quartic cases), plus the quintic `NonElementary` guard.

## Roadmap

Updated `temp-alkahest/planning/risch.md` (status table, MC1 remaining bullet, Open-items + Section B): elliptic-integral output marked **IN PROGRESS** — PR1 (primitives) done, PR2 (first-kind genus-1) done; quintic/genus≥2 and non-first-kind still bare `NonElementary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)