### PR TITLE
test(integrate): add M3 capstone tests

### DIFF
--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -904,4 +904,74 @@ mod tests {
             _ => None,
         }
     }
+
+    /// **M3 capstone (item 2):** `∫ x dx/√(x³+x)`, the lemniscatic-type
+    /// integral `∫√x/√(x²+1) dx`.  This is a genuine elliptic integral
+    /// (genus-1 curve `y² = x³+x = x(x²+1)`, one real root `x=0`), not
+    /// reducible to elementary functions — but the engine's elliptic-output
+    /// reduction (PR2/PR4) emits a closed `EllipticF`/`EllipticE` form
+    /// (Legendre normal form, `m=1/2`) whose derivative matches the
+    /// integrand. We verify `d/dx F = integrand` numerically over a wide
+    /// range of `x > 0` (where `x³+x > 0`).
+    #[test]
+    fn lemniscatic_emits_elliptic_form_via_engine() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.add(vec![pool.pow(x, pool.integer(3_i32)), x]);
+        let sq = pool.func("sqrt", vec![p]);
+        let integrand = pool.mul(vec![x, pool.pow(sq, pool.integer(-1_i32))]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("∫x dx/√(x³+x) should emit a closed elliptic form");
+        let f = res.value;
+        assert!(
+            pool.display(f).to_string().contains("Elliptic"),
+            "expected an elliptic special-function form in {}",
+            pool.display(f)
+        );
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        let mut checked = 0;
+        for &xv in &[0.05_f64, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 50.0] {
+            let lhs = eval_ell(df, x, xv, &pool).unwrap();
+            let rhs = eval_ell(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}\n  F = {}",
+                pool.display(f)
+            );
+            checked += 1;
+        }
+        assert!(checked >= 6);
+    }
+
+    /// **M3 capstone (item 4):** `∫ dx/((x²−1)√(x²+1))` — the Euler
+    /// substitution `t = x + √(x²+1)` rationalizes the integrand and yields
+    /// an elementary closed form in terms of `log`.  Verified by
+    /// `d/dx F = integrand` numerically.
+    #[test]
+    fn euler_substitution_emits_elementary_log_via_engine() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let x2m1 = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-1_i32)]);
+        let x2p1 = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(1_i32)]);
+        let sq = pool.func("sqrt", vec![x2p1]);
+        let denom = pool.mul(vec![x2m1, sq]);
+        let integrand = pool.pow(denom, pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool)
+            .expect("∫dx/((x²−1)√(x²+1)) should integrate elementarily");
+        let f = res.value;
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        let mut checked = 0;
+        // Avoid x = ±1 (poles of the integrand).
+        for &xv in &[0.3_f64, 2.0, 3.0, -2.0, -0.5] {
+            let lhs = eval_ell(df, x, xv, &pool).unwrap();
+            let rhs = eval_ell(integrand, x, xv, &pool).unwrap();
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}\n  F = {}",
+                pool.display(f)
+            );
+            checked += 1;
+        }
+        assert!(checked >= 4);
+    }
 }


### PR DESCRIPTION
## Summary

Adds the remaining unchecked M3 capstone tests from `temp-alkahest/planning/risch.md` (~line 1443), as Rust integration tests against the public engine entry point `crate::integrate::engine::integrate`.

### Tests added

- **`lemniscatic_emits_elliptic_form_via_engine`** (item 2): `∫ x dx/√(x³+x)` (lemniscatic-type, genus-1 curve `y² = x³+x = x(x²+1)`, one real root). The engine emits a closed `EllipticF`/`EllipticE` form (Legendre normal form, `m=1/2`, via the elliptic-output reduction). Verified `d/dx F = integrand` numerically at 8 sample points across `x ∈ [0.05, 50]` (all where `x³+x > 0`).

- **`euler_substitution_emits_elementary_log_via_engine`** (item 4): `∫ dx/((x²−1)√(x²+1))`. The engine rationalizes via the Euler substitution and returns an elementary closed form in terms of `log`. Verified `d/dx F = integrand` numerically at 5 sample points (avoiding the poles `x = ±1`).

### Already covered (not duplicated)

- **Item 1** — `∫ dx/√(x³+1)`: already covered by `genus1_first_kind_emits_ellipticf_via_engine` (`alkahest-core/src/integrate/algebraic/mod.rs`). As risch.md PR2 documents, the engine now emits a gate-verified `EllipticF` closed form (not `NonElementary`); that test asserts `EllipticF` appears and checks `d/dx F = integrand` at 4 points.

- **Item 3** — constructed 3-torsion residue divisor → elementary `(1/3)·log(u)`: already covered end-to-end through the public engine by `genus1_elliptic_log_via_engine`, which is exactly the documented case `∫[1/(2x) + √(x³+1)/(2x(x³+1))] dx = ⅓·log(√(x³+1) − 1)` on `y² = x³+1` (the `(0,1)` 3-torsion point / Miller function `u = y − 1`).

### Findings

No bugs found — all four behaviors are mathematically correct and gate-verified (no test needed to be marked `#[ignore]`).

## Test plan

- [x] `cargo fmt -p alkahest-cas`
- [x] `cargo clippy -p alkahest-cas --all-targets` — no new warnings
- [x] `cargo test -p alkahest-cas --lib` — 1058 passed, 0 failed, 2 pre-existing ignored
- [x] `cargo test --workspace` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test cases for algebraic integration to verify correctness of elliptic integrands and Euler-substitution elementary cases, ensuring accurate symbolic differentiation and numerical consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->