### PR TITLE
fix(poly): accept integer-valued Rational nodes in RationalFunction::from_symbolic

### DIFF
--- a/alkahest-core/src/poly/multipoly.rs
+++ b/alkahest-core/src/poly/multipoly.rs
@@ -103,6 +103,9 @@ fn expr_to_multivariate_coeffs(
             name: name.clone(),
         },
         ExprData::Integer(n) => NodeInfo::Integer(n.0.clone()),
+        // A `Rational` node whose value is integral (denominator 1) can arise
+        // from un-collapsed arithmetic; treat it as the integer numerator.
+        ExprData::Rational(r) if *r.0.denom() == 1 => NodeInfo::Integer(r.0.numer().clone()),
         ExprData::Rational(_) | ExprData::Float(_) => NodeInfo::NonIntCoeff,
         ExprData::Add(args) => NodeInfo::Add(args.clone()),
         ExprData::Mul(args) => NodeInfo::Mul(args.clone()),

--- a/alkahest-core/src/poly/rational.rs
+++ b/alkahest-core/src/poly/rational.rs
@@ -365,6 +365,30 @@ mod tests {
     }
 
     #[test]
+    fn integer_valued_rational_node_accepted() {
+        // numer = Rational(4, 1) (un-collapsed integer), denom = x
+        // Should be parsed as the integer 4, not rejected as NonIntegerCoefficient.
+        let (p, x, y) = pool_xy();
+        let n_expr = p.rational(4_i32, 1_i32);
+        let d_expr = x;
+        let rf = RationalFunction::from_symbolic(n_expr, d_expr, vec![x, y], &p).unwrap();
+        assert_eq!(rf.numer.terms[&vec![]], rug::Integer::from(4));
+        assert_eq!(rf.denom.terms[&vec![1]], rug::Integer::from(1));
+    }
+
+    #[test]
+    fn genuine_non_integer_rational_node_rejected() {
+        // numer = Rational(1, 2), denom = x — not integer-valued, must still error.
+        let (p, x, y) = pool_xy();
+        let n_expr = p.rational(1_i32, 2_i32);
+        let d_expr = x;
+        assert!(matches!(
+            RationalFunction::from_symbolic(n_expr, d_expr, vec![x, y], &p),
+            Err(ConversionError::NonIntegerCoefficient)
+        ));
+    }
+
+    #[test]
     fn trivial_rational() {
         // x / 1 → displayed without denominator
         let (p, x, y) = pool_xy();

--- a/alkahest-core/src/poly/unipoly.rs
+++ b/alkahest-core/src/poly/unipoly.rs
@@ -241,6 +241,16 @@ fn expr_to_univariate_coeffs(
             }
             Ok(map)
         }
