### PR TITLE
feat(risch): coupled_radical_rde over exp/log tower bases

### DIFF
--- a/alkahest-core/src/integrate/risch/diff_field.rs
+++ b/alkahest-core/src/integrate/risch/diff_field.rs
@@ -38,7 +38,8 @@ use super::rational_rde::{
     numerator_degree_bound, poly_div_exact, poly_gcd, solve_rational_rde_generalized,
 };
 use super::tower_field::{
-    solve_tower_rde_generic_bounded, tower_x_degree_bound, ExpTowerField, LogTowerField, TExpr,
+    solve_tower_coupled_radical_rde_bounded, solve_tower_rde_generic_bounded, tower_x_degree_bound,
+    ExpTowerField, LogTowerField, TExpr,
 };
 
 // ===========================================================================
@@ -396,6 +397,26 @@ impl DifferentialField for ExpTowerField {
         let drift = degree(self.deta.numer()).max(degree(self.deta.denom()));
         Some(tower_x_degree_bound(f, g, drift))
     }
+
+    /// Coupled radical RDE over the exponential tower `ℚ(x)(eᵑ)`: solve
+    /// `D(u) + f·u = g` in the radical extension `yⁿ = a` for a possibly
+    /// non-diagonal `f`, via the tower-base coupled solver
+    /// `solve_tower_coupled_radical_rde_bounded` (undetermined-coefficient ansatz
+    /// `uᵢ = (Σ cᵢⱼₖ xᵏ tʲ)/D` per `y`-component, exact ℚ-linear system, Gauss
+    /// solve, exact in-field verification of `D(u)+f·u=g`).  The `x`-degree search
+    /// ceiling is raised to the analytic bound (drift `η'`) but never below the
+    /// heuristic floor.  `n < 2` or `a = 0` returns `None`; the caller re-verifies.
+    fn coupled_radical_rde(
+        &self,
+        n: usize,
+        a: &TExpr,
+        f: &[TExpr],
+        g: &[TExpr],
+    ) -> Option<Vec<TExpr>> {
+        let drift = degree(self.deta.numer()).max(degree(self.deta.denom()));
+        let x_bound = tower_coupled_x_bound(a, f, g, drift);
+        solve_tower_coupled_radical_rde_bounded(self, n, a, f, g, Some(x_bound))
+    }
 }
 
 // ===========================================================================
@@ -453,6 +474,38 @@ impl DifferentialField for LogTowerField {
         let drift = degree(self.dh_over_h.numer()).max(degree(self.dh_over_h.denom()));
         Some(tower_x_degree_bound(f, g, drift))
     }
+
+    /// Coupled radical RDE over the logarithmic tower `ℚ(x)(log h)`: solve
+    /// `D(u) + f·u = g` in the radical extension `yⁿ = a` for a possibly
+    /// non-diagonal `f`, via the tower-base coupled solver
+    /// `solve_tower_coupled_radical_rde_bounded` (same ansatz / exact ℚ-linear
+    /// system / Gauss solve / exact in-field verification as the exp-tower impl;
+    /// only the tower derivation differs).  The `x`-degree ceiling uses the
+    /// log-tower drift `h'/h` and is never lowered below the heuristic floor.
+    /// `n < 2` or `a = 0` returns `None`; the caller re-verifies.
+    fn coupled_radical_rde(
+        &self,
+        n: usize,
+        a: &TExpr,
+        f: &[TExpr],
+        g: &[TExpr],
+    ) -> Option<Vec<TExpr>> {
+        let drift = degree(self.dh_over_h.numer()).max(degree(self.dh_over_h.denom()));
+        let x_bound = tower_coupled_x_bound(a, f, g, drift);
+        solve_tower_coupled_radical_rde_bounded(self, n, a, f, g, Some(x_bound))
+    }
+}
+
+/// A sound `x`-degree search ceiling for the coupled tower radical ansatz: the
+/// max of the scalar [`tower_x_degree_bound`] over the radicand `a` and every
+/// component of `f`, `g` (with the given derivation drift degree).  Over-
+/// estimating only widens the search — verification gates correctness.
+fn tower_coupled_x_bound(a: &TExpr, f: &[TExpr], g: &[TExpr], drift: i64) -> usize {
+    let mut bound = tower_x_degree_bound(a, a, drift);
+    for c in f.iter().chain(g.iter()) {
+        bound = bound.max(tower_x_degree_bound(c, c, drift));
+    }
+    bound
 }
 
 // ===========================================================================

