### PR TITLE
feat(poly): Newton-Puiseux expansion at algebraic base points

### DIFF
--- a/alkahest-core/src/poly/puiseux.rs
+++ b/alkahest-core/src/poly/puiseux.rs
@@ -40,7 +40,7 @@ use rug::{Integer, Rational};
 use std::collections::BTreeMap;
 
 use crate::flint::FlintPoly;
-use crate::integrate::risch::number_field::NumberField;
+use crate::integrate::risch::number_field::{KPoly, NumberField};
 
 /// A coefficient in a number field `ℚ[θ]/(m)`: a polynomial in `θ` (ascending),
 /// reduced mod `m`.  For the base field `ℚ` this is a constant `[r]`.
@@ -857,6 +857,502 @@ pub(crate) fn factor_over_q(p: &[Rational]) -> Vec<(Vec<Rational>, usize)> {
     out
 }
 
+// ---------------------------------------------------------------------------
+// Expansion at an ALGEBRAIC base point  x = α  (α irrational, given by minpoly)
+// ---------------------------------------------------------------------------
+
+/// A Puiseux branch at an **algebraic** base point `x = α`, with coefficients in
+/// the base number field `K = ℚ[t]/(α_minpoly)` (where the generator `t = α`).
+///
+/// The branch is `y(x) = Σ c_k (x − α)^{k/e}` with each `c_k ∈ K` (a [`KElem`],
+/// a ℚ-polynomial in `α`).  A class over a degree-`d` base field represents
+/// `conjugates = d` concrete conjugate branches (one per embedding of `α`).
+#[derive(Clone, Debug)]
+pub struct AlgBasePuiseuxSeries {
+    /// Minimal polynomial of the base point `α` over `ℚ` (monic, ascending) —
+    /// the modulus of the coefficient field `K = ℚ(α)`.
+    pub alpha_minpoly: Vec<Rational>,
+    /// Number of conjugate base points `= deg(α_minpoly)`; the class stands for
+    /// this many concrete branches (one per conjugate of `α`).
+    pub conjugates: usize,
+    /// Ramification index `e`: every exponent has denominator dividing `e`.
+    pub ramification: u64,
+    /// `(exponent, coefficient ∈ K)` pairs in `(x − α)^{·}`, ascending.
+    pub terms: Vec<(Rational, KElem)>,
+    /// Truncation order (`None` ⇒ exact).
+    pub order: Option<Rational>,
+}
+
+/// Branches of `F(x, y) = 0` at an **algebraic** base point `x = α`, where `α`
+/// is an irrational algebraic number given by its minimal polynomial
+/// `alpha_minpoly` over `ℚ`.
+///
+/// The natural construction: shift `x ↦ x + α` so the base point moves to
+/// `0`, but now over the number field `K = ℚ(α)` — the curve coefficients
+/// (polynomials in `ℚ[x]`) become `K[x]`-polynomials.  The classical
+/// Newton–Puiseux recursion then runs with **coefficient arithmetic in `K`**
+/// instead of `ℚ`, reusing the same generic `lift_k` / `substitute_k` core that
+/// backs [`puiseux_at_zero_algebraic`].  Exponents are powers of `(x − α)`.
+///
+/// Return type: a [`Vec`] of [`AlgBasePuiseuxSeries`] (each over `K`) plus a
+/// `skipped` count of branches whose continuation needs a **further** extension
+/// beyond `K` (a non-`K` characteristic root) — never mis-reported, only
+/// counted, exactly as [`puiseux_at_zero_algebraic`] does for `ℚ(θ)`.
+///
+/// ## Scope
+///
+/// Complete for every branch whose Puiseux coefficients lie in `K = ℚ(α)`
+/// itself (the constant root and every characteristic root stays in `K`).  This
+/// covers: unramified / nodal places where the branch slopes are `K`-rational,
+/// the degenerate case `α ∈ ℚ` (which agrees with [`puiseux_at`]), and radical
+/// continuations whose characteristic factor is a binomial over `K`.  A branch
+/// requiring a root in a proper extension of `K` (e.g. a ramified place whose
+/// leading coefficient is `√(·)` of a non-square of `K`) is **skipped-but-
+/// counted** — the `skipped` total plus the summed `conjugates` reveal whether
+/// every sheet over `α` was recovered.  Lifting those branches needs a Puiseux
+/// tower `ℚ(α)(θ)` (risch.md §D "Puiseux over a tower of extensions").
+///
+/// Every returned branch is back-substitution checked in the test suite:
+/// `F(α + t^e, y(t)) ≡ 0 (mod t^N)` with **exact** arithmetic in `K[t]`.
+pub fn puiseux_at_algebraic(
+    coeffs: &[(u32, u32, Rational)],
+    alpha_minpoly: &[Rational],
+    prec: u32,
+) -> (Vec<AlgBasePuiseuxSeries>, usize) {
+    let deg_alpha = {
+        let mut d = alpha_minpoly.len();
+        while d > 0 && alpha_minpoly[d - 1] == 0 {
+            d -= 1;
+        }
+        d.saturating_sub(1)
+    };
+    // Degenerate base field ℚ (deg ≤ 1): the rational path is sound and complete
+    // for the rational branches; fold it through `puiseux_at` so the algebraic
+    // entry agrees with the rational one on a rational α.
+    if deg_alpha <= 1 {
+        let alpha = if deg_alpha == 0 {
+            rzero()
+        } else {
+            // minpoly = a₀ + a₁ t  ⇒  α = −a₀/a₁.
+            -alpha_minpoly[0].clone() / alpha_minpoly[1].clone()
+        };
+        let branches = puiseux_at(coeffs, &alpha, prec);
+        let out = branches
+            .into_iter()
+            .map(|s| AlgBasePuiseuxSeries {
+                alpha_minpoly: vec![Rational::from(1)],
+                conjugates: 1,
+                ramification: s.ramification,
+                terms: s.terms.into_iter().map(|(e, c)| (e, vec![c])).collect(),
+                order: s.order,
+            })
+            .collect();
+        return (out, 0);
+    }
+
+    let nf = NumberField::new(alpha_minpoly.to_vec());
+    let alpha = nf.reduce(&vec![rzero(), Rational::from(1)]); // α = t
+    let prec_r = Rational::from(prec);
+
+    // Shift x ↦ x + α over K: F(x+α, y) as a K-bivariate `(x-exp, y-exp) → K`.
+    let mut f = shift_x_alpha(&nf, coeffs, &alpha);
+
+    // Strip a common x-power (does not change the branches).
+    factor_min_x_k(&mut f);
+    if f.is_empty() {
+        return (Vec::new(), 0);
+    }
+
+    // F(α, y): the y-fibre over the base point, a univariate over K.
+    let mut f0: BTreeMap<u32, KElem> = BTreeMap::new();
+    for ((xe, ye), a) in &f {
+        if *xe == 0 {
+            let e = f0.entry(*ye).or_default();
+            *e = nf.add(e, a);
+        }
+    }
+    let f0_dense = k_dense(&nf, &f0);
+
+    let mut out: Vec<AlgBasePuiseuxSeries> = Vec::new();
+    let mut skipped = 0usize;
+
+    // Constant roots c₀ ∈ K of F(α, y): the y-values of the branches at x = α.
+    let (roots, missed) = k_roots_in_field(&nf, &f0_dense);
+    skipped += missed;
+    for c0 in roots {
+        let g = if NumberField::is_zero(&c0) {
+            f.clone()
+        } else {
+            shift_y_k(&nf, &f, &c0)
+        };
+        let prefix: Vec<(Rational, KElem)> = if NumberField::is_zero(&c0) {
+            Vec::new()
+        } else {
+            vec![(rzero(), c0.clone())]
+        };
+        let (lifted, missed) = lift_k_counted(&nf, &g, &prec_r, 0);
+        skipped += missed;
+        for (sub, exact) in lifted {
+            let mut full = prefix.clone();
+            full.extend(sub);
+            out.push(make_alg_base_series(
+                alpha_minpoly,
+                deg_alpha,
+                full,
+                exact,
+                &prec_r,
+            ));
+        }
+    }
+    (out, skipped)
+}
+
+/// `F(x + α, y)` over `K = ℚ(α)`: the ℚ[x,y]-coefficients are embedded into `K`
+/// and `x ↦ x + α` is expanded via the binomial theorem with `α ∈ K`.
+fn shift_x_alpha(nf: &NumberField, coeffs: &[(u32, u32, Rational)], alpha: &KElem) -> KBi {
+    let mut f: KBi = BTreeMap::new();
+    for (i, j, a) in coeffs {
+        if *a == 0 {
+            continue;
+        }
+        let ak = nf.reduce(&vec![a.clone()]);
+        // (x+α)^i = Σ_m C(i,m) α^{i−m} x^m.
+        for m in 0..=*i {
+            let binom = k_from_int(nf, &binomial(*i, m));
+            let apow = k_pow(nf, alpha, *i - m);
+            let coeff = nf.mul(&nf.mul(&ak, &binom), &apow);
+            if !NumberField::is_zero(&coeff) {
+                let e = f.entry((Rational::from(m), *j)).or_default();
+                *e = nf.add(e, &coeff);
+            }
+        }
+    }
+    f.retain(|_, a| !NumberField::is_zero(a));
+    f
+}
+
+/// `F(x, c₀ + w)` over `K` — the `y ↦ c₀ + w` shift with `c₀ ∈ K`.
+fn shift_y_k(nf: &NumberField, f: &KBi, c0: &KElem) -> KBi {
+    let mut g: KBi = BTreeMap::new();
+    for ((xe, ye), a) in f {
+        let j = *ye;
+        for l in 0..=j {
+            let binom = k_from_int(nf, &binomial(j, l));
+            let cpow = k_pow(nf, c0, j - l);
+            let coeff = nf.mul(&nf.mul(a, &binom), &cpow);
+            if !NumberField::is_zero(&coeff) {
+                let e = g.entry((xe.clone(), l)).or_default();
+                *e = nf.add(e, &coeff);
+            }
+        }
+    }
+    g.retain(|_, a| !NumberField::is_zero(a));
+    g
+}
+
+/// Dense coefficient vector (index = `c`-degree) of a sparse `degree → K` map.
+fn k_dense(nf: &NumberField, m: &BTreeMap<u32, KElem>) -> Vec<KElem> {
+    let Some(&maxd) = m.keys().max() else {
+        return Vec::new();
+    };
+    let mut v = vec![NumberField::k_zero(); maxd as usize + 1];
+    for (d, c) in m {
+        v[*d as usize] = nf.reduce(c);
+    }
+    v
+}
+
+/// Roots **in `K`** of a univariate `φ(c) = Σ p[k] c^k` over `K`, returned with a
+/// count of roots that lie only in a *proper extension* of `K` (and are skipped).
+///
+/// Method (fully general, no `K`-factoring needed): factor the `ℚ`-norm `N(φ)`
+/// over `ℚ` (FLINT) into irreducible factors `g`; for each `g`, the gcd over `K`
+/// `h = gcd_K(φ, g)` isolates the roots of `φ` that are roots of `g`.  A
+/// **degree-1** `h = h₀ + h₁ c` contributes the `K`-root `−h₀/h₁` (it lies in
+/// `K`).  A higher-degree `h` collects roots that are conjugate over `K` (none
+/// individually in `K`) — counted as `deg h` skipped sheets, never mis-reported.
+/// The root `c = 0` (when `c | φ`) is handled separately.
+fn k_roots_in_field(nf: &NumberField, p: &[KElem]) -> (Vec<KElem>, usize) {
+    // Trim trailing zeros.
+    let mut hi = p.len();
+    while hi > 0 && NumberField::is_zero(&p[hi - 1]) {
+        hi -= 1;
+    }
+    let p = &p[..hi];
+    if p.is_empty() {
+        return (Vec::new(), 0);
+    }
+    let mut roots: Vec<KElem> = Vec::new();
+    // Factor out cᵗ (low-order zeros) ⇒ root 0.
+    let mut lo = 0usize;
+    while lo < p.len() && NumberField::is_zero(&p[lo]) {
+        lo += 1;
+    }
+    if lo > 0 {
+        roots.push(NumberField::k_zero());
+    }
+    let work: Vec<KElem> = p[lo..].iter().map(|c| nf.reduce(c)).collect();
+    if work.len() <= 1 {
+        return (roots, 0); // constant after factoring — no further roots
+    }
+
+    let mut skipped = 0usize;
+    // ℚ-norm of φ, factored over ℚ.  Each irreducible ℚ-factor g is lifted into
+    // K (constant coefficients) and intersected with φ via a K-gcd.
+    let norm = k_norm_poly(nf, &work);
+    for (g, _deg) in factor_over_q(&norm) {
+        let gk: KPoly = g.iter().map(|c| nf.reduce(&vec![c.clone()])).collect();
+        let Some(h) = nf.kpoly_gcd(&work, &gk) else {
+            continue;
+        };
+        let hdeg = NumberField::kdeg(&h);
+        if hdeg == 1 {
+            // h = h₀ + h₁ c, monic-in-x ⇒ root −h₀ (since h₁ = 1 after kpoly_gcd).
+            let inv = match nf.inv(&h[1]) {
+                Some(i) => i,
+                None => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+            roots.push(nf.neg(&nf.mul(&h[0], &inv)));
+        } else if hdeg >= 2 {
+            // Roots conjugate over K: none individually in K.
+            skipped += hdeg as usize;
+        }
+    }
+    (roots, skipped)
+}
+
+/// The `ℚ`-norm `N_{K/ℚ}(φ)` of a polynomial `φ(c)` over `K` — a `ℚ`-polynomial
+/// in `c` whose roots include every root of `φ` (together with the `α`-conjugate
+/// shifts).  Computed as `Res_t(m_α(t), Φ(c, t))`, the resultant eliminating the
+/// `α`-variable `t` from the bivariate lift `Φ(c, t)` of `φ` (each `K`-coefficient
+/// `p[k]` is a `ℚ`-polynomial in `t = α`).  Evaluated at enough integer points
+/// `c = s` and Lagrange-interpolated, the resultant being a `ℚ`-poly of bounded
+/// `c`-degree.
+fn k_norm_poly(nf: &NumberField, p: &[KElem]) -> Vec<Rational> {
+    let m_alpha = nf.modulus().clone();
+    let d_alpha = (m_alpha.len() as i64 - 1).max(0) as usize;
+    // deg_c Res ≤ deg_c(Φ) · deg_t(m_α) = (len(p)-1) · d_alpha.
+    let cdeg_bound = p.len().saturating_sub(1) * d_alpha;
+    let n_pts = cdeg_bound + 1;
+    let mut xs: Vec<Rational> = Vec::with_capacity(n_pts);
+    let mut ys: Vec<Rational> = Vec::with_capacity(n_pts);
+    let mut s: i64 = 0;
+    while xs.len() < n_pts {
+        let cs = Rational::from(s);
+        // Φ(s, t): a ℚ-poly in t = Σ_k p[k](t) · s^k.
+        let mut phi_t: Vec<Rational> = Vec::new();
+        let mut spow = Rational::from(1);
+        for pk in p {
+            for (i, coeff) in pk.iter().enumerate() {
+                if i >= phi_t.len() {
+                    phi_t.resize(i + 1, rzero());
+                }
+                phi_t[i] += coeff.clone() * &spow;
+            }
+            spow *= &cs;
+        }
+        let r = q_resultant(&m_alpha, &phi_t);
+        xs.push(cs);
+        ys.push(r);
+        s += 1;
+    }
+    lagrange_interpolate(&xs, &ys)
+}
+
+/// Resultant `Res(a, b)` of two `ℚ`-polynomials (ascending) via the Euclidean
+/// remainder sequence with the standard degree / leading-coefficient
+/// bookkeeping.  Returns a rational scalar.
+fn q_resultant(a: &[Rational], b: &[Rational]) -> Rational {
+    let mut a = trim_q(a.to_vec());
+    let mut b = trim_q(b.to_vec());
+    if a.is_empty() || b.is_empty() {
+        return rzero();
+    }
+    let mut res = Rational::from(1);
+    loop {
+        let da = a.len() - 1;
+        let db = b.len() - 1;
+        if db == 0 {
+            // Res(a, const) = const^{deg a}.
+            res *= rat_pow_q(&b[0], da as u32);
+            return res;
+        }
+        let rem = q_rem(&a, &b);
+        let drem = if rem.is_empty() { 0 } else { rem.len() - 1 };
+        // Res(a,b) = (-1)^{da·db} · lc(b)^{da−drem} · Res(b, rem).
+        let sign = if (da * db) % 2 == 0 {
+            Rational::from(1)
+        } else {
+            Rational::from(-1)
+        };
+        let lc_b = b[db].clone();
+        res *= sign * rat_pow_q(&lc_b, (da - drem) as u32);
+        if rem.is_empty() {
+            return rzero();
+        }
+        a = b;
+        b = rem;
+    }
+}
+
+/// Remainder of `a mod b` over `ℚ` (ascending coefficient vectors).
+fn q_rem(a: &[Rational], b: &[Rational]) -> Vec<Rational> {
+    let mut r = trim_q(a.to_vec());
+    let b = trim_q(b.to_vec());
+    let db = b.len() - 1;
+    let lc_inv = Rational::from(1) / b[db].clone();
+    loop {
+        let dr = if r.is_empty() { 0 } else { r.len() - 1 };
+        if r.is_empty() || dr < db {
+            break;
+        }
+        let factor = r[dr].clone() * &lc_inv;
+        let shift = dr - db;
+        for (i, bc) in b.iter().enumerate() {
+            r[shift + i] -= factor.clone() * bc;
+        }
+        r = trim_q(r);
+    }
+    r
+}
+
+fn trim_q(mut p: Vec<Rational>) -> Vec<Rational> {
+    while p.last().is_some_and(|c| *c == 0) {
+        p.pop();
+    }
+    p
+}
+
+fn rat_pow_q(c: &Rational, e: u32) -> Rational {
+    let mut acc = Rational::from(1);
+    for _ in 0..e {
+        acc *= c;
+    }
+    acc
+}
+
+/// Lagrange interpolation through `(xs, ys)` (distinct `xs`) → ℚ-polynomial
+/// (ascending).
+fn lagrange_interpolate(xs: &[Rational], ys: &[Rational]) -> Vec<Rational> {
+    let n = xs.len();
+    let mut acc: Vec<Rational> = vec![rzero(); n];
+    for i in 0..n {
+        // Basis poly Lᵢ = ∏_{j≠i} (x − xⱼ)/(xᵢ − xⱼ).
+        let mut basis = vec![Rational::from(1)];
+        let mut denom = Rational::from(1);
+        for j in 0..n {
+            if i == j {
+                continue;
+            }
+            // multiply basis by (x − xⱼ).
+            let mut nb = vec![rzero(); basis.len() + 1];
+            for (k, c) in basis.iter().enumerate() {
+                nb[k] += -xs[j].clone() * c;
+                nb[k + 1] += c.clone();
+            }
+            basis = nb;
+            denom *= xs[i].clone() - &xs[j];
+        }
+        let scale = ys[i].clone() / denom;
+        for (k, c) in basis.iter().enumerate() {
+            acc[k] += c.clone() * &scale;
+        }
+    }
+    trim_q(acc)
+}
+
+/// A lifted branch over `K`: its `(exponent, coefficient ∈ K)` terms and an
+/// `exact` flag (a terminating branch).
+type KLiftedBranch = (Vec<(Rational, KElem)>, bool);
+
+/// `lift_k` with a skip counter, and finding **all** `K`-roots at each edge: like
+/// [`lift_k`] but it (a) factors each edge's characteristic polynomial for every
+/// root in `K` (not just the binomial case) via [`k_roots_in_field`], and
+/// (b) returns the number of characteristic roots that are not in `K` (so their
+/// branch needs a further extension and is skipped).
+fn lift_k_counted(
+    nf: &NumberField,
+    g: &KBi,
+    prec: &Rational,
+    depth: u32,
+) -> (Vec<KLiftedBranch>, usize) {
+    const MAX_DEPTH: u32 = 48;
+    let mut g = g.clone();
+    g.retain(|_, a| !NumberField::is_zero(a));
+    if g.is_empty() {
+        return (vec![(Vec::new(), true)], 0);
+    }
+    if depth > MAX_DEPTH {
+        return (vec![(Vec::new(), false)], 0);
+    }
+    let mut result = Vec::new();
+    let mut skipped = 0usize;
+    let m0 = g.keys().map(|(_, j)| *j).min().unwrap_or(0);
+    if m0 > 0 {
+        result.push((Vec::new(), true));
+        g = g
+            .into_iter()
+            .map(|((xe, ye), a)| ((xe, ye - m0), a))
+            .collect();
+    }
+    let keys: Vec<(Rational, u32)> = g.keys().cloned().collect();
+    for (q, on_edge) in newton_edges_keys(&keys) {
+        let mut phi: BTreeMap<u32, KElem> = BTreeMap::new();
+        for k in &on_edge {
+            let e = phi.entry(k.1).or_default();
+            *e = nf.add(e, &g[k]);
+        }
+        let phi_dense = k_dense(nf, &phi);
+        let (roots, missed) = k_roots_in_field(nf, &phi_dense);
+        skipped += missed;
+        for c in roots {
+            if NumberField::is_zero(&c) {
+                continue;
+            }
+            if prec.clone() - &q <= 0 {
+                result.push((vec![(q.clone(), c)], false));
+                continue;
+            }
+            let gk = substitute_k(nf, &g, &q, &c);
+            let (sub_branches, sub_missed) =
+                lift_k_counted(nf, &gk, &(prec.clone() - &q), depth + 1);
+            skipped += sub_missed;
+            for (sub, exact) in sub_branches {
+                let mut terms = vec![(q.clone(), c.clone())];
+                for (gamma, b) in sub {
+                    terms.push((q.clone() + &gamma, b));
+                }
+                result.push((terms, exact));
+            }
+        }
+    }
+    (result, skipped)
+}
+
+fn make_alg_base_series(
+    alpha_minpoly: &[Rational],
+    conjugates: usize,
+    mut terms: Vec<(Rational, KElem)>,
+    exact: bool,
+    prec: &Rational,
+) -> AlgBasePuiseuxSeries {
+    terms.retain(|(e, c)| (exact || *e < *prec) && !NumberField::is_zero(c));
+    terms.sort_by(|a, b| a.0.cmp(&b.0));
+    let e = terms.iter().fold(1u64, |acc, (ex, _)| {
+        lcm_u64(acc, ex.denom().to_u64().unwrap_or(1))
+    });
+    AlgBasePuiseuxSeries {
+        alpha_minpoly: alpha_minpoly.to_vec(),
+        conjugates,
+        ramification: e,
+        terms,
+        order: if exact { None } else { Some(prec.clone()) },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1044,5 +1540,246 @@ mod tests {
         // Expect a branch with constant term 1 and a branch with leading x.
         assert!(br.iter().any(|s| has_term(s, r(0), r(1))));
         assert!(br.iter().any(|s| has_term(s, r(1), r(1))));
+    }
+
+    // -----------------------------------------------------------------------
+    // Puiseux at an ALGEBRAIC base point  x = α
+    // -----------------------------------------------------------------------
+
+    /// Multiply two `K`-polys in `t` (ascending), truncated to degree `< n`.
+    fn kt_mul_trunc(nf: &NumberField, a: &[KElem], b: &[KElem], n: usize) -> Vec<KElem> {
+        let mut r = vec![NumberField::k_zero(); n];
+        for (i, ca) in a.iter().enumerate() {
+            if i >= n || NumberField::is_zero(ca) {
+                continue;
+            }
+            for (j, cb) in b.iter().enumerate() {
+                if i + j >= n {
+                    break;
+                }
+                let p = nf.mul(ca, cb);
+                r[i + j] = nf.add(&r[i + j], &p);
+            }
+        }
+        r
+    }
+
+    /// `p^e` of a `K`-poly in `t`, truncated to degree `< n`.
+    fn kt_pow_trunc(nf: &NumberField, p: &[KElem], e: u32, n: usize) -> Vec<KElem> {
+        let mut acc = vec![nf.reduce(&vec![r(1)])];
+        for _ in 0..e {
+            acc = kt_mul_trunc(nf, &acc, p, n);
+        }
+        acc
+    }
+
+    /// EXACT back-substitution check of an algebraic-base branch: build
+    /// `F(α + t^e, y(t))` as a `K`-poly in `t` and assert it `≡ 0 (mod t^N)`,
+    /// where `N = e · prec`.  All arithmetic is exact in `K = ℚ(α)[t]`.
+    fn verify_alg_branch(
+        coeffs: &[(u32, u32, Rational)],
+        alpha_minpoly: &[Rational],
+        s: &AlgBasePuiseuxSeries,
+        prec: u32,
+    ) {
+        let nf = NumberField::new(alpha_minpoly.to_vec());
+        let alpha = nf.reduce(&vec![r(0), r(1)]); // α = t-generator
+        let e = s.ramification;
+        // Truncate to t-degree < N (the branch is known to relative order prec
+        // in (x−α), i.e. t-order N = e·prec).
+        let n = (e * prec as u64) as usize + 1;
+
+        // x = α + t^e  as a K-poly in t.
+        let mut xpoly = vec![NumberField::k_zero(); e as usize + 1];
+        xpoly[0] = alpha.clone();
+        xpoly[e as usize] = nf.reduce(&vec![r(1)]);
+
+        // y(t) = Σ c_k t^{(num/den)·e}; each exponent·e is an integer ≤ N.
+        let mut ypoly = vec![NumberField::k_zero(); n];
+        for (exp, c) in &s.terms {
+            let te = exp.clone() * Rational::from(e as i64);
+            assert!(*te.denom() == 1, "exponent·e must be integral: {te}");
+            let idx = te.numer().to_i64().unwrap();
+            assert!(idx >= 0);
+            let idx = idx as usize;
+            if idx < n {
+                ypoly[idx] = nf.add(&ypoly[idx], c);
+            }
+        }
+
+        // F(x, y) = Σ a_ij x^i y^j, truncated to t-degree < N.
+        let mut fpoly = vec![NumberField::k_zero(); n];
+        for (i, j, a) in coeffs {
+            if *a == 0 {
+                continue;
+            }
+            let xi = kt_pow_trunc(&nf, &xpoly, *i, n);
+            let yj = kt_pow_trunc(&nf, &ypoly, *j, n);
+            let term = kt_mul_trunc(&nf, &xi, &yj, n);
+            let ak = nf.reduce(&vec![a.clone()]);
+            for (idx, tc) in term.iter().enumerate() {
+                let scaled = nf.mul(&ak, tc);
+                fpoly[idx] = nf.add(&fpoly[idx], &scaled);
+            }
+        }
+
+        for (idx, c) in fpoly.iter().enumerate() {
+            assert!(
+                NumberField::is_zero(c),
+                "alg branch {s:?}: F(α+t^{e}, y)[t^{idx}] = {c:?} ≠ 0 (not ≡0 mod t^{n})"
+            );
+        }
+    }
+
+    #[test]
+    fn alg_base_degenerate_matches_rational() {
+        // Algebraic path with a *rational* α (minpoly t − 2) must agree with the
+        // existing rational `puiseux_at`.  Use  y² − (x−2) = y² − x + 2, whose
+        // branch at α = 2 is the ramified, *rational*-coefficient y = ±(x−2)^{1/2}.
+        let f = [(0, 2, r(1)), (1, 0, r(-1)), (0, 0, r(2))]; // y² − x + 2
+        let alpha_minpoly = vec![r(-2), r(1)]; // t − 2  ⇒  α = 2
+        let (br, skipped) = puiseux_at_algebraic(&f, &alpha_minpoly, 3);
+        assert_eq!(skipped, 0);
+        // Same as the rational expansion at α = 2: y = ±(x−2)^{1/2}.
+        let rat = puiseux_at(&f, &r(2), 3);
+        assert_eq!(br.len(), rat.len());
+        assert_eq!(br.len(), 2);
+        for s in &br {
+            assert_eq!(s.conjugates, 1);
+            assert_eq!(s.ramification, 2);
+            // Leading exponent 1/2, coefficient ±1 (a constant in ℚ ⊆ K).
+            assert_eq!(s.terms[0].0, rr(1, 2));
+            let lead = &s.terms[0].1;
+            assert!(lead == &vec![r(1)] || lead == &vec![r(-1)]);
+            verify_alg_branch(&f, &alpha_minpoly, s, 3);
+        }
+    }
+
+    #[test]
+    fn alg_base_rational_branches_at_sqrt2() {
+        // F = (y−x)(y−x²) = y² − (x+x²)·y + x³ has the two RATIONAL branches
+        // y = x and y = x²; both stay in any base field, including ℚ(√2).  At the
+        // (smooth) algebraic place x = √2 the branches are
+        //   y = √2 + (x−√2) + …         (from y = x)
+        //   y = 2 + 2√2·(x−√2) + …       (from y = x²)
+        // — coefficients genuinely in ℚ(√2).  All recovered, none skipped.
+        // y² − xy − x²y + x³:
+        let f = [(0, 2, r(1)), (1, 1, r(-1)), (2, 1, r(-1)), (3, 0, r(1))];
+        let mp = vec![r(-2), r(0), r(1)]; // t² − 2  ⇒  α = √2
+        let (br, skipped) = puiseux_at_algebraic(&f, &mp, 4);
+        assert_eq!(skipped, 0, "branches: {br:?}");
+        assert_eq!(br.len(), 2, "branches: {br:?}");
+        let total: usize = br.iter().map(|s| s.conjugates).sum();
+        assert_eq!(total, 4); // 2 classes × conjugates-2 = 4 concrete sheets
+        for s in &br {
+            assert_eq!(s.conjugates, 2);
+            assert_eq!(s.ramification, 1); // unramified place
+            verify_alg_branch(&f, &mp, s, 4);
+        }
+        // One class has constant term √2 (= [0,1]); the other has 2 (= [2]).
+        let consts: Vec<KElem> = br
+            .iter()
+            .map(|s| {
+                s.terms
+                    .iter()
+                    .find(|(e, _)| *e == r(0))
+                    .map(|(_, c)| c.clone())
+                    .unwrap_or_default()
+            })
+            .collect();
+        assert!(
+            consts.iter().any(|c| *c == vec![r(0), r(1)]),
+            "√2 const: {consts:?}"
+        );
+        assert!(
+            consts.iter().any(|c| *c == vec![r(2)]),
+            "2 const: {consts:?}"
+        );
+    }
+
+    #[test]
+    fn alg_base_constant_algebraic_node_in_field() {
+        // Exercise the in-field constant-root path on a curve whose y-fibre over
+        // α = √2 factors inside ℚ(√2).  F = y² + x²·y − 2y = y·(y + x² − 2):
+        // F(√2, y) = y·(y + 0) = y², so the constant root c₀ = 0 ∈ ℚ(√2); the
+        // second branch is the global rational y = 2 − x² = −(x−√2)(x+√2), whose
+        // value and slope at √2 are ℚ(√2)-rational.  Nothing skipped.
+        let f = [(0, 2, r(1)), (2, 1, r(1)), (0, 1, r(-2))]; // y² + x²y − 2y
+        let mp = vec![r(-2), r(0), r(1)]; // √2
+        let (br, skipped) = puiseux_at_algebraic(&f, &mp, 4);
+        assert_eq!(skipped, 0, "branches: {br:?}");
+        assert!(!br.is_empty(), "branches: {br:?}");
+        for s in &br {
+            assert_eq!(s.conjugates, 2);
+            assert_eq!(s.ramification, 1); // both branches unramified at √2
+            verify_alg_branch(&f, &mp, s, 4);
+        }
+    }
+
+    #[test]
+    fn alg_base_ramified_needs_further_extension_is_counted() {
+        // F = y² − (x²−2) at α=√2.  Shift x→x+√2: x²−2 = x² + 2√2 x, so near the
+        // place F = y² − 2√2·x − x², a ramified branch y = c·x^{1/2}+… whose
+        // leading coefficient c = ±(2√2)^{1/2} = ±2^{3/4} lies in ℚ(2^{3/4}) ⊋
+        // ℚ(√2).  Per the documented convention this branch is SKIPPED but the
+        // count must reveal the two missing sheets — never mis-reported.
+        let f = [(0, 2, r(1)), (2, 0, r(-1)), (0, 0, r(2))]; // y² − x² + 2
+        let mp = vec![r(-2), r(0), r(1)]; // √2
+        let (br, skipped) = puiseux_at_algebraic(&f, &mp, 3);
+        // No spurious branch returned; the two non-ℚ(√2) sheets are counted.
+        assert!(
+            br.iter()
+                .all(|s| s.terms.iter().all(|(e, _)| *e != rr(1, 2))),
+            "no bogus ramified branch should be returned: {br:?}"
+        );
+        assert_eq!(skipped, 2, "two sheets need a further extension: {br:?}");
+        // Anything returned must still be exactly sound.
+        for s in &br {
+            verify_alg_branch(&f, &mp, s, 3);
+        }
+    }
+
+    #[test]
+    fn alg_base_node_at_sqrt2_needs_extension_is_counted() {
+        // F = y² − (x²−2)²·(x+1) has an irrational double point at x = ±√2.
+        // (x²−2)² = x⁴−4x²+4, ×(x+1) = x⁵+x⁴−4x³−4x²+4x+4, so
+        // F = y² − x⁵ − x⁴ + 4x³ + 4x² − 4x − 4.
+        // At α=√2 the node has two branches y ≈ ±x·√(8(√2+1)) with
+        // √(8(√2+1)) ∉ ℚ(√2) ⇒ both sheets need a further extension: skipped,
+        // counted, never mis-reported.
+        let f = [
+            (0, 2, r(1)),
+            (5, 0, r(-1)),
+            (4, 0, r(-1)),
+            (3, 0, r(4)),
+            (2, 0, r(4)),
+            (1, 0, r(-4)),
+            (0, 0, r(-4)),
+        ];
+        let mp = vec![r(-2), r(0), r(1)]; // √2
+        let (br, skipped) = puiseux_at_algebraic(&f, &mp, 3);
+        // The c₀ = 0 constant root is in ℚ(√2); the two node branches escape it.
+        assert_eq!(skipped, 2, "two node sheets escape ℚ(√2): {br:?}");
+        for s in &br {
+            verify_alg_branch(&f, &mp, s, 3);
+        }
+    }
+
+    #[test]
+    fn alg_base_conjugate_count_bookkeeping() {
+        // Degree-3 base field ℚ(α), α = ∛2 (minpoly t³−2).  The smooth rational
+        // branch y = x of F = (y−x)(y−x²) = y² − (x+x²)y + x³ at x = ∛2 is a
+        // single class standing for conjugates = 3 concrete branches (one per
+        // conjugate of ∛2).  Summed conjugates over the two classes = 6 = 2·3.
+        let f = [(0, 2, r(1)), (1, 1, r(-1)), (2, 1, r(-1)), (3, 0, r(1))];
+        let mp = vec![r(-2), r(0), r(0), r(1)]; // t³ − 2  ⇒  α = ∛2, degree 3
+        let (br, skipped) = puiseux_at_algebraic(&f, &mp, 3);
+        assert_eq!(skipped, 0, "branches: {br:?}");
+        let total: usize = br.iter().map(|s| s.conjugates).sum();
+        assert_eq!(total, 6, "two classes × 3 conjugates: {br:?}");
+        for s in &br {
+            assert_eq!(s.conjugates, 3);
+            verify_alg_branch(&f, &mp, s, 3);
+        }
     }
 }

--- a/alkahest-core/src/poly/puiseux.rs
+++ b/alkahest-core/src/poly/puiseux.rs
@@ -864,7 +864,7 @@ pub(crate) fn factor_over_q(p: &[Rational]) -> Vec<(Vec<Rational>, usize)> {
 /// A Puiseux branch at an **algebraic** base point `x = α`, with coefficients in
 /// the base number field `K = ℚ[t]/(α_minpoly)` (where the generator `t = α`).
 ///
-/// The branch is `y(x) = Σ c_k (x − α)^{k/e}` with each `c_k ∈ K` (a [`KElem`],
+/// The branch is `y(x) = Σ c_k (x − α)^{k/e}` with each `c_k ∈ K` (a `KElem`,
 /// a ℚ-polynomial in `α`).  A class over a degree-`d` base field represents
 /// `conjugates = d` concrete conjugate branches (one per embedding of `α`).
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary

Implements **Newton–Puiseux expansion at an algebraic base point** `x = α`, where `α` is an irrational algebraic number given by its minimal polynomial over ℚ — the branches of `F(x, y) = 0` at `x = α`. This registers the risch.md **§D first load-bearing prerequisite** ("Puiseux at an algebraic base point"), which unblocks van Hoeij `integral_basis` enlargement at **algebraic singular places** and `find_order` on incomplete divisors.

Per the roadmap guidance, this **genericizes the existing Newton-polygon recursion over the coefficient field** rather than copy-pasting: shift `x → x + α` into `ℚ(α)[x][y]` and run the classical recursion with `ℚ(α)` arithmetic, reusing the `number_field` quotient-ring substrate (`NumberField`, `KPoly`, `kpoly_gcd`) and the same `substitute_k` core that backs `puiseux_at_zero_algebraic`.

## API added

- `poly::puiseux::puiseux_at_algebraic(coeffs, alpha_minpoly, prec) -> (Vec<AlgBasePuiseuxSeries>, usize)` — branches at `x = α` with coefficients in `K = ℚ(α)`, plus a `skipped` count.
- `poly::puiseux::AlgBasePuiseuxSeries` — a branch `y(x) = Σ cₖ (x−α)^{k/e}` with `cₖ ∈ K`, carrying `alpha_minpoly`, `conjugates` (= deg α, the number of concrete conjugate branches this class represents), `ramification`, `terms`, `order`.

Internal: `k_roots_in_field` (roots in `K` of a univariate over `K`, via the ℚ-norm — a resultant eliminating `α`, Lagrange-interpolated — factored over ℚ then intersected with a K-gcd), `lift_k_counted` (Newton recursion over `K` with skip counting), `shift_x_alpha`, `shift_y_k`, `k_norm_poly`, `q_resultant`.

## Soundness

Every returned branch is verified by **exact back-substitution** `F(α + t^e, y(t)) ≡ 0 (mod t^N)` with exact arithmetic in `K[t]` (test helper `verify_alg_branch`). No numeric/oracle checks.

## Coverage and skip-but-count limits

- **Complete** for every branch whose Puiseux coefficients lie in `K = ℚ(α)` itself: unramified / nodal places with `K`-rational slopes, the degenerate `α ∈ ℚ` case (folds through `puiseux_at`, agreement guaranteed), and radical continuations whose characteristic factor is a binomial over `K`.
- A branch needing a root in a **proper extension of `K`** (e.g. a ramified place whose leading coefficient is `√(·)` of a non-square of `K`, such as `2^{3/4} ∉ ℚ(√2)`) is **skipped-but-counted** — never mis-reported. The `skipped` total plus the summed `conjugates` reveal whether every sheet over `α` was recovered. Lifting those needs a Puiseux *tower* `ℚ(α)(θ)` (risch.md §D "Puiseux over a tower of extensions").

## Tests (all exact, back-substitution verified)

- `alg_base_ramified_needs_further_extension_is_counted` — `y²−(x²−2)` at `α=√2`: leading coeff `±2^{3/4} ∉ ℚ(√2)` ⇒ no bogus branch, `skipped == 2`.
- `alg_base_degenerate_matches_rational` — rational `α=2` (minpoly `t−2`) agrees with existing `puiseux_at` (`±(x−2)^{1/2}`).
- `alg_base_node_at_sqrt2_needs_extension_is_counted` — curve singular at irrational points `y²=(x²−2)²(x+1)` at `x=√2`: node sheets escape `ℚ(√2)`, `skipped == 2`.
- `alg_base_conjugate_count_bookkeeping` — `ℚ(∛2)` (minpoly `t³−2`): two classes × 3 conjugates = 6 concrete sheets.
- `alg_base_rational_branches_at_sqrt2`, `alg_base_constant_algebraic_node_in_field` — in-field constant/rational branch recovery at `√2`, nothing skipped.

## Consumer status — deferred (stacked follow-up)

The optional van Hoeij `integral_basis` (`integrate/algebraic/vanhoeij.rs`) enlargement at algebraic singular places is **not wired here**. It is a substantial separate change (irreducible-disc-factor singularity detection, ℚ(α)-coefficient enlargement candidates, generalized `is_integral` gate) and is explicitly listed as a stacked follow-up in the roadmap orchestration log. Gated by the existing exact `is_integral` check, wrong proposals are harmlessly rejected — so wiring it later is safe. This PR ships the prerequisite substrate.

## Quality

`cargo fmt` clean; `cargo clippy --workspace --all-targets` no new warnings (0); `cargo test --workspace` green (1062 lib tests incl. 17 in `poly::puiseux`, 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Puiseux series expansions at irrational algebraic base points given by minimal polynomials
  * New series representation that stores exact coefficients in algebraic number fields, ramification info, and counts/skips branches that require further field extension

* **Tests**
  * Expanded test coverage with algebraic-base back-substitution checks, degenerate cases, node behavior, conjugate-count bookkeeping, and scenarios requiring skipped branches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->