### PR TITLE
feat(integrate): non-diagonal f for RadicalExt over ℚ(x) (coupled_radical_rde hook)

### DIFF
--- a/alkahest-core/src/integrate/risch/diff_field.rs
+++ b/alkahest-core/src/integrate/risch/diff_field.rs
@@ -30,7 +30,8 @@
 //! on top of that scalar structure; it is deliberately a separate trait so that
 //! a level may carry solvers a bare `CoeffField` does not.
 
-use super::alg_field::{RatFn, RationalFunctionField};
+use super::alg_field::{AlgElem, AlgExtension, RatFn, RationalFunctionField};
+use super::alg_rde::solve_alg_rde_general;
 use super::number_field::CoeffField;
 use super::poly_rde::{degree, poly_deriv, trim};
 use super::rational_rde::{
@@ -119,6 +120,28 @@ pub trait DifferentialField {
     /// generous bound (or `None`).
     fn rde_degree_bound(&self, f: &Self::Elem, g: &Self::Elem) -> Option<usize> {
         let _ = (f, g);
+        None
+    }
+
+    /// Solve the *coupled* radical Risch DE `D(u) + f·u = g` over the radical
+    /// extension `yⁿ = a` of THIS field, for a possibly NON-BASE `f`.  `a` is the
+    /// radicand (an element of THIS field); `f`, `g`, and the returned `u` are
+    /// given as coefficient vectors `[c₀,…,c_{n−1}]` over the power basis
+    /// `1,y,…,y^{n−1}` (each cᵢ an element of THIS field).
+    ///
+    /// Default: `None` — "this base field has no coupled-radical solver"
+    /// (the caller then declines).  Implemented where the coupled system is
+    /// tractable (e.g. `ℚ(x)` via `AlgExtension` / `solve_alg_rde_general`).
+    /// Returns `None` for unsolvable/out-of-scope inputs; a `Some` need not be
+    /// pre-verified (the caller re-verifies in-field).
+    fn coupled_radical_rde(
+        &self,
+        n: usize,
+        a: &Self::Elem,
+        f: &[Self::Elem],
+        g: &[Self::Elem],
+    ) -> Option<Vec<Self::Elem>> {
+        let _ = (n, a, f, g);
         None
     }
 
@@ -262,6 +285,58 @@ impl DifferentialField for RationalDiffField {
         };
 
         Some(numerator_degree_bound(deg_b, deg_c, deg_e, deg_f) + deg_bf as usize)
+    }
+
+    /// Coupled radical RDE over `ℚ(x)`: solve `D(u) + f·u = g` in the radical
+    /// extension `yⁿ = a` for a possibly non-base `f`, by bridging to the proven
+    /// coupled solver `solve_alg_rde_general` over an `AlgExtension`.
+    ///
+    /// Requires the radicand `a` to be a polynomial (its canonical denominator is
+    /// the monic constant `1`); otherwise returns `None`.  Builds
+    /// `AlgExtension::radical(n, a.numer())` (so `α = a^{1/n}` with the same
+    /// diagonal derivation twist `D(α) = (1/n)(a'/a)α` as `RadicalExt`), maps the
+    /// power-basis coefficient vectors `f`, `g` (each `&[RatFn]`, padded/truncated
+    /// to length `n`) to `AlgElem`, runs the coupled solver, and maps the result
+    /// back to a length-`n` `Vec<RatFn>`.  `n < 2` returns `None`
+    /// (`AlgExtension::radical` needs degree ≥ 2; the degenerate `n = 1` case has
+    /// no `y`-coupling anyway).  The caller re-verifies in-field.
+    fn coupled_radical_rde(
+        &self,
+        n: usize,
+        a: &RatFn,
+        f: &[RatFn],
+        g: &[RatFn],
+    ) -> Option<Vec<RatFn>> {
+        if n < 2 {
+            return None;
+        }
+        // Radicand must be a polynomial: canonical denominator is monic, so a
+        // constant denominator is exactly `[1]` (poly_one).
+        if degree(a.denom()) != 0 {
+            return None;
+        }
+        let ext = AlgExtension::radical(n, a.numer());
+
+        // Pad/truncate a power-basis coefficient vector to length `n`, then reduce
+        // mod `yⁿ − a` into an `AlgElem`.
+        let to_alg = |v: &[RatFn]| -> AlgElem {
+            let mut comps = vec![RatFn::int(0); n];
+            for (i, c) in v.iter().take(n).enumerate() {
+                comps[i] = c.clone();
+            }
+            ext.reduce(&comps)
+        };
+
+        let f_alg = to_alg(f);
+        let g_alg = to_alg(g);
+        let u_alg = solve_alg_rde_general(&ext, &f_alg, &g_alg)?;
+
+        // Map the AlgElem (length ≤ n) back to a length-n power-basis vector.
+        let mut u = vec![RatFn::int(0); n];
+        for (i, c) in u_alg.into_iter().take(n).enumerate() {
+            u[i] = c;
+        }
+        Some(u)
     }
 }
 