--- a/alkahest-core/src/integrate/risch/radical_ext.rs
+++ b/alkahest-core/src/integrate/risch/radical_ext.rs
@@ -62,14 +62,21 @@
 //! declining default means a base field with no coupled solver still declines
 //! (`None`).
 //!
-//! The tractable, proven slice is the **radical-over-`ℚ(x)`** base case:
-//! [`RationalDiffField`](super::diff_field::RationalDiffField)'s
-//! `coupled_radical_rde` bridges to an [`AlgExtension`](super::alg_field::AlgExtension)
-//! and runs the coupled solver `solve_alg_rde_general` (whose derivation matches
-//! `RadicalExt`'s diagonal twist, so the bridge is sound; it is verification-
-//! gated regardless).  Tower bases (`ExpTowerField`/`LogTowerField`) keep the
-//! declining default — the fully-generic coupled solve over an arbitrary
-//! transcendental tower remains future work.
+//! The tractable, proven slices are:
+//!   * the **radical-over-`ℚ(x)`** base case:
+//!     [`RationalDiffField`](super::diff_field::RationalDiffField)'s
+//!     `coupled_radical_rde` bridges to an
+//!     [`AlgExtension`](super::alg_field::AlgExtension) and runs the coupled solver
+//!     `solve_alg_rde_general` (whose derivation matches `RadicalExt`'s diagonal
+//!     twist, so the bridge is sound; it is verification-gated regardless);
+//!   * the **radical-over-tower** case (`ExpTowerField`/`LogTowerField`): their
+//!     `coupled_radical_rde` runs the tower-base coupled solver
+//!     `solve_tower_coupled_radical_rde_bounded` — a per-`y`-component
+//!     undetermined-coefficient ansatz `uᵢ = (Σ cᵢⱼₖ xᵏ tʲ)/D` over candidate
+//!     denominators, exact ℚ-linear system, Gauss solve, and exact in-field
+//!     verification.  The fully-generic coupled solve over an arbitrary nested
+//!     tower (more than one transcendental, or radicands needing higher caps)
+//!     remains future work — a missed solution declines, never a wrong answer.
 //!
 //! `limited_integrate` / `param_log_deriv` remain unimplemented (`None`).
 
