### PR TITLE
feat(integrate): non-diagonal f — generalize coupled algebraic Risch DE to f ∈ ℚ(x)(α)

### DIFF
--- a/alkahest-core/src/integrate/risch/alg_field.rs
+++ b/alkahest-core/src/integrate/risch/alg_field.rs
@@ -337,15 +337,19 @@ impl AlgExtension {
 // slice/Vec plumbing is just `&a[..]`).  `derivation` reuses the `−qₓ/q_y`
 // rule already implemented here.
 //
-// `rational_rde` mirrors `RadicalExt`'s **`f ∈ base` restriction**: the
-// underlying coupled solver `solve_alg_rde` takes `f: RatFn` (a base scalar in
-// ℚ(x)), so when `f` is a base scalar (only its constant `y⁰` component is
-// nonzero) we extract that `RatFn` and call `solve_alg_rde`; otherwise we
-// decline (`None`).  `solve_alg_rde` self-verifies in-field, and we
+// `rational_rde` handles an **arbitrary** `f ∈ E` — base scalar *or* a general
+// extension element carrying `y`-powers (the *non-diagonal* coupled case).  It
+// calls the generalized solver `solve_alg_rde_general`, which builds the same
+// `ℚ`-linear ansatz system but multiplies by the full extension `f` (mixing the
+// power basis — the genuine coupling) and collects denominators across every
+// component of `f`.  `solve_alg_rde_general` self-verifies in-field, and we
 // additionally re-verify `D(y)+f·y=g` through the trait's own ops
-// (defense-in-depth) before returning `Some`.
+// (defense-in-depth) before returning `Some`.  The historical `f ∈ base`
+// restriction is thereby lifted.  (`RadicalExt`'s *generic* non-diagonal case
+// over an arbitrary lower differential field remains future work — see
+// `radical_ext.rs`.)
 
-use super::alg_rde::solve_alg_rde;
+use super::alg_rde::solve_alg_rde_general;
 use super::diff_field::DifferentialField;
 
 impl DifferentialField for AlgExtension {
@@ -391,32 +395,20 @@ impl DifferentialField for AlgExtension {
         AlgExtension::derivation(self, a)
     }
 
-    /// Solve `D(y) + f·y = g` over `ℚ(x)(α)` for **`f ∈ base`** (a scalar in
-    /// `ℚ(x)`), wrapping the general coupled solver `solve_alg_rde`.
+    /// Solve `D(y) + f·y = g` over `ℚ(x)(α)` for an **arbitrary** `f ∈ ℚ(x)(α)`
+    /// (base scalar *or* non-diagonal extension element), wrapping the
+    /// generalized coupled solver `solve_alg_rde_general`.
     ///
-    /// Mirrors [`RadicalExt`](super::radical_ext::RadicalExt)'s restriction: the
-    /// underlying solver only accepts `f: RatFn`, so when `f`'s only nonzero
-    /// power-basis component is the constant `y⁰` term we extract that `RatFn`
-    /// and solve; if `f` carries any higher `y`-power (`f ∉ base`) we decline
-    /// (`None`).  Declining is always sound.
+    /// The historical `f ∈ base` restriction is lifted: when `f` carries
+    /// `y`-powers, multiplication-by-`f` mixes the power basis and the system is
+    /// genuinely coupled, which the ansatz solver handles directly.
     ///
-    /// `solve_alg_rde` verifies its candidate in-field; we re-verify
+    /// `solve_alg_rde_general` verifies its candidate in-field; we re-verify
     /// `D(y)+f·y=g` through the trait's own ops as defense-in-depth before
     /// returning `Some`.  `None` therefore means "no solution found within the
-    /// ansatz bounds (or `f ∉ base`)", not a non-existence certificate.
+    /// ansatz bounds", not a non-existence certificate.
     fn rational_rde(&self, f: &AlgElem, g: &AlgElem) -> Option<AlgElem> {
-        // f ∈ base: every component above y⁰ must vanish.
-        let f_red = self.reduce(f);
-        if f_red
-            .iter()
-            .skip(1)
-            .any(|c| !self.quotient.field().is_zero(c))
-        {
-            return None; // f carries y-powers — non-base, declined (future work)
-        }
-        let f_ratfn = f_red.first().cloned().unwrap_or_else(|| RatFn::int(0));
-
-        let y = solve_alg_rde(self, &f_ratfn, g)?;
+        let y = solve_alg_rde_general(self, f, g)?;
 
         // Defense-in-depth: re-verify D(y) + f·y = g via the trait's own ops.
         let lhs = DifferentialField::add(
@@ -691,9 +683,10 @@ mod tests {
 //
 // Equivalence: the trait `rational_rde` must agree exactly with the wrapped
 // coupled solver `solve_alg_rde` for `f ∈ base`, the solution must self-verify
-// in-field, an unsolvable target must yield `None`, and `f ∉ base` must yield
-// `None`.  Field-structure ops (`derivation`, etc.) must match the existing
-// `AlgExtension` methods.
+// in-field, an unsolvable target must yield `None`.  Since PR1 lifted the
+// `f ∈ base` restriction, a constructed-solvable **non-base `f`** must now yield
+// `Some` (previously `None`).  Field-structure ops (`derivation`, etc.) must
+// match the existing `AlgExtension` methods.
 
 #[cfg(test)]
 mod diff_field_impl_tests {
@@ -865,15 +858,39 @@ mod diff_field_impl_tests {
     }
 
     #[test]
-    fn non_base_f_declines() {
-        // f = α (carries a y-power) ⇒ f ∉ base ⇒ trait declines (None),
-        // even though the equation might be solvable.  Soundness: declining ok.
+    fn non_base_f_now_solves() {
+        // PR1: f ∉ base is now solved (was declined).  Take f = 1/(2√x) =
+        // (1/(2x))·α and y = √x = α over ℚ(x)(√x); g = D(y)+f·y must be
+        // recovered with a self-verifying solution through the trait.
+        let e = sqrt_ext();
+        let alpha = e.generator();
+        let f: AlgElem = vec![RatFn::int(0), RatFn::new(poly_one(), vec![rat(0), rat(2)])];
+        let g = DifferentialField::add(
+            &e,
+            &DifferentialField::derivation(&e, &alpha),
+            &DifferentialField::mul(&e, &f, &alpha),
+        );
+        let y = DifferentialField::rational_rde(&e, &f, &g).expect("non-base f now solves");
+        let lhs = DifferentialField::add(
+            &e,
+            &DifferentialField::derivation(&e, &y),
+            &DifferentialField::mul(&e, &f, &y),
+        );
+        assert!(
+            DifferentialField::eq(&e, &lhs, &g),
+            "trait RDE solution must satisfy D(y)+f·y=g; y={y:?}"
+        );
+    }
+
+    #[test]
+    fn non_base_f_unsolvable_declines() {
+        // Non-base f = α but g = 1/x (→ log x ∉ field): still None.  Soundness.
         let e = sqrt_ext();
         let f = e.generator(); // α ∉ base
-        let g = e.one();
+        let g = e.constant(RatFn::new(poly_one(), vec![rat(0), rat(1)])); // 1/x
         assert!(
             DifferentialField::rational_rde(&e, &f, &g).is_none(),
-            "f ∉ base ⇒ declines"
+            "unsolvable non-base case ⇒ None"
         );
     }
 

--- a/alkahest-core/src/integrate/risch/alg_rde.rs
+++ b/alkahest-core/src/integrate/risch/alg_rde.rs
@@ -1,11 +1,14 @@
 //! General coupled twisted-derivation Risch DE over `ℚ(x)(α)` — Risch milestone
 //! **M1-step-2**.
 //!
-//! Solves `D(y) + f·y = g` for `y ∈ ℚ(x)(α)`, where `f ∈ ℚ(x)`, `g ∈ ℚ(x)(α)`,
-//! and `α` is algebraic of degree `d` over `ℚ(x)` given by an [`AlgExtension`]
-//! (M0).  This is the "no new logarithm" mixed integral part: an integrand
-//! `a(x,α)·exp(kη)` whose antiderivative is `v(x,α)·exp(kη)` with
-//! `v ∈ ℚ(x)(α)` and `f = kη'`.
+//! Solves `D(y) + f·y = g` for `y ∈ ℚ(x)(α)`, where `g ∈ ℚ(x)(α)`, `α` is
+//! algebraic of degree `d` over `ℚ(x)` given by an [`AlgExtension`] (M0), and `f`
+//! is **either** a base scalar `∈ ℚ(x)` (the historical *diagonal* entry point
+//! `solve_alg_rde`) **or** a general extension element `∈ ℚ(x)(α)` (the
+//! *non-diagonal* coupled entry point `solve_alg_rde_general`).  This is the
+//! "no new logarithm" mixed integral part: an integrand `a(x,α)·exp(kη)` whose
+//! antiderivative is `v(x,α)·exp(kη)` with `v ∈ ℚ(x)(α)` and `f = kη'` — when `η`
+//! is itself algebraic, `f` is non-base.
 //!
 //! Writing `y = Σⱼ bⱼ(x) αʲ` and substituting into `D(y) + f·y = g` collects, over
 //! the power basis `{1, α, …, α^{d−1}}`, into a **coupled** first-order linear ODE
@@ -40,10 +43,29 @@ use super::rational_rde::{poly_div_exact, poly_gcd};
 /// Max numerator degree tried in the ansatz `bⱼ = pⱼ(x)/Den`.
 const DEG_CAP: usize = 6;
 
-/// Solve `D(y) + f·y = g` for `y ∈ ℚ(x)(α)`, or `None` if no rational solution is
-/// found within the ansatz bounds.  Sound by exact verification — see the module
-/// docs.
+/// Solve `D(y) + f·y = g` for `y ∈ ℚ(x)(α)` with a **base scalar** `f ∈ ℚ(x)`,
+/// or `None` if no rational solution is found within the ansatz bounds.  Sound by
+/// exact verification — see the module docs.
+///
+/// Thin wrapper over [`solve_alg_rde_general`] that lifts the base scalar `f` to
+/// the constant extension element `e.constant(f)`; it preserves the exact
+/// behavior of the historical base-`f` solver for existing callers.
 pub(crate) fn solve_alg_rde(e: &AlgExtension, f: &RatFn, g: &AlgElem) -> Option<AlgElem> {
+    solve_alg_rde_general(e, &e.constant(f.clone()), g)
+}
+
+/// Solve `D(y) + f·y = g` for `y ∈ ℚ(x)(α)` with a **general** `f ∈ ℚ(x)(α)`
+/// (possibly carrying `y`-powers — the *non-diagonal* coupled case), or `None`
+/// if no rational solution is found within the ansatz bounds.
+///
+/// The operator `L(y) = D(y) + f·y` is `ℚ`-linear in the unknown coefficients of
+/// the ansatz `y = Σⱼ (pⱼ(x)/Den) αʲ` regardless of whether `f` is a base scalar
+/// or a general extension element — only the multiplication `f·(·)` and the
+/// denominator collection differ from the base-`f` path.  As in the base case we
+/// assemble an exact `ℚ`-linear system, Gauss-solve it, and **verify
+/// `D(y)+f·y=g` exactly in the field** before returning, so the result is sound
+/// for general `f` automatically.
+pub(crate) fn solve_alg_rde_general(e: &AlgExtension, f: &AlgElem, g: &AlgElem) -> Option<AlgElem> {
     let d = e.degree() as usize;
     if d == 0 {
         return None;
@@ -63,7 +85,7 @@ pub(crate) fn solve_alg_rde(e: &AlgExtension, f: &RatFn, g: &AlgElem) -> Option<
 /// LCM `B` of every `x`-denominator that appears in `D(αʲ)`, `f`, and `g`, then
 /// `B²`, `B³`.  Over-clearing is harmless (the numerator ansatz just needs more
 /// terms); verification guards correctness.
-fn candidate_denominators(e: &AlgExtension, f: &RatFn, g: &AlgElem, d: usize) -> Vec<QPoly> {
+fn candidate_denominators(e: &AlgExtension, f: &AlgElem, g: &AlgElem, d: usize) -> Vec<QPoly> {
     let mut base = poly_one();
     let gen = e.generator();
     for j in 0..d {
@@ -73,7 +95,10 @@ fn candidate_denominators(e: &AlgExtension, f: &RatFn, g: &AlgElem, d: usize) ->
             }
         }
     }
-    base = poly_lcm(&base, f.denom());
+    // f may be a general extension element — LCM every component's denominator.
+    for c in f {
+        base = poly_lcm(&base, c.denom());
+    }
     for c in g {
         base = poly_lcm(&base, c.denom());
     }
@@ -87,7 +112,7 @@ fn candidate_denominators(e: &AlgExtension, f: &RatFn, g: &AlgElem, d: usize) ->
 /// Solve seeking `y = Σⱼ (pⱼ(x)/Den) αʲ` with `deg pⱼ ≤ ncap`, for the fixed `Den`.
 fn solve_with_denominator(
     e: &AlgExtension,
-    f: &RatFn,
+    f: &AlgElem,
     g: &AlgElem,
     den: &QPoly,
     ncap: usize,
@@ -107,11 +132,11 @@ fn solve_with_denominator(
         })
         .collect();
 
-    // L(·) = D(·) + f·(·) applied to each basis element.
-    let f_elem = e.constant(f.clone());
+    // L(·) = D(·) + f·(·) applied to each basis element.  `f` is a general
+    // extension element, so `e.mul(f, m)` mixes the power basis (the coupling).
     let cols: Vec<AlgElem> = elems
         .iter()
-        .map(|m| e.add(&e.derivation(m), &e.mul(&f_elem, m)))
+        .map(|m| e.add(&e.derivation(m), &e.mul(f, m)))
         .collect();
 
     let (matrix, rhs) = extract_linear_system(&cols, g, d);
@@ -127,7 +152,7 @@ fn solve_with_denominator(
     }
 
     // Exact verification: D(y) + f·y == g.
-    let lhs = e.add(&e.derivation(&y), &e.mul(&f_elem, &y));
+    let lhs = e.add(&e.derivation(&y), &e.mul(f, &y));
     if e.elem_eq(&lhs, g) {
         Some(y)
     } else {
@@ -343,5 +368,79 @@ mod tests {
         let g = e.constant(RatFn::new(poly_one(), vec![rat(0), rat(1)]));
         let f = RatFn::int(0);
         assert!(solve_alg_rde(&e, &f, &g).is_none());
+    }
+
+    // -- Non-base (non-diagonal) f: the genuine coupled case --------------
+
+    /// **Non-base `f` over `α = √x`.**  Take `f = 1/(2√x) = (1/(2x))·α` (a
+    /// non-base extension element, the `∫exp(√x)` twist `D(√x)`) and `y = √x`.
+    /// Then `g = D(y) + f·y = (1/(2x))·α + (1/(2x))·α·α = (1/(2x))·α + 1/2`.
+    /// The generalized solver must recover a `y'` with `D(y')+f·y' = g`.
+    #[test]
+    fn nonbase_f_sqrt_coupled() {
+        let e = AlgExtension::radical(2, &vec![rat(0), rat(1)]); // α² = x
+        let alpha = e.generator();
+        // f = (1/(2x))·α   (= 1/(2√x))
+        let f: AlgElem = vec![RatFn::int(0), RatFn::new(poly_one(), vec![rat(0), rat(2)])];
+        // y = √x = α
+        let y_true = alpha.clone();
+        let g = e.add(&e.derivation(&y_true), &e.mul(&f, &y_true));
+        let y = solve_alg_rde_general(&e, &f, &g).expect("non-base f coupled solve");
+        let lhs = e.add(&e.derivation(&y), &e.mul(&f, &y));
+        assert!(e.elem_eq(&lhs, &g), "D(y)+f·y must equal g; y = {y:?}");
+        // And the headline antiderivative is recovered.
+        assert!(e.elem_eq(&y, &y_true), "expected y = √x; got {y:?}");
+    }
+
+    /// **Non-base `f` over `α = ∛x`.**  `f = (1/x)·α²` (a non-base element) and
+    /// `y = x` (a base function, but the equation couples via `f`).
+    /// `g = D(y) + f·y = 1 + (1/x)·α²·x = 1 + α²`.  Solver must recover it.
+    #[test]
+    fn nonbase_f_cbrt_coupled() {
+        let e = AlgExtension::radical(3, &vec![rat(0), rat(1)]); // α³ = x
+                                                                 // f = (1/x)·α²
+        let f: AlgElem = vec![
+            RatFn::int(0),
+            RatFn::int(0),
+            RatFn::new(poly_one(), vec![rat(0), rat(1)]),
+        ];
+        // y = x
+        let y_true = e.constant(RatFn::from_poly(&vec![rat(0), rat(1)]));
+        let g = e.add(&e.derivation(&y_true), &e.mul(&f, &y_true));
+        let y = solve_alg_rde_general(&e, &f, &g).expect("non-base cbrt f coupled solve");
+        let lhs = e.add(&e.derivation(&y), &e.mul(&f, &y));
+        assert!(e.elem_eq(&lhs, &g), "D(y)+f·y must equal g; y = {y:?}");
+        assert!(e.elem_eq(&y, &y_true), "expected y = x; got {y:?}");
+    }
+
+    /// **Wrapper equivalence / regression.**  For a base scalar `f`, the thin
+    /// `solve_alg_rde(e, &f, g)` wrapper must return exactly what
+    /// `solve_alg_rde_general(e, &e.constant(f), g)` returns.
+    #[test]
+    fn base_f_wrapper_matches_general() {
+        let e = AlgExtension::radical(2, &vec![rat(0), rat(1)]); // α² = x
+        let alpha = e.generator();
+        let f = RatFn::new(poly_one(), vec![rat(0), rat(1)]); // 1/x ∈ base
+        let f_elem = e.constant(f.clone());
+        let g = e.add(&e.derivation(&alpha), &e.mul(&f_elem, &alpha));
+        let via_wrapper = solve_alg_rde(&e, &f, &g);
+        let via_general = solve_alg_rde_general(&e, &f_elem, &g);
+        match (&via_wrapper, &via_general) {
+            (Some(a), Some(b)) => assert!(e.elem_eq(a, b), "wrapper vs general differ"),
+            (None, None) => {}
+            _ => panic!("wrapper vs general disagree on solvability"),
+        }
+        assert!(via_wrapper.is_some(), "base-f case should solve");
+    }
+
+    /// **Unsolvable non-base `f`.**  With `f = α` (non-base) and `g = 1/x`
+    /// (whose antiderivative would be `log x ∉ ℚ(x)(α)`), there is no rational
+    /// `y` — the generalized solver must return `None`, never a wrong answer.
+    #[test]
+    fn nonbase_f_unsolvable_returns_none() {
+        let e = AlgExtension::radical(2, &vec![rat(0), rat(1)]); // α² = x
+        let f = e.generator(); // α (non-base)
+        let g = e.constant(RatFn::new(poly_one(), vec![rat(0), rat(1)])); // 1/x
+        assert!(solve_alg_rde_general(&e, &f, &g).is_none());
     }
 }

--- a/alkahest-core/src/integrate/risch/radical_ext.rs
+++ b/alkahest-core/src/integrate/risch/radical_ext.rs
@@ -47,10 +47,18 @@
 //!
 //! each solved by `base.rational_rde(…)` — the M4 descent.  If `f` has any
 //! nonzero higher `y`-component, multiplication-by-`f` *mixes* components and
-//! the system is **not** diagonal; this impl then declines (returns `None`).
-//! This is sound (declining is always allowed) and covers PR2's use, where the
-//! per-component twist `ω = η' + (i/n)D(a)/a` is itself a base scalar plus the
-//! diagonal radical twist.  A full non-diagonal coupled solve is left to PR4.
+//! the system is **not** diagonal; this **generic** `RadicalExt<F>` impl then
+//! declines (returns `None`).  This is sound (declining is always allowed) and
+//! covers PR2's use, where the per-component twist
+//! `ω = η' + (i/n)D(a)/a` is itself a base scalar plus the diagonal radical
+//! twist.
+//!
+//! A full non-diagonal coupled solve over an *arbitrary* lower field `F`
+//! remains future work for the generic `RadicalExt`.  The concrete case that
+//! the downstream `exp(algebraic)` work needs — `α` algebraic over `ℚ(x)` — is
+//! instead handled by [`AlgExtension`](super::alg_field::AlgExtension)'s
+//! `DifferentialField::rational_rde`, which routes non-base `f` through the
+//! generalized ansatz solver `solve_alg_rde_general`.
 //!
 //! `limited_integrate` / `param_log_deriv` remain unimplemented (`None`).
 


### PR DESCRIPTION
## Summary

PR1 of "non-diagonal `f`" — generalize the coupled algebraic Risch-DE solver `D(y)+f·y=g` over `ℚ(x)(α)` to a **non-base `f ∈ ℚ(x)(α)`**, lifting the historical `f ∈ base` restriction in `AlgExtension::rational_rde`.

The non-diagonal case is the genuine coupled system `b' + M·b = c`, where multiplication-by-`f` mixes the power-basis components. The undetermined-coefficient ansatz machinery already handles this: `L(·)=D(·)+f·(·)` is ℚ-linear in the unknowns regardless of whether `f` is base or carries `y`-powers — only the scalar-vs-extension multiplication and the denominator collection differ.

## What changed

**`alg_rde.rs` — the generalized solver**
- New `pub(crate) fn solve_alg_rde_general(e: &AlgExtension, f: &AlgElem, g: &AlgElem) -> Option<AlgElem>`. Identical to the old solver except:
  - `solve_with_denominator` uses `f: &AlgElem` directly (`e.mul(f, m)`, which mixes the power basis — the coupling) instead of constructing `e.constant(f)`;
  - `candidate_denominators` LCMs the denominators of **every component** of `f` (loop over `f`'s `RatFn` components) instead of just `f.denom()`.
- `solve_alg_rde(e, f: &RatFn, g)` is kept as a thin wrapper `= solve_alg_rde_general(e, &e.constant(f), g)`, so the `exp_case.rs` callers are unaffected.
- The ansatz, `extract_linear_system`, `gauss_solve`, and the **exact in-field verification `D(y)+f·y=g`** are unchanged.

**`alg_field.rs` — lifted trait restriction**
- `impl DifferentialField for AlgExtension`: `rational_rde(f, g)` now calls `solve_alg_rde_general(self, f, g)` for **arbitrary `f ∈ E`** (the base-only extraction is dropped). The defense-in-depth in-field re-verification of `D(y)+f·y=g` via the trait's own ops is kept.

**`radical_ext.rs` — deferred (documented)**
- `RadicalExt<F>`'s **generic** non-diagonal case over an arbitrary lower differential field `F` remains future work (still `f ∈ base`). The concrete `AlgExtension`-over-`ℚ(x)` path is what the follow-up needs; the docs now point there.

## Soundness

Unchanged: the solver's **exact in-field verification of `D(y)+f·y=g` before returning** makes any `Some` correct; a too-small ansatz bound yields `None`, never a wrong antiderivative. The verification keeps it sound for general `f` automatically.

## Tests

- Non-base-`f` coupled solves, self-verified in-field: over `α=√x` (headline `f = 1/(2√x) = (1/(2x))·α`, `y=√x`) and `α=∛x`.
- Wrapper equivalence/regression: base-`f` `solve_alg_rde` ⇔ `solve_alg_rde_general(e, &e.constant(f), g)`; unsolvable non-base case → `None`.
- Trait: `AlgExtension::rational_rde` with a non-base `f` now returns `Some` (previously `None`) and self-verifies; an unsolvable non-base case still declines.

No regression: full `cargo test --workspace` green (1014 core lib tests); clippy/fmt/doc clean; compositum / Example-15 / radical-over-tower / elliptic / genus suites untouched.

## Follow-up (PR2, not in this PR)

Wire `∫ R(x,α)·exp(β) dx` with `β` algebraic end-to-end: detect the outer `exp`, compute the twist `f = k·D(β)` as an `AlgElem`, solve via `solve_alg_rde_general`, reconstruct `v·exp(β)`, numeric-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Risch differential equation solver to handle arbitrary elements in algebraic extensions.

* **Tests**
  * Added comprehensive test coverage for coupled differential equation cases with non-base field elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->