### PR TITLE
feat(playground): clear notebook + calculus starter demo

### DIFF
--- a/demo-playground/README.md
+++ b/demo-playground/README.md
@@ -83,7 +83,7 @@ Pushes to `main` under `demo-playground/` deploy automatically via `.github/work
 
 ## Notebook mode
 
-The default view is a notebook with two starter cells — one using alkahest, one using SymPy for comparison.
+The default view is a starter notebook with markdown sections and code cells covering simplification, differentiation, integration, and trigonometric identities (`demos/default_notebook.py`). Use **Clear notebook** in the toolbar to reset to a single empty code cell.
 
 - **⌘ Enter** — run focused cell
 - **Run all** — execute all cells top-to-bottom

--- a/demo-playground/demos/default_notebook.py
+++ b/demo-playground/demos/default_notebook.py
@@ -1,0 +1,60 @@
+# Default starter notebook for the Alkahest demo playground.
+# Cells are delimited by "# ---" for use with the record CLI:
+#
+#   npx tsx cli/src/index.ts record --code demos/default_notebook.py --output out.webm
+
+## Alkahest playground
+
+Symbolic math in Python: simplify, differentiate, integrate, and more.
+Run cells with **⌘/Ctrl+Enter**.
+
+# ---
+
+import alkahest as ak
+from alkahest import latex, sin, cos, exp, simplify, simplify_trig, diff, integrate
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+two = pool.integer(2)
+three = pool.integer(3)
+
+# ---
+
+## Simplification
+
+# ---
+
+r = simplify(x + pool.integer(0))
+print("x + 0 = $$" + latex(r.value) + "$$")
+print(f"({len(r.steps)} rewrite steps)")
+
+# ---
+
+## Differentiation
+
+# ---
+
+expr = x**three * sin(x)
+r = diff(expr, x)
+print("\\frac{d}{dx}(x^3 \\sin x) = $$" + latex(r.value) + "$$")
+
+# ---
+
+## Integration
+
+# ---
+
+r = integrate(exp(two * x), x)
+print("\\int e^{2x}\\,dx = $$" + latex(r.value) + "$$")
+
+r2 = integrate(cos(x), x)
+print("\\int \\cos x\\,dx = $$" + latex(r2.value) + "$$")
+
+# ---
+
+## Trigonometric identities
+
+# ---
+
+r = simplify_trig(sin(x)**2 + cos(x)**2)
+print("\\sin^2 x + \\cos^2 x = $$" + latex(r.value) + "$$")

--- a/demo-playground/web/src/components/notebook/Notebook.tsx
+++ b/demo-playground/web/src/components/notebook/Notebook.tsx
@@ -24,6 +24,7 @@ import { connectionFromConfig } from '@/lib/server-connection';
 import { isStaticHosting } from '@/lib/hosting';
 import { parseNotebookFile } from '@/lib/notebook-import';
 import { cellsFromDemoParam, readAutoRunFromUrl, readHideLineNumbersFromUrl } from '@/lib/recording';
+import { DEFAULT_NOTEBOOK_CELLS } from '@/lib/default-notebook';
 
 // ── State ──────────────────────────────────────────────────────────────────
 
@@ -123,26 +124,13 @@ function reducer(state: CellData[], action: Action): CellData[] {
   }
 }
 
-// Avoid JS template literals for Python code that contains ${} — use string concat instead
-const INITIAL_CELLS: CellData[] = [
-  newCell(
-    'import alkahest as ak\n' +
-    'from alkahest import latex\n' +
-    'from playground_helpers import display_lean_cert\n\n' +
-    'pool = ak.ExprPool()\n' +
-    'x = pool.symbol("x")\n' +
-    'zero = pool.integer(0)\n\n' +
-    'expr = x + zero\n' +
-    'result = ak.simplify(expr)\n' +
-    'print("simplify(x + 0) = $$" + latex(result.value) + "$$")\n' +
-    'print(result.derivation)\n' +
-    'display_lean_cert(result, operation="simplify")\n',
-  ),
-];
+const INITIAL_CELLS: CellData[] = DEFAULT_NOTEBOOK_CELLS.map(({ code, cellType }) =>
+  newCell(code, cellType),
+);
 
 function cellFromDemoSource(code: string): CellData {
   const trimmed = code.trimStart();
-  if (trimmed.startsWith('##') || trimmed.startsWith('# Groebner')) {
+  if (trimmed.startsWith('##')) {
     return newCell(code, 'markdown');
   }
   return newCell(code, 'code');
@@ -681,6 +669,23 @@ export default function Notebook({
     return () => window.removeEventListener('keydown', onKeyDown, true);
   }, [zenMode, addCodeCellBelow, undoDeleteCell]);
 
+  const handleClearNotebook = useCallback(() => {
+    if (!window.confirm('Clear all cells? This cannot be undone.')) return;
+    interruptAll();
+    execCountRef.current = 0;
+    dispatch({ type: 'CLEAR_EXEC_COUNTS' });
+    const emptyId = uuid();
+    const empty = [newCell('', 'code', emptyId)];
+    dispatch({ type: 'SET_CELLS', cells: empty });
+    localStorage.removeItem(NOTEBOOK_STORAGE_KEY);
+    deletedStack.current = [];
+    setCanUndoDelete(false);
+    isDirtyRef.current = false;
+    onDirtyChangeRef.current?.(false);
+    setFocusedCellId(emptyId);
+    setFocusTargetId(emptyId);
+  }, [interruptAll]);
+
   async function handleWheelUpload(file: File) {
     if (!sessionId) return alert('Server not connected');
     try {
@@ -725,6 +730,16 @@ export default function Notebook({
           Install wheel
           <input type="file" accept=".whl" className="hidden" onChange={(e) => e.target.files?.[0] && handleWheelUpload(e.target.files[0])} />
         </label>
+
+        <button
+          type="button"
+          onClick={handleClearNotebook}
+          title="Remove all cells and start with one empty code cell"
+          className="flex items-center gap-1.5 rounded border border-ak-border px-3 py-1.5 text-xs hover:bg-ak-code-bg transition-colors"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg>
+          Clear notebook
+        </button>
 
         <div className="flex-1" />
       </div>}

--- a/demo-playground/web/src/lib/default-notebook.ts
+++ b/demo-playground/web/src/lib/default-notebook.ts
@@ -1,0 +1,70 @@
+/** Default starter notebook — mirrors demo-playground/demos/default_notebook.py */
+
+export interface DefaultNotebookCell {
+  code: string;
+  cellType: 'code' | 'markdown';
+}
+
+export const DEFAULT_NOTEBOOK_CELLS: DefaultNotebookCell[] = [
+  {
+    cellType: 'markdown',
+    code:
+      '# Alkahest playground\n\n' +
+      'Symbolic math in Python: simplify, differentiate, integrate, and more.\n' +
+      'Run cells with **⌘/Ctrl+Enter**.',
+  },
+  {
+    cellType: 'code',
+    code:
+      'import alkahest as ak\n' +
+      'from alkahest import latex, sin, cos, exp, simplify, simplify_trig, diff, integrate\n\n' +
+      'pool = ak.ExprPool()\n' +
+      'x = pool.symbol("x")\n' +
+      'two = pool.integer(2)\n' +
+      'three = pool.integer(3)\n',
+  },
+  {
+    cellType: 'markdown',
+    code: '## Simplification',
+  },
+  {
+    cellType: 'code',
+    code:
+      'r = simplify(x + pool.integer(0))\n' +
+      'print("x + 0 = $$" + latex(r.value) + "$$")\n' +
+      'print(f"({len(r.steps)} rewrite steps)")\n',
+  },
+  {
+    cellType: 'markdown',
+    code: '## Differentiation',
+  },
+  {
+    cellType: 'code',
+    code:
+      'expr = x**three * sin(x)\n' +
+      'r = diff(expr, x)\n' +
+      'print("\\\\frac{d}{dx}(x^3 \\\\sin x) = $$" + latex(r.value) + "$$")\n',
+  },
+  {
+    cellType: 'markdown',
+    code: '## Integration',
+  },
+  {
+    cellType: 'code',
+    code:
+      'r = integrate(exp(two * x), x)\n' +
+      'print("\\\\int e^{2x}\\,dx = $$" + latex(r.value) + "$$")\n\n' +
+      'r2 = integrate(cos(x), x)\n' +
+      'print("\\\\int \\\\cos x\\,dx = $$" + latex(r2.value) + "$$")\n',
+  },
+  {
+    cellType: 'markdown',
+    code: '## Trigonometric identities',
+  },
+  {
+    cellType: 'code',
+    code:
+      'r = simplify_trig(sin(x)**2 + cos(x)**2)\n' +
+      'print("\\\\sin^2 x + \\\\cos^2 x = $$" + latex(r.value) + "$$")\n',
+  },
+];


### PR DESCRIPTION
## Summary
- Add a **Clear notebook** toolbar button that resets to a single empty code cell (same as deleting all cells)
- Replace the single simplify+Lean starter cell with a multi-section default notebook covering simplification, differentiation, integration, and trig identities
- Add `demos/default_notebook.py` for the record CLI (`# ---` delimited cells)

## Test plan
- [x] Verified default notebook Python cells run against alkahest locally
- [x] Typecheck passes (`pnpm exec tsc --noEmit` in `demo-playground/web`)
- [ ] CI green
- [ ] Manual: open playground, confirm default cells load; click Clear notebook → one empty cell


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Clear notebook" button to reset the notebook to a single empty code cell.
  * Default notebook now includes predefined example cells demonstrating simplification, differentiation, integration, and trigonometric operations.

* **Documentation**
  * Updated README to describe the default notebook's contents and the "Clear notebook" functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->