### PR TITLE
feat(integrate): M4 — radical extension as a generic DifferentialField (tower-recursive rational_rde)

### DIFF
--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -82,6 +82,7 @@ pub mod exp_case;
 pub mod log_case;
 pub mod number_field;
 pub mod poly_rde;
+pub mod radical_ext;
 pub mod rational_integrate;
 pub mod rational_rde;
 pub mod simple_radical;

--- a/alkahest-core/src/integrate/risch/radical_ext.rs
+++ b/alkahest-core/src/integrate/risch/radical_ext.rs
@@ -1,0 +1,632 @@
+//! The radical extension `F[y]/(yⁿ − a)` over a generic differential field
+//! `F: DifferentialField`, itself made a [`DifferentialField`] — the Risch
+//! **M4 PR3** core.
+//!
+//! This is what makes the [`DifferentialField`] recursion genuinely
+//! *tower-recursive*: a level may be an **algebraic (radical) extension of any
+//! lower differential field**, and its Risch DE solver descends into the lower
+//! field's solver.  PR2's `integrate_exp_times_radical` was a hand-rolled,
+//! *diagonal-twist* specialization of exactly this algorithm; PR3 lifts it into
+//! one generic place and PR2 now routes through it.
+//!
+//! ## Representation
+//!
+//! An element of the extension is the coefficient vector `[c₀, …, c_{n−1}]` of
+//! the power basis `1, y, …, y^{n−1}` with each `cᵢ ∈ F` (the lower field).  The
+//! defining relation is `yⁿ = a` (the *radical*/*diagonal* case), where the
+//! radicand `a ∈ F`.  Arithmetic is the usual polynomial arithmetic reduced mod
+//! `yⁿ − a`.
+//!
+//! ## Derivation
+//!
+//! The derivation extends `F`'s by the **diagonal twist**
+//!
+//! ```text
+//!   D(y) = (1/n)·(D(a)/a)·y      ⇒      D(yⁱ) = (i/n)·(D(a)/a)·yⁱ,
+//! ```
+//!
+//! so for `u = Σᵢ cᵢ yⁱ`,
+//!
+//! ```text
+//!   D(u) = Σᵢ ( D(cᵢ) + cᵢ·(i/n)·D(a)/a ) yⁱ.
+//! ```
+//!
+//! No reduction mod `yⁿ = a` is needed for the derivation since every `yⁱ`
+//! stays at degree `i < n`.
+//!
+//! ## `rational_rde` — the `f ∈ base` restriction
+//!
+//! [`rational_rde`](DifferentialField::rational_rde) solves `D(u) + f·u = g`.
+//! For the radical case the twist is **diagonal**, so when `f ∈ F` (i.e. `f` is
+//! a base scalar: all its higher `y`-components vanish) multiplication by `f`
+//! preserves the power basis and the system **decouples per component** into
+//!
+//! ```text
+//!   D(uᵢ) + ( f₀ + (i/n)·D(a)/a )·uᵢ = gᵢ      over F,
+//! ```
+//!
+//! each solved by `base.rational_rde(…)` — the M4 descent.  If `f` has any
+//! nonzero higher `y`-component, multiplication-by-`f` *mixes* components and
+//! the system is **not** diagonal; this impl then declines (returns `None`).
+//! This is sound (declining is always allowed) and covers PR2's use, where the
+//! per-component twist `ω = η' + (i/n)D(a)/a` is itself a base scalar plus the
+//! diagonal radical twist.  A full non-diagonal coupled solve is left to PR4.
+//!
+//! `limited_integrate` / `param_log_deriv` remain unimplemented (`None`).
+
+use super::diff_field::DifferentialField;
+
+/// A dense, ascending-degree polynomial over the base field `F` (used internally
+/// by [`RadicalExt::inv`] for the extended-Euclid inversion against `yⁿ − a`).
+type FPoly<F> = Vec<<F as DifferentialField>::Elem>;
+
+/// The radical extension `F[y]/(yⁿ − a)` over a lower differential field `F`,
+/// made a [`DifferentialField`] in its own right.
+///
+/// Elements are coefficient vectors over the power basis `1, y, …, y^{n−1}`;
+/// see the [module docs](self).
+#[derive(Clone, Debug)]
+pub struct RadicalExt<F: DifferentialField> {
+    /// The lower differential field `F`.
+    base: F,
+    /// The radicand `a ∈ F` (`yⁿ = a`).
+    radicand_a: F::Elem,
+    /// The radical degree `n ≥ 1`.
+    n: usize,
+}
+
+impl<F: DifferentialField> RadicalExt<F> {
+    /// Build `F[y]/(yⁿ − a)`.  `n` must be `≥ 1`.
+    pub fn new(base: F, radicand_a: F::Elem, n: usize) -> Self {
+        assert!(n >= 1, "RadicalExt: degree n must be ≥ 1");
+        Self {
+            base,
+            radicand_a,
+            n,
+        }
+    }
+
+    /// The lower field `F`.
+    pub fn base(&self) -> &F {
+        &self.base
+    }
+
+    /// The radical degree `n`.
+    pub fn degree(&self) -> usize {
+        self.n
+    }
+
+    /// The radicand `a`.
+    pub fn radicand(&self) -> &F::Elem {
+        &self.radicand_a
+    }
+
+    /// `D(a)/a` in the lower field — the logarithmic derivative of the radicand,
+    /// the building block of the diagonal twist.  `None` if `a` is zero.
+    fn log_deriv_a(&self) -> Option<F::Elem> {
+        let da = self.base.derivation(&self.radicand_a);
+        let inv_a = self.base.inv(&self.radicand_a)?;
+        Some(self.base.mul(&da, &inv_a))
+    }
+
+    /// The base scalar `m/n ∈ ℚ ⊂ F` (used to scale the twist for component
+    /// `i = m`).  Built from `F::one` via repeated addition and one inversion,
+    /// since [`DifferentialField`] has no `from_i64`.
+    fn base_scalar_ratio(&self, m: usize) -> F::Elem {
+        let num = self.base_int(m as i64);
+        let den = self.base_int(self.n as i64);
+        // n ≥ 1, so den is invertible.
+        let den_inv = self
+            .base
+            .inv(&den)
+            .expect("n ≥ 1 ⇒ nonzero base integer is invertible");
+        self.base.mul(&num, &den_inv)
+    }
+
+    /// Embed an integer into `F` via repeated addition.
+    fn base_int(&self, m: i64) -> F::Elem {
+        let one = self.base.one();
+        let mut acc = self.base.zero();
+        for _ in 0..m.unsigned_abs() {
+            acc = self.base.add(&acc, &one);
+        }
+        if m < 0 {
+            self.base.neg(&acc)
+        } else {
+            acc
+        }
+    }
+
+    /// Trim trailing zero components (canonicalization helper).
+    fn trim(&self, mut v: Vec<F::Elem>) -> Vec<F::Elem> {
+        while v.last().is_some_and(|c| self.base.is_zero(c)) {
+            v.pop();
+        }
+        v
+    }
+
+    /// Reduce an arbitrary `F`-polynomial in `y` (possibly degree ≥ n) modulo
+    /// `yⁿ = a` into a canonical element (length ≤ n).
+    fn reduce(&self, v: &[F::Elem]) -> Vec<F::Elem> {
+        if v.len() <= self.n {
+            return self.trim(v.to_vec());
+        }
+        let mut v = v.to_vec();
+        // Fold high powers down: y^k = a · y^{k-n}.
+        for k in (self.n..v.len()).rev() {
+            let c = v[k].clone();
+            if self.base.is_zero(&c) {
+                continue;
+            }
+            let folded = self.base.mul(&c, &self.radicand_a);
+            let lower = k - self.n;
+            v[lower] = self.base.add(&v[lower], &folded);
+            v[k] = self.base.zero();
+        }
+        v.truncate(self.n);
+        self.trim(v)
+    }
+}
+
+impl<F: DifferentialField> DifferentialField for RadicalExt<F> {
+    /// Coefficient vector `[c₀, …, c_{n−1}]` over the power basis `1,…,y^{n−1}`.
+    type Elem = Vec<F::Elem>;
+
+    fn zero(&self) -> Self::Elem {
+        Vec::new()
+    }
+
+    fn one(&self) -> Self::Elem {
+        vec![self.base.one()]
+    }
+
+    fn add(&self, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+        let len = a.len().max(b.len());
+        let mut r = Vec::with_capacity(len);
+        for i in 0..len {
+            let ai = a.get(i).cloned().unwrap_or_else(|| self.base.zero());
+            let bi = b.get(i).cloned().unwrap_or_else(|| self.base.zero());
+            r.push(self.base.add(&ai, &bi));
+        }
+        self.trim(r)
+    }
+
+    fn sub(&self, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+        let len = a.len().max(b.len());
+        let mut r = Vec::with_capacity(len);
+        for i in 0..len {
+            let ai = a.get(i).cloned().unwrap_or_else(|| self.base.zero());
+            let bi = b.get(i).cloned().unwrap_or_else(|| self.base.zero());
+            r.push(self.base.sub(&ai, &bi));
+        }
+        self.trim(r)
+    }
+
+    fn mul(&self, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+        if a.is_empty() || b.is_empty() {
+            return Vec::new();
+        }
+        let mut raw = vec![self.base.zero(); a.len() + b.len() - 1];
+        for (i, ca) in a.iter().enumerate() {
+            if self.base.is_zero(ca) {
+                continue;
+            }
+            for (j, cb) in b.iter().enumerate() {
+                let p = self.base.mul(ca, cb);
+                raw[i + j] = self.base.add(&raw[i + j], &p);
+            }
+        }
+        self.reduce(&raw)
+    }
+
+    fn neg(&self, a: &Self::Elem) -> Self::Elem {
+        self.trim(a.iter().map(|c| self.base.neg(c)).collect())
+    }
+
+    /// `a⁻¹` via the extended Euclidean algorithm in `F[y]` against the modulus
+    /// `yⁿ − a`.  `None` if `a` is zero or a zero divisor.
+    fn inv(&self, a: &Self::Elem) -> Option<Self::Elem> {
+        let a = self.trim(a.to_vec());
+        if a.is_empty() {
+            return None;
+        }
+        // Modulus m(y) = yⁿ − a (length n+1).
+        let mut modulus = vec![self.base.zero(); self.n + 1];
+        modulus[0] = self.base.neg(&self.radicand_a);
+        modulus[self.n] = self.base.one();
+        let (g, s, _t) = self.fpoly_ext_gcd(&a, &modulus);
+        // gcd must be a (nonzero) unit in F (degree 0) for an inverse to exist.
+        if g.len() != 1 || self.base.is_zero(&g[0]) {
+            return None;
+        }
+        let g_inv = self.base.inv(&g[0])?;
+        let s = self.fpoly_scale(&s, &g_inv);
+        Some(self.reduce(&s))
+    }
+
+    fn is_zero(&self, a: &Self::Elem) -> bool {
+        self.trim(a.to_vec()).is_empty()
+    }
+
+    fn eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool {
+        let a = self.trim(a.to_vec());
+        let b = self.trim(b.to_vec());
+        a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| self.base.eq(x, y))
+    }
+
+    /// `D(Σᵢ cᵢ yⁱ) = Σᵢ ( D(cᵢ) + cᵢ·(i/n)·D(a)/a ) yⁱ` — the diagonal twist.
+    fn derivation(&self, a: &Self::Elem) -> Self::Elem {
+        if a.is_empty() {
+            return Vec::new();
+        }
+        let lda = match self.log_deriv_a() {
+            Some(v) => v,
+            None => {
+                // a = 0: y is undefined; fall back to the base derivation of the
+                // constant term only.
+                let mut out = vec![self.base.zero(); a.len()];
+                if let Some(c0) = a.first() {
+                    out[0] = self.base.derivation(c0);
+                }
+                return self.trim(out);
+            }
+        };
+        let mut out = Vec::with_capacity(a.len());
+        for (i, ci) in a.iter().enumerate() {
+            let dci = self.base.derivation(ci);
+            if i == 0 {
+                out.push(dci);
+            } else {
+                let scale = self.base_scalar_ratio(i); // i/n
+                let twist = self.base.mul(ci, &self.base.mul(&scale, &lda));
+                out.push(self.base.add(&dci, &twist));
+            }
+        }
+        self.trim(out)
+    }
+
+    /// Solve `D(u) + f·u = g` over the radical extension, **diagonal case only**.
+    ///
+    /// Requires `f ∈ F` (the base): only its `1`-component may be nonzero.  Then
+    /// the system decouples per `y`-power into
+    /// `D(uᵢ) + (f₀ + (i/n)·D(a)/a)·uᵢ = gᵢ` over `F`, each solved by the lower
+    /// field's [`rational_rde`](DifferentialField::rational_rde).  Returns
+    /// `None` (declines) when `f` has any nonzero higher component (the
+    /// non-diagonal case, deferred to PR4) or when any component is unsolvable.
+    ///
+    /// The assembled candidate is **verified in-field** (`D(u) + f·u = g`)
+    /// before being returned, mirroring PR1's verification discipline.
+    fn rational_rde(&self, f: &Self::Elem, g: &Self::Elem) -> Option<Self::Elem> {
+        // f ∈ base: every higher component must be zero.
+        let f_trim = self.trim(f.to_vec());
+        if f_trim.len() > 1 {
+            return None; // non-diagonal multiplication — declined (PR4)
+        }
+        let f0 = f_trim
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| self.base.zero());
+
+        let lda = self.log_deriv_a()?; // D(a)/a; needs a ≠ 0
+
+        let g = self.trim(g.to_vec());
+        let mut u = vec![self.base.zero(); g.len()];
+        for (i, gi) in g.iter().enumerate() {
+            if self.base.is_zero(gi) {
+                continue;
+            }
+            // ωᵢ = f₀ + (i/n)·D(a)/a.
+            let omega = if i == 0 {
+                f0.clone()
+            } else {
+                let scale = self.base_scalar_ratio(i);
+                let twist = self.base.mul(&scale, &lda);
+                self.base.add(&f0, &twist)
+            };
+            let ui = self.base.rational_rde(&omega, gi)?; // M4 descent
+            u[i] = ui;
+        }
+        let u = self.trim(u);
+
+        // In-field verification: D(u) + f·u = g.
+        let lhs = self.add(&self.derivation(&u), &self.mul(f, &u));
+        if self.eq(&lhs, &g) {
+            Some(u)
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Small F[y] (dense, ascending) polynomial helpers for `inv`.
+// These operate on *unreduced* polynomials over the base field F.
+// ---------------------------------------------------------------------------
+
+impl<F: DifferentialField> RadicalExt<F> {
+    fn fpoly_trim(&self, mut p: Vec<F::Elem>) -> Vec<F::Elem> {
+        while p.last().is_some_and(|c| self.base.is_zero(c)) {
+            p.pop();
+        }
+        p
+    }
+
+    fn fpoly_degree(&self, p: &[F::Elem]) -> i64 {
+        let mut d = p.len() as i64 - 1;
+        while d >= 0 && self.base.is_zero(&p[d as usize]) {
+            d -= 1;
+        }
+        d
+    }
+
+    fn fpoly_scale(&self, p: &[F::Elem], s: &F::Elem) -> Vec<F::Elem> {
+        if self.base.is_zero(s) {
+            return Vec::new();
+        }
+        self.fpoly_trim(p.iter().map(|c| self.base.mul(c, s)).collect())
+    }
+
+    fn fpoly_sub(&self, a: &[F::Elem], b: &[F::Elem]) -> Vec<F::Elem> {
+        let n = a.len().max(b.len());
+        let mut r = Vec::with_capacity(n);
+        for i in 0..n {
+            let ai = a.get(i).cloned().unwrap_or_else(|| self.base.zero());
+            let bi = b.get(i).cloned().unwrap_or_else(|| self.base.zero());
+            r.push(self.base.sub(&ai, &bi));
+        }
+        self.fpoly_trim(r)
+    }
+
+    fn fpoly_mul(&self, a: &[F::Elem], b: &[F::Elem]) -> Vec<F::Elem> {
+        if a.is_empty() || b.is_empty() {
+            return Vec::new();
+        }
+        let mut r = vec![self.base.zero(); a.len() + b.len() - 1];
+        for (i, ca) in a.iter().enumerate() {
+            if self.base.is_zero(ca) {
+                continue;
+            }
+            for (j, cb) in b.iter().enumerate() {
+                let p = self.base.mul(ca, cb);
+                r[i + j] = self.base.add(&r[i + j], &p);
+            }
+        }
+        self.fpoly_trim(r)
+    }
+
+    /// Long division `a = q·b + r`, `deg r < deg b`, over `F[y]`.
+    fn fpoly_divrem(&self, a: &[F::Elem], b: &[F::Elem]) -> (Vec<F::Elem>, Vec<F::Elem>) {
+        let b = self.fpoly_trim(b.to_vec());
+        let bd = self.fpoly_degree(&b);
+        debug_assert!(bd >= 0, "division by zero polynomial");
+        let lc_inv = self
+            .base
+            .inv(&b[bd as usize])
+            .expect("nonzero leading coefficient of a field element is invertible");
+        let mut r = self.fpoly_trim(a.to_vec());
+        let ad = self.fpoly_degree(&r);
+        if ad < bd {
+            return (Vec::new(), r);
+        }
+        let mut q = vec![self.base.zero(); (ad - bd + 1) as usize];
+        loop {
+            let rd = self.fpoly_degree(&r);
+            if rd < bd {
+                break;
+            }
+            let shift = (rd - bd) as usize;
+            let factor = self.base.mul(&r[rd as usize], &lc_inv);
+            q[shift] = self.base.add(&q[shift], &factor);
+            for (i, bc) in b.iter().enumerate() {
+                let prod = self.base.mul(&factor, bc);
+                r[shift + i] = self.base.sub(&r[shift + i], &prod);
+            }
+            r = self.fpoly_trim(r);
+            if r.is_empty() {
+                break;
+            }
+        }
+        (self.fpoly_trim(q), r)
+    }
+
+    /// Extended GCD over `F[y]`: returns `(g, s, t)` with `s·a + t·b = g`.
+    fn fpoly_ext_gcd(&self, a: &[F::Elem], b: &[F::Elem]) -> (FPoly<F>, FPoly<F>, FPoly<F>) {
+        let (mut old_r, mut r) = (self.fpoly_trim(a.to_vec()), self.fpoly_trim(b.to_vec()));
+        let one = vec![self.base.one()];
+        let (mut old_s, mut s) = (one.clone(), Vec::new());
+        let (mut old_t, mut t) = (Vec::new(), one);
+        while !r.is_empty() {
+            let (q, rem) = self.fpoly_divrem(&old_r, &r);
+            old_r = r;
+            r = rem;
+            let ns = self.fpoly_sub(&old_s, &self.fpoly_mul(&q, &s));
+            old_s = s;
+            s = ns;
+            let nt = self.fpoly_sub(&old_t, &self.fpoly_mul(&q, &t));
+            old_t = t;
+            t = nt;
+        }
+        (old_r, old_s, old_t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrate::risch::alg_field::RatFn;
+    use crate::integrate::risch::diff_field::RationalDiffField;
+    use crate::integrate::risch::poly_rde::QPoly;
+    use crate::integrate::risch::tower_field::{LogTowerField, TExpr};
+    use rug::Rational;
+
+    fn rat(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    fn rf_poly(c: &[i64]) -> RatFn {
+        let p: QPoly = c.iter().map(|&n| rat(n)).collect();
+        RatFn::from_poly(&p)
+    }
+
+    // ---- Arithmetic & derivation over ℚ(x): y = √x  (n = 2, a = x) ----
+
+    /// `RadicalExt<RationalDiffField>` with `y = √x`.
+    fn sqrt_x() -> RadicalExt<RationalDiffField> {
+        RadicalExt::new(RationalDiffField::new(), rf_poly(&[0, 1]), 2)
+    }
+
+    #[test]
+    fn arithmetic_mod_y2_eq_x() {
+        let ext = sqrt_x();
+        // y · y = x.
+        let y = vec![ext.base().zero(), ext.base().one()];
+        let yy = ext.mul(&y, &y);
+        assert!(
+            ext.eq(&yy, &vec![rf_poly(&[0, 1])]),
+            "y² should reduce to x; got {yy:?}"
+        );
+        // (1 + y)² = 1 + 2y + x  = (1 + x) + 2y.
+        let one_plus_y = ext.add(&ext.one(), &y);
+        let sq = ext.mul(&one_plus_y, &one_plus_y);
+        let expected = vec![rf_poly(&[1, 1]), rf_poly(&[2])]; // (1+x) + 2y
+        assert!(ext.eq(&sq, &expected), "got {sq:?}");
+    }
+
+    #[test]
+    fn inverse_of_y_is_y_over_x() {
+        let ext = sqrt_x();
+        let y = vec![ext.base().zero(), ext.base().one()];
+        let inv = ext.inv(&y).expect("y invertible");
+        // y · y⁻¹ = 1.
+        assert!(ext.eq(&ext.mul(&y, &inv), &ext.one()));
+        // y⁻¹ = (1/x)·y.
+        let expected = vec![
+            ext.base().zero(),
+            RatFn::new(vec![rat(1)], vec![rat(0), rat(1)]),
+        ];
+        assert!(ext.eq(&inv, &expected), "got {inv:?}");
+    }
+
+    #[test]
+    fn derivation_of_y_is_half_over_x_times_y() {
+        // D(y) = (1/2)(D(x)/x)·y = (1/(2x))·y.
+        let ext = sqrt_x();
+        let y = vec![ext.base().zero(), ext.base().one()];
+        let dy = ext.derivation(&y);
+        let expected = vec![
+            ext.base().zero(),
+            RatFn::new(vec![rat(1)], vec![rat(0), rat(2)]), // 1/(2x)
+        ];
+        assert!(ext.eq(&dy, &expected), "D(y) should be y/(2x); got {dy:?}");
+    }
+
+    #[test]
+    fn derivation_product_rule_holds() {
+        // Sanity: D(y·y) = D(x) = 1, and product rule D(y)y + yD(y) agrees.
+        let ext = sqrt_x();
+        let y = vec![ext.base().zero(), ext.base().one()];
+        let d_yy = ext.derivation(&ext.mul(&y, &y));
+        assert!(ext.eq(&d_yy, &ext.one()), "D(y²)=D(x)=1; got {d_yy:?}");
+        let dy = ext.derivation(&y);
+        let pr = ext.add(&ext.mul(&dy, &y), &ext.mul(&y, &dy));
+        assert!(ext.eq(&d_yy, &pr), "product rule mismatch");
+    }
+
+    // ---- rational_rde: per-component descent + self-verification ----
+
+    /// Battery: for a target `u` and base scalar `f`, build `g = D(u) + f·u`,
+    /// then assert `rational_rde(f, g)` recovers a solution verifying the RDE.
+    fn check_solvable(ext: &RadicalExt<RationalDiffField>, f: &Vec<RatFn>, u: &Vec<RatFn>) {
+        let g = ext.add(&ext.derivation(u), &ext.mul(f, u));
+        let sol = ext.rational_rde(f, &g).expect("should be solvable");
+        // Self-verify D(sol)+f·sol = g.
+        let lhs = ext.add(&ext.derivation(&sol), &ext.mul(f, &sol));
+        assert!(ext.eq(&lhs, &g), "RDE not satisfied; sol={sol:?}");
+    }
+
+    #[test]
+    fn rde_pure_antiderivative_per_component() {
+        let ext = sqrt_x();
+        let f = ext.zero(); // f = 0  ⇒  D(u) = g
+                            // u = x + x²·y  (component 0 = x, component 1 = x²).
+        let u = vec![rf_poly(&[0, 1]), rf_poly(&[0, 0, 1])];
+        check_solvable(&ext, &f, &u);
+    }
+
+    #[test]
+    fn rde_base_scalar_f() {
+        let ext = sqrt_x();
+        let f = vec![ext.base().one()]; // f = 1 ∈ base
+        let u = vec![rf_poly(&[0, 1]), rf_poly(&[1])]; // x + 1·y
+        check_solvable(&ext, &f, &u);
+    }
+
+    #[test]
+    fn rde_unsolvable_component_is_none() {
+        // f = 0, g = (1/x)·1  ⇒  component 0 needs ∫1/x = log x ∉ ℚ(x): None.
+        let ext = sqrt_x();
+        let f = ext.zero();
+        let g = vec![RatFn::new(vec![rat(1)], vec![rat(0), rat(1)])]; // 1/x in comp 0
+        assert!(ext.rational_rde(&f, &g).is_none(), "log x ∉ ℚ(x) ⇒ None");
+    }
+
+    #[test]
+    fn rde_non_base_f_declines() {
+        // f has a nonzero y-component ⇒ non-diagonal ⇒ declined (None).
+        let ext = sqrt_x();
+        let f = vec![ext.base().zero(), ext.base().one()]; // f = y
+        let g = ext.one();
+        assert!(
+            ext.rational_rde(&f, &g).is_none(),
+            "f ∉ base ⇒ declines (PR4 territory)"
+        );
+    }
+
+    // ---- recursion depth: radical over a LOG tower ----
+
+    /// `y = √(x + log x)` over the log tower ℚ(x)(log x): a genuine two-level
+    /// `DifferentialField` (radical-over-transcendental).  Exercises the M4
+    /// descent
+    /// `RadicalExt<LogTowerField>::rational_rde → LogTowerField::rational_rde`.
+    #[test]
+    fn radical_over_log_tower_descent() {
+        // Tower: t = log x, D(t) = 1/x.
+        let dh_over_h = RatFn::new(vec![rat(1)], vec![rat(0), rat(1)]); // 1/x
+        let log_field = LogTowerField::new(dh_over_h);
+        // Radicand a = x + t  (∈ ℚ(x)(t)).
+        let a = {
+            let x = TExpr::from_ratfn(rf_poly(&[0, 1]));
+            <LogTowerField as DifferentialField>::add(&log_field, &x, &TExpr::t())
+        };
+        let ext = RadicalExt::new(log_field.clone(), a, 2);
+
+        // PR2 headline per-component shape: solve D(w) + w = R with target
+        // w = √(x+log x) = 1·y  (component 1 = 1).  Here f = 1 (base scalar).
+        let f = vec![<LogTowerField as DifferentialField>::one(&log_field)];
+        let target = vec![
+            <LogTowerField as DifferentialField>::zero(&log_field),
+            <LogTowerField as DifferentialField>::one(&log_field),
+        ]; // y
+        let g = ext.add(&ext.derivation(&target), &ext.mul(&f, &target));
+        let sol = ext
+            .rational_rde(&f, &g)
+            .expect("radical-over-log descent should solve");
+        assert!(
+            ext.eq(&sol, &target),
+            "recovered w should be y; got {sol:?}"
+        );
+        // In-field verification.
+        let lhs = ext.add(&ext.derivation(&sol), &ext.mul(&f, &sol));
+        assert!(ext.eq(&lhs, &g), "D(w)+f·w=g must hold in-field");
+    }
+
+    #[test]
+    fn stubs_decline() {
+        let ext = sqrt_x();
+        let one = ext.one();
+        assert!(ext
+            .limited_integrate(&one, std::slice::from_ref(&one))
+            .is_none());
+        assert!(ext.param_log_deriv(&one, &one).is_none());
+    }
+}

--- a/alkahest-core/src/integrate/risch/tower_integrate.rs
+++ b/alkahest-core/src/integrate/risch/tower_integrate.rs
@@ -52,6 +52,7 @@ use super::number_field::{
     gdegree, gext_gcd, gpoly_divrem, gpoly_mul, gtrim, CoeffField, Quotient,
 };
 use super::poly_rde::{contains_subexpr, expr_to_qpoly, is_free_of_var, poly_deriv};
+use super::radical_ext::RadicalExt;
 use super::tower::find_generators;
 use super::tower_field::{solve_tower_rde_generic, ExpTowerField, LogTowerField, TExpr};
 
@@ -241,42 +242,37 @@ where
         return None;
     }
 
-    // The quotient ring ℚ(x)(t)[y]/(yⁿ − a).
+    // The quotient ring ℚ(x)(t)[y]/(yⁿ − a) (for decomposing R over the
+    // power basis), and the *same* extension as a generic `DifferentialField`
+    // (for the per-component RDE descent — M4 PR3).
     let a_tx = expr_to_texpr(field, a_expr, var, t_gen, pool)?;
     let mut modulus = vec![<F as CoeffField>::zero(field); n + 1];
     modulus[0] = <F as CoeffField>::neg(field, &a_tx);
     modulus[n] = <F as CoeffField>::one(field);
     let q = Quotient::new(field.clone(), modulus);
+    let ext = RadicalExt::new(field.clone(), a_tx, n);
 
     // Decompose R over the power basis {1, y, …, y^{n−1}}.
     let r_elem = decompose_over_tower_radical(r_expr, n, a_expr, &q, field, var, t_gen, pool)?;
 
-    // a'/a in the tower (for the twist ωᵢ).
-    let a_prime = <F as CoeffField>::derivation(field, &a_tx);
-    let a_inv = <F as CoeffField>::inv(field, &a_tx)?;
-    let log_deriv_a = <F as CoeffField>::mul(field, &a_prime, &a_inv);
-    let eta_prime_tx = TExpr::from_ratfn(eta_prime);
+    // Solve D(w) + η'·w = R over the radical extension in ONE call: the generic
+    // `RadicalExt::rational_rde` (M4 PR3) performs the per-component descent
+    //   D(wᵢ) + (η' + (i/n)·a'/a)·wᵢ = Rᵢ      over ℚ(x)(t)
+    // through `DifferentialField::rational_rde` on the lower field, and
+    // self-verifies the assembled solution in-field.  `f = η'` is a *base*
+    // scalar (the diagonal twist is baked in per component), so this is exactly
+    // the supported `f ∈ base` case.
+    let eta_prime_elem = vec![TExpr::from_ratfn(eta_prime)]; // η' ∈ base, component 0
+    let w_elem =
+        <RadicalExt<F> as DifferentialField>::rational_rde(&ext, &eta_prime_elem, &r_elem)?;
 
-    // Solve D(wᵢ) + (η' + (i/n)·a'/a)·wᵢ = Rᵢ per component, descending one
-    // tower level via the DifferentialField::rational_rde recursion.
+    // Reconstruct F = exp(η)·w from the solution components wᵢ.
     let mut w_terms: Vec<ExprId> = Vec::new();
-    for (i, ri) in r_elem.iter().enumerate() {
-        if <F as CoeffField>::is_zero(field, ri) {
+    for (i, wi) in w_elem.iter().enumerate() {
+        if <F as CoeffField>::is_zero(field, wi) {
             continue;
         }
-        let scale = TExpr::from_ratfn(RatFn::new(
-            vec![Rational::from(i as i64)],
-            vec![Rational::from(n as i64)],
-        ));
-        let twist = <F as CoeffField>::mul(field, &scale, &log_deriv_a);
-        let omega = <F as CoeffField>::add(field, &eta_prime_tx, &twist);
-
-        // M4 recursion: descend to the coefficient field's RDE solver.
-        let wi = DifferentialField::rational_rde(field, &omega, ri)?;
-        if <F as CoeffField>::is_zero(field, &wi) {
-            continue;
-        }
-        let wi_expr = texpr_to_expr(&wi, var, t_gen, pool);
+        let wi_expr = texpr_to_expr(wi, var, t_gen, pool);
         if i == 0 {
             w_terms.push(wi_expr);
         } else {
@@ -1247,6 +1243,64 @@ mod tests {
             assert!(
                 (fv - ev).abs() < 1e-6 * (1.0 + ev.abs()),
                 "x={xv}: F = {fv}, eˣ√(x+log x) = {ev}"
+            );
+        }
+    }
+
+    /// M4 PR3 new nesting case — radical over an *exp* tower (vs the headline's
+    /// *log* tower), demonstrating the same tower-recursive descent now lives in
+    /// the generic `RadicalExt::rational_rde`.
+    ///
+    /// ∫ [ eˣ·√(x+e^{x²}) + eˣ·(1+2x·e^{x²})/(2·√(x+e^{x²})) ] dx
+    ///     = eˣ·√(x+e^{x²}).
+    ///
+    /// Outer transcendental coefficient `eˣ` multiplies a radical
+    /// `y = √(x+e^{x²})` over a *separate, independent* exp tower `e^{x²}`.  The
+    /// twisted Risch DE `D(w)+w = R` over `Quotient<ExpTowerField>` is solved
+    /// per radical component by descending one tower level via
+    /// `ExpTowerField::rational_rde` — through the generic `RadicalExt` impl.
+    #[test]
+    fn exp_times_sqrt_x_plus_exp_x_squared_end_to_end() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let exp_x2 = pool.func("exp", vec![x2]); // e^{x²}
+        let a = pool.add(vec![x, exp_x2]); // x + e^{x²}
+        let y = pool.pow(a, pool.rational(1_i32, 2_i32)); // √(x+e^{x²})
+        let inv_y = pool.pow(a, pool.rational(-1_i32, 2_i32));
+
+        // term1 = eˣ·√(x+e^{x²})
+        let term1 = pool.mul(vec![exp_x, y]);
+        // a' = 1 + 2x·e^{x²};  term2 = eˣ·a'/(2√(x+e^{x²}))
+        let a_prime = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(2_i32), x, exp_x2]),
+        ]);
+        let term2 = pool.mul(vec![exp_x, a_prime, pool.rational(1_i32, 2_i32), inv_y]);
+        let integrand = pool.add(vec![term1, term2]);
+
+        // Direct path integrates.
+        let direct = try_integrate_exp_times_radical_over_tower(integrand, x, &pool);
+        assert!(
+            matches!(direct, Some(Ok(_))),
+            "new exp-tower nesting case should integrate; got {direct:?}"
+        );
+
+        // End-to-end through the public engine.
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(res.is_ok(), "should integrate; got {res:?}");
+        let g = res.unwrap().value;
+
+        // d/dx F = integrand, verified numerically.
+        let ds = simplify(crate::diff::diff(g, x, &pool).unwrap().value, &pool).value;
+        for &xv in &[0.4_f64, 0.8, 1.2] {
+            let lhs = eval(ds, x, xv, &pool).unwrap();
+            let rhs = eval(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, f = {rhs}\n  F = {}",
+                pool.display(g)
             );
         }
     }


### PR DESCRIPTION
## What

M4/MD capstone **PR3**. Makes the radical extension `F[y]/(yⁿ − a)` over **any** `F: DifferentialField` itself a `DifferentialField` (new module `alkahest-core/src/integrate/risch/radical_ext.rs`, `RadicalExt<F>`), so the trait recursion is genuinely **tower-recursive**: a level may be an algebraic (radical) extension of any lower differential field, and its Risch DE solver descends into the lower field's solver. Builds on PR1 (`DifferentialField` trait) and PR2 (multi-generator integrator).

## The generic impl

- **Representation.** Element = coefficient vector `[c₀…c_{n−1}]` over the power basis `1, y, …, y^{n−1}`, each `cᵢ ∈ F`. Modulus `yⁿ = a`, radicand `a ∈ F`.
- **Arithmetic.** `mul` multiplies and reduces mod `yⁿ = a`; `inv` runs extended-Euclid in `F[y]` against `yⁿ − a`. `eq`/`is_zero` route through the trimmed canonical form (no `derive(PartialEq)`, per PR1's note).
- **Derivation** — the diagonal twist `D(y) = (1/n)(D(a)/a)·y`, hence
  `D(Σᵢ cᵢ yⁱ) = Σᵢ (D(cᵢ) + cᵢ·(i/n)·D(a)/a) yⁱ`.

## Per-component descent (`rational_rde`)

Solves `D(u) + f·u = g`. For the diagonal radical case, when `f ∈ base` (only its `1`-component nonzero) the system **decouples per `y`-power** into

```
D(uᵢ) + (f₀ + (i/n)·D(a)/a)·uᵢ = gᵢ      over F,
```

each solved by `base.rational_rde(…)` — the M4 descent. The assembled candidate is **verified in-field** (`D(u)+f·u=g`) before returning `Some`.

### Documented restriction (option (b))

If `f` has any nonzero higher `y`-component, multiplication-by-`f` *mixes* components (non-diagonal) and `rational_rde` **declines (`None`)**. This is sound (declining is always allowed) and covers PR2's use, where the per-component twist `ω = η' + (i/n)D(a)/a` is itself a base scalar plus the diagonal radical twist. The full non-diagonal coupled solve is deferred to PR4. `limited_integrate`/`param_log_deriv` stay `None` (documented not-implemented).

## PR2 now routes through it

`integrate_exp_times_radical` constructs `RadicalExt::new(field, a, n)`, embeds `η'` as the base scalar `f = [η']`, and the entire per-component loop is replaced by a **single** `RadicalExt::rational_rde` call — the descent algorithm now lives in exactly one place. The **headline stays green** end-to-end:

```
∫[eˣ√(x+log x) + eˣ(1+1/x)/(2√(x+log x))] dx = eˣ√(x+log x)
```

## New nesting case

Radical over an **exp** tower (vs the headline's **log** tower) with two **independent** exp generators, integrates end-to-end (gate-verified):

```
∫[eˣ√(x+e^{x²}) + eˣ(1+2x·e^{x²})/(2√(x+e^{x²}))] dx = eˣ√(x+e^{x²})
```

## Soundness

Numeric `d/dx F = integrand` gate (reused from PR2) **plus** the in-field RDE self-check inside `rational_rde`. Never ships a wrong answer; declining is always fine.

## Additive / no regression

`cargo test --workspace` green (997 lib tests); `cargo clippy -p alkahest-cas --all-targets -- -D warnings`, `cargo fmt`, and `RUSTDOCFLAGS="-D warnings" cargo doc` all clean. Example-15 `∛(x+eˣ)`, `∫(1/3)(1+1/x)(x+log x)^{−2/3}`, single-generator exp/log, and elliptic/genus paths unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added radical extension support for algebraic field operations in integration.
  * Extended integration capabilities for nested exponential-radical expressions.

* **Refactor**
  * Optimized tower integration handling for radical expressions using improved algorithmic structure.

* **Tests**
  * Added comprehensive test coverage for radical arithmetic operations and multi-generator integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->