### PR TITLE
feat(risch): certify NonElementary for entangled K-log coefficients

### DIFF
--- a/alkahest-core/src/integrate/risch/log_case.rs
+++ b/alkahest-core/src/integrate/risch/log_case.rs
@@ -127,6 +127,27 @@ fn integrate_log_poly(
     // ∫ c_n(x)·log(h)^n dx = P_n(x)·log(h)^n − n·∫ P_n(x)·(h'/h)·log(h)^{n-1} dx
     // where P_n is an antiderivative of c_n.
 
+    // §E — NonElementary certificate for entangled K-log coefficients.
+    // Before attempting the IBP, test Bronstein eq (18) on the *top* coefficient
+    // c_n: a necessary condition for ∫ Σ c_k log(h)^k dx to be elementary is that
+    // c_n = v' + (n+1)·e·(h'/h) be solvable for v ∈ K(x) and a constant e.  When
+    // c_n is a genuinely-K-rational coefficient whose partial-fraction poles
+    // include a K-irrational point that is NOT a zero of h (so no constant e can
+    // absorb its residue), eq (18) has no solution and the integral is provably
+    // non-elementary (Bronstein 2005, §5.10 / Tutorial §3.5: "either proving that
+    // (18) has no solution, in which case f has no elementary integral").  The
+    // headline case is ∫ 1/(x+√2)·log(x) dx (dilogarithm pole at x = −√2).
+    if certify_klog_top_obstruction(coeffs, h, var, pool) {
+        return Err(IntegrationError::NonElementary(format!(
+            "∫ Σ c_k·log({})^k dx: the top coefficient has a K-irrational pole \
+             whose residue is not a constant multiple of the tower generator's \
+             logarithmic derivative — Bronstein eq (18) (primitive case) has no \
+             solution, so the integral is non-elementary (dilogarithm-type) \
+             (Bronstein 2005, Symbolic Integration I, §5.10)",
+            pool.display(h)
+        )));
+    }
+
     // Start with the full polynomial and collect terms.
     integrate_log_poly_recursive(coeffs, log_gen, h, var, pool, log)
 }
@@ -496,6 +517,110 @@ fn try_integrate_k_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Optio
     let (v_num, v_den) = solve_rational_rde_k(&field, &k_zero, &c_num, &c_den)?;
 
     Some(build_krational_ext(&v_num, &v_den, var, &ext, pool))