@@ -350,7 +357,8 @@ impl<F: DifferentialField> DifferentialField for RadicalExt<F> {
     /// is coupled; this delegates to the base field's
     /// [`coupled_radical_rde`](DifferentialField::coupled_radical_rde) hook (the
     /// `ℚ(x)` impl bridges to `solve_alg_rde_general` over an `AlgExtension`;
-    /// tower bases keep the declining default and so still return `None`).
+    /// the `ExpTowerField`/`LogTowerField` impls run the tower-base coupled
+    /// solver; a base field without a coupled solver keeps the declining default).
     ///
     /// In both cases the assembled candidate is **verified in-field**
     /// (`D(u) + f·u = g`) before being returned, mirroring PR1's verification
@@ -363,8 +371,8 @@ impl<F: DifferentialField> DifferentialField for RadicalExt<F> {
             // Non-diagonal: multiplication-by-`f` mixes the power basis into a
             // genuinely coupled system.  Defer to the base field's coupled-radical
             // solver (the `ℚ(x)` impl bridges to `solve_alg_rde_general` over an
-            // `AlgExtension`; tower bases keep the declining default).  Any
-            // returned candidate is re-verified in-field before being accepted.
+            // `AlgExtension`; the tower impls run the tower-base coupled solver).
+            // Any returned candidate is re-verified in-field before acceptance.
             return self.coupled_nondiagonal_rde(f, g);
         }
         let f0 = f_trim
@@ -521,7 +529,7 @@ mod tests {
     use crate::integrate::risch::alg_field::RatFn;
     use crate::integrate::risch::diff_field::RationalDiffField;
     use crate::integrate::risch::poly_rde::QPoly;
-    use crate::integrate::risch::tower_field::{LogTowerField, TExpr};
+    use crate::integrate::risch::tower_field::{ExpTowerField, LogTowerField, TExpr};
     use rug::Rational;
 
     fn rat(n: i64) -> Rational {
@@ -677,28 +685,78 @@ mod tests {
     }
 
     #[test]
-    fn rde_nondiagonal_f_over_tower_base_declines() {
-        // RadicalExt over a LOG tower base: the base field has no coupled-radical
-        // solver (default hook ⇒ None), so a non-diagonal f still declines.  This
-        // documents the remaining hard case (coupled solve over a transcendental
-        // tower).
+    fn rde_nondiagonal_f_over_log_tower_base_solves() {
+        // RadicalExt over a LOG tower base, y = √(x + log x), now solves the
+        // non-diagonal coupled RDE via the tower-base coupled solver.
+        // Take a non-base twist f = c·y with c = 1/(x+log x) ∈ ℚ(x)(t) and the
+        // target u_true = y.  Then g = D(y) + c·y·y = D(y) + c·(x+log x) = D(y)+1,
+        // a genuinely coupled construction that the solver must recover.
         let dh_over_h = RatFn::new(vec![rat(1)], vec![rat(0), rat(1)]); // 1/x
         let log_field = LogTowerField::new(dh_over_h);
-        // Radicand a = x + log x.
-        let a = {
-            let x = TExpr::from_ratfn(rf_poly(&[0, 1]));
-            <LogTowerField as DifferentialField>::add(&log_field, &x, &TExpr::t())
-        };
+        let x = TExpr::from_ratfn(rf_poly(&[0, 1]));
+        let a = <LogTowerField as DifferentialField>::add(&log_field, &x, &TExpr::t()); // x + log x
+        let ext = RadicalExt::new(log_field.clone(), a.clone(), 2);
+
+        // c = 1/(x+log x); f = c·y (non-diagonal: nonzero y-component, c ∉ ℚ).
+        let c = <LogTowerField as DifferentialField>::inv(&log_field, &a).unwrap();
+        let f = vec![<LogTowerField as DifferentialField>::zero(&log_field), c];
+        let u_true = vec![
+            <LogTowerField as DifferentialField>::zero(&log_field),
+            <LogTowerField as DifferentialField>::one(&log_field),
+        ]; // y
+        assert!(ext.trim(f.clone()).len() > 1, "f must be non-diagonal");
+        let g = ext.add(&ext.derivation(&u_true), &ext.mul(&f, &u_true));
+        let sol = ext.rational_rde(&f, &g).expect("log-tower coupled solve");
+        // In-field re-verification of D(u)+f·u=g.
+        let lhs = ext.add(&ext.derivation(&sol), &ext.mul(&f, &sol));
+        assert!(ext.eq(&lhs, &g), "coupled RDE not satisfied; sol={sol:?}");
+        // And the headline solution u = y is recovered.
+        assert!(ext.eq(&sol, &u_true), "expected u = y; got {sol:?}");
+    }
+
+    #[test]
+    fn rde_nondiagonal_f_over_exp_tower_base_solves() {
+        // RadicalExt over an EXP tower base, y = √(x + eˣ).  Non-base twist
+        // f = (1/(x+eˣ))·y, target u_true = y.  Exercises the exp-tower drift.
+        let exp_field = ExpTowerField::new(RatFn::int(1)); // t = eˣ
+        let x = TExpr::from_ratfn(rf_poly(&[0, 1]));
+        let a = <ExpTowerField as DifferentialField>::add(&exp_field, &x, &TExpr::t()); // x + eˣ
+        let ext = RadicalExt::new(exp_field.clone(), a.clone(), 2);
+
+        let c = <ExpTowerField as DifferentialField>::inv(&exp_field, &a).unwrap();
+        let f = vec![<ExpTowerField as DifferentialField>::zero(&exp_field), c];
+        let u_true = vec![
+            <ExpTowerField as DifferentialField>::zero(&exp_field),
+            <ExpTowerField as DifferentialField>::one(&exp_field),
+        ];
+        let g = ext.add(&ext.derivation(&u_true), &ext.mul(&f, &u_true));
+        let sol = ext.rational_rde(&f, &g).expect("exp-tower coupled solve");
+        let lhs = ext.add(&ext.derivation(&sol), &ext.mul(&f, &sol));
+        assert!(ext.eq(&lhs, &g), "coupled RDE not satisfied; sol={sol:?}");
+    }
+
+    #[test]
+    fn rde_nondiagonal_f_over_tower_base_unsolvable_is_none() {
+        // y = √(x + log x), non-base f = 1·y, g = (1/x)·1 in component 0:
+        // the component-0 equation needs ∫1/x = log x, but the coupling cannot
+        // produce a rational/tower solution — the solver declines (None), never a
+        // wrong answer.  A genuine decline over the tower base.
+        let dh_over_h = RatFn::new(vec![rat(1)], vec![rat(0), rat(1)]); // 1/x
+        let log_field = LogTowerField::new(dh_over_h);
+        let x = TExpr::from_ratfn(rf_poly(&[0, 1]));
+        let a = <LogTowerField as DifferentialField>::add(&log_field, &x, &TExpr::t());
         let ext = RadicalExt::new(log_field.clone(), a, 2);
-        // Non-base f = 1·y (nonzero y-component).
         let f = vec![
             <LogTowerField as DifferentialField>::zero(&log_field),
             <LogTowerField as DifferentialField>::one(&log_field),
         ];
-        let g = ext.one();
+        // g = 1/x in component 0 (whose antiderivative log x is not reachable as
+        // a rational solution of this coupled system within the ansatz bounds).
+        let inv_x = TExpr::from_ratfn(RatFn::new(vec![rat(1)], vec![rat(0), rat(1)]));
+        let g = vec![inv_x];
         assert!(
             ext.rational_rde(&f, &g).is_none(),
-            "tower-base non-diagonal f ⇒ declines (default hook)"
+            "unsolvable tower-base coupled case ⇒ None"
         );
     }
 

--- a/alkahest-core/src/integrate/risch/tower_field.rs
+++ b/alkahest-core/src/integrate/risch/tower_field.rs
@@ -627,6 +627,280 @@ fn gauss_solve(
 }
 
 // ===========================================================================
+// Coupled radical Risch DE over a tower base ℚ(x)(t)  (M4 tower-base step)
+// ===========================================================================
+//
+// Solve the *coupled* radical Risch DE `D(u) + f·u = g` in the radical extension
+// `yⁿ = a` of a tower field `F = ℚ(x)(t)`, for a possibly NON-DIAGONAL `f`
+// (carrying higher `y`-powers).  Element are coefficient vectors `[u₀,…,u_{n−1}]`
+// over the power basis `1,y,…,y^{n−1}`, each `uᵢ ∈ ℚ(x)(t)`.
+//
+// This combines the two proven patterns:
+//   * the SCALAR tower ansatz `v = (Σⱼₖ cⱼₖ xᵏ tʲ)/D` ([`solve_with_denominator`]),
+//     extended to a per-`y`-component ansatz `uᵢ = (Σ cᵢⱼₖ xᵏ tʲ)/D`;
+//   * the COUPLED power-basis lift of [`super::alg_rde::solve_alg_rde_general`]:
+//     the operator `L(u) = D(u) + f·u` is ℚ-linear in the unknown coefficients,
+//     with the radical-extension diagonal-twist derivation
+//     `D(Σ uᵢ yⁱ) = Σ (D(uᵢ) + uᵢ·(i/n)·D(a)/a) yⁱ` and the mul-by-`f` mixing
+//     reduced mod `yⁿ = a`.
+//
+// We evaluate `L` on each basis element `xᵏ tʲ yⁱ / D`, extract one big exact
+// ℚ-linear system (match `y`-powers, then `t`-powers, then `x`-powers),
+// Gauss-solve it, reconstruct `u`, and **verify `D(u) + f·u = g` exactly in the
+// radical extension** before returning — sound by construction (a bounded ansatz
+// that misses the solution yields `None`, never a wrong answer).
+
+/// `D(a)/a` in the tower field `F`, or `None` if `a` is zero.
+fn tower_log_deriv<F: CoeffField<Elem = TExpr>>(field: &F, a: &TExpr) -> Option<TExpr> {
+    let da = field.derivation(a);
+    let inv_a = field.inv(a)?;
+    Some(field.mul(&da, &inv_a))
+}
+
+/// The base scalar `m/n ∈ ℚ ⊂ F` as a tower element.
+fn tower_ratio<F: CoeffField<Elem = TExpr>>(field: &F, m: usize, n: usize) -> TExpr {
+    let _ = field;
+    TExpr::from_ratfn(RatFn::new(
+        vec![Rational::from(m as i64)],
+        vec![Rational::from(n as i64)],
+    ))
+}
+
+/// Reduce an `F`-polynomial in `y` (length possibly `> n`) modulo `yⁿ = a` into a
+/// length-`n` coefficient vector over the tower field `F`.
+fn rad_reduce<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    a: &TExpr,
+    n: usize,
+    raw: &[TExpr],
+) -> Vec<TExpr> {
+    let mut v: Vec<TExpr> = raw.to_vec();
+    if v.len() < n {
+        v.resize(n, field.zero());
+    }
+    for k in (n..v.len()).rev() {
+        let c = v[k].clone();
+        if field.is_zero(&c) {
+            continue;
+        }
+        let folded = field.mul(&c, a); // y^k = a · y^{k−n}
+        v[k - n] = field.add(&v[k - n], &folded);
+        v[k] = field.zero();
+    }
+    v.truncate(n);
+    v
+}
+
+/// Multiply two length-`n` power-basis vectors over `F`, reduced mod `yⁿ = a`.
+fn rad_mul<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    a: &TExpr,
+    n: usize,
+    p: &[TExpr],
+    q: &[TExpr],
+) -> Vec<TExpr> {
+    if p.is_empty() || q.is_empty() {
+        return vec![field.zero(); n];
+    }
+    let mut raw = vec![field.zero(); p.len() + q.len() - 1];
+    for (i, ci) in p.iter().enumerate() {
+        if field.is_zero(ci) {
+            continue;
+        }
+        for (j, cj) in q.iter().enumerate() {
+            let prod = field.mul(ci, cj);
+            raw[i + j] = field.add(&raw[i + j], &prod);
+        }
+    }
+    rad_reduce(field, a, n, &raw)
+}
+
+/// The radical-extension derivation (diagonal twist) of a length-`n` vector:
+/// `D(Σ uᵢ yⁱ) = Σ (D(uᵢ) + uᵢ·(i/n)·D(a)/a) yⁱ`.  Needs `a ≠ 0`.
+fn rad_derivation<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    a: &TExpr,
+    n: usize,
+    u: &[TExpr],
+) -> Option<Vec<TExpr>> {
+    let lda = tower_log_deriv(field, a)?; // D(a)/a
+    let mut out = vec![field.zero(); n];
+    for (i, ui) in u.iter().enumerate().take(n) {
+        let dci = field.derivation(ui);
+        if i == 0 {
+            out[0] = dci;
+        } else {
+            let scale = tower_ratio(field, i, n); // i/n
+            let twist = field.mul(ui, &field.mul(&scale, &lda));
+            out[i] = field.add(&dci, &twist);
+        }
+    }
+    Some(out)
+}
+
+/// Solve the coupled radical Risch DE `D(u) + f·u = g` over the radical
+/// extension `yⁿ = a` of a tower field `F`, with an optional analytic `x`-degree
+/// search ceiling (passed through to the per-component ansatz cap).
+pub(crate) fn solve_tower_coupled_radical_rde_bounded<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    n: usize,
+    a: &TExpr,
+    f: &[TExpr],
+    g: &[TExpr],
+    x_bound: Option<usize>,
+) -> Option<Vec<TExpr>> {
+    if n < 2 || field.is_zero(a) {
+        return None;
+    }
+    // Pad f, g to length n.
+    let pad = |v: &[TExpr]| -> Vec<TExpr> {
+        let mut out = vec![field.zero(); n];
+        for (i, c) in v.iter().take(n).enumerate() {
+            out[i] = c.clone();
+        }
+        out
+    };
+    let f = pad(f);
+    let g = pad(g);
+
+    // Candidate common denominators (TExpr), gathered from a, every component of
+    // f and g, and the diagonal-twist coefficient D(a)/a.
+    let mut probe = field.zero();
+    probe = field.add(&probe, a);
+    if let Some(lda) = tower_log_deriv(field, a) {
+        probe = field.add(&probe, &lda);
+    }
+    for c in f.iter().chain(g.iter()) {
+        probe = field.add(&probe, c);
+    }
+    // Reuse the scalar candidate set (D=1, denominators of probe / its parts).
+    let dens = candidate_denominators(field, &probe, &g_combined(field, &g));
+
+    for d in &dens {
+        if let Some(u) = solve_coupled_with_denominator(field, n, a, &f, &g, d, x_bound) {
+            return Some(u);
+        }
+    }
+    None
+}
+
+/// Sum the components of a length-`n` vector into a single `TExpr` (only used to
+/// seed the candidate-denominator heuristic — soundness is from verification).
+fn g_combined<F: CoeffField<Elem = TExpr>>(field: &F, g: &[TExpr]) -> TExpr {
+    let mut acc = field.zero();
+    for c in g {
+        acc = field.add(&acc, c);
+    }
+    acc
+}
+
+/// Solve the coupled radical RDE seeking `uᵢ = (Σⱼₖ cᵢⱼₖ xᵏ tʲ)/D` for the fixed
+/// common denominator `D`.
+fn solve_coupled_with_denominator<F: CoeffField<Elem = TExpr>>(
+    field: &F,
+    n: usize,
+    a: &TExpr,
+    f: &[TExpr],
+    g: &[TExpr],
+    d: &TExpr,
+    x_bound: Option<usize>,
+) -> Option<Vec<TExpr>> {
+    const JCAP: usize = 3; // max degree in t
+    const KCAP: usize = 5; // heuristic floor on the max degree in x
+
+    let kcap = x_bound
+        .map_or(KCAP, |b| b.max(KCAP))
+        .min(X_DEGREE_SANITY_CAP);
+
+    let inv_d = field.inv(d)?;
+
+    // Basis: (component i, t-degree j, x-degree k) → element xᵏtʲ/D in component i.
+    let basis: Vec<(usize, usize, usize)> = (0..n)
+        .flat_map(|i| (0..=JCAP).flat_map(move |j| (0..=kcap).map(move |k| (i, j, k))))
+        .collect();
+
+    let one = Rational::from(1);
+    // Each ansatz basis element as a length-n power-basis vector over F.
+    let elems: Vec<Vec<TExpr>> = basis
+        .iter()
+        .map(|&(i, j, k)| {
+            let scalar = field.mul(&monomial(j, k, &one), &inv_d); // xᵏtʲ/D ∈ F
+            let mut v = vec![field.zero(); n];
+            v[i] = scalar;
+            v
+        })
+        .collect();
+
+    // L(elem) = D_rad(elem) + f·elem, each a length-n vector.
+    let mut cols: Vec<Vec<TExpr>> = Vec::with_capacity(elems.len());
+    for elem in &elems {
+        let dv = rad_derivation(field, a, n, elem)?;
+        let fv = rad_mul(field, a, n, f, elem);
+        let mut lv = vec![field.zero(); n];
+        for i in 0..n {
+            lv[i] = field.add(&dv[i], &fv[i]);
+        }
+        cols.push(lv);
+    }
+
+    let (matrix, rhs) = extract_linear_system_coupled(&cols, g, n);
+    let sol = gauss_solve(matrix, rhs, basis.len())?;
+
+    // Reconstruct u = Σ solᵢ · elemᵢ (each contributes to one component).
+    let mut u = vec![field.zero(); n];
+    for (idx, elem) in elems.iter().enumerate() {
+        if sol[idx] != 0 {
+            let s = TExpr::from_ratfn(RatFn::from_poly(&vec![sol[idx].clone()]));
+            for i in 0..n {
+                u[i] = field.add(&u[i], &field.mul(&s, &elem[i]));
+            }
+        }
+    }
+
+    // Exact in-field verification: D(u) + f·u == g.
+    let du = rad_derivation(field, a, n, &u)?;
+    let fu = rad_mul(field, a, n, f, &u);
+    let g_pad = {
+        let mut gp = vec![field.zero(); n];
+        for (i, c) in g.iter().take(n).enumerate() {
+            gp[i] = c.clone();
+        }
+        gp
+    };
+    for i in 0..n {
+        let lhs = field.add(&du[i], &fu[i]);
+        if !field.eq(&lhs, &g_pad[i]) {
+            return None;
+        }
+    }
+    Some(u)
+}
+
+/// Build the exact ℚ-linear system for the coupled solve by matching every
+/// `y`-power component (then `t`-powers, then `x`-powers via the scalar
+/// [`extract_linear_system`]) and concatenating the per-component rows.
+fn extract_linear_system_coupled(
+    cols: &[Vec<TExpr>],
+    target: &[TExpr],
+    n: usize,
+) -> (Vec<Vec<Rational>>, Vec<Rational>) {
+    let mut matrix: Vec<Vec<Rational>> = Vec::new();
+    let mut rhs: Vec<Rational> = Vec::new();
+    let zero = TExpr::int(0);
+    for comp in 0..n {
+        let comp_cols: Vec<TExpr> = cols
+            .iter()
+            .map(|c| c.get(comp).cloned().unwrap_or_else(|| zero.clone()))
+            .collect();
+        let comp_tgt = target.get(comp).cloned().unwrap_or_else(|| zero.clone());
+        let (m, r) = extract_linear_system(&comp_cols, &comp_tgt);
+        matrix.extend(m);
+        rhs.extend(r);
+    }
+    (matrix, rhs)
+}
+
+// ===========================================================================
 // Tests
 // ===========================================================================
 


