### PR TITLE
feat(algebraic): van Hoeij enlargement at algebraic singular places

### DIFF
--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -18,8 +18,8 @@
 //! whose only cost is a squarefree factorization of `p`.
 //!
 //! Scope: enlargements are proposed at **rational** singular places (rational
-//! `α`, [`try_enlarge`]) and at **algebraic** singular places (irreducible
-//! discriminant factors `q` of degree ≥ 2 with `q² | disc`, [`try_enlarge_algebraic`]).
+//! `α`, `try_enlarge`) and at **algebraic** singular places (irreducible
+//! discriminant factors `q` of degree ≥ 2 with `q² | disc`, `try_enlarge_algebraic`).
 //! At an algebraic place the proposal has van Hoeij's q-adic form
 //! `(Σ aᵢ(x) bᵢ + bd)/q(x)` with `aᵢ ∈ ℚ[x]` of degree `< deg q`; the
 //! coefficients are found from the **`K`-valued** Puiseux sheets over a root `α`
@@ -76,7 +76,7 @@ pub fn integral_basis(f_coeffs: &[QPoly]) -> Option<Vec<AlgElem>> {
     let sing = rational_singularities(&disc);
     // Algebraic singular places: irreducible factors `q` of the discriminant of
     // degree ≥ 2 with `q² | disc`.  Enlargements there carry coefficients in
-    // `K = ℚ(α)`, `q(α)=0` (see [`try_enlarge_algebraic`]).
+    // `K = ℚ(α)`, `q(α)=0` (see `try_enlarge_algebraic`).
     let alg_sing = algebraic_singularities(&disc);
 
     let mut b: Vec<AlgElem> = vec![ext.from_int(1)]; // b₀ = 1

--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -17,23 +17,33 @@
 //! explicit basis `wᵢ = yⁱ/dᵢ` ([`super::integral_basis::radical_integral_basis`]),
 //! whose only cost is a squarefree factorization of `p`.
 //!
-//! Scope: enlargements are proposed only at **rational** singular places, using
-//! their rational Puiseux sheets.  Sheets with algebraic coefficients are simply
-//! absent from the linear system, so a proposal there is under-constrained and
-//! `is_integral` rejects it — the basis may then be non-maximal at such a place,
-//! but is **never incorrect**.  Produces correct integral bases for radical
-//! curves and rational-branch curves such as the nodal cubic `y² = x³ + x²`
-//! (`{1, y/x}`).  Algebraic singular places (and algebraic sheets) are the
-//! follow-up, building on `puiseux_at_zero_algebraic`.
+//! Scope: enlargements are proposed at **rational** singular places (rational
+//! `α`, [`try_enlarge`]) and at **algebraic** singular places (irreducible
+//! discriminant factors `q` of degree ≥ 2 with `q² | disc`, [`try_enlarge_algebraic`]).
+//! At an algebraic place the proposal has van Hoeij's q-adic form
+//! `(Σ aᵢ(x) bᵢ + bd)/q(x)` with `aᵢ ∈ ℚ[x]` of degree `< deg q`; the
+//! coefficients are found from the **`K`-valued** Puiseux sheets over a root `α`
+//! of `q` (`K = ℚ(α)`, via [`crate::poly::puiseux::puiseux_at_algebraic`]) —
+//! each negative-power `K`-coefficient is `deg q` rational equations, so the
+//! linear system is still over ℚ.  Sheets whose coefficients escape `K` (skipped
+//! by `puiseux_at_algebraic`) merely *under*-constrain the system, so a proposal
+//! there is rejected by the exact [`super::integral_basis::is_integral`] gate —
+//! the basis may then be non-maximal at such a place, but is **never incorrect**.
+//! Produces correct integral bases for radical curves, rational-branch curves
+//! such as the nodal cubic `y² = x³ + x²` (`{1, y/x}`), and curves singular only
+//! at an irrational place such as `y² = (x²−2)²·(x+3)` (`{1, y/(x²−2)}`).
 
 use rug::{Integer, Rational};
 use std::collections::BTreeMap;
 
 use super::super::risch::alg_field::{AlgElem, AlgExtension, RatFn, RationalFunctionField};
-use super::super::risch::number_field::CoeffField;
-use super::super::risch::poly_rde::{degree, QPoly};
+use super::super::risch::number_field::{CoeffField, KElem, NumberField};
+use super::super::risch::poly_rde::{degree, poly_deriv, QPoly};
+use super::super::risch::rational_rde::poly_gcd;
 use super::integral_basis::{discriminant, is_integral, rational_singularities};
-use crate::poly::puiseux::{puiseux_at, PuiseuxSeries};
+use crate::poly::puiseux::{
+    factor_over_q, puiseux_at, puiseux_at_algebraic, AlgBasePuiseuxSeries, PuiseuxSeries,
+};
 
 /// A Laurent series in the place uniformizer `t = (x−α)^{1/e}` (integer
 /// `t`-exponents), truncated.  Shared with [`super::residues`].
@@ -64,12 +74,17 @@ pub fn integral_basis(f_coeffs: &[QPoly]) -> Option<Vec<AlgElem>> {
     let monos = to_monomials(f_coeffs);
     let disc = discriminant(f_coeffs);
     let sing = rational_singularities(&disc);
+    // Algebraic singular places: irreducible factors `q` of the discriminant of
+    // degree ≥ 2 with `q² | disc`.  Enlargements there carry coefficients in
+    // `K = ℚ(α)`, `q(α)=0` (see [`try_enlarge_algebraic`]).
+    let alg_sing = algebraic_singularities(&disc);
 
     let mut b: Vec<AlgElem> = vec![ext.from_int(1)]; // b₀ = 1
     for d in 1..n {
         let mut bd = ext.mul(&b[d - 1], &ext.generator()); // y·b_{d−1}
-                                                           // Each real enlargement drops the discriminant by (x−α)²; bound the work.
-        let cap = (degree(&disc).max(0) as usize + 2) * sing.len().max(1) + 4;
+                                                           // Each real enlargement drops the discriminant by (x−α)² (rational) or q²
+                                                           // (algebraic); bound the work.
+        let cap = (degree(&disc).max(0) as usize + 2) * (sing.len() + alg_sing.len()).max(1) + 4;
         let mut iters = 0;
         'enlarge: loop {
             if iters >= cap {
@@ -77,6 +92,15 @@ pub fn integral_basis(f_coeffs: &[QPoly]) -> Option<Vec<AlgElem>> {
             }
             for alpha in &sing {
                 if let Some(cand) = try_enlarge(&ext, &b, &bd, d, alpha, &monos, n) {
+                    if !ext.elem_eq(&cand, &bd) && is_integral(f_coeffs, &cand) {
+                        bd = cand;
+                        iters += 1;
+                        continue 'enlarge;
+                    }
+                }
+            }
+            for q in &alg_sing {
+                if let Some(cand) = try_enlarge_algebraic(&ext, &b, &bd, d, q, &monos, n) {
                     if !ext.elem_eq(&cand, &bd) && is_integral(f_coeffs, &cand) {
                         bd = cand;
                         iters += 1;
@@ -166,6 +190,317 @@ fn try_enlarge(
         vec![-alpha.clone(), Rational::from(1)],
     );
     Some(scale(&num, &inv_lin))
+}
+
+// ---------------------------------------------------------------------------
+// Algebraic singular places  (irreducible q, deg ≥ 2, q² | disc)
+// ---------------------------------------------------------------------------
+
+/// The **algebraic** singular places of the curve: monic irreducible factors `q`
+/// of the discriminant of degree `≥ 2` with `q² | disc` (equivalently `q` divides
+/// the repeated part `gcd(D, D′)`).  A root `α` of such a `q` is an irrational
+/// singular base point; the place(s) over it are where the power basis can fail
+/// integrality but the existing **rational** loop never enlarges.
+fn algebraic_singularities(disc: &QPoly) -> Vec<QPoly> {
+    if degree(disc) < 2 {
+        return Vec::new();
+    }
+    let repeated = poly_gcd(disc, &poly_deriv(disc)); // = ∏ qⱼ^{mⱼ−1}
+    if degree(&repeated) < 2 {
+        return Vec::new();
+    }
+    factor_over_q(disc)
+        .into_iter()
+        .filter_map(|(q, deg)| {
+            // Only genuinely-algebraic places (deg ≥ 2) with q² | disc, i.e.
+            // q | gcd(D, D′).  (The deg-1 / rational case is the existing loop.)
+            if deg < 2 {
+                return None;
+            }
+            let g = poly_gcd(&repeated, &q);
+            if degree(&g) == deg as i64 {
+                Some(q)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Try to enlarge `bd` at the **algebraic** place over a root `α` of the monic
+/// irreducible `q` (`deg q = m ≥ 2`, `q² | disc`): find polynomials
+/// `a₀, …, a_{d−1} ∈ ℚ[x]` of degree `< m` so that `(Σ aᵢ bᵢ + bd)/q(x)` is
+/// integral, returning that element (unverified — the caller gates it with the
+/// exact [`is_integral`]).  `None` if no enlargement exists or the place's
+/// branches could not be expanded over `K = ℚ(α)`.
+///
+/// van Hoeij's q-adic form (1994 §2/§4 non-rational singularities): the
+/// numerator `Σ aᵢ(x) bᵢ + bd` is expanded along each Puiseux sheet over `α`
+/// (coefficients in `K`, via [`puiseux_at_algebraic`]); requiring the
+/// negative-power coefficients in the place uniformizer to vanish gives a
+/// **ℚ-linear** system in the unknown rationals `aᵢₗ` (`aᵢ = Σ_{l<m} aᵢₗ xˡ`),
+/// since each `K`-coefficient is `m` ℚ-components.
+fn try_enlarge_algebraic(
+    ext: &AlgExtension,
+    b: &[AlgElem],
+    bd: &AlgElem,
+    d: usize,
+    q: &QPoly,
+    monos: &[(u32, u32, Rational)],
+    n: usize,
+) -> Option<AlgElem> {
+    let m = degree(q) as usize; // = [K:ℚ]
+    if m < 2 {
+        return None;
+    }
+    let nf = NumberField::new(q.clone());
+    let alpha = nf.reduce(&vec![Rational::from(0), Rational::from(1)]); // α = t
+
+    let dmax = max_denom_degree(b, bd);
+    let prec = (dmax + n + 3) as u32;
+    let (branches, _skipped) = puiseux_at_algebraic(monos, q, prec);
+    // A skipped branch can only *under*-constrain the system → an unverified
+    // proposal that `is_integral` (the caller's gate) then rejects; soundness
+    // never depends on completeness.
+    if branches.is_empty() {
+        return None;
+    }
+    let emax = branches.iter().map(|s| s.ramification).max().unwrap_or(1) as i64;
+    let u_bound = (prec as i64 + 3) * emax + 4;
+
+    // Unknown layout: column (i·m + l) ↔ coefficient aᵢₗ of xˡ in aᵢ (i<d, l<m).
+    let ncols = d * m;
+    // x = α + t^e as a K-series: powers xˡ are reused per branch.
+    let mut matrix: Vec<Vec<Rational>> = Vec::new();
+    let mut rhs: Vec<Rational> = Vec::new();
+
+    for s in &branches {
+        let e = s.ramification as i64;
+        let bts = branch_kts(&nf, s);
+        let xseries = x_alpha_kts(&nf, &alpha, e); // x along the branch
+                                                   // Series of `xˡ` (l = 0..m−1).
+        let mut xpows: Vec<KTS> = Vec::with_capacity(m);
+        xpows.push(kts_one(&nf));
+        for l in 1..m {
+            xpows.push(kts_mul(&nf, &xpows[l - 1], &xseries, u_bound));
+        }
+        // Series of each bᵢ and of bd along this branch (K-coefficients).
+        let bi_ts: Vec<KTS> = (0..d)
+            .map(|i| elem_kts(&nf, &b[i], &alpha, e, u_bound, &bts))
+            .collect();
+        let bd_ts = elem_kts(&nf, bd, &alpha, e, u_bound, &bts);
+        // For column (i,l): the series of `xˡ·bᵢ` (the linear contribution of
+        // aᵢₗ to the numerator).
+        let mut col_ts: Vec<KTS> = Vec::with_capacity(ncols);
+        for bi in &bi_ts {
+            for xl in &xpows {
+                col_ts.push(kts_mul(&nf, xl, bi, u_bound));
+            }
+        }
+        // Negative-power range: keys k < e (after dividing by q ~ t^e at this
+        // simple, ramification-`e` place — same valuation drop as `(x−α)`).
+        let low = col_ts
+            .iter()
+            .chain(std::iter::once(&bd_ts))
+            .filter_map(|s| s.keys().next().copied())
+            .min()
+            .unwrap_or(0);
+        for k in low..e {
+            // Each K-coefficient (length m) is m ℚ-equations.
+            for comp in 0..m {
+                let row: Vec<Rational> = col_ts.iter().map(|s| kts_comp(s, k, comp)).collect();
+                let r = -kts_comp(&bd_ts, k, comp);
+                matrix.push(row);
+                rhs.push(r);
+            }
+        }
+    }
+    let a = gauss_solve(matrix, rhs, ncols)?;
+
+    // candidate = (Σ aᵢ(x) bᵢ + bd) · 1/q(x), with aᵢ = Σ_{l<m} a[i·m+l] xˡ.
+    let mut num = bd.clone();
+    for i in 0..d {
+        let ai: QPoly = (0..m).map(|l| a[i * m + l].clone()).collect();
+        if degree(&ai) >= 0 {
+            num = ext.add(&num, &scale(&b[i], &RatFn::from_poly(&ai)));
+        }
+    }
+    let inv_q = RatFn::new(vec![Rational::from(1)], q.clone());
+    Some(scale(&num, &inv_q))
+}
+
+// ---------------------------------------------------------------------------
+// Laurent-series-in-t arithmetic over K = ℚ(α)  (for algebraic places)
+// ---------------------------------------------------------------------------
+
+/// A Laurent series in the place uniformizer `t`, coefficients in `K = ℚ(α)`.
+type KTS = BTreeMap<i64, KElem>;
+
+fn kts_one(nf: &NumberField) -> KTS {
+    let mut s = KTS::new();
+    s.insert(0, nf.from_int(1));
+    s
+}
+
+/// `α + t^e` as a `K`-series in `t`.
+fn x_alpha_kts(nf: &NumberField, alpha: &KElem, e: i64) -> KTS {
+    let mut s = KTS::new();
+    if !NumberField::is_zero(alpha) {
+        s.insert(0, alpha.clone());
+    }
+    s.insert(e, nf.from_int(1));
+    s
+}
+
+/// The Puiseux branch `y(t) = Σ c_k t^{exp·e}` (`c_k ∈ K`) as a `KTS`.
+fn branch_kts(nf: &NumberField, s: &AlgBasePuiseuxSeries) -> KTS {
+    let e = s.ramification as i64;
+    let mut ts = KTS::new();
+    for (exp, c) in &s.terms {
+        let k = (exp.clone() * Rational::from(e))
+            .numer()
+            .to_i64()
+            .unwrap_or(0);
+        let slot = ts.entry(k).or_insert_with(NumberField::k_zero);
+        *slot = nf.add(slot, c);
+    }
+    ts.retain(|_, c| !NumberField::is_zero(c));
+    ts
+}
+
+/// Series of `b = Σⱼ bⱼ(x) yʲ` (`bⱼ ∈ ℚ(x)`) along a `K`-branch `y = bts(t)`,
+/// `x = α + t^e`.
+fn elem_kts(nf: &NumberField, b: &AlgElem, alpha: &KElem, e: i64, u: i64, bts: &KTS) -> KTS {
+    let mut acc = KTS::new();
+    for (j, coeff) in b.iter().enumerate() {
+        if coeff.numer().is_empty() {
+            continue;
+        }
+        let cj = ratfn_kts(nf, coeff, alpha, e, u);
+        let yj = kts_pow(nf, bts, j as u32, u);
+        acc = kts_add(nf, &acc, &kts_mul(nf, &cj, &yj, u));
+    }
+    acc
+}
+
+fn ratfn_kts(nf: &NumberField, r: &RatFn, alpha: &KElem, e: i64, u: i64) -> KTS {
+    let num = poly_kts(nf, r.numer(), alpha, e, u);
+    let den = poly_kts(nf, r.denom(), alpha, e, u);
+    match kts_inv(nf, &den, u) {
+        Some(inv) => kts_mul(nf, &num, &inv, u),
+        None => KTS::new(),
+    }
+}
+
+/// `p(α + t^e)` (`p ∈ ℚ[x]`) as a `K`-series truncated to `t`-exponents `< u`.
+fn poly_kts(nf: &NumberField, p: &QPoly, alpha: &KElem, e: i64, u: i64) -> KTS {
+    let mut ts = KTS::new();
+    for (mexp, pm) in p.iter().enumerate() {
+        if *pm == 0 {
+            continue;
+        }
+        let pmk = nf.from_rational(pm);
+        // (α + t^e)^m = Σ_l C(m,l) α^{m−l} t^{e l}.
+        for l in 0..=mexp {
+            let exp = e * l as i64;
+            if exp >= u {
+                break;
+            }
+            let binom = nf.from_rational(&Rational::from(binom(mexp as u32, l as u32)));
+            let apow = k_pow(nf, alpha, (mexp - l) as u32);
+            let coeff = nf.mul(&nf.mul(&pmk, &binom), &apow);
+            if !NumberField::is_zero(&coeff) {
+                let slot = ts.entry(exp).or_insert_with(NumberField::k_zero);
+                *slot = nf.add(slot, &coeff);
+            }
+        }
+    }
+    ts.retain(|_, c| !NumberField::is_zero(c));
+    ts
+}
+
+fn kts_add(nf: &NumberField, a: &KTS, b: &KTS) -> KTS {
+    let mut r = a.clone();
+    for (k, c) in b {
+        let slot = r.entry(*k).or_insert_with(NumberField::k_zero);
+        *slot = nf.add(slot, c);
+    }
+    r.retain(|_, c| !NumberField::is_zero(c));
+    r
+}
+
+fn kts_mul(nf: &NumberField, a: &KTS, b: &KTS, u: i64) -> KTS {
+    let mut r = KTS::new();
+    for (ka, ca) in a {
+        for (kb, cb) in b {
+            let k = ka + kb;
+            if k < u {
+                let slot = r.entry(k).or_insert_with(NumberField::k_zero);
+                *slot = nf.add(slot, &nf.mul(ca, cb));
+            }
+        }
+    }
+    r.retain(|_, c| !NumberField::is_zero(c));
+    r
+}
+
+fn kts_pow(nf: &NumberField, a: &KTS, m: u32, u: i64) -> KTS {
+    let mut acc = kts_one(nf);
+    for _ in 0..m {
+        acc = kts_mul(nf, &acc, a, u);
+    }
+    acc
+}
+
+/// Inverse of a `K`-Laurent series, truncated to exponents `< u`.  `None` if the
+/// leading coefficient is not invertible in `K` (e.g. a zero divisor mod a
+/// reducible `q` — which cannot arise for an irreducible discriminant factor).
+fn kts_inv(nf: &NumberField, s: &KTS, u: i64) -> Option<KTS> {
+    let (&v0, c0) = s.iter().next()?; // lowest exponent
+    let inv_c0 = nf.inv(c0)?;
+    let kmax = (u + v0).max(1);
+    // Normalized series u[k] = s[v0+k]·c0⁻¹  (u[0] = 1).
+    let mut us = vec![NumberField::k_zero(); kmax as usize + 1];
+    for (exp, c) in s {
+        let k = exp - v0;
+        if (0..=kmax).contains(&k) {
+            us[k as usize] = nf.mul(c, &inv_c0);
+        }
+    }
+    let mut iu = vec![NumberField::k_zero(); kmax as usize + 1];
+    iu[0] = nf.from_int(1);
+    for k in 1..=kmax as usize {
+        let mut acc = NumberField::k_zero();
+        for i in 1..=k {
+            acc = nf.add(&acc, &nf.mul(&us[i], &iu[k - i]));
+        }
+        iu[k] = nf.neg(&acc);
+    }
+    let mut res = KTS::new();
+    for (k, iuk) in iu.iter().enumerate() {
+        let exp = -v0 + k as i64;
+        if exp < u && !NumberField::is_zero(iuk) {
+            res.insert(exp, nf.mul(&inv_c0, iuk));
+        }
+    }
+    Some(res)
+}
+
+/// The ℚ-component `comp` (coefficient of `αᶜᵒᵐᵖ`) of `s[t^k]`.
+fn kts_comp(s: &KTS, k: i64, comp: usize) -> Rational {
+    s.get(&k)
+        .and_then(|c| c.get(comp))
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0))
+}
+
+/// `c^e` in `K`.
+fn k_pow(nf: &NumberField, c: &KElem, e: u32) -> KElem {
+    let mut acc = nf.from_int(1);
+    for _ in 0..e {
+        acc = nf.mul(&acc, c);
+    }
+    acc
 }
 
 // ---------------------------------------------------------------------------
@@ -495,6 +830,58 @@ mod tests {
             ]
         ); // y²/x
         assert!(via_loop.iter().all(|bi| is_integral(&f, bi)));
+    }
+
+    /// Algebraic singular place: `y² = (x²−2)²·(x+3)` is singular only at the
+    /// **irrational** points `x = ±√2` (disc `= 4(x+3)(x²−2)²`, the only repeated
+    /// factor `q = x²−2` is irreducible of degree 2).  The rational loop never
+    /// enlarges; the algebraic loop must produce `w = y/(x²−2)` (integral, since
+    /// `w² = x+3`).
+    #[test]
+    fn algebraic_singular_place_sqrt2() {
+        // F = y² − (x²−2)²(x+3) = y² − (x⁵ + 3x⁴ − 4x³ − 12x² + 4x + 12).
+        let f = [qp(&[-12, -4, 12, 4, -3, -1]), qp(&[]), qp(&[1])];
+        let basis = integral_basis(&f).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(basis[0], vec![RatFn::int(1)]);
+        // b₁ = y/(x²−2): component 1 is 1/(x²−2).
+        assert_eq!(
+            basis[1],
+            vec![RatFn::int(0), RatFn::new(qp(&[1]), qp(&[-2, 0, 1]))]
+        );
+        assert!(basis.iter().all(|bi| is_integral(&f, bi)));
+    }
+
+    /// The same `q = x²−2` factor appears in the discriminant, but only to the
+    /// **first** power (`y² = (x²−2)(x+3)`, disc `= 4(x²−2)(x+3)`): no algebraic
+    /// singular place, so the basis stays the power basis `{1, y}` (control — no
+    /// enlargement should be attempted/accepted).
+    #[test]
+    fn algebraic_factor_simple_no_enlargement() {
+        // F = y² − (x²−2)(x+3) = y² − (x³ + 3x² − 2x − 6).
+        let f = [qp(&[-6, -2, 3, 1]), qp(&[]), qp(&[1])];
+        // Sanity: q=x²−2 is not a repeated discriminant factor here.
+        let disc = discriminant(&f);
+        assert!(algebraic_singularities(&disc).is_empty());
+        let basis = integral_basis(&f).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(basis[0], vec![RatFn::int(1)]);
+        assert_eq!(basis[1], vec![RatFn::int(0), RatFn::int(1)]);
+        assert!(basis.iter().all(|bi| is_integral(&f, bi)));
+    }
+
+    /// Agreement with the radical fast-path where both apply: a simple radical
+    /// `y² = x²−2` whose (irrational) branch points `±√2` are **simple** disc
+    /// roots is non-singular; both paths give the power basis `{1, y}`.  (The
+    /// fast-path short-circuits; this checks the general loop would agree.)
+    #[test]
+    fn radical_with_irrational_branch_points() {
+        let f = [qp(&[2, 0, -1]), qp(&[]), qp(&[1])]; // y² − x² + 2 = y² − (x²−2)
+        let basis = integral_basis(&f).expect("basis");
+        assert_eq!(basis.len(), 2);
+        assert_eq!(basis[0], vec![RatFn::int(1)]);
+        assert_eq!(basis[1], vec![RatFn::int(0), RatFn::int(1)]);
+        assert!(basis.iter().all(|bi| is_integral(&f, bi)));
     }
 
     /// Degree-3 radical y³ = x² ⇒ {1, y, y²/x}.

--- a/alkahest-core/src/integrate/algebraic/vanhoeij.rs
+++ b/alkahest-core/src/integrate/algebraic/vanhoeij.rs
@@ -279,19 +279,19 @@ fn try_enlarge_algebraic(
         let bts = branch_kts(&nf, s);
         let xseries = x_alpha_kts(&nf, &alpha, e); // x along the branch
                                                    // Series of `xˡ` (l = 0..m−1).
-        let mut xpows: Vec<KTS> = Vec::with_capacity(m);
+        let mut xpows: Vec<Kts> = Vec::with_capacity(m);
         xpows.push(kts_one(&nf));
         for l in 1..m {
             xpows.push(kts_mul(&nf, &xpows[l - 1], &xseries, u_bound));
         }
         // Series of each bᵢ and of bd along this branch (K-coefficients).
-        let bi_ts: Vec<KTS> = (0..d)
+        let bi_ts: Vec<Kts> = (0..d)
             .map(|i| elem_kts(&nf, &b[i], &alpha, e, u_bound, &bts))
             .collect();
         let bd_ts = elem_kts(&nf, bd, &alpha, e, u_bound, &bts);
         // For column (i,l): the series of `xˡ·bᵢ` (the linear contribution of
         // aᵢₗ to the numerator).
-        let mut col_ts: Vec<KTS> = Vec::with_capacity(ncols);
+        let mut col_ts: Vec<Kts> = Vec::with_capacity(ncols);
         for bi in &bi_ts {
             for xl in &xpows {
                 col_ts.push(kts_mul(&nf, xl, bi, u_bound));
@@ -334,17 +334,17 @@ fn try_enlarge_algebraic(
 // ---------------------------------------------------------------------------
 
 /// A Laurent series in the place uniformizer `t`, coefficients in `K = ℚ(α)`.
-type KTS = BTreeMap<i64, KElem>;
+type Kts = BTreeMap<i64, KElem>;
 
-fn kts_one(nf: &NumberField) -> KTS {
-    let mut s = KTS::new();
+fn kts_one(nf: &NumberField) -> Kts {
+    let mut s = Kts::new();
     s.insert(0, nf.from_int(1));
     s
 }
 
 /// `α + t^e` as a `K`-series in `t`.
-fn x_alpha_kts(nf: &NumberField, alpha: &KElem, e: i64) -> KTS {
-    let mut s = KTS::new();
+fn x_alpha_kts(nf: &NumberField, alpha: &KElem, e: i64) -> Kts {
+    let mut s = Kts::new();
     if !NumberField::is_zero(alpha) {
         s.insert(0, alpha.clone());
     }
@@ -352,10 +352,10 @@ fn x_alpha_kts(nf: &NumberField, alpha: &KElem, e: i64) -> KTS {
     s
 }
 
-/// The Puiseux branch `y(t) = Σ c_k t^{exp·e}` (`c_k ∈ K`) as a `KTS`.
-fn branch_kts(nf: &NumberField, s: &AlgBasePuiseuxSeries) -> KTS {
+/// The Puiseux branch `y(t) = Σ c_k t^{exp·e}` (`c_k ∈ K`) as a `Kts`.
+fn branch_kts(nf: &NumberField, s: &AlgBasePuiseuxSeries) -> Kts {
     let e = s.ramification as i64;
-    let mut ts = KTS::new();
+    let mut ts = Kts::new();
     for (exp, c) in &s.terms {
         let k = (exp.clone() * Rational::from(e))
             .numer()
@@ -370,8 +370,8 @@ fn branch_kts(nf: &NumberField, s: &AlgBasePuiseuxSeries) -> KTS {
 
 /// Series of `b = Σⱼ bⱼ(x) yʲ` (`bⱼ ∈ ℚ(x)`) along a `K`-branch `y = bts(t)`,
 /// `x = α + t^e`.
-fn elem_kts(nf: &NumberField, b: &AlgElem, alpha: &KElem, e: i64, u: i64, bts: &KTS) -> KTS {
-    let mut acc = KTS::new();
+fn elem_kts(nf: &NumberField, b: &AlgElem, alpha: &KElem, e: i64, u: i64, bts: &Kts) -> Kts {
+    let mut acc = Kts::new();
     for (j, coeff) in b.iter().enumerate() {
         if coeff.numer().is_empty() {
             continue;
@@ -383,18 +383,18 @@ fn elem_kts(nf: &NumberField, b: &AlgElem, alpha: &KElem, e: i64, u: i64, bts: &
     acc
 }
 
-fn ratfn_kts(nf: &NumberField, r: &RatFn, alpha: &KElem, e: i64, u: i64) -> KTS {
+fn ratfn_kts(nf: &NumberField, r: &RatFn, alpha: &KElem, e: i64, u: i64) -> Kts {
     let num = poly_kts(nf, r.numer(), alpha, e, u);
     let den = poly_kts(nf, r.denom(), alpha, e, u);
     match kts_inv(nf, &den, u) {
         Some(inv) => kts_mul(nf, &num, &inv, u),
-        None => KTS::new(),
+        None => Kts::new(),
     }
 }
 
 /// `p(α + t^e)` (`p ∈ ℚ[x]`) as a `K`-series truncated to `t`-exponents `< u`.
-fn poly_kts(nf: &NumberField, p: &QPoly, alpha: &KElem, e: i64, u: i64) -> KTS {
-    let mut ts = KTS::new();
+fn poly_kts(nf: &NumberField, p: &QPoly, alpha: &KElem, e: i64, u: i64) -> Kts {
+    let mut ts = Kts::new();
     for (mexp, pm) in p.iter().enumerate() {
         if *pm == 0 {
             continue;
@@ -419,7 +419,7 @@ fn poly_kts(nf: &NumberField, p: &QPoly, alpha: &KElem, e: i64, u: i64) -> KTS {
     ts
 }
 
-fn kts_add(nf: &NumberField, a: &KTS, b: &KTS) -> KTS {
+fn kts_add(nf: &NumberField, a: &Kts, b: &Kts) -> Kts {
     let mut r = a.clone();
     for (k, c) in b {
         let slot = r.entry(*k).or_insert_with(NumberField::k_zero);
@@ -429,8 +429,8 @@ fn kts_add(nf: &NumberField, a: &KTS, b: &KTS) -> KTS {
     r
 }
 
-fn kts_mul(nf: &NumberField, a: &KTS, b: &KTS, u: i64) -> KTS {
-    let mut r = KTS::new();
+fn kts_mul(nf: &NumberField, a: &Kts, b: &Kts, u: i64) -> Kts {
+    let mut r = Kts::new();
     for (ka, ca) in a {
         for (kb, cb) in b {
             let k = ka + kb;
@@ -444,7 +444,7 @@ fn kts_mul(nf: &NumberField, a: &KTS, b: &KTS, u: i64) -> KTS {
     r
 }
 
-fn kts_pow(nf: &NumberField, a: &KTS, m: u32, u: i64) -> KTS {
+fn kts_pow(nf: &NumberField, a: &Kts, m: u32, u: i64) -> Kts {
     let mut acc = kts_one(nf);
     for _ in 0..m {
         acc = kts_mul(nf, &acc, a, u);
@@ -455,7 +455,7 @@ fn kts_pow(nf: &NumberField, a: &KTS, m: u32, u: i64) -> KTS {
 /// Inverse of a `K`-Laurent series, truncated to exponents `< u`.  `None` if the
 /// leading coefficient is not invertible in `K` (e.g. a zero divisor mod a
 /// reducible `q` — which cannot arise for an irreducible discriminant factor).
-fn kts_inv(nf: &NumberField, s: &KTS, u: i64) -> Option<KTS> {
+fn kts_inv(nf: &NumberField, s: &Kts, u: i64) -> Option<Kts> {
     let (&v0, c0) = s.iter().next()?; // lowest exponent
     let inv_c0 = nf.inv(c0)?;
     let kmax = (u + v0).max(1);
@@ -476,7 +476,7 @@ fn kts_inv(nf: &NumberField, s: &KTS, u: i64) -> Option<KTS> {
         }
         iu[k] = nf.neg(&acc);
     }
-    let mut res = KTS::new();
+    let mut res = Kts::new();
     for (k, iuk) in iu.iter().enumerate() {
         let exp = -v0 + k as i64;
         if exp < u && !NumberField::is_zero(iuk) {
@@ -487,7 +487,7 @@ fn kts_inv(nf: &NumberField, s: &KTS, u: i64) -> Option<KTS> {
 }
 
 /// The ℚ-component `comp` (coefficient of `αᶜᵒᵐᵖ`) of `s[t^k]`.
-fn kts_comp(s: &KTS, k: i64, comp: usize) -> Rational {
+fn kts_comp(s: &Kts, k: i64, comp: usize) -> Rational {
     s.get(&k)
         .and_then(|c| c.get(comp))
         .cloned()


### PR DESCRIPTION
## Summary

Extends the van Hoeij `integral_basis` enlargement loop (MB — general integral basis, risch.md §A) to **algebraic** singular places: irreducible discriminant factors `q` of degree ≥ 2 with `q² | disc`. Previously enlargements were proposed only at *rational* singular places, so curves singular only at irrational base points (e.g. `x = ±√2`) returned a non-maximal power basis.

## Algorithm

For each algebraic place over a root `α` of a monic irreducible `q` (`m = deg q ≥ 2`, `K = ℚ(α)`):

- Detect places via `q | gcd(disc, disc′)` among the degree-≥2 factors from `factor_over_q`.
- Propose van Hoeij's q-adic form `(Σ aᵢ(x) bᵢ + bd)/q(x)` with `aᵢ ∈ ℚ[x]`, `deg aᵢ < m`.
- Expand the numerator along each `K`-valued Puiseux sheet over `α` using `puiseux_at_algebraic` (PR #141), in a Laurent-series-in-`t` arithmetic over `K` (`Kts`).
- Require every negative-power coefficient (keys `k < e`) to vanish. Each `K`-coefficient contributes `m` ℚ-equations, so the unknowns `aᵢₗ` solve a **ℚ-linear** system (Gaussian elimination).

### Safety

Every proposal is gated by the exact `is_integral` check. A sheet whose coefficients escape `K` (skipped by `puiseux_at_algebraic`) only *under*-constrains the system → the proposal is rejected, never mis-accepted. Soundness never depends on completeness; the only failure mode is non-maximality. Termination: each accepted enlargement divides the discriminant by `q²`, bounded by the iteration cap.

## Coverage

- ✅ Curves singular only at an irrational place, e.g. `y² = (x²−2)²(x+3) → {1, y/(x²−2)}`.
- ✅ Control: same factor appearing to the first power only → no enlargement (`{1, y}`).
- ✅ Agreement with the radical fast-path on irrational simple branch points.

## Deferred (non-maximal, never incorrect)

Places whose Puiseux coefficients require a *proper* extension of `K` (a ramified leading coefficient that is `√(·)` of a non-square of `K`) are skipped-but-counted by `puiseux_at_algebraic`; enlargement there needs a Puiseux tower `ℚ(α)(θ)` (risch.md §D "Puiseux over a tower of extensions"). Such bases remain non-maximal at those places but are never incorrect.

## Tests

`cargo test --workspace` green (1079+ tests, 0 failures): vanhoeij 8/8 (incl. 3 new algebraic-place tests), puiseux 17/17, integral_basis 6/6. `cargo fmt` clean; `cargo clippy --workspace --all-targets` no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integral-basis computation now handles algebraic singular places (not just rational), improving correctness for repeated discriminant factors and enabling new algebraic enlargement candidates via q-adic–style constructions and exact verification.
  * Extended enlargement iteration bounds and added arithmetic over algebraic coefficient fields for more robust series manipulations.

* **Tests**
  * Added unit tests validating algebraic singular enlargement behavior and agreement with existing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->