+        // A `Rational` node whose value is integral (denominator 1) can arise
+        // from un-collapsed arithmetic; treat it as the integer numerator.
+        ExprData::Rational(r) if *r.0.denom() == 1 => {
+            let mut map = CoeffMap::new();
+            let n = r.0.numer().clone();
+            if n != 0 {
+                map.insert(0, n);
+            }
+            Ok(map)
+        }
         ExprData::Rational(_) | ExprData::Float(_) => Err(ConversionError::NonIntegerCoefficient),
         // n-ary sum: recurse and accumulate
         ExprData::Add(args) => {
@@ -664,6 +674,27 @@ mod tests {
         let (p, x) = pool_and_var();
         let poly = UniPoly::from_symbolic(x, x, &p).unwrap();
         assert_eq!(poly.coefficients_i64(), vec![0, 1]);
+    }
+
+    #[test]
+    fn from_symbolic_integer_valued_rational_node() {
+        // An un-collapsed Rational(4, 1) node should be accepted as the
+        // integer constant 4.
+        let (p, x) = pool_and_var();
+        let four = p.rational(4_i32, 1_i32);
+        let poly = UniPoly::from_symbolic(four, x, &p).unwrap();
+        assert_eq!(poly.coefficients_i64(), vec![4]);
+    }
+
+    #[test]
+    fn from_symbolic_non_integer_rational_still_rejected() {
+        // A genuine non-integer Rational(1, 2) node must still error.
+        let (p, x) = pool_and_var();
+        let half = p.rational(1_i32, 2_i32);
+        assert!(matches!(
+            UniPoly::from_symbolic(half, x, &p),
+            Err(ConversionError::NonIntegerCoefficient)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`MultiPoly::from_symbolic` / `UniPoly::from_symbolic` (and therefore
`RationalFunction::from_symbolic`) rejected `ExprData::Rational` nodes whose
value is an integer (denominator 1, e.g. a `Rational(4, 1)` produced by
un-collapsed arithmetic) with `ConversionError::NonIntegerCoefficient`, even
though the value *is* an integer.

This was found during Risch orchestration (PR #146 work), where a downstream
workaround in `risch/radical_subst.rs` (`rat_expr`) collapses integer-valued
`Rational` nodes to `Integer` nodes before parsing. That workaround is
harmless normalization and can stay, but the underlying parsers should accept
these nodes directly.

## Root cause

`pool.rational(numer, denom)` builds an `ExprData::Rational(BigRat(rug::Rational))`
node. `rug::Rational` auto-reduces `4/1` to numerator 4 / denominator 1, but
the node remains a `Rational` *variant* — it is not automatically collapsed
to `ExprData::Integer`. The two coefficient-extraction helpers matched
`ExprData::Rational(_)` unconditionally and returned
`ConversionError::NonIntegerCoefficient`, regardless of whether the
denominator was 1.

## Fix

- `alkahest-core/src/poly/multipoly.rs`: `expr_to_multivariate_coeffs` now
  matches `ExprData::Rational(r) if *r.0.denom() == 1` and treats it as the
  integer numerator (used by `MultiPoly::from_symbolic` →
  `RationalFunction::from_symbolic`).
- `alkahest-core/src/poly/unipoly.rs`: `expr_to_univariate_coeffs` gets the
  identical treatment (used by `UniPoly::from_symbolic`).

Genuine non-integer `Rational` nodes (denominator != 1) are still rejected
with `NonIntegerCoefficient` as before — `expr_to_univariate_rat_coeffs`
(rational-coefficient path used by `from_symbolic_clear_denoms`) was already
correct and untouched.

## Tests added

- `poly::rational::tests::integer_valued_rational_node_accepted` —
  `RationalFunction::from_symbolic` with a `Rational(4, 1)` numerator node
  parses to integer 4.
- `poly::rational::tests::genuine_non_integer_rational_node_rejected` —
  `Rational(1, 2)` numerator still errors with `NonIntegerCoefficient`.
- `poly::unipoly::tests::from_symbolic_integer_valued_rational_node` —
  `UniPoly::from_symbolic` accepts `Rational(4, 1)` as constant 4.
- `poly::unipoly::tests::from_symbolic_non_integer_rational_still_rejected` —
  `Rational(1, 2)` still errors.

## Sites deliberately left unchanged

Other `ExprData::Rational(_) | ExprData::Float(_)` matches treat `Rational`
as a generic constant/literal (not an "integer-or-error" coefficient parser),
so they are out of scope for this fix:
- `kernel/expr_props.rs` (constant/literal classification)
- `diff/diff_impl.rs` (constant detection for differentiation)
- `pattern/matcher.rs` (pattern literal classification)
- `sum/expr_ratio.rs` (rational-function constant case, already handles
  `Rational` correctly as a constant)
- `simplify/egraph.rs` (egraph node classification)
- `poly/resultant.rs` (free-variable detection)
- `poly/unipoly.rs::expr_to_univariate_rat_coeffs` (already correctly treats
  `Rational` nodes as rational coefficients, not an error case)

## Quality checks

- `cargo fmt` — no changes needed
- `cargo clippy --workspace --all-targets` — no new warnings
- `cargo test --workspace` — all green (1089 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Polynomial expressions now correctly accept integer-valued rational coefficients (e.g., 4/1 treated as 4) while maintaining rejection of non-integer rationals.

* **Tests**
  * Added validation tests for rational coefficient handling in polynomial parsing across multiple polynomial types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->