--- a/alkahest-core/src/integrate/risch/radical_ext.rs
+++ b/alkahest-core/src/integrate/risch/radical_ext.rs
@@ -45,20 +45,31 @@
 //!   D(uᵢ) + ( f₀ + (i/n)·D(a)/a )·uᵢ = gᵢ      over F,
 //! ```
 //!
-//! each solved by `base.rational_rde(…)` — the M4 descent.  If `f` has any
-//! nonzero higher `y`-component, multiplication-by-`f` *mixes* components and
-//! the system is **not** diagonal; this **generic** `RadicalExt<F>` impl then
-//! declines (returns `None`).  This is sound (declining is always allowed) and
-//! covers PR2's use, where the per-component twist
-//! `ω = η' + (i/n)D(a)/a` is itself a base scalar plus the diagonal radical
-//! twist.
+//! each solved by `base.rational_rde(…)` — the M4 descent.  This diagonal
+//! fast-path is kept unchanged (it is correct and cheaper) and covers PR2's
+//! use, where the per-component twist `ω = η' + (i/n)D(a)/a` is itself a base
+//! scalar plus the diagonal radical twist.
 //!
-//! A full non-diagonal coupled solve over an *arbitrary* lower field `F`
-//! remains future work for the generic `RadicalExt`.  The concrete case that
-//! the downstream `exp(algebraic)` work needs — `α` algebraic over `ℚ(x)` — is
-//! instead handled by [`AlgExtension`](super::alg_field::AlgExtension)'s
-//! `DifferentialField::rational_rde`, which routes non-base `f` through the
-//! generalized ansatz solver `solve_alg_rde_general`.
+//! ### Non-diagonal `f` — the coupled case
+//!
+//! If `f` has any nonzero higher `y`-component, multiplication-by-`f` *mixes*
+//! components and the system is **not** diagonal: it becomes a genuinely
+//! coupled linear system `b' + M·b = c` over `F`.  Rather than always
+//! declining, this impl now delegates to the base field's
+//! [`coupled_radical_rde`](DifferentialField::coupled_radical_rde) hook (gather
+//! `f`, `g` as length-`n` component vectors over `F`, call the hook, then
+//! re-verify `D(u)+f·u=g` exactly in-field before accepting).  The hook's
+//! declining default means a base field with no coupled solver still declines
+//! (`None`).
+//!
+//! The tractable, proven slice is the **radical-over-`ℚ(x)`** base case:
+//! [`RationalDiffField`](super::diff_field::RationalDiffField)'s
+//! `coupled_radical_rde` bridges to an [`AlgExtension`](super::alg_field::AlgExtension)
+//! and runs the coupled solver `solve_alg_rde_general` (whose derivation matches
+//! `RadicalExt`'s diagonal twist, so the bridge is sound; it is verification-
+//! gated regardless).  Tower bases (`ExpTowerField`/`LogTowerField`) keep the
+//! declining default — the fully-generic coupled solve over an arbitrary
+//! transcendental tower remains future work.
 //!
 //! `limited_integrate` / `param_log_deriv` remain unimplemented (`None`).
 
@@ -173,6 +184,41 @@ impl<F: DifferentialField> RadicalExt<F> {
         }
         v.truncate(self.n);
         self.trim(v)
