### PR TITLE
feat(transform): symbolic Laplace transform and inverse

### DIFF
--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -41,6 +41,8 @@ pub mod diffalg;
 // V2-10 — Gosper / creative telescoping (WZ certificates)
 pub mod stablehlo;
 pub mod sum;
+// §3.3 — symbolic integral transforms (Laplace and inverse Laplace)
+pub mod transform;
 // Plot — dependency-free SVG / DOT renderers
 pub mod plot;
 
@@ -92,6 +94,9 @@ pub use poly::{
     RootInterval, SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP,
     UniPolyFactorization,
 };
+
+// §3.3 — Laplace transform and inverse (experimental surface; see `experimental`)
+pub use transform::{inverse_laplace_transform, laplace_transform, LaplaceError};
 
 // Phase 24 — Horner form
 pub use horner::{emit_horner_c, eval_horner_f64, eval_horner_f64_batch, horner};
@@ -297,6 +302,8 @@ pub mod experimental {
         CONTEXT_COLOR, ROOT_COLOR,
     };
     pub use crate::stablehlo::emit_stablehlo;
+    pub use crate::transform::laplace::laplace_derivative_rule;
+    pub use crate::transform::{inverse_laplace_transform, laplace_transform, LaplaceError};
 
     #[cfg(feature = "parallel")]
     pub use crate::simplify::parallel::{simplify_par, simplify_par_with_config};

--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -316,6 +316,8 @@ impl PrimitiveRegistry {
         reg.register(Box::new(builtins::EllipticPiPrimitive));
         reg.register(Box::new(builtins::AbsPrimitive));
         reg.register(Box::new(builtins::SignPrimitive));
+        reg.register(Box::new(builtins::HeavisidePrimitive));
+        reg.register(Box::new(builtins::DiracDeltaPrimitive));
         reg.register(Box::new(builtins::FloorPrimitive));
         reg.register(Box::new(builtins::CeilPrimitive));
         reg.register(Box::new(builtins::RoundPrimitive));
@@ -1675,6 +1677,72 @@ pub mod builtins {
             } else {
                 0.0
             })
+        }
+    }
+
+    // ── Heaviside (unit step) ──────────────────────────────────────────────────
+
+    /// The Heaviside unit-step function `θ(x)`: `0` for `x < 0`, `1` for `x > 0`.
+    ///
+    /// The value at `x = 0` is left unspecified (the half-maximum convention
+    /// `θ(0) = 1/2` is used for numeric evaluation).  Its distributional
+    /// derivative is the [`DiracDeltaPrimitive`].  Registered so the Laplace
+    /// transform can recognise shifted steps `θ(t − a)`.
+    pub struct HeavisidePrimitive;
+
+    impl Primitive for HeavisidePrimitive {
+        fn name(&self) -> &'static str {
+            "heaviside"
+        }
+
+        fn pretty(&self, args: &[ExprId], pool: &ExprPool) -> String {
+            format!("θ({})", pool.display(args[0]))
+        }
+
+        fn diff_forward(&self, args: &[ExprId], wrt: ExprId, pool: &ExprPool) -> Option<ExprId> {
+            // d/dx θ(g(x)) = δ(g(x))·g'(x)  (distributional derivative).
+            let g = args[0];
+            let dg = crate::diff::diff(g, wrt, pool).ok()?.value;
+            let delta = pool.func("diracdelta", vec![g]);
+            Some(pool.mul(vec![delta, dg]))
+        }
+
+        fn diff_reverse(
+            &self,
+            args: &[ExprId],
+            cotan: ExprId,
+            pool: &ExprPool,
+        ) -> Option<Vec<ExprId>> {
+            let delta = pool.func("diracdelta", vec![args[0]]);
+            Some(vec![pool.mul(vec![cotan, delta])])
+        }
+
+        fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
+            Some(if args[0] > 0.0 {
+                1.0
+            } else if args[0] < 0.0 {
+                0.0
+            } else {
+                0.5
+            })
+        }
+    }
+
+    // ── Dirac delta ─────────────────────────────────────────────────────────────
+
+    /// The Dirac delta distribution `δ(x)`: the distributional derivative of the
+    /// [`HeavisidePrimitive`], with `∫ δ = 1`.  Not a classical function; numeric
+    /// evaluation is intentionally unimplemented.  Registered as a symbol so the
+    /// Laplace transform can map `δ(t − a) ↦ e^{−as}`.
+    pub struct DiracDeltaPrimitive;
+
+    impl Primitive for DiracDeltaPrimitive {
+        fn name(&self) -> &'static str {
+            "diracdelta"
+        }
+
+        fn pretty(&self, args: &[ExprId], pool: &ExprPool) -> String {
+            format!("δ({})", pool.display(args[0]))
         }
     }
 

--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -31,8 +31,13 @@
 //! assert!(caps.contains(Capabilities::DIFF_FORWARD));
 //!
 //! let report = reg.coverage_report();
-//! // Every built-in has at least NUMERIC_F64 coverage.
+//! // Every built-in *function* has at least NUMERIC_F64 coverage; the only
+//! // exception is the Dirac delta `δ`, which is a distribution with no
+//! // pointwise `f64` value.
 //! for row in &report.rows {
+//!     if row.name == "diracdelta" {
+//!         continue;
+//!     }
 //!     assert!(row.caps.contains(Capabilities::NUMERIC_F64));
 //! }
 //! ```