+}
+
+// ---------------------------------------------------------------------------
+// §E — NonElementary certificate for entangled K-log coefficients
+// ---------------------------------------------------------------------------
+
+/// Decide whether the *top* coefficient of the log polynomial obstructs
+/// elementarity by Bronstein's primitive-case eq (18).
+///
+/// Given `∫ Σ_{k=0}^{n} c_k(x)·log(h)^k dx` with `t = log(h)` a logarithmic
+/// monomial over `K(x)` (`K = ℚ(α)` a number field), the integral can be
+/// elementary only if the top coefficient `c_n` admits
+///
+/// ```text
+///     c_n = v' + (n+1)·e·(h'/h),     v ∈ K(x),  e ∈ Const(K)
+/// ```
+/// (Bronstein 2005, *Symbolic Integration I*, §5.10; Tutorial §3.5, eq (18)).
+/// We test exactly this with [`solve_primitive_top_rde_k`]: a `None` means no
+/// `(v, e)` exists, which **proves** the whole integral non-elementary.
+///
+/// **Soundness gates (the certificate fires only when fully justified):**
+/// - **EVERY** coefficient `c_0, …, c_n` must parse as a *genuinely K-rational*
+///   function (no residual transcendental generator) over one detected `ℚ(α)`.
+///   This is the load-bearing gate: eq (18) is a valid necessary condition only
+///   when the integrand is a true polynomial in the single monomial `t = log(h)`
+///   over `K(x)`.  If any coefficient still carries a *second* `log`/`exp`
+///   generator (e.g. the combined integrand
+///   `1/(x+√2)·log(x) + log(x+√2)/x = (log x · log(x+√2))'`, whose `c_0`
+///   coefficient is `log(x+√2)/x`), the single-monomial structure does **not**
+///   hold, eq (18) does not apply, and we return `false` (decline, never
+///   certify).  Without this gate the certificate would wrongly fire on that
+///   *elementary* sum.
+/// - `h'/h` must itself be K-rational (always true for `h ∈ K(x)`); if the parse
+///   fails we decline.
+/// - We require the extension to be *non-trivial* (an actual algebraic α): a pure
+///   `ℚ(x)` coefficient is not detected as an extension, and its log obstruction
+///   is the ordinary rational `Li`/`Ei` case already handled elsewhere.
+///
+/// Returns `true` ⟺ eq (18) is provably unsolvable for the top coefficient
+/// **and** the integrand is a genuine K(x)-polynomial in `t = log(h)`.
+fn certify_klog_top_obstruction(
+    coeffs: &[ExprId],
+    h: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> bool {
+    use super::rational_rde::solve_primitive_top_rde_k;
+
+    // Locate the genuine top degree n and its coefficient c_n.
+    let n = find_top_degree(coeffs, pool);
+    if n == 0 {
+        return false; // degree-0: ordinary base-field integration, not eq (18).
+    }
+    let c_n = simplify(coeffs[n], pool).value;
+    // Strip any algebraic constant factor (e.g. √2·…); the residue structure is
+    // unchanged by a constant scalar, so the obstruction test is unaffected.
+    let (_k_alg, c_n_rest) = split_const_factor(c_n, var, pool);
+
+    // Parse c_n_rest as a rational function over a detected algebraic extension K.
+    let Some(ext) = detect_algebraic_extension(c_n_rest, pool) else {
+        return false; // not an algebraic-extension coefficient → not our case.
+    };
+    let (field, gens) = build_field_and_gens(&ext);
+    let Some((c_num, c_den)) = expr_to_krational_general(c_n_rest, var, &gens, &field, pool) else {
+        return false; // c_n carries a transcendental / foreign term → decline.
+    };
+
+    // GATE: every *lower* coefficient must also be genuinely K-rational over the
+    // same field.  A coefficient that still contains a second transcendental
+    // (e.g. another log) breaks the poly-in-t-over-K(x) structure that eq (18)
+    // relies on — the integral may then be elementary by cancellation across
+    // levels (the `log(x)·log(x+√2)` combined-sum case).  Declining here is the
+    // single most important soundness guard for this certificate.
+    for &ck_raw in &coeffs[..n] {
+        let ck = simplify(ck_raw, pool).value;
+        if is_zero(ck, pool) {
+            continue;
+        }
+        let (_k_alg_k, ck_rest) = split_const_factor(ck, var, pool);
+        if expr_to_krational_general(ck_rest, var, &gens, &field, pool).is_none() {
+            return false; // c_k ∉ K(x): structure invalid → decline.
+        }
+    }
+
+    // Build h'/h as a K-rational function (h ∈ K(x)).
+    let h_prime = match crate::diff::diff(h, var, pool) {
+        Ok(d) => simplify(d.value, pool).value,
+        Err(_) => return false,
+    };
+    if is_zero(h_prime, pool) {
+        return false; // h' = 0 → no drift; not the entangled case.
+    }
+    // h'/h symbolically, then parse numerator/denominator over K.
+    let hph = simplify(
+        pool.mul(vec![h_prime, pool.pow(h, pool.integer(-1_i32))]),
+        pool,
+    )
+    .value;
+    let Some((gd_num, gd_den)) = expr_to_krational_general(hph, var, &gens, &field, pool) else {
+        return false; // h'/h not K-rational (shouldn't happen for h ∈ K(x)).
+    };
+
+    // eq (18): solvable ⇒ Some(..); provably unsolvable ⇒ None ⇒ certify.
+    solve_primitive_top_rde_k(&field, &c_num, &c_den, &gd_num, &gd_den, n as i64).is_none()
 }
 
 // ---------------------------------------------------------------------------
@@ -1253,6 +1378,195 @@ mod tests {
         assert!(
             result.is_ok(),
             "∫ [1/(x+√2)²+1/(x+√2)]·log(x+√2) dx must be elementary; got {result:?}"
+        );
+        verify_numeric_e(integrand, result.unwrap().value, x, &pool);
+    }
+
+    // -----------------------------------------------------------------------
+    // §E — NonElementary certificate for entangled K-log coefficients
+    //      (Bronstein 2005, §5.10 / Tutorial §3.5, eq (18))
+    // -----------------------------------------------------------------------
+
+    /// ∫ 1/(x+√2)·log(x) dx is genuinely non-elementary (dilogarithm): the top
+    /// coefficient 1/(x+√2) has a residue 1 at the K-irrational pole x=−√2,
+    /// which is *not* a zero of the tower argument h=x, so no constant e absorbs
+    /// it in eq (18).  Must now certify NonElementary (was NotImplemented).
+    #[test]
+    fn klog_inv_x_plus_sqrt2_log_x_nonelementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let x_plus_sqrt2 = pool.add(vec![x, sqrt2]);
+        let log_x = pool.func("log", vec![x]);
+        let integrand = pool.mul(vec![pool.pow(x_plus_sqrt2, pool.integer(-1_i32)), log_x]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ 1/(x+√2)·log(x) dx must be certified NonElementary; got {result:?}"
+        );
+    }
+
+    /// Generalisation: 1/(x+√3)·log(x) — same obstruction over K = ℚ(√3).
+    #[test]
+    fn klog_inv_x_plus_sqrt3_log_x_nonelementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt3 = pool.func("sqrt", vec![pool.integer(3_i32)]);
+        let x_plus_sqrt3 = pool.add(vec![x, sqrt3]);
+        let log_x = pool.func("log", vec![x]);
+        let integrand = pool.mul(vec![pool.pow(x_plus_sqrt3, pool.integer(-1_i32)), log_x]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ 1/(x+√3)·log(x) dx must be certified NonElementary; got {result:?}"
+        );
+    }
+
+    /// Const-factored variant √2/(x+√2)·log(x): the algebraic constant factor is
+    /// split off before the obstruction test, which is unchanged; still
+    /// non-elementary.
+    #[test]
+    fn klog_sqrt2_over_x_plus_sqrt2_log_x_nonelementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let x_plus_sqrt2 = pool.add(vec![x, sqrt2]);
+        let log_x = pool.func("log", vec![x]);
+        let integrand = pool.mul(vec![
+            sqrt2,
+            pool.pow(x_plus_sqrt2, pool.integer(-1_i32)),
+            log_x,
+        ]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ √2/(x+√2)·log(x) dx must be certified NonElementary; got {result:?}"
+        );
+    }
+
+    // ----- Adversarial elementary cases: the certificate must NOT fire -----
+
+    /// ∫ 1/(x+√2)²·log(x) dx IS mathematically elementary (double pole at x=−√2
+    /// has zero simple residue; P_1 = −1/(x+√2) is K-rational), so eq (18) is
+    /// solvable (e=0) and the §E certificate correctly does NOT fire.  The engine
+    /// still *declines* this one (NotImplemented) because integrating the IBP base
+    /// term `∫ 1/(x(x+√2)) dx = (1/√2)(log x − log(x+√2))` needs a K-rational
+    /// integrator *with* logarithms, which the base field path lacks — a
+    /// pre-existing gap, NOT introduced here.  The load-bearing invariant is the
+    /// negative: it must NEVER be certified NonElementary.
+    #[test]
+    fn klog_inv_x_plus_sqrt2_sq_log_x_not_nonelementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let x_plus_sqrt2 = pool.add(vec![x, sqrt2]);
+        let log_x = pool.func("log", vec![x]);
+        let integrand = pool.mul(vec![pool.pow(x_plus_sqrt2, pool.integer(-2_i32)), log_x]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            !matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ 1/(x+√2)²·log(x) dx is elementary; must NEVER be NonElementary; got {result:?}"
+        );
+        // If an antiderivative is produced, it must be correct.
+        if let Ok(d) = result {
+            verify_numeric_e(integrand, d.value, x, &pool);
+        }
+    }
+
+    /// ∫ 1/(x+√2)·log(x+√2) dx = ½·log(x+√2)² — the log-derivative case, h=x+√2.
+    /// The residue at x=−√2 IS a zero of h, so eq (18) is solvable (e=1/2).
+    /// (Caught earlier by the log-derivative shortcut; here we re-assert it stays
+    /// elementary even though the coefficient is K-rational with a pole.)
+    #[test]
+    fn klog_inv_x_plus_sqrt2_log_same_arg_elementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let h = pool.add(vec![x, sqrt2]);
+        let log_h = pool.func("log", vec![h]);
+        let integrand = pool.mul(vec![pool.pow(h, pool.integer(-1_i32)), log_h]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            result.is_ok(),
+            "∫ 1/(x+√2)·log(x+√2) dx must stay elementary (=½log²); got {result:?}"
+        );
+        verify_numeric_e(integrand, result.unwrap().value, x, &pool);
+    }
+
+    /// ∫ log(x)/x dx = ½·log(x)² — pure ℚ(x) coefficient, no algebraic extension,
+    /// certificate declines (detect_algebraic_extension returns None).  Elementary.
+    #[test]
+    fn klog_log_x_over_x_elementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let log_x = pool.func("log", vec![x]);
+        let integrand = pool.mul(vec![pool.pow(x, pool.integer(-1_i32)), log_x]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            result.is_ok(),
+            "∫ log(x)/x dx must be elementary (=½log²); got {result:?}"
+        );
+        verify_numeric_e(integrand, result.unwrap().value, x, &pool);
+    }
+
+    /// Adversarial combined sum: ∫ [1/(x+√2)·log(x) + log(x+√2)/x] dx is
+    /// elementary — it equals log(x)·log(x+√2) (the two non-elementary
+    /// dilogarithm halves cancel).  The integrand has TWO log generators, so it
+    /// never reaches the single-generator poly-in-t path with a K-rational top
+    /// coefficient; the §E certificate must NOT fire.  The engine may either
+    /// integrate it (to log·log) or decline — but it must NEVER certify
+    /// NonElementary.  This is the load-bearing safety case.
+    #[test]
+    fn klog_combined_sum_not_nonelementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let x_plus_sqrt2 = pool.add(vec![x, sqrt2]);
+        let log_x = pool.func("log", vec![x]);
+        let log_xps2 = pool.func("log", vec![x_plus_sqrt2]);
+        // 1/(x+√2)·log(x) + (1/x)·log(x+√2)
+        let term1 = pool.mul(vec![pool.pow(x_plus_sqrt2, pool.integer(-1_i32)), log_x]);
+        let term2 = pool.mul(vec![pool.pow(x, pool.integer(-1_i32)), log_xps2]);
+        let integrand = pool.add(vec![term1, term2]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            !matches!(result, Err(IntegrationError::NonElementary(_))),
+            "∫ [1/(x+√2)·log(x) + log(x+√2)/x] dx = log(x)log(x+√2) is ELEMENTARY; \
+             must never be certified NonElementary; got {result:?}"
+        );
+        // If the engine produced an antiderivative, it must be correct.
+        if let Ok(d) = result {
+            verify_numeric_e(integrand, d.value, x, &pool);
+        }
+    }
+
+    /// Adversarial: ∫ (h'/h)·log(h)² with h=x+√2, i.e. 2(x+√2)/(x+√2)²·log²… —
+    /// the standard log-derivative power rule, elementary.  Must not be
+    /// certified: the top coefficient's pole IS a zero of h.
+    #[test]
+    fn klog_log_deriv_power_rule_sqrt2_elementary() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let h = pool.add(vec![x, sqrt2]);
+        let log_h = pool.func("log", vec![h]);
+        // (1/(x+√2))·log(x+√2)² = (h'/h)·t²  → t³/3
+        let integrand = pool.mul(vec![
+            pool.pow(h, pool.integer(-1_i32)),
+            pool.pow(log_h, pool.integer(2_i32)),
+        ]);
+
+        let result = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            result.is_ok(),
+            "∫ (1/(x+√2))·log(x+√2)² dx must be elementary (=log³/3); got {result:?}"
         );
         verify_numeric_e(integrand, result.unwrap().value, x, &pool);
     }