+    }
+
+    /// Coupled (non-diagonal) `D(u) + f·u = g` solve for a non-base `f`, via the
+    /// base field's [`coupled_radical_rde`](DifferentialField::coupled_radical_rde)
+    /// hook.  Gathers `f` and `g` as length-`n` component vectors over `F`, calls
+    /// the hook, and — like the diagonal fast-path — **verifies `D(u) + f·u = g`
+    /// in-field** before returning.  Returns `None` if the base field has no
+    /// coupled solver (the default), the hook finds no solution, or verification
+    /// fails; so a `Some` is always correct.
+    fn coupled_nondiagonal_rde(&self, f: &[F::Elem], g: &[F::Elem]) -> Option<Vec<F::Elem>> {
+        // Component vectors of length n over F (pad with base zeros).
+        let comps = |v: &[F::Elem]| -> Vec<F::Elem> {
+            let mut out = vec![self.base.zero(); self.n];
+            for (i, c) in v.iter().take(self.n).enumerate() {
+                out[i] = c.clone();
+            }
+            out
+        };
+        let f_comps = comps(f);
+        let g_comps = comps(g);
+
+        let u = self
+            .base
+            .coupled_radical_rde(self.n, &self.radicand_a, &f_comps, &g_comps)?;
+        let u = self.trim(u);
+
+        // In-field verification: D(u) + f·u = g (mirrors the diagonal path).
+        let f_elem = f.to_vec();
+        let g_elem = self.trim(g.to_vec());
+        let lhs = self.add(&self.derivation(&u), &self.mul(&f_elem, &u));
+        if self.eq(&lhs, &g_elem) {
+            Some(u)
+        } else {
+            None
+        }
     }
 }
 
@@ -293,22 +339,33 @@ impl<F: DifferentialField> DifferentialField for RadicalExt<F> {
         self.trim(out)
     }
 
-    /// Solve `D(u) + f·u = g` over the radical extension, **diagonal case only**.
+    /// Solve `D(u) + f·u = g` over the radical extension.
     ///
-    /// Requires `f ∈ F` (the base): only its `1`-component may be nonzero.  Then
-    /// the system decouples per `y`-power into
-    /// `D(uᵢ) + (f₀ + (i/n)·D(a)/a)·uᵢ = gᵢ` over `F`, each solved by the lower
-    /// field's [`rational_rde`](DifferentialField::rational_rde).  Returns
-    /// `None` (declines) when `f` has any nonzero higher component (the
-    /// non-diagonal case, deferred to PR4) or when any component is unsolvable.
+    /// **Diagonal case (`f ∈ F`, only the `1`-component nonzero):** the system
+    /// decouples per `y`-power into `D(uᵢ) + (f₀ + (i/n)·D(a)/a)·uᵢ = gᵢ` over
+    /// `F`, each solved by the lower field's
+    /// [`rational_rde`](DifferentialField::rational_rde).
     ///