@@ -2046,6 +2051,35 @@ mod tests {
 
         let got = reg.numeric_f64("tanh", &[0.0]).unwrap();
         assert!((got - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn heaviside_and_dirac_registered() {
+        use crate::kernel::{Domain, ExprData, ExprPool};
+        let reg = PrimitiveRegistry::default_registry();
+        assert!(reg.is_registered("heaviside"));
+        assert!(reg.is_registered("diracdelta"));
+
+        // Heaviside numeric: θ(−1)=0, θ(0)=1/2, θ(1)=1.
+        assert_eq!(reg.numeric_f64("heaviside", &[-1.0]), Some(0.0));
+        assert_eq!(reg.numeric_f64("heaviside", &[0.0]), Some(0.5));
+        assert_eq!(reg.numeric_f64("heaviside", &[1.0]), Some(1.0));
+
+        // Dirac delta has no pointwise f64 value (it is a distribution).
+        assert_eq!(reg.numeric_f64("diracdelta", &[0.0]), None);
+
+        // d/dx θ(x) = δ(x): the forward derivative is a δ-function node.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let dh = reg.diff_forward("heaviside", &[x], x, &pool).unwrap();
+        let dh = crate::simplify::simplify(dh, &pool).value;
+        match pool.get(dh) {
+            ExprData::Func { name, args } => {
+                assert_eq!(name, "diracdelta");
+                assert_eq!(args, vec![x]);
+            }
+            other => panic!("expected diracdelta(x), got {other:?}"),
+        }
     }
 
     // ── Elliptic special functions ─────────────────────────────────────────────

--- a/alkahest-core/src/transform/laplace.rs
+++ b/alkahest-core/src/transform/laplace.rs
@@ -1,0 +1,995 @@
+//! Symbolic Laplace transform `L{f(t)}(s)` and inverse `L⁻¹{F(s)}(t)`.
+//!
+//! # Forward transform
+//!
+//! [`laplace_transform`] is a rule/table-based structural recursion over `f(t)`:
+//!
+//! | `f(t)`                 | `L{f}(s)`                       | rule              |
+//! |------------------------|---------------------------------|-------------------|
+//! | `c` (const)            | `c/s`                           | constant          |
+//! | `t^n` (`n ∈ ℤ₊`)       | `n! / s^{n+1}`                  | power             |
+//! | `e^{a t}`              | `1/(s−a)`                       | exponential       |
+//! | `sin(b t)`             | `b/(s²+b²)`                     | sine              |
+//! | `cos(b t)`             | `s/(s²+b²)`                     | cosine            |
+//! | `sinh(b t)`            | `b/(s²−b²)`                     | hyperbolic sine   |
+//! | `cosh(b t)`            | `s/(s²−b²)`                     | hyperbolic cosine |
+//! | `α·f + β·g`            | `α·L{f} + β·L{g}`               | linearity         |
+//! | `e^{a t}·f(t)`         | `F(s−a)`                        | s-shift theorem   |
+//! | `t^n·f(t)`             | `(−1)^n F^{(n)}(s)`             | frequency-diff    |
+//! | `θ(t−a)·g(t−a)`        | `e^{−a s} G(s)`                | t-shift (`a ≥ 0`) |
+//! | `θ(t−a)`               | `e^{−a s}/s`                    | shifted step      |
+//! | `δ(t−a)`               | `e^{−a s}`  (`δ(t) ↦ 1`)        | impulse           |
+//!
+//! The derivative rule `L{f^{(n)}} = sⁿF − sⁿ⁻¹f(0) − … − f^{(n−1)}(0)` is
+//! exposed separately as [`laplace_derivative_rule`] for the ODE workflow (it
+//! operates on the *symbol* `F = L{f}` plus initial values, since `f` itself is
+//! an unknown function).
+//!
+//! # Inverse transform
+//!
+//! [`inverse_laplace_transform`] inverts a **proper rational** `F(s) = p(s)/q(s)`
+//! by partial fractions (via [`crate::poly::apart`]) and a per-term table:
+//!
+//! | term in `F(s)`              | `L⁻¹` term                       |
+//! |-----------------------------|----------------------------------|
+//! | `A/(s−a)^n`                 | `A·t^{n−1} e^{a t}/(n−1)!`        |
+//! | `(B s + C)/((s−p)²+ω²)^n`   | damped sin/cos (`n = 1`)         |
+//! | `e^{−a s} F(s)`             | `θ(t−a)·(L⁻¹F)(t−a)`             |
+//!
+//! A leading polynomial part of `F` (improper rational) maps back to derivatives
+//! of `δ(t)`, which we decline rather than fabricate.
+//!
+//! # Caveats
+//!
+//! Both directions are **formal** — no convergence region is computed and no
+//! existence side-conditions are attached.  Unrecognised forms return
+//! [`LaplaceError::NoRule`] (forward) / [`LaplaceError::NotInvertible`] (inverse)
+//! rather than guessing.
+
+use rug::Integer;
+
+use crate::kernel::{ExprData, ExprId, ExprPool};
+
+/// Errors from the Laplace transform routines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaplaceError {
+    /// No forward rule matched `f(t)` (E-TRANSFORM-001).
+    NoRule(String),
+    /// The inverse-transform input is not a form the table can invert
+    /// (E-TRANSFORM-002).
+    NotInvertible(String),
+    /// The frequency variable `s` and time variable `t` must be distinct
+    /// symbols (E-TRANSFORM-003).
+    SameVariable,
+}
+
+impl std::fmt::Display for LaplaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LaplaceError::NoRule(m) => {
+                write!(f, "laplace_transform: no rule for {m} [E-TRANSFORM-001]")
+            }
+            LaplaceError::NotInvertible(m) => write!(
+                f,
+                "inverse_laplace_transform: cannot invert {m} [E-TRANSFORM-002]"
+            ),
+            LaplaceError::SameVariable => write!(
+                f,
+                "laplace_transform: time and frequency variables must differ [E-TRANSFORM-003]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LaplaceError {}
+
+// ===========================================================================
+// Small helpers
+// ===========================================================================
+
+fn is_free_of(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    crate::integrate::risch::poly_rde::is_free_of_var(expr, var, pool)
+}
+
+/// `n!` as an interned integer.
+fn factorial(n: u64, pool: &ExprPool) -> ExprId {
+    let mut acc = Integer::from(1);
+    for k in 2..=n {
+        acc *= Integer::from(k);
+    }
+    pool.integer(acc)
+}
+
+/// Extract `a` from an expression that is `a·var + b` with `a, b` free of `var`,
+/// returning `(a, b)`.  Returns `None` when the expression is not affine in
+/// `var`.
+fn as_affine(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<(ExprId, ExprId)> {
+    if expr == var {
+        return Some((pool.integer(1_i32), pool.integer(0_i32)));
+    }
+    if is_free_of(expr, var, pool) {
+        return Some((pool.integer(0_i32), expr));
+    }
+    match pool.get(expr) {
+        ExprData::Mul(_) => {
+            let (a, b) = as_affine_term(expr, var, pool)?;
+            // a single Mul term has no constant part
+            if b == pool.integer(0_i32) {
+                Some((a, pool.integer(0_i32)))
+            } else {
+                None
+            }
+        }
+        ExprData::Add(args) => {
+            let mut a_acc: Vec<ExprId> = Vec::new();
+            let mut b_acc: Vec<ExprId> = Vec::new();
+            for arg in args {
+                if is_free_of(arg, var, pool) {
+                    b_acc.push(arg);
+                } else {
+                    let (a, b) = as_affine_term(arg, var, pool)?;
+                    if b != pool.integer(0_i32) {
+                        return None;
+                    }
+                    a_acc.push(a);
+                }
+            }
+            let a = match a_acc.len() {
+                0 => pool.integer(0_i32),
+                1 => a_acc[0],
+                _ => pool.add(a_acc),
+            };
+            let b = match b_acc.len() {
+                0 => pool.integer(0_i32),
+                1 => b_acc[0],
+                _ => pool.add(b_acc),
+            };
+            Some((a, b))
+        }
+        _ => None,
+    }
+}
+
+/// Affine analysis of a single (non-Add) term: returns `(coeff, 0)` for a term
+/// `coeff·var`, else `None` unless it is free of `var` (`(0, term)`).
+fn as_affine_term(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<(ExprId, ExprId)> {
+    if expr == var {
+        return Some((pool.integer(1_i32), pool.integer(0_i32)));
+    }
+    if is_free_of(expr, var, pool) {
+        return Some((pool.integer(0_i32), expr));
+    }
+    if let ExprData::Mul(args) = pool.get(expr) {
+        let pos = args.iter().position(|&a| a == var)?;
+        let others: Vec<ExprId> = args
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| i != pos)
+            .map(|(_, &a)| a)
+            .collect();
+        if others.iter().all(|&o| is_free_of(o, var, pool)) {
+            let coeff = match others.len() {
+                0 => pool.integer(1_i32),
+                1 => others[0],
+                _ => pool.mul(others),
+            };
+            return Some((coeff, pool.integer(0_i32)));
+        }
+    }
+    None
+}
+
+/// Simplify and return the bare `ExprId`.
+fn simp(expr: ExprId, pool: &ExprPool) -> ExprId {
+    crate::simplify::simplify(expr, pool).value
+}
+
+fn neg(expr: ExprId, pool: &ExprPool) -> ExprId {
+    pool.mul(vec![pool.integer(-1_i32), expr])
+}
+
+fn recip(expr: ExprId, pool: &ExprPool) -> ExprId {
+    pool.pow(expr, pool.integer(-1_i32))
+}
+
+// ===========================================================================
+// Forward transform
+// ===========================================================================
+
+/// Compute the Laplace transform `L{f(t)}(s) = ∫₀^∞ f(t) e^{−s t} dt`.
+///
+/// `t` is the time variable, `s` the frequency variable; both must be distinct
+/// symbols.  This is a *formal* transform — see the [module docs](self) for the
+/// rule table, caveats, and declines.
+///
+/// # Errors
+///
+/// - [`LaplaceError::SameVariable`] if `t == s`.
+/// - [`LaplaceError::NoRule`] if no table rule matches `f(t)`.
+///
+/// # Examples
+///
+/// ```
+/// use alkahest_cas::kernel::{Domain, ExprPool};
+/// use alkahest_cas::transform::laplace_transform;
+///
+/// let pool = ExprPool::new();
+/// let t = pool.symbol("t", Domain::Real);
+/// let s = pool.symbol("s", Domain::Real);
+/// // L{1}(s) = 1/s
+/// let one = pool.integer(1_i32);
+/// let f = laplace_transform(one, t, s, &pool).unwrap();
+/// assert_eq!(pool.display(f).to_string(), pool.display(pool.pow(s, pool.integer(-1_i32))).to_string());
+/// ```
+pub fn laplace_transform(
+    f: ExprId,
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, LaplaceError> {
+    if t == s {
+        return Err(LaplaceError::SameVariable);
+    }
+    let out = laplace_inner(f, t, s, pool, 0)?;
+    Ok(simp(out, pool))
+}
+
+const MAX_DEPTH: usize = 32;
+
+fn laplace_inner(
+    f: ExprId,
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<ExprId, LaplaceError> {
+    if depth > MAX_DEPTH {
+        return Err(LaplaceError::NoRule("recursion depth exceeded".into()));
+    }
+
+    // Constant (free of t): L{c} = c/s.
+    if is_free_of(f, t, pool) {
+        return Ok(pool.mul(vec![f, recip(s, pool)]));
+    }
+
+    // Bare t: L{t} = 1/s².
+    if f == t {
+        return Ok(recip(pool.pow(s, pool.integer(2_i32)), pool));
+    }
+
+    match pool.get(f) {
+        // Linearity over sums.
+        ExprData::Add(args) => {
+            let mut terms = Vec::with_capacity(args.len());
+            for a in args {
+                terms.push(laplace_inner(a, t, s, pool, depth + 1)?);
+            }
+            Ok(pool.add(terms))
+        }
+
+        // Products: split off the t-free scalar (linearity), then dispatch the
+        // remaining t-dependent factor through the structural product rules.
+        ExprData::Mul(args) => laplace_mul(&args, t, s, pool, depth),
+
+        // Pure power t^n.
+        ExprData::Pow { base, exp } if base == t => {
+            if let Some(n) = nonneg_int_exp(exp, pool) {
+                // L{t^n} = n! / s^{n+1}
+                let fact = factorial(n, pool);
+                let denom = pool.pow(s, pool.integer(Integer::from(n + 1)));
+                Ok(pool.mul(vec![fact, recip(denom, pool)]))
+            } else {
+                Err(LaplaceError::NoRule(format!(
+                    "t^e with non-integer exponent: {}",
+                    pool.display(f)
+                )))
+            }
+        }
+
+        ExprData::Func { name, args } if args.len() == 1 => {
+            laplace_func(&name, args[0], t, s, pool, depth)
+        }
+
+        _ => Err(LaplaceError::NoRule(pool.display(f).to_string())),
+    }
+}
+
+/// Non-negative integer value of an exponent `ExprId`, if it is one.
+fn nonneg_int_exp(exp: ExprId, pool: &ExprPool) -> Option<u64> {
+    if let ExprData::Integer(n) = pool.get(exp) {
+        let n = n.0;
+        if n >= 0 {
+            return n.to_u64();
+        }
+    }
+    None
+}
+
+/// Laplace transform of a product `∏ args`.
+fn laplace_mul(
+    args: &[ExprId],
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<ExprId, LaplaceError> {
+    // Pull out the constant (t-free) scalar prefactor.
+    let (consts, rest): (Vec<ExprId>, Vec<ExprId>) =
+        args.iter().partition(|&&a| is_free_of(a, t, pool));
+    let scalar = match consts.len() {
+        0 => None,
+        1 => Some(consts[0]),
+        _ => Some(pool.mul(consts.clone())),
+    };
+
+    let inner = match rest.len() {
+        0 => {
+            // Wholly constant — handled by caller, but be safe.
+            let c = scalar.unwrap_or_else(|| pool.integer(1_i32));
+            return Ok(pool.mul(vec![c, recip(s, pool)]));
+        }
+        1 => rest[0],
+        _ => pool.mul(rest.clone()),
+    };
+
+    let transformed = laplace_product_body(inner, t, s, pool, depth)?;
+    Ok(match scalar {
+        Some(c) => pool.mul(vec![c, transformed]),
+        None => transformed,
+    })
+}
+
+/// Transform a t-dependent product with no constant scalar factor, applying the
+/// structural product theorems (frequency-diff `t^n·f`, s-shift `e^{at}·f`,
+/// t-shift `θ(t−a)·g(t−a)`).
+fn laplace_product_body(
+    body: ExprId,
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<ExprId, LaplaceError> {
+    let factors: Vec<ExprId> = match pool.get(body) {
+        ExprData::Mul(a) => a,
+        _ => vec![body],
+    };
+
+    // (1) e^{a t} · g(t)  →  G(s − a)   [s-shift theorem]
+    for (i, &fac) in factors.iter().enumerate() {
+        if let Some(a) = match_exp_linear(fac, t, pool) {
+            let rest = remove_index(&factors, i, pool);
+            let g_transform = laplace_inner(rest, t, s, pool, depth + 1)?;
+            let s_minus_a = simp(pool.add(vec![s, neg(a, pool)]), pool);
+            return Ok(subs_one(g_transform, s, s_minus_a, pool));
+        }
+    }
+
+    // (2) θ(t − a) · g(t − a)  →  e^{−a s} G(s)   [t-shift / second shift]
+    if let Some(res) = try_time_shift(&factors, t, s, pool, depth)? {
+        return Ok(res);
+    }
+
+    // (3) t^n · g(t)  →  (−1)^n F^{(n)}(s)   [frequency differentiation]
+    for (i, &fac) in factors.iter().enumerate() {
+        if let Some(n) = match_t_power(fac, t, pool) {
+            let rest = remove_index(&factors, i, pool);
+            let mut g_transform = laplace_inner(rest, t, s, pool, depth + 1)?;
+            for _ in 0..n {
+                g_transform = crate::diff::diff(g_transform, s, pool)
+                    .map_err(|_| LaplaceError::NoRule("frequency-diff failed".into()))?
+                    .value;
+            }
+            let sign = if n % 2 == 0 {
+                pool.integer(1_i32)
+            } else {
+                pool.integer(-1_i32)
+            };
+            return Ok(pool.mul(vec![sign, g_transform]));
+        }
+    }
+
+    // No product theorem applied.  If `body` was not actually a product (a lone
+    // factor, e.g. a bare `cos(b t)` whose t-free scalar was already peeled off
+    // by `laplace_mul`), fall back to the structural table.  This cannot recurse
+    // forever: `laplace_inner` only re-enters `laplace_product_body` for a `Mul`,
+    // and here `body` is not a `Mul`.
+    if !matches!(pool.get(body), ExprData::Mul(_)) {
+        return laplace_inner(body, t, s, pool, depth + 1);
+    }
+
+    Err(LaplaceError::NoRule(pool.display(body).to_string()))
+}
+
+/// If `fac` is `e^{a·t}` (or `e^{a·t+b}` collapsed), return `a` (the linear
+/// coefficient), with the additive constant folded into the coefficient via
+/// `e^{b}` only when `b` is free of `t` — here we require pure `a·t`.
+fn match_exp_linear(fac: ExprId, t: ExprId, pool: &ExprPool) -> Option<ExprId> {
+    if let ExprData::Func { name, args } = pool.get(fac) {
+        if name == "exp" && args.len() == 1 {
+            let (a, b) = as_affine(args[0], t, pool)?;
+            if b == pool.integer(0_i32) && a != pool.integer(0_i32) {
+                return Some(a);
+            }
+        }
+    }
+    // exp written as a power e^(…) is normalised to Func("exp", …) in this CAS.
+    None
+}
+
+/// If `fac` is `t^n` with `n ∈ ℤ₊`, or bare `t`, return `n`.
+fn match_t_power(fac: ExprId, t: ExprId, pool: &ExprPool) -> Option<u64> {
+    if fac == t {
+        return Some(1);
+    }
+    if let ExprData::Pow { base, exp } = pool.get(fac) {
+        if base == t {
+            return nonneg_int_exp(exp, pool).filter(|&n| n >= 1);
+        }
+    }
+    None
+}
+
+/// Recognise `θ(t − a) · g(t − a)` (any number of g-factors), returning
+/// `e^{−a s} · L{g(t)}` when every t-dependent non-Heaviside factor is a
+/// function of `(t − a)` with the *same* shift `a ≥ 0` as the Heaviside.
+fn try_time_shift(
+    factors: &[ExprId],
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<Option<ExprId>, LaplaceError> {
+    // Find a Heaviside factor and its shift a (from θ(t − a)).
+    let mut heaviside_idx = None;
+    let mut shift = None;
+    for (i, &fac) in factors.iter().enumerate() {
+        if let ExprData::Func { name, args } = pool.get(fac) {
+            if name == "heaviside" && args.len() == 1 {
+                // arg = t − a  ⇒  (coeff 1)·t + (−a)
+                if let Some((coeff, b)) = as_affine(args[0], t, pool) {
+                    if coeff == pool.integer(1_i32) {
+                        heaviside_idx = Some(i);
+                        shift = Some(neg(b, pool)); // a = −b
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    let (hi, a) = match (heaviside_idx, shift) {
+        (Some(hi), Some(a)) => (hi, simp(a, pool)),
+        _ => return Ok(None),
+    };
+
+    // The remaining factors form g(t − a).  Substitute u = t + a (i.e. shift the
+    // argument back) and transform g(u), then attach e^{−a s}.
+    let rest = remove_index(factors, hi, pool);
+    let exp_neg_as = pool.func("exp", vec![simp(neg(pool.mul(vec![a, s]), pool), pool)]);
+
+    // g(t − a): replace t by (t + a) to recover g(t), require the result be a
+    // genuine function of t (the standard second-shift form).  If `rest` is just
+    // the constant 1 (bare shifted step), G(s) = 1/s.
+    if rest == pool.integer(1_i32) {
+        return Ok(Some(pool.mul(vec![exp_neg_as, recip(s, pool)])));
+    }
+    let t_plus_a = simp(pool.add(vec![t, a]), pool);
+    let g_of_t = subs_one(rest, t, t_plus_a, pool);
+    let g_transform = laplace_inner(simp(g_of_t, pool), t, s, pool, depth + 1)?;
+    Ok(Some(pool.mul(vec![exp_neg_as, g_transform])))
+}
+
+/// Single-argument primitive functions: sin/cos/sinh/cosh/exp/heaviside/dirac.
+fn laplace_func(
+    name: &str,
+    arg: ExprId,
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+    _depth: usize,
+) -> Result<ExprId, LaplaceError> {
+    // exp(a t) → 1/(s − a)
+    if name == "exp" {
+        let (a, b) = as_affine(arg, t, pool).ok_or_else(|| {
+            LaplaceError::NoRule(format!("exp of non-affine argument: {}", pool.display(arg)))
+        })?;
+        if b != pool.integer(0_i32) {
+            return Err(LaplaceError::NoRule(
+                "exp(a t + b): nonzero constant offset".into(),
+            ));
+        }
+        let denom = pool.add(vec![s, neg(a, pool)]);
+        return Ok(recip(denom, pool));
+    }
+
+    // For sin/cos/sinh/cosh the argument must be a pure linear b·t.
+    let trig = matches!(name, "sin" | "cos" | "sinh" | "cosh");
+    if trig {
+        let (b, off) = as_affine(arg, t, pool).ok_or_else(|| {
+            LaplaceError::NoRule(format!(
+                "{name} of non-affine argument: {}",
+                pool.display(arg)
+            ))
+        })?;
+        if off != pool.integer(0_i32) || b == pool.integer(0_i32) {
+            return Err(LaplaceError::NoRule(format!(
+                "{name}(b t): argument must be a nonzero multiple of t"
+            )));
+        }
+        let b2 = pool.pow(b, pool.integer(2_i32));
+        let s2 = pool.pow(s, pool.integer(2_i32));
+        return Ok(match name {
+            // sin(bt) = b/(s²+b²)
+            "sin" => {
+                let denom = pool.add(vec![s2, b2]);
+                pool.mul(vec![b, recip(denom, pool)])
+            }
+            // cos(bt) = s/(s²+b²)
+            "cos" => {
+                let denom = pool.add(vec![s2, b2]);
+                pool.mul(vec![s, recip(denom, pool)])
+            }
+            // sinh(bt) = b/(s²−b²)
+            "sinh" => {
+                let denom = pool.add(vec![s2, neg(b2, pool)]);
+                pool.mul(vec![b, recip(denom, pool)])
+            }
+            // cosh(bt) = s/(s²−b²)
+            "cosh" => {
+                let denom = pool.add(vec![s2, neg(b2, pool)]);
+                pool.mul(vec![s, recip(denom, pool)])
+            }
+            _ => unreachable!(),
+        });
+    }
+
+    // θ(t − a) → e^{−a s}/s   (a ≥ 0 assumed; a = 0 ⇒ 1/s).
+    if name == "heaviside" {
+        let (coeff, b) = as_affine(arg, t, pool).ok_or_else(|| {
+            LaplaceError::NoRule(format!(
+                "heaviside of non-affine argument: {}",
+                pool.display(arg)
+            ))
+        })?;
+        if coeff != pool.integer(1_i32) {
+            return Err(LaplaceError::NoRule(
+                "heaviside(c·t − a): coefficient of t must be 1".into(),
+            ));
+        }
+        let a = simp(neg(b, pool), pool); // a = −b
+        let exp_neg_as = pool.func("exp", vec![simp(neg(pool.mul(vec![a, s]), pool), pool)]);
+        return Ok(pool.mul(vec![exp_neg_as, recip(s, pool)]));
+    }
+
+    // δ(t − a) → e^{−a s}   (δ(t) ↦ 1).
+    if name == "diracdelta" {
+        let (coeff, b) = as_affine(arg, t, pool).ok_or_else(|| {
+            LaplaceError::NoRule(format!(
+                "diracdelta of non-affine argument: {}",
+                pool.display(arg)
+            ))
+        })?;
+        if coeff != pool.integer(1_i32) {
+            return Err(LaplaceError::NoRule(
+                "diracdelta(c·t − a): coefficient of t must be 1".into(),
+            ));
+        }
+        let a = simp(neg(b, pool), pool);
+        return Ok(pool.func("exp", vec![simp(neg(pool.mul(vec![a, s]), pool), pool)]));
+    }
+
+    Err(LaplaceError::NoRule(format!("{name}(...)")))
+}
+
+/// Substitute every occurrence of `from` with `to` in `expr`.
+fn subs_one(expr: ExprId, from: ExprId, to: ExprId, pool: &ExprPool) -> ExprId {
+    let mut map = std::collections::HashMap::new();
+    map.insert(from, to);
+    crate::kernel::subs(expr, &map, pool)
+}
+
+/// Remove the factor at `idx` from `factors`, returning the product of the rest
+/// (or `1` if none remain).
+fn remove_index(factors: &[ExprId], idx: usize, pool: &ExprPool) -> ExprId {
+    let rest: Vec<ExprId> = factors
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| i != idx)
+        .map(|(_, &f)| f)
+        .collect();
+    match rest.len() {
+        0 => pool.integer(1_i32),
+        1 => rest[0],
+        _ => pool.mul(rest),
+    }
+}
+
+// ===========================================================================
+// Derivative rule (for the ODE workflow)
+// ===========================================================================
+
+/// The Laplace transform of the `order`-th derivative `f^{(order)}(t)` in terms
+/// of `F = L{f}(s)` and the initial values `f(0), f'(0), …, f^{(order−1)}(0)`:
+///
+/// ```text
+///   L{f^{(n)}} = sⁿ F − sⁿ⁻¹ f(0) − sⁿ⁻² f'(0) − … − f^{(n−1)}(0).
+/// ```
+///
+/// `initial_values[k]` must be `f^{(k)}(0)`.  Because `f` is an *unknown*
+/// function, this operates on the placeholder symbol `f_transform = F(s)` rather
+/// than a concrete `f`; it is the building block consumed by an
+/// (algebraic-solve) ODE-via-Laplace workflow.  Missing trailing initial values
+/// default to `0`.
+///
+/// Returns the simplified expression for `L{f^{(order)}}(s)`.
+pub fn laplace_derivative_rule(
+    f_transform: ExprId,
+    s: ExprId,
+    order: u32,
+    initial_values: &[ExprId],
+    pool: &ExprPool,
+) -> ExprId {
+    // sⁿ F
+    let s_n = pool.pow(s, pool.integer(order as i32));
+    let mut terms = vec![pool.mul(vec![s_n, f_transform])];
+    // − Σ_{k=0}^{n−1} s^{n−1−k} f^{(k)}(0)
+    for k in 0..order {
+        let f_k0 = initial_values
+            .get(k as usize)
+            .copied()
+            .unwrap_or_else(|| pool.integer(0_i32));
+        if f_k0 == pool.integer(0_i32) {
+            continue;
+        }
+        let power = (order - 1 - k) as i32;
+        let s_pow = pool.pow(s, pool.integer(power));
+        terms.push(pool.mul(vec![pool.integer(-1_i32), s_pow, f_k0]));
+    }
+    simp(pool.add(terms), pool)
+}
+
+// ===========================================================================
+// Inverse transform
+// ===========================================================================
+
+/// Compute the inverse Laplace transform `L⁻¹{F(s)}(t)` for a **proper rational**
+/// `F(s)` (optionally times a delay factor `e^{−a s}`).
+///
+/// Strategy: factor out any `e^{−a s}` delay (→ Heaviside shift), partial-fraction
+/// the rational part via [`crate::poly::apart`], then map each term through the
+/// inverse table.  See the [module docs](self) for the table and caveats.
+///
+/// # Errors
+///
+/// - [`LaplaceError::SameVariable`] if `s == t`.
+/// - [`LaplaceError::NotInvertible`] for non-rational `F`, an improper rational
+///   (polynomial part ≠ 0 ⇒ derivatives of `δ`), or an irreducible denominator
+///   factor of degree > 2.
+pub fn inverse_laplace_transform(
+    big_f: ExprId,
+    s: ExprId,
+    t: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, LaplaceError> {
+    if s == t {
+        return Err(LaplaceError::SameVariable);
+    }
+
+    // Peel a delay factor e^{−a s}: L⁻¹{e^{−a s} G(s)} = θ(t−a)·g(t−a).
+    if let Some((a, g)) = split_delay(big_f, s, pool) {
+        let g_inv = inverse_laplace_transform(g, s, t, pool)?;
+        let t_minus_a = simp(pool.add(vec![t, neg(a, pool)]), pool);
+        let shifted = subs_one(g_inv, t, t_minus_a, pool);
+        let heaviside = pool.func("heaviside", vec![t_minus_a]);
+        return Ok(simp(pool.mul(vec![heaviside, shifted]), pool));
+    }
+
+    // Rational route: partial fractions, then table per term.
+    let pf = crate::poly::apart(big_f, s, pool)
+        .map_err(|e| LaplaceError::NotInvertible(format!("apart failed: {e}")))?;
+
+    let terms: Vec<ExprId> = match pool.get(pf) {
+        ExprData::Add(args) => args,
+        _ => vec![pf],
+    };
+
+    let mut out = Vec::with_capacity(terms.len());
+    for term in terms {
+        out.push(invert_term(term, s, t, pool)?);
+    }
+    Ok(simp(pool.add(out), pool))
+}
+
+/// Split `F = e^{−a s} · G(s)` returning `(a, G)`, or `None` if there is no
+/// exponential delay factor.
+fn split_delay(big_f: ExprId, s: ExprId, pool: &ExprPool) -> Option<(ExprId, ExprId)> {
+    let factors: Vec<ExprId> = match pool.get(big_f) {
+        ExprData::Mul(a) => a,
+        _ => vec![big_f],
+    };
+    for (i, &fac) in factors.iter().enumerate() {
+        if let ExprData::Func { name, args } = pool.get(fac) {
+            if name == "exp" && args.len() == 1 {
+                // arg should be −a·s (linear in s, no constant)
+                if let Some((coeff, b)) = as_affine(args[0], s, pool) {
+                    if b == pool.integer(0_i32) && coeff != pool.integer(0_i32) {
+                        let a = simp(neg(coeff, pool), pool); // arg = −a s ⇒ a = −coeff
+                        let g = remove_index(&factors, i, pool);
+                        return Some((a, g));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Invert a single partial-fraction term `A·(s−a)^{−n}` or a quadratic-denominator
+/// term `(B s + C)/((s−p)² + ω²)`.
+fn invert_term(
+    term: ExprId,
+    s: ExprId,
+    t: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, LaplaceError> {
+    // Split term = numer · denom_pow, where denom_pow = D(s)^{−n}.
+    let (numer, base, n) = split_rational_term(term, pool)
+        .ok_or_else(|| LaplaceError::NotInvertible(pool.display(term).to_string()))?;
+
+    // A polynomial part (n == 0) is the transform of `δ(t)` (constant term) or
+    // its derivatives (higher terms) — outside the rational table.  We decline
+    // it rather than emit distributional `δ` output, keeping the inverse on
+    // ordinary functions (matching the "proper rational" scope).
+    if n == 0 {
+        return Err(LaplaceError::NotInvertible(format!(
+            "polynomial part {} (δ / derivatives of δ — improper rational)",
+            pool.display(term)
+        )));
+    }
+
+    match poly_degree(base, s, pool) {
+        Some(1) => invert_linear_pole(numer, base, n, s, t, pool),
+        Some(2) => invert_quadratic(numer, base, n, s, t, pool),
+        _ => Err(LaplaceError::NotInvertible(format!(
+            "denominator factor of degree > 2: {}",
+            pool.display(base)
+        ))),
+    }
+}
+
+/// Decompose a term into `(numerator, denom_base, n)` with `term = numerator ·
+/// denom_base^{−n}` and `n ≥ 0`, `numerator` free of any negative power of `s`.
+fn split_rational_term(term: ExprId, pool: &ExprPool) -> Option<(ExprId, ExprId, u64)> {
+    let factors: Vec<ExprId> = match pool.get(term) {
+        ExprData::Mul(a) => a,
+        _ => vec![term],
+    };
+    let mut numer_parts: Vec<ExprId> = Vec::new();
+    let mut base: Option<ExprId> = None;
+    let mut n: u64 = 0;
+
+    for &fac in &factors {
+        if let ExprData::Pow { base: b, exp } = pool.get(fac) {
+            if let ExprData::Integer(e) = pool.get(exp) {
+                let ev = e.0;
+                if ev < 0 {
+                    // negative power → part of denominator
+                    if base.is_some() && base != Some(b) {
+                        // Two distinct denominator factors — not a single PF term.
+                        return None;
+                    }
+                    base = Some(b);
+                    n = (-ev).to_u64()?;
+                    continue;
+                }
+            }
+        }
+        numer_parts.push(fac);
+    }
+
+    let numer = match numer_parts.len() {
+        0 => pool.integer(1_i32),
+        1 => numer_parts[0],
+        _ => pool.mul(numer_parts),
+    };
+    match base {
+        Some(b) => Some((numer, b, n)),
+        None => Some((numer, pool.integer(1_i32), 0)),
+    }
+}
+
+/// Degree of `base` as a polynomial in `s` (only handles `s`, `s ± c`, and
+/// `s² + …` forms via structural inspection).  Returns `None` if not obviously
+/// polynomial of degree 1 or 2.
+fn poly_degree(base: ExprId, s: ExprId, pool: &ExprPool) -> Option<u64> {
+    if base == s {
+        return Some(1);
+    }
+    match pool.get(base) {
+        ExprData::Add(args) => {
+            let mut deg = 0u64;
+            for a in args {
+                deg = deg.max(monomial_degree(a, s, pool)?);
+            }
+            Some(deg)
+        }
+        ExprData::Pow { .. } | ExprData::Mul(_) => monomial_degree(base, s, pool),
+        _ if is_free_of(base, s, pool) => Some(0),
+        _ => None,
+    }
+}
+
+fn monomial_degree(term: ExprId, s: ExprId, pool: &ExprPool) -> Option<u64> {
+    if term == s {
+        return Some(1);
+    }
+    if is_free_of(term, s, pool) {
+        return Some(0);
+    }
+    match pool.get(term) {
+        ExprData::Pow { base, exp } if base == s => nonneg_int_exp(exp, pool),
+        ExprData::Mul(args) => {
+            let mut deg = 0u64;
+            for a in args {
+                deg += monomial_degree(a, s, pool)?;
+            }
+            Some(deg)
+        }
+        _ => None,
+    }
+}
+
+/// `L⁻¹{A/(s−a)^n} = A·t^{n−1} e^{a t}/(n−1)!`.
+fn invert_linear_pole(
+    numer: ExprId,
+    base: ExprId,
+    n: u64,
+    s: ExprId,
+    t: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, LaplaceError> {
+    // numer must be free of s (deg < deg(base) = 1).
+    if !is_free_of(numer, s, pool) {
+        return Err(LaplaceError::NotInvertible(format!(
+            "linear-pole numerator depends on s: {}",
+            pool.display(numer)
+        )));
+    }
+    // base = s − a (monic).  Extract a from (coeff·s + b): a = −b/coeff, require coeff = 1.
+    let (coeff, b) = as_affine(base, s, pool)
+        .ok_or_else(|| LaplaceError::NotInvertible(pool.display(base).to_string()))?;
+    if coeff != pool.integer(1_i32) {
+        return Err(LaplaceError::NotInvertible(
+            "non-monic linear denominator".into(),
+        ));
+    }
+    let a = simp(neg(b, pool), pool); // a = −b
+
+    let exp_at = pool.func("exp", vec![pool.mul(vec![a, t])]);
+    let mut parts = vec![numer, exp_at];
+    if n >= 2 {
+        let t_pow = pool.pow(t, pool.integer(Integer::from(n - 1)));
+        parts.push(t_pow);
+        let fact = factorial(n - 1, pool);
+        parts.push(recip(fact, pool));
+    }
+    Ok(pool.mul(parts))
+}
+
+/// Invert `(B s + C)/((s−p)² + ω²)` (single power `n = 1`) into damped sin/cos:
+///
+/// ```text
+///   L⁻¹ = e^{p t} ( B cos(ω t) + ((C + B p)/ω) sin(ω t) ).
+/// ```
+fn invert_quadratic(
+    numer: ExprId,
+    base: ExprId,
+    n: u64,
+    s: ExprId,
+    t: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, LaplaceError> {
+    if n != 1 {
+        return Err(LaplaceError::NotInvertible(
+            "repeated irreducible quadratic pole (n ≥ 2) not in table".into(),
+        ));
+    }
+    // Write base = s² + β s + γ. Complete the square: (s + β/2)² + (γ − β²/4).
+    let (alpha, beta, gamma) = quadratic_coeffs(base, s, pool)
+        .ok_or_else(|| LaplaceError::NotInvertible(pool.display(base).to_string()))?;
+    if alpha != pool.integer(1_i32) {
+        return Err(LaplaceError::NotInvertible(
+            "non-monic quadratic denominator".into(),
+        ));
+    }
+    // p = −β/2 ; ω² = γ − β²/4 ; ω = sqrt(ω²).
+    let half = pool.rational(1_i32, 2_i32);
+    let p = simp(pool.mul(vec![neg(beta, pool), half]), pool);
+    let beta2 = pool.pow(beta, pool.integer(2_i32));
+    let quarter = pool.rational(1_i32, 4_i32);
+    let omega_sq = simp(
+        pool.add(vec![gamma, neg(pool.mul(vec![beta2, quarter]), pool)]),
+        pool,
+    );
+    let omega = simp(pool.pow(omega_sq, half), pool);
+
+    // numerator B s + C.
+    let (bb, cc) = as_affine(numer, s, pool)
+        .ok_or_else(|| LaplaceError::NotInvertible(pool.display(numer).to_string()))?;
+
+    // e^{p t} [ B cos(ω t) + ((C + B p)/ω) sin(ω t) ]
+    let exp_pt = pool.func("exp", vec![pool.mul(vec![p, t])]);
+    let omega_t = pool.mul(vec![omega, t]);
+    let cos_term = pool.mul(vec![bb, pool.func("cos", vec![omega_t])]);
+    let bp = pool.mul(vec![bb, p]);
+    let sin_coeff = pool.mul(vec![pool.add(vec![cc, bp]), recip(omega, pool)]);
+    let sin_term = pool.mul(vec![sin_coeff, pool.func("sin", vec![omega_t])]);
+    Ok(pool.mul(vec![exp_pt, pool.add(vec![cos_term, sin_term])]))
+}
+
+/// Coefficients `(α, β, γ)` of a monic-or-scaled quadratic `α s² + β s + γ`.
+fn quadratic_coeffs(base: ExprId, s: ExprId, pool: &ExprPool) -> Option<(ExprId, ExprId, ExprId)> {
+    let args: Vec<ExprId> = match pool.get(base) {
+        ExprData::Add(a) => a,
+        _ => vec![base],
+    };
+    let mut alpha = pool.integer(0_i32);
+    let mut beta = pool.integer(0_i32);
+    let mut gamma_parts: Vec<ExprId> = Vec::new();
+    for term in args {
+        match monomial_degree(term, s, pool)? {
+            2 => alpha = monomial_coeff(term, s, 2, pool)?,
+            1 => beta = monomial_coeff(term, s, 1, pool)?,
+            0 => gamma_parts.push(term),
+            _ => return None,
+        }
+    }
+    let gamma = match gamma_parts.len() {
+        0 => pool.integer(0_i32),
+        1 => gamma_parts[0],
+        _ => pool.add(gamma_parts),
+    };
+    Some((alpha, beta, gamma))
+}
+
+/// Coefficient of `s^deg` in a single monomial `c·s^deg`.
+fn monomial_coeff(term: ExprId, s: ExprId, deg: u64, pool: &ExprPool) -> Option<ExprId> {
+    if deg == 0 {
+        return Some(term);
+    }
+    if deg == 1 && term == s {
+        return Some(pool.integer(1_i32));
+    }
+    if let ExprData::Pow { base, exp } = pool.get(term) {
+        if base == s && nonneg_int_exp(exp, pool) == Some(deg) {
+            return Some(pool.integer(1_i32));
+        }
+    }
+    if let ExprData::Mul(args) = pool.get(term) {
+        let mut coeff_parts: Vec<ExprId> = Vec::new();
+        let mut found = false;
+        for a in args {
+            if a == s && deg == 1 {
+                found = true;
+                continue;
+            }
+            if let ExprData::Pow { base, exp } = pool.get(a) {
+                if base == s && nonneg_int_exp(exp, pool) == Some(deg) {
+                    found = true;
+                    continue;
+                }
+            }
+            coeff_parts.push(a);
+        }
+        if found {
+            return Some(match coeff_parts.len() {
+                0 => pool.integer(1_i32),
+                1 => coeff_parts[0],
+                _ => pool.mul(coeff_parts),
+            });
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/alkahest-core/src/transform/laplace/tests.rs
+++ b/alkahest-core/src/transform/laplace/tests.rs
@@ -1,0 +1,507 @@
+//! Tests for the Laplace transform and its inverse.
+//!
+//! Forward transforms are checked against the analytic table; round-trips
+//! `L⁻¹{L{f}}` are checked by `simplify`-to-equality (or, where exact structural
+//! equality is brittle, by numeric sampling of `F(s) − F_expected(s)`).
+
+use super::*;
+use crate::kernel::{Domain, ExprPool};
+
+/// Numeric evaluation of an expression in a single variable at `var = val`,
+/// used for sampling-based equality checks.  Handles the function heads the
+/// Laplace table emits (incl. `sinh`/`cosh`/`heaviside`), which the generic
+/// `jit::eval_interp` does not.
+fn eval_at(expr: ExprId, var: ExprId, val: f64, pool: &ExprPool) -> Option<f64> {
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some(n.0.to_f64()),
+        ExprData::Rational(r) => {
+            let (n, d) = r.0.clone().into_numer_denom();
+            Some(n.to_f64() / d.to_f64())
+        }
+        ExprData::Float(f) => Some(f.inner.to_f64()),
+        ExprData::Symbol { .. } => {
+            if expr == var {
+                Some(val)
+            } else {
+                None
+            }
+        }
+        ExprData::Add(args) => args
+            .iter()
+            .try_fold(0.0, |acc, &a| Some(acc + eval_at(a, var, val, pool)?)),
+        ExprData::Mul(args) => args
+            .iter()
+            .try_fold(1.0, |acc, &a| Some(acc * eval_at(a, var, val, pool)?)),
+        ExprData::Pow { base, exp } => {
+            Some(eval_at(base, var, val, pool)?.powf(eval_at(exp, var, val, pool)?))
+        }
+        ExprData::Func { name, args } if args.len() == 1 => {
+            let x = eval_at(args[0], var, val, pool)?;
+            Some(match name.as_str() {
+                "sin" => x.sin(),
+                "cos" => x.cos(),
+                "tan" => x.tan(),
+                "sinh" => x.sinh(),
+                "cosh" => x.cosh(),
+                "exp" => x.exp(),
+                "log" => x.ln(),
+                "sqrt" => x.sqrt(),
+                "heaviside" => {
+                    if x > 0.0 {
+                        1.0
+                    } else if x < 0.0 {
+                        0.0
+                    } else {
+                        0.5
+                    }
+                }
+                _ => return None,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Assert two single-variable expressions agree numerically at a set of sample
+/// points (avoids brittle structural comparison after simplification).
+fn assert_numeric_eq(a: ExprId, b: ExprId, var: ExprId, samples: &[f64], pool: &ExprPool) {
+    for &x in samples {
+        let va = eval_at(a, var, x, pool);
+        let vb = eval_at(b, var, x, pool);
+        match (va, vb) {
+            (Some(va), Some(vb)) => assert!(
+                (va - vb).abs() < 1e-6 * (1.0 + va.abs() + vb.abs()),
+                "mismatch at {x}: {} = {va} vs {} = {vb}",
+                pool.display(a),
+                pool.display(b),
+            ),
+            _ => panic!(
+                "could not numerically evaluate at {x}: {} / {}",
+                pool.display(a),
+                pool.display(b)
+            ),
+        }
+    }
+}
+
+fn setup() -> (ExprPool, ExprId, ExprId) {
+    let pool = ExprPool::new();
+    let t = pool.symbol("t", Domain::Real);
+    let s = pool.symbol("s", Domain::Real);
+    (pool, t, s)
+}
+
+// ── forward table ──────────────────────────────────────────────────────────
+
+#[test]
+fn forward_constant() {
+    let (pool, t, s) = setup();
+    let f = pool.integer(5_i32);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    // 5/s
+    let want = pool.mul(vec![pool.integer(5_i32), pool.pow(s, pool.integer(-1_i32))]);
+    assert_numeric_eq(got, want, s, &[2.0, 3.0, 5.0], &pool);
+}
+
+#[test]
+fn forward_t_power() {
+    let (pool, t, s) = setup();
+    // L{t^3} = 6/s^4
+    let f = pool.pow(t, pool.integer(3_i32));
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.mul(vec![pool.integer(6_i32), pool.pow(s, pool.integer(-4_i32))]);
+    assert_numeric_eq(got, want, s, &[2.0, 3.0, 5.0], &pool);
+}
+
+#[test]
+fn forward_exp() {
+    let (pool, t, s) = setup();
+    // L{e^{2t}} = 1/(s-2)
+    let f = pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.pow(
+        pool.add(vec![s, pool.integer(-2_i32)]),
+        pool.integer(-1_i32),
+    );
+    assert_numeric_eq(got, want, s, &[3.0, 4.0, 5.0], &pool);
+}
+
+#[test]
+fn forward_sin_cos() {
+    let (pool, t, s) = setup();
+    let s2 = pool.pow(s, pool.integer(2_i32));
+    // L{sin(3t)} = 3/(s²+9)
+    let sin3t = pool.func("sin", vec![pool.mul(vec![pool.integer(3_i32), t])]);
+    let got = laplace_transform(sin3t, t, s, &pool).unwrap();
+    let want = pool.mul(vec![
+        pool.integer(3_i32),
+        pool.pow(
+            pool.add(vec![s2, pool.integer(9_i32)]),
+            pool.integer(-1_i32),
+        ),
+    ]);
+    assert_numeric_eq(got, want, s, &[2.0, 3.0, 5.0], &pool);
+
+    // L{cos(3t)} = s/(s²+9)
+    let cos3t = pool.func("cos", vec![pool.mul(vec![pool.integer(3_i32), t])]);
+    let got = laplace_transform(cos3t, t, s, &pool).unwrap();
+    let want = pool.mul(vec![
+        s,
+        pool.pow(
+            pool.add(vec![s2, pool.integer(9_i32)]),
+            pool.integer(-1_i32),
+        ),
+    ]);
+    assert_numeric_eq(got, want, s, &[2.0, 3.0, 5.0], &pool);
+}
+
+#[test]
+fn forward_sinh_cosh() {
+    let (pool, t, s) = setup();
+    let s2 = pool.pow(s, pool.integer(2_i32));
+    // L{sinh(2t)} = 2/(s²−4)
+    let f = pool.func("sinh", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.mul(vec![
+        pool.integer(2_i32),
+        pool.pow(
+            pool.add(vec![s2, pool.integer(-4_i32)]),
+            pool.integer(-1_i32),
+        ),
+    ]);
+    assert_numeric_eq(got, want, s, &[3.0, 4.0, 5.0], &pool);
+
+    // L{cosh(2t)} = s/(s²−4)
+    let f = pool.func("cosh", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.mul(vec![
+        s,
+        pool.pow(
+            pool.add(vec![s2, pool.integer(-4_i32)]),
+            pool.integer(-1_i32),
+        ),
+    ]);
+    assert_numeric_eq(got, want, s, &[3.0, 4.0, 5.0], &pool);
+}
+
+#[test]
+fn forward_linearity() {
+    let (pool, t, s) = setup();
+    // L{2t + 3} = 2/s² + 3/s
+    let f = pool.add(vec![
+        pool.mul(vec![pool.integer(2_i32), t]),
+        pool.integer(3_i32),
+    ]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.add(vec![
+        pool.mul(vec![pool.integer(2_i32), pool.pow(s, pool.integer(-2_i32))]),
+        pool.mul(vec![pool.integer(3_i32), pool.pow(s, pool.integer(-1_i32))]),
+    ]);
+    assert_numeric_eq(got, want, s, &[2.0, 3.0, 5.0], &pool);
+}
+
+#[test]
+fn forward_s_shift() {
+    let (pool, t, s) = setup();
+    // L{e^{2t} cos(3t)} = (s−2)/((s−2)²+9)
+    let cos3t = pool.func("cos", vec![pool.mul(vec![pool.integer(3_i32), t])]);
+    let exp2t = pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    let f = pool.mul(vec![exp2t, cos3t]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+
+    let s_minus_2 = pool.add(vec![s, pool.integer(-2_i32)]);
+    let sm2_sq = pool.pow(s_minus_2, pool.integer(2_i32));
+    let want = pool.mul(vec![
+        s_minus_2,
+        pool.pow(
+            pool.add(vec![sm2_sq, pool.integer(9_i32)]),
+            pool.integer(-1_i32),
+        ),
+    ]);
+    assert_numeric_eq(got, want, s, &[3.0, 4.0, 6.0], &pool);
+}
+
+#[test]
+fn forward_t_times_exp_sin() {
+    // Task test: L{t e^{2t} sin(3t)}.
+    // L{sin(3t)} = 3/(s²+9); shift s→s−2: 3/((s−2)²+9);
+    // ×t ⇒ −d/ds: 6(s−2)/((s−2)²+9)².
+    let (pool, t, s) = setup();
+    let sin3t = pool.func("sin", vec![pool.mul(vec![pool.integer(3_i32), t])]);
+    let exp2t = pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    let f = pool.mul(vec![t, exp2t, sin3t]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+
+    let s_minus_2 = pool.add(vec![s, pool.integer(-2_i32)]);
+    let sm2_sq = pool.pow(s_minus_2, pool.integer(2_i32));
+    let denom = pool.add(vec![sm2_sq, pool.integer(9_i32)]);
+    let want = pool.mul(vec![
+        pool.integer(6_i32),
+        s_minus_2,
+        pool.pow(denom, pool.integer(-2_i32)),
+    ]);
+    assert_numeric_eq(got, want, s, &[3.0, 4.0, 5.5], &pool);
+}
+
+#[test]
+fn forward_heaviside_step() {
+    let (pool, t, s) = setup();
+    // L{θ(t−2)} = e^{−2s}/s
+    let arg = pool.add(vec![t, pool.integer(-2_i32)]);
+    let f = pool.func("heaviside", vec![arg]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.mul(vec![
+        pool.func("exp", vec![pool.mul(vec![pool.integer(-2_i32), s])]),
+        pool.pow(s, pool.integer(-1_i32)),
+    ]);
+    assert_numeric_eq(got, want, s, &[1.0, 2.0, 3.0], &pool);
+}
+
+#[test]
+fn forward_heaviside_shifted_function() {
+    let (pool, t, s) = setup();
+    // L{θ(t−1)·(t−1)} = e^{−s}·L{t} = e^{−s}/s²
+    let tm1 = pool.add(vec![t, pool.integer(-1_i32)]);
+    let f = pool.mul(vec![pool.func("heaviside", vec![tm1]), tm1]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.mul(vec![
+        pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), s])]),
+        pool.pow(s, pool.integer(-2_i32)),
+    ]);
+    assert_numeric_eq(got, want, s, &[1.5, 2.0, 3.0], &pool);
+}
+
+#[test]
+fn forward_dirac() {
+    let (pool, t, s) = setup();
+    // L{δ(t)} = 1
+    let f = pool.func("diracdelta", vec![t]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    assert_numeric_eq(got, pool.integer(1_i32), s, &[1.0, 2.0, 3.0], &pool);
+
+    // L{δ(t−3)} = e^{−3s}
+    let arg = pool.add(vec![t, pool.integer(-3_i32)]);
+    let f = pool.func("diracdelta", vec![arg]);
+    let got = laplace_transform(f, t, s, &pool).unwrap();
+    let want = pool.func("exp", vec![pool.mul(vec![pool.integer(-3_i32), s])]);
+    assert_numeric_eq(got, want, s, &[0.5, 1.0, 2.0], &pool);
+}
+
+#[test]
+fn forward_same_variable_errors() {
+    let (pool, t, _s) = setup();
+    let f = pool.integer(1_i32);
+    assert_eq!(
+        laplace_transform(f, t, t, &pool),
+        Err(LaplaceError::SameVariable)
+    );
+}
+
+#[test]
+fn forward_declines_unknown() {
+    let (pool, t, s) = setup();
+    // L{log(t)} is not in the table (it is −(γ + log s)/s) — decline.
+    let f = pool.func("log", vec![t]);
+    assert!(matches!(
+        laplace_transform(f, t, s, &pool),
+        Err(LaplaceError::NoRule(_))
+    ));
+}
+
+// ── derivative rule ──────────────────────────────────────────────────────────
+
+#[test]
+fn derivative_rule_second_order() {
+    // L{y'' + y} at the rule level with y(0)=y0, y'(0)=y1, F = L{y}.
+    // L{y''} = s²F − s·y0 − y1 ; plus L{y} = F.
+    let (pool, _t, s) = setup();
+    let big_f = pool.symbol("F", Domain::Real);
+    let y0 = pool.symbol("y0", Domain::Real);
+    let y1 = pool.symbol("y1", Domain::Real);
+
+    let l_ypp = laplace_derivative_rule(big_f, s, 2, &[y0, y1], &pool);
+    // s²F − s·y0 − y1 ; compare via difference simplifying to 0.
+    let want = pool.add(vec![
+        pool.mul(vec![pool.pow(s, pool.integer(2_i32)), big_f]),
+        pool.mul(vec![pool.integer(-1_i32), s, y0]),
+        pool.mul(vec![pool.integer(-1_i32), y1]),
+    ]);
+    let diff =
+        crate::simplify::simplify_expanded(pool.add(vec![l_ypp, neg(want, &pool)]), &pool).value;
+    assert_eq!(
+        diff,
+        pool.integer(0_i32),
+        "L{{y''}} mismatch: {}",
+        pool.display(l_ypp)
+    );
+}
+
+#[test]
+fn derivative_rule_first_order_zero_ic() {
+    // L{y'} with y(0)=0 is s·F.
+    let (pool, _t, s) = setup();
+    let big_f = pool.symbol("F", Domain::Real);
+    let got = laplace_derivative_rule(big_f, s, 1, &[pool.integer(0_i32)], &pool);
+    let want = pool.mul(vec![s, big_f]);
+    let diff =
+        crate::simplify::simplify_expanded(pool.add(vec![got, neg(want, &pool)]), &pool).value;
+    assert_eq!(diff, pool.integer(0_i32), "got {}", pool.display(got));
+}
+
+// ── inverse transform ──────────────────────────────────────────────────────
+
+#[test]
+fn inverse_simple_pole() {
+    let (pool, t, s) = setup();
+    // L⁻¹{1/(s−2)} = e^{2t}
+    let big_f = pool.pow(
+        pool.add(vec![s, pool.integer(-2_i32)]),
+        pool.integer(-1_i32),
+    );
+    let got = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    let want = pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    assert_numeric_eq(got, want, t, &[0.0, 0.5, 1.0], &pool);
+}
+
+#[test]
+fn inverse_repeated_pole() {
+    let (pool, t, s) = setup();
+    // L⁻¹{1/(s−1)³} = t² e^{t}/2
+    let base = pool.add(vec![s, pool.integer(-1_i32)]);
+    let big_f = pool.pow(base, pool.integer(-3_i32));
+    let got = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    let want = pool.mul(vec![
+        pool.rational(1_i32, 2_i32),
+        pool.pow(t, pool.integer(2_i32)),
+        pool.func("exp", vec![t]),
+    ]);
+    assert_numeric_eq(got, want, t, &[0.0, 0.5, 1.0, 2.0], &pool);
+}
+
+#[test]
+fn inverse_complex_poles() {
+    let (pool, t, s) = setup();
+    // L⁻¹{1/(s²+4)} = sin(2t)/2
+    let s2 = pool.pow(s, pool.integer(2_i32));
+    let big_f = pool.pow(
+        pool.add(vec![s2, pool.integer(4_i32)]),
+        pool.integer(-1_i32),
+    );
+    let got = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    let want = pool.mul(vec![
+        pool.rational(1_i32, 2_i32),
+        pool.func("sin", vec![pool.mul(vec![pool.integer(2_i32), t])]),
+    ]);
+    assert_numeric_eq(got, want, t, &[0.1, 0.5, 1.0, 2.0], &pool);
+}
+
+#[test]
+fn inverse_damped_oscillation() {
+    let (pool, t, s) = setup();
+    // L⁻¹{ s / (s²+2s+5) }.  Denominator = (s+1)²+4, p=−1, ω=2.
+    // numerator B s + C with B=1, C=0 ⇒ e^{−t}( cos2t + ((0+1·(−1))/2) sin2t )
+    //   = e^{−t}( cos2t − (1/2) sin2t ).
+    let s2 = pool.pow(s, pool.integer(2_i32));
+    let denom = pool.add(vec![
+        s2,
+        pool.mul(vec![pool.integer(2_i32), s]),
+        pool.integer(5_i32),
+    ]);
+    let big_f = pool.mul(vec![s, pool.pow(denom, pool.integer(-1_i32))]);
+    let got = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+
+    let exp_neg_t = pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), t])]);
+    let two_t = pool.mul(vec![pool.integer(2_i32), t]);
+    let want = pool.mul(vec![
+        exp_neg_t,
+        pool.add(vec![
+            pool.func("cos", vec![two_t]),
+            pool.mul(vec![
+                pool.rational(-1_i32, 2_i32),
+                pool.func("sin", vec![two_t]),
+            ]),
+        ]),
+    ]);
+    assert_numeric_eq(got, want, t, &[0.0, 0.3, 0.8, 1.5], &pool);
+}
+
+#[test]
+fn inverse_proper_rational_repeated_and_complex() {
+    // Task test: a proper rational with repeated + complex poles.
+    // F(s) = 1 / ((s−1)² (s²+1)).  Verify by round-trip numeric sampling of
+    // L{ L⁻¹{F} } == F.
+    let (pool, t, s) = setup();
+    let s2 = pool.pow(s, pool.integer(2_i32));
+    let sm1 = pool.add(vec![s, pool.integer(-1_i32)]);
+    let sm1_sq = pool.pow(sm1, pool.integer(2_i32));
+    let quad = pool.add(vec![s2, pool.integer(1_i32)]);
+    let denom = pool.mul(vec![sm1_sq, quad]);
+    let big_f = pool.pow(denom, pool.integer(-1_i32));
+
+    let f_of_t = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    // Round-trip: transform back and compare to F(s) numerically.
+    let back = laplace_transform(f_of_t, t, s, &pool).unwrap();
+    assert_numeric_eq(back, big_f, s, &[2.0, 3.0, 4.0, 5.0], &pool);
+}
+
+#[test]
+fn inverse_delay_heaviside() {
+    let (pool, t, s) = setup();
+    // L⁻¹{ e^{−2s}/s } = θ(t−2)
+    let big_f = pool.mul(vec![
+        pool.func("exp", vec![pool.mul(vec![pool.integer(-2_i32), s])]),
+        pool.pow(s, pool.integer(-1_i32)),
+    ]);
+    let got = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    // θ(t−2): 0 for t<2, 1 for t>2.
+    let want = pool.func("heaviside", vec![pool.add(vec![t, pool.integer(-2_i32)])]);
+    assert_numeric_eq(got, want, t, &[0.5, 1.0, 3.0, 4.0], &pool);
+}
+
+#[test]
+fn inverse_declines_improper() {
+    let (pool, t, s) = setup();
+    // F(s) = s/(s−1) is improper (= 1 + 1/(s−1)); polynomial part ⇒ derivative
+    // of δ, which we decline.
+    let big_f = pool.mul(vec![
+        s,
+        pool.pow(
+            pool.add(vec![s, pool.integer(-1_i32)]),
+            pool.integer(-1_i32),
+        ),
+    ]);
+    assert!(matches!(
+        inverse_laplace_transform(big_f, s, t, &pool),
+        Err(LaplaceError::NotInvertible(_))
+    ));
+}
+
+// ── round-trips ──────────────────────────────────────────────────────────────
+
+#[test]
+fn round_trip_exp() {
+    let (pool, t, s) = setup();
+    // f(t) = e^{3t} ; L⁻¹{L{f}} = f.
+    let f = pool.func("exp", vec![pool.mul(vec![pool.integer(3_i32), t])]);
+    let big_f = laplace_transform(f, t, s, &pool).unwrap();
+    let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    assert_numeric_eq(back, f, t, &[0.0, 0.2, 0.5, 1.0], &pool);
+}
+
+#[test]
+fn round_trip_sin() {
+    let (pool, t, s) = setup();
+    let f = pool.func("sin", vec![pool.mul(vec![pool.integer(2_i32), t])]);
+    let big_f = laplace_transform(f, t, s, &pool).unwrap();
+    let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    assert_numeric_eq(back, f, t, &[0.1, 0.5, 1.0, 2.5], &pool);
+}
+
+#[test]
+fn round_trip_t_squared() {
+    let (pool, t, s) = setup();
+    let f = pool.pow(t, pool.integer(2_i32));
+    let big_f = laplace_transform(f, t, s, &pool).unwrap();
+    let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    assert_numeric_eq(back, f, t, &[0.0, 0.5, 1.0, 2.0], &pool);
+}

--- a/alkahest-core/src/transform/mod.rs
+++ b/alkahest-core/src/transform/mod.rs
@@ -1,0 +1,12 @@
+//! Symbolic integral transforms.
+//!
+//! Currently the [`laplace`] submodule provides the **Laplace transform**
+//! `L{f(t)}(s)` and its **inverse** `L⁻¹{F(s)}(t)`.
+//!
+//! These are *formal* transforms: no region-of-convergence is tracked and no
+//! convergence side-conditions are emitted (matching SymPy's `noconds=True`
+//! default).  See [`laplace`] for the rule coverage, fallbacks, and declines.
+
+pub mod laplace;
+
+pub use laplace::{inverse_laplace_transform, laplace_transform, LaplaceError};

--- a/tests/test_v10.py
+++ b/tests/test_v10.py
@@ -94,7 +94,12 @@ class TestExpandedPrimitives:
         reg = alkahest.PrimitiveRegistry()
         report = reg.coverage_report()
         missing = [r["name"] for r in report if not r["numeric_f64"]]
-        assert not missing, f"primitives missing numeric_f64: {missing}"
+        # DiracDelta is the documented distributional exception: it is not a
+        # pointwise function, so it deliberately has no numeric_f64 kernel
+        # (mirrors the Rust-side primitive coverage doctest).
+        assert missing == ["diracdelta"], (
+            f"primitives missing numeric_f64 (only diracdelta allowed): {missing}"
+        )
 
     def test_primitive_registry_most_have_diff_forward(self):
         reg = alkahest.PrimitiveRegistry()


### PR DESCRIPTION
Implements §3.3 of the mathematical-coverage roadmap: symbolic Laplace transform `L{f(t)}(s)` and inverse `L⁻¹{F(s)}(t)`, in a new top-level `transform/` module (`alkahest_core::transform::laplace`).

## Rule coverage

**Forward** (`laplace_transform`, rule/table-based structural recursion):
- Constants `c ↦ c/s`; powers `t^n ↦ n!/s^{n+1}`
- `e^{at} ↦ 1/(s−a)`; `sin/cos(bt)`, `sinh/cosh(bt)`
- Linearity over sums and constant scalar factors
- s-shift theorem: `e^{at}·f(t) ↦ F(s−a)`
- Frequency differentiation: `t^n·f(t) ↦ (−1)^n F^{(n)}(s)` (reuses existing `diff`)
- t-shift / second-shift: `θ(t−a)·g(t−a) ↦ e^{−as}G(s)`, shifted step `θ(t−a) ↦ e^{−as}/s`
- Dirac impulse: `δ(t−a) ↦ e^{−as}`, `δ(t) ↦ 1`

**Derivative rule** (`laplace_derivative_rule`, experimental): `L{f^{(n)}} = sⁿF − sⁿ⁻¹f(0) − … − f^{(n−1)}(0)`, exposed separately for the ODE-via-Laplace workflow since `f` is an unknown function (operates on the symbol `F = L{f}` + initial values).

**Inverse** (`inverse_laplace_transform`): proper rational `F(s)` via `apart` (PR #135) + per-term table:
- `A/(s−a)^n ↦ A·t^{n−1}e^{at}/(n−1)!` (real, incl. repeated poles)
- irreducible quadratic `(Bs+C)/((s−p)²+ω²) ↦` damped sin/cos
- `e^{−as}F(s) ↦ θ(t−a)·(L⁻¹F)(t−a)`

## Heaviside / DiracDelta decision

Added **both** as registered primitives (high-value per the task): `Heaviside` (θ, numeric step value with half-maximum at 0, distributional derivative δ) and `DiracDelta` (δ, symbolic-only — no pointwise `f64`). The "every built-in has NUMERIC_F64" coverage doctest now documents δ as the explicit distributional exception.

## Fallbacks and declines

- The definition fallback `∫₀^∞ f e^{−st} dt` via FTC + limits was **scoped out**: the table + structural theorems cover the standard pairs, and the def-integral route requires improper-integral/limit-at-∞ plumbing not yet wired for this class. Unmatched forward inputs return `LaplaceError::NoRule` rather than guessing.
- Inverse declines: non-rational `F`, **improper rationals** (polynomial part ⇒ δ and its derivatives — declined rather than emitting distributional output), and irreducible denominator factors of degree > 2 or repeated irreducible quadratics.
- **Convolution theorem skipped** — no convolution primitive exists in the kernel.

## Caveats

Formal transform: no convergence region tracked, no existence side-conditions emitted (matches SymPy's `noconds=True` default). Documented in the module.

## API surface

All additive — new `transform` module + `experimental::{laplace_transform, inverse_laplace_transform, laplace_derivative_rule, LaplaceError}`. `stable.rs` untouched (semver-checks safe). **Python/PyO3 bindings deferred as follow-up.**

## Tests

25 Rust tests in `transform::laplace::tests` (full forward table, `L{t e^{2t} sin 3t}`, derivative rule for `y''+y` at the rule level, inverse of a proper rational with repeated + complex poles, Heaviside shifted step, round-trips verified by numeric sampling) + 1 primitive test for Heaviside/Dirac. `cargo test --workspace` green (1145 lib + doctests), `cargo clippy` clean, `RUSTDOCFLAGS="-D warnings" cargo doc` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forward and inverse Laplace transforms (symbolic) and a Laplace derivative rule for ODE workflows.
  * Introduced Heaviside step and Dirac delta as new built-in primitives with appropriate symbolic and numeric behaviors.

* **Tests**
  * Comprehensive test suite for Laplace transforms, inverses, derivative rules, and primitive behavior; updated an existing test to permit diracdelta as the sole missing numeric kernel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->