### PR TITLE
feat(risch): K-rational integration with K-log emission

### DIFF
--- a/alkahest-core/src/integrate/risch/exp_case.rs
+++ b/alkahest-core/src/integrate/risch/exp_case.rs
@@ -1381,7 +1381,7 @@ pub(super) fn expr_to_krational_general(
 // ---------------------------------------------------------------------------
 
 /// Convert a K-element back to a symbolic `ExprId` for the given extension.
-fn kelem_to_expr_ext(e: &KElem, ext: &AlgebraicExtension, pool: &ExprPool) -> ExprId {
+pub(super) fn kelem_to_expr_ext(e: &KElem, ext: &AlgebraicExtension, pool: &ExprPool) -> ExprId {
     match ext {
         AlgebraicExtension::SingleSqrt { sqrt_expr, .. } => kelem_to_expr(e, *sqrt_expr, pool),
         AlgebraicExtension::NthRoot { root_expr, .. } => {
@@ -1480,7 +1480,12 @@ fn kelem_to_expr_ext(e: &KElem, ext: &AlgebraicExtension, pool: &ExprPool) -> Ex
 
 /// Convert a K-polynomial `p` in `var` back to a symbolic expression for the
 /// given algebraic extension.
-fn kpoly_to_expr_ext(p: &KPoly, var: ExprId, ext: &AlgebraicExtension, pool: &ExprPool) -> ExprId {
+pub(super) fn kpoly_to_expr_ext(
+    p: &KPoly,
+    var: ExprId,
+    ext: &AlgebraicExtension,
+    pool: &ExprPool,
+) -> ExprId {
     let mut terms: Vec<ExprId> = Vec::new();
     for (i, c) in p.iter().enumerate() {
         if NumberField::is_zero(c) {
@@ -2799,7 +2804,7 @@ fn poly_sqrt_exact(b: &QPoly) -> Option<QPoly> {
 }
 
 /// Exact rational square root, or `None` if `r` is not a perfect square.
-fn rational_sqrt(r: &rug::Rational) -> Option<rug::Rational> {
+pub(super) fn rational_sqrt(r: &rug::Rational) -> Option<rug::Rational> {
     if *r.numer() < 0 {
         return None;
     }

--- a/alkahest-core/src/integrate/risch/k_rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/k_rational_integrate.rs
@@ -1,0 +1,379 @@
+//! K-rational integration **with logarithms** — Risch §E follow-up.
+//!
+//! [`super::rational_rde::solve_rational_rde_k`] decides whether `∫ c(x) dx`
+//! (`c ∈ K(x)`, `K = ℚ(α)` a number field) has a **K-rational** antiderivative,
+//! i.e. one with no new transcendental generators.  When it returns `None` the
+//! antiderivative may still be **elementary** — it just needs new `log` terms
+//! with `K`-coefficients, e.g.
+//!
+//! ```text
+//!   ∫ 1/(x·(x+√2)) dx = (1/√2)·[log(x) − log(x+√2)]
+//! ```
+//!
+//! This module provides [`integrate_k_rational_with_logs`], a Rothstein–Trager
+//! / partial-fractions step over `K` that produces the **rational part** plus a
+//! list of `(residue, linear factor)` pairs `(cᵢ, x − rᵢ)` with `cᵢ, rᵢ ∈ K`,
+//! i.e. `Σ cᵢ·log(x − rᵢ)`.
+//!
+//! ## Scope
+//!
+//! - The polynomial part `Q` of `c_num = Q·c_den + R` is always integrated
+//!   (`∫Q` is a `K`-polynomial — always elementary).
+//! - The proper fraction `R/D` (`D` made monic, `gcd(R,D)=1`) must have a
+//!   **squarefree** denominator `D`.  Repeated factors (Hermite reduction) are
+//!   **not yet handled** — declines (`None`).  (The Hermite-reduced rational
+//!   part can still be produced separately by
+//!   [`super::rational_rde::solve_rational_rde_k`] when no logs are needed for
+//!   that piece; combining the two is a follow-up.)
+//! - `D` must split **completely into distinct `K`-linear factors** (`deg ≤ 2`
+//!   with the quadratic case requiring its discriminant to be a perfect square
+//!   in `K`, currently only for `K = ℚ(√d)` — [`AlgebraicExtension::SingleSqrt`]).
+//!   For each root `rᵢ ∈ K` of `D`, the residue is the simple-pole formula
+//!   `cᵢ = R(rᵢ) / D'(rᵢ)` evaluated by `K`-arithmetic.
+//! - Non-linear irreducible `K`-factors of `D` (e.g. an irreducible quadratic
+//!   over `K` whose discriminant is not a `K`-square) **decline** (`None`).
+//!   Documented as a follow-up: would need a `K`-algebraic extension `K(β)`
+//!   (Lazard–Rioboo–Trager `RootSum`-style) to express the residues.
+
+use rug::Rational;
+
+use super::exp_case::{rational_sqrt, AlgebraicExtension};
+use super::number_field::{KElem, KPoly, NumberField};
+
+/// Result of [`integrate_k_rational_with_logs`]: the polynomial/rational part
+/// (as a `K`-rational function `(num, den)`) plus the logarithmic terms
+/// `Σ cᵢ·log(x − rᵢ)`.
+pub struct KRationalLogResult {
+    /// `K`-rational antiderivative of the "no new log" part: `(num, den)`.
+    pub rational_num: KPoly,
+    pub rational_den: KPoly,
+    /// `(residue, root)` pairs: contributes `Σ residue·log(x − root)`.
+    pub log_terms: Vec<(KElem, KElem)>,
+}
+
+/// Evaluate a `K`-polynomial `p(x)` at `x = point ∈ K` via Horner's method.
+fn eval_kpoly_at(field: &NumberField, p: &[KElem], point: &KElem) -> KElem {
+    let mut acc = NumberField::k_zero();
+    for c in p.iter().rev() {
+        acc = field.add(&field.mul(&acc, point), c);
+    }
+    acc
+}
+
+/// Square root of a `K`-element `D = a + b·√d` in `K = ℚ(√d)` (modulus
+/// `t² − d`), or `None` if `D` is not a perfect square in `K`.
+///
+/// Solves `(p + q√d)² = D`, i.e. `p² + d·q² = a` and `2pq = b`:
+/// - `b = 0`: either `q = 0, p = √a` or `p = 0, q = √(a/d)`.
+/// - `b ≠ 0`: `p² = (a ± √(a² − d·b²)) / 2` for some sign, with `q = b/(2p)`.
+fn k_sqrt_quadratic(field: &NumberField, d: i64, elem: &KElem) -> Option<KElem> {
+    let zero = Rational::from(0);
+    let a = elem.first().cloned().unwrap_or_else(|| zero.clone());
+    let b = elem.get(1).cloned().unwrap_or_else(|| zero.clone());
+    let d_r = Rational::from(d);
+
+    if b == 0 {
+        if let Some(p) = rational_sqrt(&a) {
+            return Some(field.from_rational(&p));
+        }
+        // q = sqrt(a/d)
+        if a != 0 {
+            let aod = a.clone() / d_r.clone();
+            if let Some(q) = rational_sqrt(&aod) {
+                return Some(vec![zero, q]);
+            }
+        }
+        return None;
+    }
+
+    // a² − d·b²
+    let disc = a.clone() * a.clone() - d_r.clone() * b.clone() * b.clone();
+    let s = rational_sqrt(&disc)?;
+    for sign in [1i32, -1i32] {
+        let numer = if sign == 1 {
+            a.clone() + s.clone()
+        } else {
+            a.clone() - s.clone()
+        };
+        if numer < 0 {
+            continue;
+        }
+        let p_sq = numer / Rational::from(2);
+        if let Some(p) = rational_sqrt(&p_sq) {
+            if p == 0 {
+                continue; // p = 0 would require b = 0, handled above.
+            }
+            let q = b.clone() / (Rational::from(2) * p.clone());
+            return Some(vec![p, q]);
+        }
+    }
+    None
+}
+
+/// Find all roots of a monic `K`-polynomial `den` of `K`-degree 1 or 2 in `K`.
+///
+/// Returns `None` if `den` has degree ≥ 3, or (for degree 2) its discriminant
+/// is not a `K`-square — i.e. `den` does not split completely into distinct
+/// `K`-linear factors.  `ext` selects the field-specific square-root routine
+/// (currently only [`AlgebraicExtension::SingleSqrt`] supports the degree-2
+/// case).
+fn find_k_roots(
+    field: &NumberField,
+    den: &[KElem],
+    ext: &AlgebraicExtension,
+) -> Option<Vec<KElem>> {
+    match NumberField::kdeg(den) {
+        1 => {
+            // den = x + c  (monic)  ⇒  root = −c.
+            let c = den.first().cloned().unwrap_or_else(NumberField::k_zero);
+            Some(vec![field.neg(&c)])
+        }
+        2 => {
+            // den = x² + b x + c (monic).  Discriminant Δ = b² − 4c.
+            let b = den.get(1).cloned().unwrap_or_else(NumberField::k_zero);
+            let c = den.first().cloned().unwrap_or_else(NumberField::k_zero);
+            let four_c = field.mul(&c, &field.from_int(4));
+            let disc = field.sub(&field.mul(&b, &b), &four_c);
+            let AlgebraicExtension::SingleSqrt { d, .. } = ext else {
+                return None; // K-sqrt not implemented for this extension shape
+            };
+            let sqrt_disc = k_sqrt_quadratic(field, *d, &disc)?;
+            let two = field.from_int(2);
+            let two_inv = field.inv(&two)?;
+            let neg_b = field.neg(&b);
+            let r1 = field.mul(&field.add(&neg_b, &sqrt_disc), &two_inv);
+            let r2 = field.mul(&field.sub(&neg_b, &sqrt_disc), &two_inv);
+            if NumberField::kpoly_eq(std::slice::from_ref(&r1), std::slice::from_ref(&r2)) {
+                return None; // repeated root: den not squarefree (shouldn't happen)
+            }
+            Some(vec![r1, r2])
+        }
+        _ => None,
+    }
+}
+
+/// Try to compute `∫ c_num/c_den dx` over `K = ℚ(α)`, allowing `log` terms
+/// with `K`-coefficients in the result.
+///
+/// `c_num`, `c_den` are `K`-polynomials in `x`; `field`/`ext` describe `K`.
+///
+/// Returns `None` when:
+/// - `c_den` reduces to a polynomial (no logs needed — caller should use the
+///   plain `solve_rational_rde_k` path instead),
+/// - the squarefree remainder's denominator has a repeated factor (Hermite
+///   reduction over `K` not yet implemented), or
+/// - the squarefree remainder's denominator does not split completely into
+///   distinct `K`-linear factors (non-linear irreducible `K`-factor).
+pub(super) fn integrate_k_rational_with_logs(
+    field: &NumberField,
+    ext: &AlgebraicExtension,
+    c_num: &KPoly,
+    c_den: &KPoly,
+) -> Option<KRationalLogResult> {
+    let c_num = NumberField::kpoly_trim(c_num.clone());
+    let c_den = NumberField::kpoly_trim(c_den.clone());
+    if c_den.is_empty() {
+        return None; // division by zero
+    }
+    if NumberField::kdeg(&c_den) < 1 {
+        return None; // polynomial integrand — no logs needed
+    }
+
+    // Reduce to lowest terms with c_den monic.
+    let g = field.kpoly_gcd(&c_num, &c_den)?;
+    let num = field.kpoly_div_exact(&c_num, &g)?;
+    let den_raw = field.kpoly_div_exact(&c_den, &g)?;
+    let den = field.kpoly_monic(&den_raw)?;
+    let lead_inv = {
+        let lead = den_raw[NumberField::kdeg(&den_raw) as usize].clone();
+        field.inv(&lead)?
+    };
+    let num = field.kpoly_scale(&num, &lead_inv);
+
+    if NumberField::kdeg(&den) < 1 {
+        return None; // reduced to a polynomial
+    }
+
+    // Polynomial division: num = q·den + r.
+    let (q, r) = field.kpoly_divrem(&num, &den)?;
+    let r = NumberField::kpoly_trim(r);
+
+    if r.is_empty() {
+        // Exact division — purely polynomial, handled by the caller's
+        // K-rational path; no logs needed.
+        return None;
+    }
+
+    // Squarefree check: gcd(den, den') must be a (nonzero) constant.
+    let dprime = field.kpoly_deriv(&den);
+    let gd = field.kpoly_gcd(&den, &dprime)?;
+    if NumberField::kdeg(&gd) > 0 {
+        return None; // repeated factor — Hermite reduction over K not yet implemented
+    }
+
+    // Find all roots of `den` in K (must split completely).
+    let roots = find_k_roots(field, &den, ext)?;
+    if roots.len() != NumberField::kdeg(&den) as usize {
+        return None;
+    }
+
+    // Simple-pole residues: cᵢ = R(rᵢ) / D'(rᵢ).
+    let mut log_terms = Vec::new();
+    for root in &roots {
+        let r_val = eval_kpoly_at(field, &r, root);
+        let dp_val = eval_kpoly_at(field, &dprime, root);
+        let dp_inv = field.inv(&dp_val)?;
+        let residue = field.mul(&r_val, &dp_inv);
+        if NumberField::is_zero(&residue) {
+            continue;
+        }
+        log_terms.push((residue, root.clone()));
+    }
+
+    Some(KRationalLogResult {
+        rational_num: NumberField::kpoly_trim(q),
+        rational_den: vec![field.from_int(1)],
+        log_terms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrate::risch::exp_case::AlgebraicExtension;
+
+    /// K = ℚ(√2), modulus t² − 2.
+    fn k_sqrt2() -> (NumberField, AlgebraicExtension) {
+        let field = NumberField::new(vec![
+            Rational::from(-2),
+            Rational::from(0),
+            Rational::from(1),
+        ]);
+        let ext = AlgebraicExtension::SingleSqrt {
+            d: 2,
+            sqrt_expr: crate::kernel::ExprId(0), // unused by the arithmetic path
+        };
+        (field, ext)
+    }
+
+    /// `√2` as a K-element [0, 1].
+    fn sqrt2_elem() -> KElem {
+        vec![Rational::from(0), Rational::from(1)]
+    }
+
+    #[test]
+    fn k_sqrt_perfect_squares() {
+        let (field, _ext) = k_sqrt2();
+        // 2 = (√2)² ⇒ sqrt(2) = √2 in K.
+        let two = field.from_int(2);
+        let s = k_sqrt_quadratic(&field, 2, &two).expect("2 is a square in Q(sqrt2)");
+        assert!(NumberField::kpoly_eq(
+            &[field.mul(&s, &s)],
+            &[field.reduce(&two)]
+        ));
+
+        // 9 = 3² (rational square).
+        let nine = field.from_int(9);
+        let s = k_sqrt_quadratic(&field, 2, &nine).expect("9 is a perfect square");
+        assert!(NumberField::kpoly_eq(
+            &[field.mul(&s, &s)],
+            &[field.reduce(&nine)]
+        ));
+
+        // (1+√2)² = 3 + 2√2 ⇒ sqrt(3+2√2) = 1+√2.
+        let one_plus_sqrt2 = field.add(&field.from_int(1), &sqrt2_elem());
+        let target = field.mul(&one_plus_sqrt2, &one_plus_sqrt2);
+        let s = k_sqrt_quadratic(&field, 2, &target).expect("(1+sqrt2)^2 is a K-square");
+        let s_sq = field.mul(&s, &s);
+        assert!(NumberField::kpoly_eq(&[s_sq], &[field.reduce(&target)]));
+    }
+
+    #[test]
+    fn k_sqrt_non_square() {
+        let (field, _ext) = k_sqrt2();
+        // 3 is not a square in Q(sqrt2): N(3) = 9, but Q(sqrt2) has no
+        // element of norm... actually verify directly: no (p+q√2) with
+        // p^2+2q^2=3 and 2pq=0 has rational p,q (p=√3 or q=√(3/2), neither rational).
+        let three = field.from_int(3);
+        assert!(k_sqrt_quadratic(&field, 2, &three).is_none());
+    }
+
+    #[test]
+    fn x_times_x_plus_sqrt2_log_terms() {
+        // ∫ 1/(x·(x+√2)) dx = (1/√2)·[log(x) − log(x+√2)]
+        let (field, ext) = k_sqrt2();
+        let sqrt2 = sqrt2_elem();
+
+        // den = x*(x+sqrt2) = x^2 + sqrt2*x  (monic)
+        let den: KPoly = vec![NumberField::k_zero(), sqrt2.clone(), field.from_int(1)];
+        // num = 1
+        let num: KPoly = vec![field.from_int(1)];
+
+        let result = integrate_k_rational_with_logs(&field, &ext, &num, &den)
+            .expect("x(x+sqrt2) splits into K-linear factors");
+
+        assert!(NumberField::kdeg(&result.rational_num) < 0); // no polynomial part
+        assert_eq!(result.log_terms.len(), 2);
+
+        // Roots should be {0, -sqrt2}; residues should be {1/sqrt2, -1/sqrt2}.
+        let sqrt2_inv = field.inv(&sqrt2).expect("sqrt2 invertible");
+        let neg_sqrt2_inv = field.neg(&sqrt2_inv);
+
+        let mut found_zero = false;
+        let mut found_neg_sqrt2 = false;
+        for (residue, root) in &result.log_terms {
+            if NumberField::kpoly_eq(std::slice::from_ref(root), &[NumberField::k_zero()]) {
+                found_zero = true;
+                assert!(NumberField::kpoly_eq(
+                    std::slice::from_ref(residue),
+                    std::slice::from_ref(&sqrt2_inv)
+                ));
+            } else if NumberField::kpoly_eq(std::slice::from_ref(root), &[field.neg(&sqrt2)]) {
+                found_neg_sqrt2 = true;
+                assert!(NumberField::kpoly_eq(
+                    std::slice::from_ref(residue),
+                    std::slice::from_ref(&neg_sqrt2_inv)
+                ));
+            }
+        }
+        assert!(found_zero && found_neg_sqrt2);
+    }
+
+    #[test]
+    fn polynomial_denominator_declines() {
+        // den has K-degree 0 → not a genuine rational function.
+        let (field, ext) = k_sqrt2();
+        let den: KPoly = vec![field.from_int(1)];
+        let num: KPoly = vec![field.from_int(1)];
+        assert!(integrate_k_rational_with_logs(&field, &ext, &num, &den).is_none());
+    }
+
+    #[test]
+    fn exact_polynomial_quotient_declines() {
+        // num = den ⇒ exact division, no logs needed.
+        let (field, ext) = k_sqrt2();
+        let den: KPoly = vec![NumberField::k_zero(), sqrt2_elem(), field.from_int(1)];
+        let num = den.clone();
+        assert!(integrate_k_rational_with_logs(&field, &ext, &num, &den).is_none());
+    }
+
+    #[test]
+    fn repeated_factor_declines() {
+        // den = (x+sqrt2)^2 = x^2 + 2sqrt2 x + 2  (not squarefree)
+        let (field, ext) = k_sqrt2();
+        let sqrt2 = sqrt2_elem();
+        let two_sqrt2 = field.mul(&field.from_int(2), &sqrt2);
+        let den: KPoly = vec![field.from_int(2), two_sqrt2, field.from_int(1)];
+        let num: KPoly = vec![field.from_int(1)];
+        assert!(integrate_k_rational_with_logs(&field, &ext, &num, &den).is_none());
+    }
+
+    #[test]
+    fn irreducible_quadratic_over_k_declines() {
+        // den = x^2 + 1 over Q(sqrt2): discriminant -4, sqrt(-4) not in Q(sqrt2).
+        let (field, ext) = k_sqrt2();
+        let den: KPoly = vec![field.from_int(1), NumberField::k_zero(), field.from_int(1)];
+        let num: KPoly = vec![field.from_int(1)];
+        assert!(integrate_k_rational_with_logs(&field, &ext, &num, &den).is_none());
+    }
+}

--- a/alkahest-core/src/integrate/risch/k_rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/k_rational_integrate.rs
@@ -10,7 +10,7 @@
 //!   ∫ 1/(x·(x+√2)) dx = (1/√2)·[log(x) − log(x+√2)]
 //! ```
 //!
-//! This module provides [`integrate_k_rational_with_logs`], a Rothstein–Trager
+//! This module provides `integrate_k_rational_with_logs`, a Rothstein–Trager
 //! / partial-fractions step over `K` that produces the **rational part** plus a
 //! list of `(residue, linear factor)` pairs `(cᵢ, x − rᵢ)` with `cᵢ, rᵢ ∈ K`,
 //! i.e. `Σ cᵢ·log(x − rᵢ)`.
@@ -27,7 +27,7 @@
 //!   that piece; combining the two is a follow-up.)
 //! - `D` must split **completely into distinct `K`-linear factors** (`deg ≤ 2`
 //!   with the quadratic case requiring its discriminant to be a perfect square
-//!   in `K`, currently only for `K = ℚ(√d)` — [`AlgebraicExtension::SingleSqrt`]).
+//!   in `K`, currently only for `K = ℚ(√d)` — `AlgebraicExtension::SingleSqrt`).
 //!   For each root `rᵢ ∈ K` of `D`, the residue is the simple-pole formula
 //!   `cᵢ = R(rᵢ) / D'(rᵢ)` evaluated by `K`-arithmetic.
 //! - Non-linear irreducible `K`-factors of `D` (e.g. an irreducible quadratic
@@ -40,7 +40,7 @@ use rug::Rational;
 use super::exp_case::{rational_sqrt, AlgebraicExtension};
 use super::number_field::{KElem, KPoly, NumberField};
 
-/// Result of [`integrate_k_rational_with_logs`]: the polynomial/rational part
+/// Result of `integrate_k_rational_with_logs`: the polynomial/rational part
 /// (as a `K`-rational function `(num, den)`) plus the logarithmic terms
 /// `Σ cᵢ·log(x − rᵢ)`.
 pub struct KRationalLogResult {
@@ -115,7 +115,7 @@ fn k_sqrt_quadratic(field: &NumberField, d: i64, elem: &KElem) -> Option<KElem> 
 /// Returns `None` if `den` has degree ≥ 3, or (for degree 2) its discriminant
 /// is not a `K`-square — i.e. `den` does not split completely into distinct
 /// `K`-linear factors.  `ext` selects the field-specific square-root routine
-/// (currently only [`AlgebraicExtension::SingleSqrt`] supports the degree-2
+/// (currently only `AlgebraicExtension::SingleSqrt` supports the degree-2
 /// case).
 fn find_k_roots(
     field: &NumberField,

--- a/alkahest-core/src/integrate/risch/log_case.rs
+++ b/alkahest-core/src/integrate/risch/log_case.rs
@@ -43,8 +43,10 @@ use crate::simplify::engine::simplify;
 
 use super::exp_case::{
     build_field_and_gens, build_krational_ext, detect_algebraic_extension,
-    expr_to_krational_general,
+    expr_to_krational_general, kelem_to_expr_ext,
 };
+use super::k_rational_integrate::integrate_k_rational_with_logs;
+use super::number_field::NumberField;
 use super::poly_rde::{apply_const, contains_subexpr, is_free_of_var, split_const_factor};
 use super::rational_rde::solve_rational_rde_k;
 use super::tower::{decompose_as_log_poly, ExtensionKind, TowerLevel};
@@ -401,6 +403,12 @@ fn integrate_base_unchecked(
         return Ok(crate::simplify::engine::simplify(r, pool).value);
     }
 
+    // Gap E (follow-up): K-rational integration WITH new K-log terms, e.g.
+    // ∫ 1/(x·(x+√2)) dx = (1/√2)·[log(x) − log(x+√2)].
+    if let Some(r) = try_integrate_k_rational_with_logs(expr, var, pool) {
+        return Ok(crate::simplify::engine::simplify(r, pool).value);
+    }
+
     // Full engine for lower-tower generators (Gap B).
     match crate::integrate::engine::integrate(expr, var, pool) {
         Ok(d) => Ok(crate::simplify::engine::simplify(d.value, pool).value),
@@ -467,6 +475,17 @@ fn integrate_base(
         }
     }
 
+    // Gap E (follow-up): K-rational integration WITH new K-log terms.  These
+    // new logs are over K-linear arguments (x − rᵢ, rᵢ ∈ K) — distinct from
+    // `excluded_gen` (the current transcendental log generator h), so is_safe
+    // should always hold; check anyway for soundness.
+    if let Some(r) = try_integrate_k_rational_with_logs(expr, var, pool) {
+        let r = crate::simplify::engine::simplify(r, pool).value;
+        if is_safe(r) {
+            return Ok(r);
+        }
+    }
+
     // Slower path (Gap B): use the full integration engine for coefficients
     // that live in the lower tower (e.g. log(x) coefficients when integrating
     // at the log(log(x)) level).  Guard: the result must not contain
@@ -517,6 +536,85 @@ fn try_integrate_k_rational(expr: ExprId, var: ExprId, pool: &ExprPool) -> Optio
     let (v_num, v_den) = solve_rational_rde_k(&field, &k_zero, &c_num, &c_den)?;
 
     Some(build_krational_ext(&v_num, &v_den, var, &ext, pool))
+}
+
+/// Try to compute a K-rational antiderivative of `expr` **allowing new
+/// `K`-coefficient `log` terms** when `expr` is a rational function over a
+/// number field `K = ℚ(α)`.
+///
+/// This is the fallback for when [`try_integrate_k_rational`] declines (i.e.
+/// `solve_rational_rde_k` returns `None` because the antiderivative needs new
+/// logarithms).  Uses [`integrate_k_rational_with_logs`] (Rothstein–Trager /
+/// partial fractions over `K`) to produce
+/// `∫ c dx = (K-rational part) + Σ cᵢ·log(x − rᵢ)`, `cᵢ, rᵢ ∈ K`.
+///
+/// Returns `None` when:
+/// - `expr` does not parse as a `K`-rational function over a detected `ℚ(α)`,
+/// - the denominator has a repeated factor (Hermite reduction over `K` not
+///   yet implemented), or
+/// - the denominator does not split completely into distinct `K`-linear
+///   factors (e.g. an irreducible quadratic over `K`).
+fn try_integrate_k_rational_with_logs(
+    expr: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    let ext = detect_algebraic_extension(expr, pool)?;
+    let (field, gens) = build_field_and_gens(&ext);
+    let (c_num, c_den) = expr_to_krational_general(expr, var, &gens, &field, pool)?;
+
+    let result = integrate_k_rational_with_logs(&field, &ext, &c_num, &c_den)?;
+
+    // Rational part: result.rational_num/result.rational_den = Q, a K-polynomial
+    // (rational_den is always [1] — see integrate_k_rational_with_logs).
+    // Integrate term-by-term: ∫ Σ qᵢ xⁱ dx = Σ qᵢ·x^{i+1}/(i+1).
+    let mut terms: Vec<ExprId> = Vec::new();
+    for (i, c) in result.rational_num.iter().enumerate() {
+        if NumberField::is_zero(c) {
+            continue;
+        }
+        let c_expr = kelem_to_expr_ext(c, &ext, pool);
+        let i1 = (i + 1) as i32;
+        let pow_term = pool.pow(var, pool.integer(i1));
+        let scaled = pool.mul(vec![
+            c_expr,
+            pool.pow(pool.integer(i1), pool.integer(-1_i32)),
+            pow_term,
+        ]);
+        terms.push(scaled);
+    }
+    let rational_antideriv = match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    };
+
+    // Log terms: Σ cᵢ·log(x − rᵢ).
+    let mut log_terms: Vec<ExprId> = Vec::new();
+    for (residue, root) in &result.log_terms {
+        let residue_expr = kelem_to_expr_ext(residue, &ext, pool);
+        let root_expr = kelem_to_expr_ext(root, &ext, pool);
+        let arg = if is_zero(root_expr, pool) {
+            var
+        } else {
+            pool.add(vec![var, pool.mul(vec![pool.integer(-1_i32), root_expr])])
+        };
+        let log_arg = pool.func("log", vec![arg]);
+        let term = pool.mul(vec![residue_expr, log_arg]);
+        log_terms.push(term);
+    }
+
+    let mut all_terms = Vec::new();
+    if !is_zero(rational_antideriv, pool) {
+        all_terms.push(rational_antideriv);
+    }
+    all_terms.extend(log_terms);
+
+    match all_terms.len() {
+        0 => Some(pool.integer(0_i32)),
+        1 => Some(all_terms[0]),
+        _ => Some(pool.add(all_terms)),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1451,11 +1549,12 @@ mod tests {
 
     /// ∫ 1/(x+√2)²·log(x) dx IS mathematically elementary (double pole at x=−√2
     /// has zero simple residue; P_1 = −1/(x+√2) is K-rational), so eq (18) is
-    /// solvable (e=0) and the §E certificate correctly does NOT fire.  The engine
-    /// still *declines* this one (NotImplemented) because integrating the IBP base
-    /// term `∫ 1/(x(x+√2)) dx = (1/√2)(log x − log(x+√2))` needs a K-rational
-    /// integrator *with* logarithms, which the base field path lacks — a
-    /// pre-existing gap, NOT introduced here.  The load-bearing invariant is the
+    /// solvable (e=0) and the §E certificate correctly does NOT fire.  The IBP
+    /// base term `∫ 1/(x(x+√2)) dx = (1/√2)(log x − log(x+√2))` requires a
+    /// K-rational integrator *with* logarithms
+    /// ([`super::k_rational_integrate::integrate_k_rational_with_logs`]), now
+    /// wired into [`try_integrate_k_rational_with_logs`], so the engine produces
+    /// a verified antiderivative.  The load-bearing invariant remains the
     /// negative: it must NEVER be certified NonElementary.
     #[test]
     fn klog_inv_x_plus_sqrt2_sq_log_x_not_nonelementary() {
@@ -1471,9 +1570,13 @@ mod tests {
             !matches!(result, Err(IntegrationError::NonElementary(_))),
             "∫ 1/(x+√2)²·log(x) dx is elementary; must NEVER be NonElementary; got {result:?}"
         );
-        // If an antiderivative is produced, it must be correct.
-        if let Ok(d) = result {
-            verify_numeric_e(integrand, d.value, x, &pool);
+        // The K-rational-with-logs path now closes this gap: it must succeed.
+        match &result {
+            Ok(d) => {
+                println!("∫ 1/(x+√2)²·log(x) dx = {}", pool.display(d.value));
+                verify_numeric_e(integrand, d.value, x, &pool);
+            }
+            Err(e) => panic!("∫ 1/(x+√2)²·log(x) dx must now be elementary; got {e:?}"),
         }
     }
 

--- a/alkahest-core/src/integrate/risch/log_case.rs
+++ b/alkahest-core/src/integrate/risch/log_case.rs
@@ -1673,4 +1673,71 @@ mod tests {
         );
         verify_numeric_e(integrand, result.unwrap().value, x, &pool);
     }
+
+    // ----- Gap E follow-up: K-rational integration with K-log emission -----
+
+    /// `try_integrate_k_rational_with_logs` directly: ∫ 1/(x·(x+√2)) dx
+    /// = (1/√2)·[log(x) − log(x+√2)].  Both poles are K-rational (x=0 and
+    /// x=−√2), neither is a removable (zero-residue) pole, so the plain
+    /// K-rational RDE solver declines and `try_integrate_k_rational_with_logs`
+    /// must produce the dilog-free closed form (matches the module-doc
+    /// example and the `x_times_x_plus_sqrt2_log_terms` algebra-level test).
+    #[test]
+    fn k_rational_with_logs_x_times_x_plus_sqrt2() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let x_plus_sqrt2 = pool.add(vec![x, sqrt2]);
+        let integrand = pool.pow(pool.mul(vec![x, x_plus_sqrt2]), pool.integer(-1_i32));
+
+        let r = try_integrate_k_rational_with_logs(integrand, x, &pool)
+            .expect("∫ 1/(x(x+√2)) dx = (1/√2)(log x − log(x+√2)) must succeed");
+        let r = crate::simplify::engine::simplify(r, &pool).value;
+        println!("∫ 1/(x(x+√2)) dx = {}", pool.display(r));
+        verify_numeric_e(integrand, r, x, &pool);
+    }
+
+    /// `try_integrate_k_rational_with_logs` directly: ∫ 1/((x−√2)·(x+√2)) dx
+    /// = (1/(2√2))·[log(x−√2) − log(x+√2)], exercising a non-zero pair of
+    /// K-roots from a degree-2 denominator (both factors written explicitly
+    /// with √2 so the integrand is detected as K=ℚ(√2)-rational).
+    #[test]
+    fn k_rational_with_logs_inv_x_sq_minus_2() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        let neg_sqrt2 = pool.mul(vec![pool.integer(-1_i32), sqrt2]);
+        let x_minus_sqrt2 = pool.add(vec![x, neg_sqrt2]);
+        let x_plus_sqrt2 = pool.add(vec![x, sqrt2]);
+        let denom = pool.mul(vec![x_minus_sqrt2, x_plus_sqrt2]);
+        let integrand = pool.pow(denom, pool.integer(-1_i32));
+
+        let r = try_integrate_k_rational_with_logs(integrand, x, &pool)
+            .expect("∫ 1/((x−√2)(x+√2)) dx = (1/(2√2))[log(x−√2) − log(x+√2)] must succeed");
+        let r = crate::simplify::engine::simplify(r, &pool).value;
+        println!("∫ 1/((x−√2)(x+√2)) dx = {}", pool.display(r));
+        verify_numeric_e(integrand, r, x, &pool);
+    }
+
+    /// Decline: ∫ √2/(x²+1) dx — the denominator's discriminant (−4) is not a
+    /// K-square in K=ℚ(√2), so x²+1 does not split into K-linear factors.
+    /// `try_integrate_k_rational_with_logs` must decline (`None`); the
+    /// (rational, K-free) `arctan` path handles this elsewhere.
+    #[test]
+    fn k_rational_with_logs_irreducible_quadratic_declines() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let sqrt2 = pool.func("sqrt", vec![pool.integer(2_i32)]);
+        // Multiply by √2 so the integrand parses as a K=ℚ(√2)-rational
+        // function (otherwise detect_algebraic_extension finds no extension
+        // and this isn't exercising the K-rational-with-logs path at all).
+        let two = pool.integer(2_i32);
+        let denom = pool.add(vec![pool.pow(x, two), pool.integer(1_i32)]);
+        let integrand = pool.mul(vec![sqrt2, pool.pow(denom, pool.integer(-1_i32))]);
+
+        assert!(
+            try_integrate_k_rational_with_logs(integrand, x, &pool).is_none(),
+            "∫ √2/(x²+1) dx: denominator x²+1 is K-irreducible over ℚ(√2); must decline"
+        );
+    }
 }

--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -80,6 +80,7 @@ pub mod alg_rde;
 pub mod diff_field;
 pub mod exp_algebraic;
 pub mod exp_case;
+pub mod k_rational_integrate;
 pub mod log_case;
 pub mod number_field;
 pub mod poly_rde;


### PR DESCRIPTION
## Summary

- Adds `integrate_k_rational_with_logs` in a new module
  `alkahest-core/src/integrate/risch/k_rational_integrate.rs`: a
  Rothstein–Trager / partial-fractions step over a number field
  `K = ℚ(α)` for the proper fraction `R/D` of `c_num/c_den`, producing
  the polynomial part plus `Σ cᵢ·log(x − rᵢ)` log terms with
  `cᵢ, rᵢ ∈ K`.
- Wires this into `log_case.rs`'s `integrate_base` /
  `integrate_base_unchecked` (Gap E follow-up) as the fallback when the
  plain K-rational RDE solver (`solve_rational_rde_k`, `f = 0`)
  declines because the antiderivative needs new K-coefficient
  logarithms.
- Fixed a pre-existing bug found while testing the WIP module: a
  zero-K-element discriminant constant term caused `kpoly_scale(&[c],
  …)[0]` to panic (index out of bounds) in `find_k_roots` for the
  degree-2 case. Replaced with a direct `field.mul`.

## Algorithm / coverage

- `D = den` (monic, `gcd(num, den) = 1`) is checked squarefree
  (`gcd(D, D') = const`); repeated factors → decline (Hermite
  reduction over K not yet implemented, documented follow-up).
- `D` of K-degree 1: root `= −c` always available.
- `D` of K-degree 2: discriminant `Δ = b² − 4c` must be a K-square —
  currently only implemented for `K = ℚ(√d)`
  (`AlgebraicExtension::SingleSqrt`) via `k_sqrt_quadratic`.  Otherwise
  (irreducible-over-K quadratic, or K-degree ≥ 3) → decline.
- For each K-root `rᵢ`, residue `cᵢ = R(rᵢ)/D'(rᵢ)` via K-arithmetic.

This closes the integral `∫ 1/(x+√2)²·log(x) dx`, whose IBP base term
is `∫ 1/(x·(x+√2)) dx = (1/√2)·[log(x) − log(x+√2)]`. The engine now
returns a d/dx-verified elementary antiderivative
(`(√2/2)·log(x) − (√2/2)·log(x+√2) − log(x)/(x+√2)`) instead of
`NotImplemented`.

## Declines (return `None`, by design)

- Repeated denominator factors over K (Hermite reduction over K — follow-up).
- Denominators that don't split completely into distinct K-linear
  factors (e.g. `x²+1` over `ℚ(√2)`: discriminant `−4` is not a
  K-square) — covered by a new decline test.
- Quadratic K-degree-2 splitting for extensions other than
  `SingleSqrt` (e.g. `NthRoot`, `CompositumTwoSqrts`) — documented
  follow-up requiring a `K(β)`-algebraic extension
  (Lazard–Rioboo–Trager `RootSum`-style).

## #140 regression verification

`solve_primitive_top_rde_k` (the NonElementary certificate) is
unaffected — the new K-log path is reached only from the IBP
*base-case* integrator, never from the certificate's eq (18) check.
All #140 tests stay green, including the load-bearing negative:

- `klog_inv_x_plus_sqrt2_log_x_nonelementary` — `∫ 1/(x+√2)·log(x) dx`
  STAYS certified `NonElementary`.
- `klog_inv_x_plus_sqrt3_log_x_nonelementary`,
  `klog_sqrt2_over_x_plus_sqrt2_log_x_nonelementary`, and the
  adversarial `klog_combined_sum_not_nonelementary` /
  `klog_inv_x_plus_sqrt2_sq_log_x_not_nonelementary` (the gap closed by
  this PR) all pass.

## Test plan

- [x] `cargo test --workspace` — 1086 unit tests pass (was 1083), 0
      failed, 2 ignored (pre-existing, feature-gated).
- [x] `cargo fmt --all` — clean.
- [x] `cargo clippy --workspace --all-targets` — 0 new warnings.
- [x] New unit tests (all d/dx-verified via `verify_numeric_e`):
  - `k_rational_integrate::tests::x_times_x_plus_sqrt2_log_terms` (algebra-level)
  - `log_case::tests::k_rational_with_logs_x_times_x_plus_sqrt2`
  - `log_case::tests::k_rational_with_logs_inv_x_sq_minus_2`
  - `log_case::tests::k_rational_with_logs_irreducible_quadratic_declines`
  - `log_case::tests::klog_inv_x_plus_sqrt2_sq_log_x_not_nonelementary` (now produces and verifies a real antiderivative, not just "not NonElementary")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended integration to handle K‑rational functions that produce additional logarithmic terms, returning rational plus log components.

* **Refactor**
  * Made select internal helpers accessible to the parent module to support the new integration path and module exposure.

* **Tests**
  * Added and updated unit tests including numeric validation and cases covering quadratic-field behaviors and decline conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->