-    /// The assembled candidate is **verified in-field** (`D(u) + f·u = g`)
-    /// before being returned, mirroring PR1's verification discipline.
+    /// **Non-diagonal case (`f` carries higher `y`-powers):** the multiplication
+    /// is coupled; this delegates to the base field's
+    /// [`coupled_radical_rde`](DifferentialField::coupled_radical_rde) hook (the
+    /// `ℚ(x)` impl bridges to `solve_alg_rde_general` over an `AlgExtension`;
+    /// tower bases keep the declining default and so still return `None`).
+    ///
+    /// In both cases the assembled candidate is **verified in-field**
+    /// (`D(u) + f·u = g`) before being returned, mirroring PR1's verification
+    /// discipline; so a `Some` is always correct and `None` means
+    /// declined/not-found.
     fn rational_rde(&self, f: &Self::Elem, g: &Self::Elem) -> Option<Self::Elem> {
         // f ∈ base: every higher component must be zero.
         let f_trim = self.trim(f.to_vec());
         if f_trim.len() > 1 {
-            return None; // non-diagonal multiplication — declined (PR4)
+            // Non-diagonal: multiplication-by-`f` mixes the power basis into a
+            // genuinely coupled system.  Defer to the base field's coupled-radical
+            // solver (the `ℚ(x)` impl bridges to `solve_alg_rde_general` over an
+            // `AlgExtension`; tower bases keep the declining default).  Any
+            // returned candidate is re-verified in-field before being accepted.
+            return self.coupled_nondiagonal_rde(f, g);
         }
         let f0 = f_trim
             .into_iter()
@@ -578,15 +635,70 @@ mod tests {
         assert!(ext.rational_rde(&f, &g).is_none(), "log x ∉ ℚ(x) ⇒ None");
     }
 
+    // ---- non-diagonal f over ℚ(x): coupled solve via the AlgExtension bridge ----
+
+    /// Assert `rational_rde(f, g)` solves the *non-diagonal* (coupled) RDE for a
+    /// non-base `f`, with `g = D(u_true) + f·u_true` constructed in-field, and
+    /// that the returned `u` re-verifies `D(u) + f·u = g`.
+    fn check_nondiag_solvable(
+        ext: &RadicalExt<RationalDiffField>,
+        f: &Vec<RatFn>,
+        u_true: &Vec<RatFn>,
+    ) {
+        // Sanity: f really is non-diagonal (has a higher y-component).
+        assert!(ext.trim(f.clone()).len() > 1, "test f must be non-diagonal");
+        let g = ext.add(&ext.derivation(u_true), &ext.mul(f, u_true));
+        let sol = ext
+            .rational_rde(f, &g)
+            .expect("non-diagonal f over ℚ(x) should now solve");
+        let lhs = ext.add(&ext.derivation(&sol), &ext.mul(f, &sol));
+        assert!(ext.eq(&lhs, &g), "coupled RDE not satisfied; sol={sol:?}");
+    }
+
     #[test]
-    fn rde_non_base_f_declines() {
-        // f has a nonzero y-component ⇒ non-diagonal ⇒ declined (None).
+    fn rde_nondiagonal_f_sqrt_x_solves() {
+        // y = √x (n=2, a=x).  Non-base f = (1/(2x))·y, target u_true = y.
+        // Previously this declined (PR4); now the ℚ(x) coupled hook solves it.
         let ext = sqrt_x();
-        let f = vec![ext.base().zero(), ext.base().one()]; // f = y
+        let inv_2x = RatFn::new(vec![rat(1)], vec![rat(0), rat(2)]); // 1/(2x)
+        let f = vec![ext.base().zero(), inv_2x]; // (1/(2x))·y
+        let u_true = vec![ext.base().zero(), ext.base().one()]; // y
+        check_nondiag_solvable(&ext, &f, &u_true);
+    }
+
+    #[test]
+    fn rde_nondiagonal_f_cbrt_x_solves() {
+        // y = ∛x (n=3, a=x).  Non-base f = (1/(3x))·y, target u_true = y.
+        let ext = RadicalExt::new(RationalDiffField::new(), rf_poly(&[0, 1]), 3);
+        let inv_3x = RatFn::new(vec![rat(1)], vec![rat(0), rat(3)]); // 1/(3x)
+        let f = vec![ext.base().zero(), inv_3x]; // (1/(3x))·y
+        let u_true = vec![ext.base().zero(), ext.base().one()]; // y
+        check_nondiag_solvable(&ext, &f, &u_true);
+    }
+
+    #[test]
+    fn rde_nondiagonal_f_over_tower_base_declines() {
+        // RadicalExt over a LOG tower base: the base field has no coupled-radical
+        // solver (default hook ⇒ None), so a non-diagonal f still declines.  This
+        // documents the remaining hard case (coupled solve over a transcendental
+        // tower).
+        let dh_over_h = RatFn::new(vec![rat(1)], vec![rat(0), rat(1)]); // 1/x
+        let log_field = LogTowerField::new(dh_over_h);
+        // Radicand a = x + log x.
+        let a = {
+            let x = TExpr::from_ratfn(rf_poly(&[0, 1]));
+            <LogTowerField as DifferentialField>::add(&log_field, &x, &TExpr::t())
+        };
+        let ext = RadicalExt::new(log_field.clone(), a, 2);
+        // Non-base f = 1·y (nonzero y-component).
+        let f = vec![
+            <LogTowerField as DifferentialField>::zero(&log_field),
+            <LogTowerField as DifferentialField>::one(&log_field),
+        ];
         let g = ext.one();
         assert!(
             ext.rational_rde(&f, &g).is_none(),
-            "f ∉ base ⇒ declines (PR4 territory)"
+            "tower-base non-diagonal f ⇒ declines (default hook)"
         );
     }
 


### PR DESCRIPTION
## Summary

Lifts the `f ∈ base` (diagonal) restriction in `RadicalExt::rational_rde` for the tractable, proven **radical-over-ℚ(x)** base case. Previously, any `f` carrying higher `y`-powers (the genuinely *coupled* / non-diagonal case) was declined (`None`); now it is solved through a new base-field hook, while tower bases honestly keep declining.

## Base-field hook design

New trait method on `DifferentialField` with a declining default:

```rust
fn coupled_radical_rde(
    &self, n: usize, a: &Self::Elem, f: &[Self::Elem], g: &[Self::Elem],
) -> Option<Vec<Self::Elem>> { let _ = (n, a, f, g); None }
```

Solves the coupled radical RDE `D(u) + f·u = g` over the extension `yⁿ = a` of THIS field, for a possibly non-base `f`. `a` is the radicand; `f`, `g`, and the returned `u` are power-basis coefficient vectors `[c₀,…,c_{n−1}]` over THIS field. Default `None` = "no coupled solver at this level". A `Some` need not be pre-verified — the caller re-verifies in-field.

## ℚ(x) → AlgExtension bridge

`RationalDiffField` (`Elem = RatFn`) implements the hook:
- Requires the radicand `a` to be a polynomial (its canonical denominator is monic, so a constant denom is exactly `[1]`); else `None`.
- Builds `AlgExtension::radical(n, a.numer())` — `α = a^{1/n}` with derivation `D(α) = (1/n)(a'/a)α`, matching `RadicalExt`'s diagonal twist, so the bridge is sound (and verification-gated regardless).
- Maps `f`/`g` (each `&[RatFn]`, padded/truncated to length `n`) to `AlgElem`, runs the proven coupled solver `solve_alg_rde_general`, and maps the result back to a length-`n` `Vec<RatFn>`.
- `n < 2` returns `None` (radical needs degree ≥ 2; `n = 1` has no coupling).

Tower fields (`ExpTowerField`/`LogTowerField`) and `AlgExtension` keep the declining default.

## What `RadicalExt::rational_rde` now does for non-diagonal `f`

Instead of `return None`, it gathers `f` and `g` as length-`n` component vectors over `F`, calls `self.base.coupled_radical_rde(self.n, &self.radicand_a, …)`, then — exactly like the diagonal fast-path — **verifies `D(u) + f·u = g` in-field** via the trait's own ops before accepting. On verification failure or a `None` hook result it declines. The diagonal fast-path is unchanged (correct and cheaper).

## Newly solves vs still declines

- **Newly solves:** non-diagonal `f` over `RadicalExt<RationalDiffField>` (headline `√x` and `∛x` cases).
- **Still declines:** tower bases (`RadicalExt<ExpTowerField>` / `<LogTowerField>`) — the fully-generic coupled solve over an arbitrary transcendental tower is the remaining hard case (documented).

## Verification gate

Unchanged soundness discipline: the assembled `u` is re-verified exactly in-field before return, and `solve_alg_rde_general` self-verifies, so a `Some` is always correct; `None` = declined/not-found. No wrong answers.

## Tests

- `rde_nondiagonal_f_sqrt_x_solves` — `n=2, a=x`, `f=(1/(2x))·y`, recovers/verifies (previously declined).
- `rde_nondiagonal_f_cbrt_x_solves` — `n=3, a=x` non-diagonal case.
- `rde_nondiagonal_f_over_tower_base_declines` — `RadicalExt<LogTowerField>` non-diagonal `f` still returns `None`.
- Diagonal regressions (`rde_base_scalar_f`, per-component, log-tower descent) unchanged.

`cargo fmt`, `cargo clippy -p alkahest-cas --all-targets -- -D warnings`, `cargo test -p alkahest-cas` (1032 passed), `RUSTDOCFLAGS="-D warnings" cargo doc -p alkahest-cas --no-deps --lib`, and `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the differential field solver to support coupled radical differential equations, significantly expanding the solver's ability to handle complex equations involving radical field extensions.

* **Tests**
  * Added test coverage verifying correct handling of coupled radical differential equations across multiple extension scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->