### PR DESCRIPTION
## Design

Lifts `DifferentialField::coupled_radical_rde(n, a, f, g)` from its declining
default to a working solver for `ExpTowerField` and `LogTowerField` — so a
**non-diagonal** `f` (carrying `y`-powers) over a radical extension `yⁿ = a`
of a transcendental tower `ℚ(x)(t)` is solved instead of returning `None`.

This is the tower-base companion to PR #134 (`coupled_radical_rde` over `ℚ(x)`,
which bridges to `solve_alg_rde_general`/`AlgExtension`). The roadmap's
"Stale-note correction" identified exactly this gap: `RadicalExt` over an
`ExpTowerField`/`LogTowerField` base previously kept the declining default.

### Algorithm

New `solve_tower_coupled_radical_rde_bounded` (`tower_field.rs`) fuses the two
proven patterns already in the codebase:

* the **scalar** tower ansatz `v = (Σⱼₖ cⱼₖ xᵏ tʲ)/D` (`solve_with_denominator`),
  extended to a per-`y`-component ansatz `uᵢ = (Σ cᵢⱼₖ xᵏ tʲ)/D`;
* the **coupled** power-basis lift of `solve_alg_rde_general`: the radical
  diagonal-twist derivation `D(Σ uᵢ yⁱ) = Σ (D(uᵢ) + uᵢ·(i/n)·D(a)/a) yⁱ`
  plus mul-by-`f` mixing reduced mod `yⁿ = a`.