--- a/alkahest-core/src/integrate/risch/rational_rde.rs
+++ b/alkahest-core/src/integrate/risch/rational_rde.rs
@@ -598,6 +598,159 @@ pub fn solve_rational_rde_k(
     Some((num, den))
 }
 
+/// Decide Bronstein eq (18) for the primitive (log) case top coefficient.
+///
+/// For a logarithmic monomial `t = log(b)` over `K(x)` and integrand
+/// `f = Σ fᵢ tⁱ`, the structure theorem (Bronstein 2005, §5.10; *Symbolic
+/// Integration Tutorial* §3.5, eq (18)) requires that the **top** coefficient
+/// `f_d` satisfy
+///
+/// ```text
+///     f_d = v_d' + (d+1)·e·(b'/b),     v_d ∈ K(x),  e ∈ Const(K).
+/// ```
+///
+/// i.e. `∫ f_d dx` is elementary **and** its only new logarithm is a constant
+/// multiple of the tower generator `t = log(b)` itself.  Equation (18) has a
+/// solution iff the affine family `{ f_d − e·g_drift : e ∈ K }` (with
+/// `g_drift = (d+1)·b'/b`) contains a `K(x)`-rational antiderivative — a single
+/// free scalar `e` that can cancel the residue at the zeros/poles of `b`, but
+/// **nothing else**.
+///
+/// This routine returns:
+/// - `Some(Some(e))` — eq (18) is solvable with that constant `e` (so `f_d` does
+///   not by itself obstruct elementarity; the lower coefficients decide the rest);
+/// - `Some(None)`    — `g_drift` is identically zero (degenerate `b' = 0`); falls
+///   back to the plain `e = 0` antidifferentiation decision by the caller;
+/// - `None`          — eq (18) has **no** solution for any `e`, which by the
+///   structure theorem **proves `∫ f dx` is non-elementary** (the obstruction is
+///   a residue at a pole that is not a zero of `b`, e.g. the dilogarithm pole of
+///   `1/(x+√2)·log(x)` at `x = −√2`).
+///
+/// The decision is exact linear algebra over `K`: the ansatz `v_d = N/E` with
+/// `E = gcd(B, B')` reduces eq (18) to a `K`-linear system in the coefficients of
+/// `N` **and** the single unknown `e`; a verified solution of that system is
+/// returned, an inconsistent system is `None`.  Soundness: a `None` is only
+/// emitted after the exact system proves no `(N, e)` exists, exactly mirroring
+/// the `f = 0` solver's certificate that the residual simple poles cannot be
+/// absorbed.
+///
+/// `c_num/c_den = f_d` and `gd_num/gd_den = b'/b`, all `K`-polynomials in `x`.
+#[allow(clippy::type_complexity)]
+pub fn solve_primitive_top_rde_k(
+    field: &NumberField,
+    c_num: &KPoly,
+    c_den: &KPoly,
+    gd_num: &KPoly,
+    gd_den: &KPoly,
+    d: i64,
+) -> Option<Option<KElem>> {
+    let c_num = NumberField::kpoly_trim(c_num.clone());
+    let c_den = NumberField::kpoly_trim(c_den.clone());
+    if c_den.is_empty() {
+        return None; // malformed input (division by zero)
+    }
+    // f_d = 0 ⇒ trivially solvable with e = 0.
+    if c_num.is_empty() {
+        return Some(Some(NumberField::k_zero()));
+    }
+
+    let gd_num = NumberField::kpoly_trim(gd_num.clone());
+    let gd_den = NumberField::kpoly_trim(gd_den.clone());
+
+    // (d+1)·(b'/b).  If b'/b is zero (b' = 0), there is no drift direction.
+    let dp1 = field.from_int(d + 1);
+    let drift_num = field.kpoly_scale(&gd_num, &dp1);
+    if drift_num.is_empty() || gd_den.is_empty() {
+        return Some(None);
+    }
+
+    // Put f_d and g_drift over a common denominator Bc (monic).
+    //   f_d      = c_num/c_den
+    //   g_drift  = drift_num/gd_den
+    // Common denominator Bc = lcm(c_den, gd_den); numerators rescaled.
+    let g = field.kpoly_gcd(&c_den, &gd_den)?;
+    let cd_over_g = field.kpoly_div_exact(&c_den, &g)?;
+    let gdd_over_g = field.kpoly_div_exact(&gd_den, &g)?;
+    let bc_raw = field.kpoly_mul(&c_den, &gdd_over_g); // = lcm(c_den, gd_den)
+    let bcd = NumberField::kdeg(&bc_raw);
+    let lead_inv = field.inv(&bc_raw[bcd as usize])?;
+    let bc = field.kpoly_scale(&bc_raw, &lead_inv);
+    // f_d  = (c_num·gdd_over_g)/(Bc·lead)   ⇒ scale numerators by lead_inv too.
+    let cf = field.kpoly_scale(&field.kpoly_mul(&c_num, &gdd_over_g), &lead_inv);
+    // g_drift = (drift_num·cd_over_g)/(Bc·lead)
+    let cg = field.kpoly_scale(&field.kpoly_mul(&drift_num, &cd_over_g), &lead_inv);
+
+    // v_d = N/E with E = gcd(Bc, Bc'),  G = Bc/E.
+    let bcp = field.kpoly_deriv(&bc);
+    let e_poly = field.kpoly_gcd(&bc, &bcp)?;
+    let g_poly = field.kpoly_div_exact(&bc, &e_poly)?;
+    let eprime = field.kpoly_deriv(&e_poly);
+    let ge = field.kpoly_mul(&g_poly, &e_poly);
+    let gep = field.kpoly_mul(&g_poly, &eprime);
+    // RHS target: (Cf − e·Cg)·E, with e unknown ⇒ split into Cf·E and (Cg·E).
+    let target = field.kpoly_mul(&cf, &e_poly);
+    let cg_e = field.kpoly_mul(&cg, &e_poly);
+
+    // Degree bound for N (numerator of v_d = N/E), f = 0 here.
+    let deg_bc = NumberField::kdeg(&bc);
+    let deg_cf = NumberField::kdeg(&cf);
+    let deg_e = NumberField::kdeg(&e_poly).max(0);
+    let poly_part = (deg_cf - deg_bc).max(0);
+    let dbound = (deg_e + poly_part + 2).max(0) as usize;
+    let n_cols = dbound + 1; // coefficients of N
+    let cols = n_cols + 1; // + the unknown constant e (last column)
+
+    let max_deg = (NumberField::kdeg(&ge) + dbound as i64)
+        .max(NumberField::kdeg(&gep) + dbound as i64)
+        .max(NumberField::kdeg(&target))
+        .max(NumberField::kdeg(&cg_e))
+        .max(0) as usize;
+    let n_rows = max_deg + 1;
+
+    // Assemble M·[n; e] = target.
+    //   Σ_j n_j·(G·E·j x^{j-1} − G·E'·x^j)  +  e·(Cg·E)  =  Cf·E
+    // (no f·v term: f = 0 for the primitive antidifferentiation).
+    let mut mat = vec![vec![NumberField::k_zero(); cols]; n_rows];
+    for (deg, row) in mat.iter_mut().enumerate() {
+        let deg = deg as i64;
+        for (j, cell) in row.iter_mut().take(n_cols).enumerate() {
+            let jj = j as i64;
+            // [G·E·(j x^{j-1})]_deg = j · (G·E)[deg-j+1]
+            let mut v = field.mul(&field.from_int(jj), &NumberField::kcoeff(&ge, deg - jj + 1));
+            // − [G·E'·x^j]_deg = −(G·E')[deg-j]
+            v = field.sub(&v, &NumberField::kcoeff(&gep, deg - jj));
+            *cell = v;
+        }
+        // e-column: + (Cg·E)[deg]
+        row[n_cols] = NumberField::kcoeff(&cg_e, deg);
+    }
+    let rhs: Vec<KElem> = (0..n_rows)
+        .map(|deg| NumberField::kcoeff(&target, deg as i64))
+        .collect();
+
+    let solution = solve_linear_system_k(field, mat, rhs, cols)?;
+
+    // Verify: with N = solution[..n_cols], e = solution[n_cols],
+    //   (N'·E − N·E')·Bc  ==  (Cf − e·Cg)·E².
+    let n_poly = NumberField::kpoly_trim(solution[..n_cols].to_vec());
+    let e_val = solution[n_cols].clone();
+    let np = field.kpoly_deriv(&n_poly);
+    let lhs = field.kpoly_mul(
+        &field.kpoly_sub(
+            &field.kpoly_mul(&np, &e_poly),
+            &field.kpoly_mul(&n_poly, &eprime),
+        ),
+        &bc,
+    );
+    let rhs_num = field.kpoly_sub(&cf, &field.kpoly_scale(&cg, &e_val));
+    let rhs_check = field.kpoly_mul(&rhs_num, &field.kpoly_mul(&e_poly, &e_poly));
+    if !NumberField::kpoly_eq(&lhs, &rhs_check) {
+        return None;
+    }
+
+    Some(Some(e_val))
+}
+
 /// Solve `mat · x = rhs` over a number field `K` by Gauss–Jordan elimination.
 /// Returns a particular solution (free variables 0), or `None` if inconsistent.
 fn solve_linear_system_k(
@@ -881,6 +1034,92 @@ mod tests {
         let (vn, vd) = solve_rational_rde_k(&field, &f, &c_num, &c_den).expect("elementary");
         assert_eq!(trim(vn[0].clone()), vec![Rational::from((1, 2))]);
         assert_eq!(trim(vd[0].clone()), vec![rat(1)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Primitive (log) case eq (18) — solve_primitive_top_rde_k
+    // -----------------------------------------------------------------------
+
+    /// ∫ 1/(x+√2)·log(x) dx: top coefficient f_1 = 1/(x+√2), tower arg b = x so
+    /// b'/b = 1/x.  eq (18): 1/(x+√2) = v' + 2·e·(1/x) has NO solution (residue 1
+    /// at x=−√2 cannot be absorbed by any e acting at x=0).  Must return None →
+    /// certify NonElementary.
+    #[test]
+    fn primitive_top_inv_x_plus_sqrt2_over_log_x_none() {
+        let field = field_sqrt2();
+        let sqrt2 = vec![rat(0), rat(1)];
+        // f_1 = 1/(x+√2):  c_num = 1, c_den = x + √2.
+        let c_num: KPoly = vec![kc(&field, 1)];
+        let c_den: KPoly = vec![sqrt2.clone(), kc(&field, 1)];
+        // b'/b = 1/x: gd_num = 1, gd_den = x.
+        let gd_num: KPoly = vec![kc(&field, 1)];
+        let gd_den: KPoly = vec![NumberField::k_zero(), kc(&field, 1)];
+        let r = solve_primitive_top_rde_k(&field, &c_num, &c_den, &gd_num, &gd_den, 1);
+        assert!(
+            r.is_none(),
+            "eq (18) for 1/(x+√2) with b=x must be unsolvable (None); got {r:?}"
+        );
+    }
+
+    /// ∫ 1/(x+√2)²·log(x) dx: f_1 = 1/(x+√2)² is K-rationally integrable on its
+    /// own (P = −1/(x+√2), zero simple residue), so eq (18) is solvable with e=0.
+    /// Must return Some(..) → certificate declines.
+    #[test]
+    fn primitive_top_inv_x_plus_sqrt2_sq_over_log_x_some() {
+        let field = field_sqrt2();
+        let sqrt2 = vec![rat(0), rat(1)];
+        let base: KPoly = vec![sqrt2.clone(), kc(&field, 1)]; // x + √2
+        let c_num: KPoly = vec![kc(&field, 1)]; // 1
+        let c_den = field.kpoly_mul(&base, &base); // (x+√2)²
+        let gd_num: KPoly = vec![kc(&field, 1)];
+        let gd_den: KPoly = vec![NumberField::k_zero(), kc(&field, 1)]; // x
+        let r = solve_primitive_top_rde_k(&field, &c_num, &c_den, &gd_num, &gd_den, 1);
+        assert!(
+            r.is_some(),
+            "eq (18) for 1/(x+√2)² with b=x must be solvable (Some); got {r:?}"
+        );
+    }
+
+    /// ∫ 1/(x+√2)·log(x+√2) dx: f_1 = 1/(x+√2) = b'/b with b = x+√2.  eq (18) is
+    /// solvable with e = 1/2 (v=0): the residue at x=−√2 IS the drift pole.  Must
+    /// return Some(..) → certificate declines (the log-derivative shortcut covers
+    /// this elsewhere, but the obstruction test must agree it is solvable).
+    #[test]
+    fn primitive_top_log_derivative_same_arg_some() {
+        let field = field_sqrt2();
+        let sqrt2 = vec![rat(0), rat(1)];
+        let base: KPoly = vec![sqrt2.clone(), kc(&field, 1)]; // x + √2
+        let c_num: KPoly = vec![kc(&field, 1)]; // 1
+        let c_den = base.clone(); // x + √2
+                                  // b = x+√2 ⇒ b'/b = 1/(x+√2).
+        let gd_num: KPoly = vec![kc(&field, 1)];
+        let gd_den = base.clone();
+        let r = solve_primitive_top_rde_k(&field, &c_num, &c_den, &gd_num, &gd_den, 1);
+        assert!(
+            r.is_some(),
+            "eq (18) for 1/(x+√2) with b=x+√2 must be solvable (Some); got {r:?}"
+        );
+    }
+
+    /// Soundness probe for the degree bound: a *polynomial* top coefficient
+    /// f_1 = x has the trivial K-rational antiderivative v = x²/2 (e = 0), so
+    /// eq (18) must be solvable.  This guards against a too-small `dbound`
+    /// spuriously rejecting a genuine polynomial-part solution (a false None
+    /// here would be a wrong NonElementary).  b = x ⇒ b'/b = 1/x.
+    #[test]
+    fn primitive_top_polynomial_coeff_some() {
+        let field = field_sqrt2();
+        // f_1 = x:  c_num = x, c_den = 1.
+        let c_num: KPoly = vec![NumberField::k_zero(), kc(&field, 1)];
+        let c_den: KPoly = vec![kc(&field, 1)];
+        // b'/b = 1/x: gd_num = 1, gd_den = x.
+        let gd_num: KPoly = vec![kc(&field, 1)];
+        let gd_den: KPoly = vec![NumberField::k_zero(), kc(&field, 1)];
+        let r = solve_primitive_top_rde_k(&field, &c_num, &c_den, &gd_num, &gd_den, 1);
+        assert!(
+            r.is_some(),
+            "eq (18) for the polynomial coeff f_1=x (v=x²/2, e=0) must be solvable; got {r:?}"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`∫ 1/(x+√2)·log(x) dx` is genuinely non-elementary (it is a dilogarithm). The engine previously returned `NotImplemented` (a decline); it now returns a **certified `NonElementary`** where mathematically justified, per Bronstein's primitive-case structure theorem.

## Exact mathematical criterion

For `∫ Σ_{k=0}^{n} c_k(x)·log(h)^k dx` with `t = log(h)` a logarithmic monomial over `K(x)` where `K = ℚ(α)` is a number field, a **necessary** condition for the integral to be elementary is that the **top** coefficient `c_n` satisfy Bronstein eq (18):

```
c_n = v' + (n+1)·e·(h'/h),   v ∈ K(x),  e ∈ Const(K).
```

`solve_primitive_top_rde_k` decides this **exactly**: with the ansatz `v = N/E`, `E = gcd(Bc, Bc')` (squarefree part of the polar denominator), eq (18) reduces to a `K`-linear system in the coefficients of `N` plus the single scalar unknown `e`. The returned solution is re-verified against the exact polynomial identity `(N'E − NE')·Bc == (Cf − e·Cg)·E²`, so a `None` is emitted only after the system **provably** has no `(N, e)`. A `None` proves the whole integral non-elementary: a residue at a pole of `c_n` that is **not** a zero of `h` cannot be absorbed by any constant `e` (the dilogarithm pole of `1/(x+√2)` at `x = −√2`, with `h = x`).

**Citation:** Bronstein (2005), *Symbolic Integration I: Transcendental Functions*, §5.10; *Symbolic Integration Tutorial* (ISSAC'98) §3.5, eq (18) — "either proving that (18) has no solution, in which case `f` has no elementary integral".

## Soundness gates

A wrong `NonElementary` on an elementary integral is the one unacceptable outcome. The certificate fires only when fully justified:

- It runs **inside** `integrate_log_poly`, AFTER the engine has committed to the single-generator poly-in-`t` structure (`decompose_as_log_poly` succeeded). It applies to the single-term `∫ c·tⁿ` analysis only.
- **Every** coefficient `c_0 … c_n` must parse as a *genuinely K-rational* function over one detected `ℚ(α)`. If any coefficient still carries a second `log`/`exp` generator, the single-monomial structure does not hold → decline, never certify.
- Pure `ℚ(x)` coefficients (no algebraic extension detected) are not this case → decline (ordinary `Li`/`Ei` rational case, handled elsewhere).
- Algebraic constant factors are split off first (residue structure is scalar-invariant).

## Cases certified NonElementary

- `∫ 1/(x+√2)·log(x) dx` (headline, dilogarithm pole at `x=−√2`)
- `∫ 1/(x+√3)·log(x) dx` (same obstruction over `K=ℚ(√3)`)
- `∫ √2/(x+√2)·log(x) dx` (const-factored variant)

## Adversarial / regression cases verified SAFE (never NonElementary)

- **`∫ [1/(x+√2)·log(x) + log(x+√2)/x] dx` IS elementary** (`= log(x)·log(x+√2)`; the two dilog halves cancel). Two log generators → never reaches the single-generator K-rational-top path; certificate must not fire. Verified it is NOT certified NonElementary.
- `∫ 1/(x+√2)²·log(x) dx` stays elementary (double pole, zero simple residue; eq (18) solvable with `e=0`). Still declines (a pre-existing K-rational-with-logs base-field gap, not introduced here) but is never certified NonElementary.
- `∫ 1/(x+√2)·log(x+√2) dx = ½log²` (log-derivative case; residue IS a zero of `h`, `e=½`) — stays elementary.
- `∫ (1/(x+√2))·log(x+√2)² dx = log³/3` (`h'/h·tⁿ` power rule) — stays elementary.
- `∫ log(x)/x dx = ½log²` (pure ℚ(x), no extension) — stays elementary.
- Unit probe: polynomial top coefficient `f_1 = x` (`v = x²/2`, `e=0`) returns `Some` — guards the degree bound against a spurious false `None`.

## Still declining (not regressed)

- `∫ 1/(x+√2)²·log(x) dx` still returns a decline: integrating the IBP base term `∫1/(x(x+√2))dx` needs a K-rational integrator *with* logarithms, a pre-existing base-field gap. The certificate correctly does not fire (elementary).

## Quality

`cargo fmt` clean; `cargo clippy --workspace --all-targets` no new warnings; `cargo test --workspace` green (all risch tests + 12 new tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bronstein-based certificate for improved detection of non-elementary integrals in logarithmic cases.
  * Integrator now proves certain integrals cannot be expressed in elementary functions before attempting further reduction.

* **Tests**
  * Extended test suite with comprehensive coverage for non-elementary integral certification, including edge cases and adversarial integrands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->