The operator `L(u) = D(u) + f·u` is evaluated on every ansatz basis element
`xᵏ tʲ yⁱ / D`, one big exact ℚ-linear system is extracted (match `y`-powers,
then `t`-powers, then `x`-powers), Gauss-solved, the candidate reconstructed,
and `D(u)+f·u = g` is **verified exactly in the radical extension** before
returning `Some`.

### Ansatz bounds

The `x`-degree search ceiling reuses `tower_x_degree_bound` (new
`tower_coupled_x_bound` takes the max over the radicand `a` and every
component of `f`, `g`, with the tower drift `η'` / `h'/h`), clamped by the
existing `X_DEGREE_SANITY_CAP`. Per the project rule, the ceiling is **never
lowered below the existing heuristic floor** (`JCAP=3`, `KCAP=5`) — only raised.
Candidate denominators reuse the scalar `candidate_denominators` set.

## Soundness

Sound by construction: every candidate is exact-verified in-field
(`D(u)+f·u = g` over `F[y]/(yⁿ−a)`) before being returned. A bounded ansatz
that misses the true solution yields `None`, never a wrong answer.

## Coverage

**Unit-level.** The public engine's `try_integrate_exp_times_radical_over_tower`
(the only constructor of a tower-based `RadicalExt`) passes a **base** scalar
`f = η'` only, which takes the diagonal `f ∈ base` path — so the non-diagonal
tower hook is not yet reached by any public integrand. It is exercised by the
new `radical_ext.rs` tests:

* `rde_nondiagonal_f_over_log_tower_base_solves` — `y=√(x+log x)`, non-base
  twist `f = (1/(x+log x))·y`, recovers `u=y`, in-field re-verified;
* `rde_nondiagonal_f_over_exp_tower_base_solves` — `y=√(x+eˣ)`, exercises the
  exp-tower drift;
* `rde_nondiagonal_f_over_tower_base_unsolvable_is_none` — a genuine decline.

## Declines

`n < 2` or `a = 0`; any input whose solution exceeds the ansatz caps
(t-degree > 3, or x-degree > the analytic ceiling) or needs a denominator
outside the candidate set; any input with no in-field solution. All decline
to `None` — never a wrong elementary form.

## Tests / quality

`cargo test -p alkahest-cas` green (1078 lib tests; previous headline
`∫[eˣ√(x+log x)+…] = eˣ√(x+log x)` and the exp-tower nesting case untouched).
`cargo fmt`, `cargo clippy -p alkahest-cas --all-targets` clean (no new
warnings), CI-equivalent `cargo doc --no-deps` (RUSTDOCFLAGS=-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the differential equation solver to handle coupled radical expressions over exponential and logarithmic tower extensions.

* **Tests**
  * Added comprehensive test coverage for tower-base coupled differential equation cases over multiple field types.

* **Documentation**
  * Refined solver behavior documentation and clarified solution verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->