### PR TITLE
fix(simplify): fold elementary constants, trivial powers, and rational canonicalization

### DIFF
--- a/alkahest-core/src/simplify/egraph.rs
+++ b/alkahest-core/src/simplify/egraph.rs
@@ -673,6 +673,14 @@ mod backend {
         let simplified = fold_numeric_pow(simplified, pool);
         // RW-3: apply linear canonizer as a post-extraction pass.
         let simplified = canonicalize_linear(simplified, pool);
+        // Final post-extraction pass: run the rule-based simplifier so that
+        // constant-folding rules not modeled inside the egglog program
+        // (elementary functions at 0/1, x^1, 1^r, power-of-power, even-power
+        // sign folding, Rational(n/1) canonicalization, and numeric
+        // cancellation across products) also apply to the extracted term.
+        // The expression is typically already near-normal-form at this
+        // point, so this is a cheap bounded pass.
+        let simplified = super::super::engine::simplify(simplified, pool).value;
 
         let mut log = DerivationLog::new();
         if simplified != expr {

--- a/alkahest-core/src/simplify/egraph.rs
+++ b/alkahest-core/src/simplify/egraph.rs
@@ -628,6 +628,75 @@ mod backend {
     }
 
     // -----------------------------------------------------------------------
+    // Final post-extraction constant-fold pass
+    // -----------------------------------------------------------------------
+
+    /// Apply only the cheap constant-folding rules to `expr`, bottom-up, to a
+    /// per-node fixpoint.
+    ///
+    /// This covers the folds not modeled inside the egglog program itself:
+    /// elementary functions at 0/1, `x^0`/`x^1`, `1^r`, power-of-power,
+    /// even-power sign folding, distribution of `pow` over a literal `Mul`
+    /// coefficient, `Rational(n/1)` canonicalization, and `0`/`1`
+    /// identities for `Add`/`Mul` — all via [`ConstFold`], [`PowZero`],
+    /// [`PowOne`], [`AddZero`], [`MulOne`], and [`MulZero`].
+    ///
+    /// Unlike [`super::super::engine::simplify`], this does **not** run the
+    /// full rule engine (no flattening, no `SubSelf`/`DivSelf`, no
+    /// discrimination-net pattern rules, no fixed-point loop over the whole
+    /// tree) — each node is visited once and folded to a local fixpoint, so
+    /// the pass is `O(n)` in the size of the extracted term rather than
+    /// `O(n * iterations)`. The extracted term is already near-normal-form,
+    /// so this bounded local fold is sufficient to pick up the constant
+    /// folds above without re-running the whole simplifier.
+    pub(super) fn apply_const_folds(expr: ExprId, pool: &ExprPool) -> ExprId {
+        use crate::simplify::rules::{
+            AddZero, ConstFold, MulOne, MulZero, PowOne, PowZero, RewriteRule,
+        };
+
+        // Recurse into children first.
+        let rebuilt = match pool.get(expr) {
+            ExprData::Add(args) => {
+                let args: Vec<ExprId> = args.iter().map(|&a| apply_const_folds(a, pool)).collect();
+                pool.add(args)
+            }
+            ExprData::Mul(args) => {
+                let args: Vec<ExprId> = args.iter().map(|&a| apply_const_folds(a, pool)).collect();
+                pool.mul(args)
+            }
+            ExprData::Pow { base, exp } => {
+                let base = apply_const_folds(base, pool);
+                let exp = apply_const_folds(exp, pool);
+                pool.pow(base, exp)
+            }
+            ExprData::Func { name, args } => {
+                let args: Vec<ExprId> = args.iter().map(|&a| apply_const_folds(a, pool)).collect();
+                pool.func(&name, args)
+            }
+            _ => expr,
+        };
+
+        // Fold the rebuilt node to a local fixpoint with the cheap rules
+        // only. Each rule either strictly shrinks the term or returns
+        // `None`, so this loop terminates quickly.
+        let mut current = rebuilt;
+        loop {
+            let next = AddZero
+                .apply(current, pool)
+                .or_else(|| MulZero.apply(current, pool))
+                .or_else(|| MulOne.apply(current, pool))
+                .or_else(|| PowZero.apply(current, pool))
+                .or_else(|| PowOne.apply(current, pool))
+                .or_else(|| ConstFold.apply(current, pool));
+            match next {
+                Some((after, _)) if after != current => current = after,
+                _ => break,
+            }
+        }
+        current
+    }
+
+    // -----------------------------------------------------------------------
     // 4. Public implementation
     // -----------------------------------------------------------------------
 
@@ -673,14 +742,14 @@ mod backend {
         let simplified = fold_numeric_pow(simplified, pool);
         // RW-3: apply linear canonizer as a post-extraction pass.
         let simplified = canonicalize_linear(simplified, pool);
-        // Final post-extraction pass: run the rule-based simplifier so that
-        // constant-folding rules not modeled inside the egglog program
-        // (elementary functions at 0/1, x^1, 1^r, power-of-power, even-power
-        // sign folding, Rational(n/1) canonicalization, and numeric
-        // cancellation across products) also apply to the extracted term.
-        // The expression is typically already near-normal-form at this
-        // point, so this is a cheap bounded pass.
-        let simplified = super::super::engine::simplify(simplified, pool).value;
+        // Final post-extraction pass: apply only the cheap constant-folding
+        // rules (elementary functions at 0/1, x^0/x^1, 1^r, power-of-power,
+        // even-power sign folding, distribution of pow over a literal Mul
+        // coefficient, Rational(n/1) canonicalization, and Add/Mul 0/1
+        // identities) to the extracted term. See `apply_const_folds` — this
+        // is a single bottom-up O(n) pass, not a full re-run of the rule
+        // engine.
+        let simplified = apply_const_folds(simplified, pool);
 
         let mut log = DerivationLog::new();
         if simplified != expr {

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -1,6 +1,7 @@
 use super::rules::{
-    AddZero, CanonicalOrder, ConstFold, DivSelf, ExpandMul, FlattenAdd, FlattenMul, MulOne,
-    MulZero, PowOne, PowZero, RewriteRule, SqrtInteger, SubSelf,
+    AddZero, CanonicalOrder, ConstFold, DistributePowOverLiteralCoeff, DivSelf, ElementaryAtConst,
+    EvenPowerSignFold, ExpandMul, FlattenAdd, FlattenMul, MulOne, MulZero, PowOfPow, PowOne,
+    PowZero, RationalCanon, RewriteRule, SqrtInteger, SubSelf,
 };
 use super::rulesets::PatternRuleSet;
 use crate::deriv::log::{DerivationLog, DerivedExpr};
@@ -56,11 +57,16 @@ pub fn rules_for_config(config: &SimplifyConfig) -> Vec<Box<dyn RewriteRule>> {
     let mut rules: Vec<Box<dyn RewriteRule>> = vec![
         Box::new(FlattenMul),
         Box::new(FlattenAdd),
+        Box::new(RationalCanon),
         Box::new(MulZero),
         Box::new(AddZero),
         Box::new(MulOne),
+        Box::new(ElementaryAtConst),
         Box::new(PowZero),
         Box::new(PowOne),
+        Box::new(EvenPowerSignFold),
+        Box::new(PowOfPow),
+        Box::new(DistributePowOverLiteralCoeff),
         Box::new(ConstFold),
         Box::new(SqrtInteger),
         Box::new(SubSelf),

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -1,7 +1,6 @@
 use super::rules::{
-    AddZero, CanonicalOrder, ConstFold, DistributePowOverLiteralCoeff, DivSelf, ElementaryAtConst,
-    EvenPowerSignFold, ExpandMul, FlattenAdd, FlattenMul, MulOne, MulZero, PowOfPow, PowOne,
-    PowZero, RationalCanon, RewriteRule, SqrtInteger, SubSelf,
+    AddZero, CanonicalOrder, ConstFold, DivSelf, ExpandMul, FlattenAdd, FlattenMul, MulOne,
+    MulZero, PowOne, PowZero, RewriteRule, SqrtInteger, SubSelf,
 };
 use super::rulesets::PatternRuleSet;
 use crate::deriv::log::{DerivationLog, DerivedExpr};
@@ -57,16 +56,17 @@ pub fn rules_for_config(config: &SimplifyConfig) -> Vec<Box<dyn RewriteRule>> {
     let mut rules: Vec<Box<dyn RewriteRule>> = vec![
         Box::new(FlattenMul),
         Box::new(FlattenAdd),
-        Box::new(RationalCanon),
         Box::new(MulZero),
         Box::new(AddZero),
         Box::new(MulOne),
-        Box::new(ElementaryAtConst),
         Box::new(PowZero),
         Box::new(PowOne),
-        Box::new(EvenPowerSignFold),
-        Box::new(PowOfPow),
-        Box::new(DistributePowOverLiteralCoeff),
+        // ConstFold also covers elementary-functions-at-const, power-of-power,
+        // even-power sign folding, distribution of pow over a literal Mul
+        // coefficient, and Rational(n/1) canonicalization — these were
+        // previously separate rules but are now extra match arms inside
+        // ConstFold's existing per-node dispatch (see rules.rs) so they don't
+        // add per-node iterations to the rule loop below.
         Box::new(ConstFold),
         Box::new(SqrtInteger),
         Box::new(SubSelf),
@@ -649,5 +649,71 @@ mod tests {
         // Compiled path (interpreter fallback, no LLVM needed)
         let f = compile(expr, &[x], &pool).unwrap();
         assert!((f.call(&[3.0]) - 16.0).abs() < 1e-10);
+    }
+
+    /// Local perf probe for the rule-dispatch hot path: builds a corpus of
+    /// largish polynomial/rational expressions (mimicking the
+    /// jacobian/integrate-style benchmarks that hammer `simplify` on
+    /// expressions that do NOT contain any of the elementary-at-const /
+    /// pow-of-pow / even-power-sign / distribute-pow / rational-canon
+    /// patterns) and times repeated `simplify` calls.
+    ///
+    /// Not part of the default test run (`--ignored`); intended for manual
+    /// before/after comparisons of rule-dispatch overhead, e.g.:
+    ///
+    /// ```text
+    /// cargo test -p alkahest-cas --release --lib \
+    ///     simplify::engine::tests::perf_simplify_hot_path -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore]
+    fn perf_simplify_hot_path() {
+        use std::time::Instant;
+
+        let pool = p();
+        let vars: Vec<ExprId> = (0..8)
+            .map(|i| pool.symbol(format!("x{i}"), Domain::Real))
+            .collect();
+
+        // Build a corpus of expressions resembling an 8x8 Jacobian /
+        // degree-16 polynomial workload: nested sums of products of
+        // (var + integer)^k terms, none of which contain Integer(0)/(1)
+        // bases for Pow, elementary functions at 0/1, or `(-1*x)^n` / Mul
+        // coefficients on the Pow base — i.e. none of the new fold patterns
+        // fire, so this isolates pure dispatch overhead.
+        let mut exprs: Vec<ExprId> = Vec::new();
+        for row in 0..vars.len() {
+            let mut terms: Vec<ExprId> = Vec::new();
+            for (col, &v) in vars.iter().enumerate() {
+                let shifted = pool.add(vec![v, pool.integer((row * 3 + col + 2) as i64)]);
+                let power = pool.pow(shifted, pool.integer(((col % 4) + 1) as i64));
+                terms.push(power);
+            }
+            // Product of all the shifted-power terms, plus a polynomial sum.
+            let prod = pool.mul(terms.clone());
+            let sum = pool.add(terms);
+            exprs.push(pool.add(vec![prod, sum]));
+        }
+
+        // Warm up (pool interning, JIT-free path).
+        for &e in &exprs {
+            let _ = simplify(e, &pool);
+        }
+
+        const ITERS: usize = 200;
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            for &e in &exprs {
+                let _ = simplify(e, &pool);
+            }
+        }
+        let elapsed = start.elapsed();
+        eprintln!(
+            "perf_simplify_hot_path: {ITERS} iterations over {} exprs in {:?} ({:?}/iter, {:?}/expr)",
+            exprs.len(),
+            elapsed,
+            elapsed / ITERS as u32,
+            elapsed / (ITERS * exprs.len()) as u32
+        );
     }
 }

--- a/alkahest-core/src/simplify/rules.rs
+++ b/alkahest-core/src/simplify/rules.rs
@@ -318,51 +318,33 @@ impl RewriteRule for PowZero {
 }
 
 // ---------------------------------------------------------------------------
-// ElementaryAtConst: fold single-argument elementary functions at known
-// literal arguments where the value is *exact and branch-free*.
+// ConstFold: numeric folding for Add/Mul (partial), Pow (integer exponents,
+// power-of-power, and distribution over a literal coefficient), Func
+// (elementary functions at exact literal arguments), and Rational
+// (denominator-1 canonicalization).
 //
-//   exp(0)  → 1        sin(0)  → 0        cos(0)  → 1
-//   sinh(0) → 0        cosh(0) → 1        tan(0)  → 0
-//   atan(0) → 0        asin(0) → 0
-//   log(1)  → 0        ln(1)   → 0   (alternate head for log, see fps.rs)
+// All of the `Func`/`Pow` sub-cases below were originally separate rules
+// (`ElementaryAtConst`, `PowOfPow`, `DistributePowOverLiteralCoeff`,
+// `EvenPowerSignFold`, `RationalCanon`); they are folded into ConstFold's
+// existing per-node dispatch so the rule-iteration loop in `simplify_node`
+// does not pay a separate per-node check for each of them. Each sub-case
+// retains its original soundness argument (see git history / PR description
+// for the detailed proofs):
 //
-// All of these are exact values at points strictly inside the domain of
-// analyticity of each function (no branch cuts, no poles), so the fold is
-// universally sound — it does not depend on the sign/positivity/realness of
-// any other symbol.
-// ---------------------------------------------------------------------------
-
-pub struct ElementaryAtConst;
-
-impl RewriteRule for ElementaryAtConst {
-    fn name(&self) -> &'static str {
-        "elementary_at_const"
-    }
-
-    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let (name, args) = match pool.get(expr) {
-            ExprData::Func { name, args } if args.len() == 1 => (name, args),
-            _ => return None,
-        };
-        let arg = args[0];
-        let after = match name.as_str() {
-            "exp" if is_zero(arg, pool) => pool.integer(1_i32),
-            "cos" if is_zero(arg, pool) => pool.integer(1_i32),
-            "cosh" if is_zero(arg, pool) => pool.integer(1_i32),
-            "sin" | "sinh" | "tan" | "atan" | "asin" if is_zero(arg, pool) => pool.integer(0_i32),
-            "log" | "ln" if is_one(arg, pool) => pool.integer(0_i32),
-            _ => return None,
-        };
-        if after == expr {
-            return None;
-        }
-        Some((after, one_step(self.name(), expr, after)))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// ConstFold: numeric folding for Add/Mul (partial) and Pow (integer exponents)
-// Handles Integer, Rational (with promotion), and Float atoms.
+//   Func, single arg, elementary functions at 0/1:
+//     exp(0)→1  sin(0)→0  cos(0)→1  sinh(0)→0  cosh(0)→1  tan(0)→0
+//     atan(0)→0  asin(0)→0  log(1)→0  ln(1)→0
+//     (exact values strictly inside the domain of analyticity — no branch
+//     cuts, no poles — sound regardless of sign/positivity of other symbols)
+//
+//   Pow:
+//     1^r → 1                                  (any literal rational r)
+//     (-1·x)^n → x^n                           (literal even integer n)
+//     (x^a)^b → x^(a·b)                        (literal integer a, b)
+//     (c·rest)^n → c^n · rest^n                (literal integer c ≠ 0,±1, n)
+//     b^e → integer/rational fold              (literal integer base/exp)
+//
+//   Rational(n/1) → Integer(n)
 // ---------------------------------------------------------------------------
 
 fn intern_rational(r: rug::Rational, pool: &ExprPool) -> ExprId {
@@ -462,6 +444,53 @@ impl RewriteRule for ConstFold {
                     }
                     return Some((after, one_step(self.name(), expr, after)));
                 }
+
+                // (-1·x)^n → x^n for literal even integer n (EvenPowerSignFold).
+                // Cheap discriminant: exp must be an integer literal and base
+                // must be a Mul — both checks are O(1) and fail fast for the
+                // overwhelmingly common case of a plain symbol/atom base.
+                if let Some(after) = even_power_sign_fold(base, exp, pool) {
+                    if after != expr {
+                        return Some((after, one_step(self.name(), expr, after)));
+                    }
+                }
+
+                // (x^a)^b → x^(a·b) for literal integer a, b (PowOfPow).
+                // Cheap discriminant: base must itself be a Pow node.
+                if let ExprData::Pow {
+                    base: inner_base,
+                    exp: inner_exp,
+                } = pool.get(base)
+                {
+                    if let (Some(a), Some(b)) = (as_integer(inner_exp, pool), as_integer(exp, pool))
+                    {
+                        let new_exp = pool.integer(a * b);
+                        let after = pool.pow(inner_base, new_exp);
+                        if after != expr {
+                            return Some((after, one_step(self.name(), expr, after)));
+                        }
+                    }
+                }
+
+                // (c·rest)^n → c^n · rest^n for a literal integer coefficient
+                // c (!= 0, ±1) and literal integer exponent n
+                // (DistributePowOverLiteralCoeff). This is the key step that
+                // lets `π · (4π)^(-1)` reduce to `π · 4^(-1) · π^(-1)`, which
+                // `DivSelf` and the b^e fold below then collapse to `1/4`.
+                if let Some(n) = as_integer(exp, pool) {
+                    if let ExprData::Mul(_) = pool.get(base) {
+                        let (coeff, rest) = extract_int_coeff(base, pool);
+                        if coeff != 1 && coeff != -1 && coeff != 0 && rest != pool.integer(1_i32) {
+                            let coeff_pow = pool.pow(pool.integer(coeff), pool.integer(n.clone()));
+                            let rest_pow = pool.pow(rest, pool.integer(n));
+                            let after = pool.mul(vec![coeff_pow, rest_pow]);
+                            if after != expr {
+                                return Some((after, one_step(self.name(), expr, after)));
+                            }
+                        }
+                    }
+                }
+
                 let b = as_integer(base, pool)?;
                 let e = as_integer(exp, pool)?;
                 // 1^e = 1 and (-1)^e = ±1 for any integer e (including negative)
@@ -506,185 +535,71 @@ impl RewriteRule for ConstFold {
                 }
                 Some((after, one_step(self.name(), expr, after)))
             }
+            ExprData::Func { name, args } if args.len() == 1 => {
+                // Elementary functions at exact literal arguments
+                // (ElementaryAtConst).
+                let arg = args[0];
+                let after = match name.as_str() {
+                    "exp" if is_zero(arg, pool) => pool.integer(1_i32),
+                    "cos" if is_zero(arg, pool) => pool.integer(1_i32),
+                    "cosh" if is_zero(arg, pool) => pool.integer(1_i32),
+                    "sin" | "sinh" | "tan" | "atan" | "asin" if is_zero(arg, pool) => {
+                        pool.integer(0_i32)
+                    }
+                    "log" | "ln" if is_one(arg, pool) => pool.integer(0_i32),
+                    _ => return None,
+                };
+                if after == expr {
+                    return None;
+                }
+                Some((after, one_step(self.name(), expr, after)))
+            }
+            // Rational(n/1) → Integer(n) (RationalCanon).
+            //
+            // `ExprPool::rational` reduces to lowest terms but does not
+            // collapse a denominator of 1 to an `Integer` node — such nodes
+            // can also arise from un-collapsed arithmetic (see PR #147).
+            // Canonicalizing here ensures `Rational` nodes always have
+            // denominator > 1, simplifying downstream pattern matches (e.g.
+            // `as_integer`, polynomial coefficient extraction). Always sound:
+            // the value is unchanged, only the representation changes.
+            ExprData::Rational(r) if *r.0.denom() == 1 => {
+                let after = pool.integer(r.0.numer().clone());
+                Some((after, one_step(self.name(), expr, after)))
+            }
             _ => None,
         }
     }
 }
 
-// ---------------------------------------------------------------------------
-// PowOfPow: (x^a)^b → x^(a·b) for literal integer exponents a, b.
-//
-// Soundness: for *integer* a and b, integer exponentiation obeys the group
-// law `(x^a)^b = x^(ab)` for all x ≠ 0, and the b == 0 / a == 0 boundary
-// cases agree on both sides as well (both reduce via PowZero/PowOne). At
-// x == 0 the two sides are simultaneously defined or simultaneously
-// undefined (0^n is 0 for n > 0 and undefined for n ≤ 0), so no domain
-// violation is introduced.
-//
-// Fractional `a` is deliberately **not** handled: `(x^(p/q))^b = x^(pb/q)`
-// can fail for complex x because raising to a fractional power selects a
-// branch, and re-exponentiating that branch value need not coincide with
-// the principal branch of `x^(a·b)` (e.g. `((-1)^(1/3))^2 ≠ (-1)^(2/3)`
-// under some branch conventions). Restricting to integer `a` and `b` avoids
-// all such branch-cut ambiguity.
-// ---------------------------------------------------------------------------
-
-pub struct PowOfPow;
-
-impl RewriteRule for PowOfPow {
-    fn name(&self) -> &'static str {
-        "pow_of_pow"
+/// Helper for `ConstFold`'s `(-1·x)^n → x^n` fold (literal even integer `n`).
+/// Returns `None` if the pattern doesn't match (cheap discriminant checks
+/// fail fast for the common case).
+fn even_power_sign_fold(base: ExprId, exp: ExprId, pool: &ExprPool) -> Option<ExprId> {
+    let n = as_integer(exp, pool)?;
+    if !n.is_even() || n == 0 {
+        return None;
     }
-
-    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let (outer_base, outer_exp) = match pool.get(expr) {
-            ExprData::Pow { base, exp } => (base, exp),
-            _ => return None,
-        };
-        let (inner_base, inner_exp) = match pool.get(outer_base) {
-            ExprData::Pow { base, exp } => (base, exp),
-            _ => return None,
-        };
-        let a = as_integer(inner_exp, pool)?;
-        let b = as_integer(outer_exp, pool)?;
-        let new_exp = a * b;
-        let new_exp_id = pool.integer(new_exp);
-        let after = pool.pow(inner_base, new_exp_id);
-        if after == expr {
-            return None;
-        }
-        Some((after, one_step(self.name(), expr, after)))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// DistributePowOverLiteralCoeff: (c · rest)^n → c^n · rest^n for a literal
-// integer coefficient `c` (extracted from a Mul) and a literal integer
-// exponent `n`.
-//
-// Soundness: integer-power exponentiation distributes over multiplication
-// for *integer* exponents — `(c·rest)^n = c^n · rest^n` for all complex
-// `c, rest` and integer `n`, including negative `n` (where both sides are
-// simultaneously undefined iff `c·rest == 0`). This is the key step that
-// lets `π · (4π)^(-1)` reduce to `π · 4^(-1) · π^(-1)`, which `DivSelf` and
-// `ConstFold` then collapse to `1/4`.
-//
-// Only fires when `c` is a literal integer `!= ±1` (those cases are
-// already handled / no-ops) and `rest` is non-trivial, to avoid loops with
-// `PowOne`/`ConstFold`.
-// ---------------------------------------------------------------------------
-
-pub struct DistributePowOverLiteralCoeff;
-
-impl RewriteRule for DistributePowOverLiteralCoeff {
-    fn name(&self) -> &'static str {
-        "distribute_pow_literal_coeff"
-    }
-
-    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let (base, exp) = match pool.get(expr) {
-            ExprData::Pow { base, exp } => (base, exp),
-            _ => return None,
-        };
-        let n = as_integer(exp, pool)?;
-        let (coeff, rest) = extract_int_coeff(base, pool);
-        if coeff == 1 || coeff == -1 || coeff == 0 {
-            return None;
-        }
-        if rest == pool.integer(1_i32) {
-            // base was purely numeric — leave to ConstFold.
-            return None;
-        }
-        let coeff_pow = pool.pow(pool.integer(coeff), pool.integer(n.clone()));
-        let rest_pow = pool.pow(rest, pool.integer(n));
-        let after = pool.mul(vec![coeff_pow, rest_pow]);
-        if after == expr {
-            return None;
-        }
-        Some((after, one_step(self.name(), expr, after)))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// EvenPowerSignFold: (-1 · x)^n → x^n for literal even integer n.
-//
-// Soundness: for even integer n, (-y)^n = y^n for all y (real or complex),
-// since (-1)^n = 1. This holds unconditionally — no domain restriction on
-// x is needed.
-// ---------------------------------------------------------------------------
-
-pub struct EvenPowerSignFold;
-
-impl RewriteRule for EvenPowerSignFold {
-    fn name(&self) -> &'static str {
-        "even_power_sign_fold"
-    }
-
-    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let (base, exp) = match pool.get(expr) {
-            ExprData::Pow { base, exp } => (base, exp),
-            _ => return None,
-        };
-        let n = as_integer(exp, pool)?;
-        if !n.is_even() || n == 0 {
-            return None;
-        }
-        let args = match pool.get(base) {
-            ExprData::Mul(v) => v,
-            _ => return None,
-        };
-        // Find a literal -1 factor.
-        let neg_pos = args
-            .iter()
-            .position(|&a| as_integer(a, pool).is_some_and(|i| i == -1))?;
-        let rest: Vec<ExprId> = args
-            .iter()
-            .enumerate()
-            .filter(|&(i, _)| i != neg_pos)
-            .map(|(_, &a)| a)
-            .collect();
-        let new_base = match rest.len() {
-            0 => pool.integer(1_i32),
-            1 => rest[0],
-            _ => pool.mul(rest),
-        };
-        let after = pool.pow(new_base, exp);
-        if after == expr {
-            return None;
-        }
-        Some((after, one_step(self.name(), expr, after)))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// RationalCanon: Rational(n/1) → Integer(n)
-//
-// `ExprPool::rational` reduces to lowest terms but does not collapse a
-// denominator of 1 to an `Integer` node — such nodes can also arise from
-// un-collapsed arithmetic (see PR #147). Canonicalizing here ensures
-// `Rational` nodes always have denominator > 1, simplifying downstream
-// pattern matches (e.g. `as_integer`, polynomial coefficient extraction).
-// Always sound: the value is unchanged, only the representation changes.
-// ---------------------------------------------------------------------------
-
-pub struct RationalCanon;
-
-impl RewriteRule for RationalCanon {
-    fn name(&self) -> &'static str {
-        "rational_canon"
-    }
-
-    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let r = match pool.get(expr) {
-            ExprData::Rational(r) => r.0,
-            _ => return None,
-        };
-        if *r.denom() != 1 {
-            return None;
-        }
-        let after = pool.integer(r.numer().clone());
-        Some((after, one_step(self.name(), expr, after)))
-    }
+    let args = match pool.get(base) {
+        ExprData::Mul(v) => v,
+        _ => return None,
+    };
+    // Find a literal -1 factor.
+    let neg_pos = args
+        .iter()
+        .position(|&a| as_integer(a, pool).is_some_and(|i| i == -1))?;
+    let rest: Vec<ExprId> = args
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| i != neg_pos)
+        .map(|(_, &a)| a)
+        .collect();
+    let new_base = match rest.len() {
+        0 => pool.integer(1_i32),
+        1 => rest[0],
+        _ => pool.mul(rest),
+    };
+    Some(pool.pow(new_base, exp))
 }
 
 // ---------------------------------------------------------------------------
@@ -1348,7 +1263,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("exp", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(1_i32));
     }
 
@@ -1357,7 +1272,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("sin", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1366,7 +1281,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("cos", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(1_i32));
     }
 
@@ -1375,7 +1290,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("sinh", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1384,7 +1299,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("cosh", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(1_i32));
     }
 
@@ -1393,7 +1308,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("tan", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1402,7 +1317,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("atan", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1411,7 +1326,7 @@ mod tests {
         let pool = p();
         let zero = pool.integer(0_i32);
         let expr = pool.func("asin", vec![zero]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1420,7 +1335,7 @@ mod tests {
         let pool = p();
         let one = pool.integer(1_i32);
         let expr = pool.func("log", vec![one]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1429,7 +1344,7 @@ mod tests {
         let pool = p();
         let one = pool.integer(1_i32);
         let expr = pool.func("ln", vec![one]);
-        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(0_i32));
     }
 
@@ -1438,7 +1353,7 @@ mod tests {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.func("exp", vec![x]);
-        assert!(ElementaryAtConst.apply(expr, &pool).is_none());
+        assert!(ConstFold.apply(expr, &pool).is_none());
     }
 
     #[test]
@@ -1498,7 +1413,7 @@ mod tests {
         let s = pool.symbol("s", Domain::Real);
         let s4 = pool.pow(s, pool.integer(4_i32));
         let expr = pool.pow(s4, pool.integer(-1_i32));
-        let (result, _) = PowOfPow.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.pow(s, pool.integer(-4_i32)));
     }
 
@@ -1521,7 +1436,7 @@ mod tests {
         let half = pool.rational(1_i32, 2_i32);
         let x_half = pool.pow(x, half);
         let expr = pool.pow(x_half, pool.integer(2_i32));
-        assert!(PowOfPow.apply(expr, &pool).is_none());
+        assert!(ConstFold.apply(expr, &pool).is_none());
     }
 
     // -------------------------------------------------------------------
@@ -1534,7 +1449,7 @@ mod tests {
         let x = pool.symbol("x", Domain::Real);
         let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
         let expr = pool.pow(neg_x, pool.integer(2_i32));
-        let (result, _) = EvenPowerSignFold.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.pow(x, pool.integer(2_i32)));
     }
 
@@ -1555,7 +1470,7 @@ mod tests {
         let x = pool.symbol("x", Domain::Real);
         let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
         let expr = pool.pow(neg_x, pool.integer(3_i32));
-        assert!(EvenPowerSignFold.apply(expr, &pool).is_none());
+        assert!(ConstFold.apply(expr, &pool).is_none());
     }
 
     // -------------------------------------------------------------------
@@ -1569,7 +1484,7 @@ mod tests {
         // own reduction, which still leaves a Rational node for denom == 1).
         let r = rug::Rational::from((rug::Integer::from(3), rug::Integer::from(1)));
         let expr = pool.intern(ExprData::Rational(crate::kernel::expr::BigRat(r)));
-        let (result, _) = RationalCanon.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         assert_eq!(result, pool.integer(3_i32));
     }
 
@@ -1577,7 +1492,7 @@ mod tests {
     fn rational_with_denom_gt_one_unchanged() {
         let pool = p();
         let half = pool.rational(1_i32, 2_i32);
-        assert!(RationalCanon.apply(half, &pool).is_none());
+        assert!(ConstFold.apply(half, &pool).is_none());
     }
 
     // -------------------------------------------------------------------
@@ -1593,7 +1508,7 @@ mod tests {
         let pi = pool.symbol("pi", Domain::Real);
         let four_pi = pool.mul(vec![pool.integer(4_i32), pi]);
         let expr = pool.pow(four_pi, pool.integer(-1_i32));
-        let (result, _) = DistributePowOverLiteralCoeff.apply(expr, &pool).unwrap();
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
         let expected = pool.mul(vec![
             pool.pow(pool.integer(4_i32), pool.integer(-1_i32)),
             pool.pow(pi, pool.integer(-1_i32)),

--- a/alkahest-core/src/simplify/rules.rs
+++ b/alkahest-core/src/simplify/rules.rs
@@ -202,6 +202,19 @@ impl RewriteRule for MulZero {
         if !args.iter().any(|&a| is_zero(a, pool)) {
             return None;
         }
+        // Do not fold `0 * 0^(-1) * ...` (or `0 * 0^(-2)`, etc.) to `0`: a
+        // literal `0^(negative)` factor is itself undefined (division by
+        // zero), so the product is indeterminate, not `0`. This is the
+        // n=0 boundary of `0 * x^(-1)` being indeterminate at x=0.
+        let has_zero_to_neg_pow = args.iter().any(|&a| match pool.get(a) {
+            ExprData::Pow { base, exp } => {
+                is_zero(base, pool) && as_integer(exp, pool).is_some_and(|e| e < 0)
+            }
+            _ => false,
+        });
+        if has_zero_to_neg_pow {
+            return None;
+        }
         let after = pool.integer(0_i32);
         Some((after, one_step(self.name(), expr, after)))
     }
@@ -305,6 +318,49 @@ impl RewriteRule for PowZero {
 }
 
 // ---------------------------------------------------------------------------
+// ElementaryAtConst: fold single-argument elementary functions at known
+// literal arguments where the value is *exact and branch-free*.
+//
+//   exp(0)  → 1        sin(0)  → 0        cos(0)  → 1
+//   sinh(0) → 0        cosh(0) → 1        tan(0)  → 0
+//   atan(0) → 0        asin(0) → 0
+//   log(1)  → 0        ln(1)   → 0   (alternate head for log, see fps.rs)
+//
+// All of these are exact values at points strictly inside the domain of
+// analyticity of each function (no branch cuts, no poles), so the fold is
+// universally sound — it does not depend on the sign/positivity/realness of
+// any other symbol.
+// ---------------------------------------------------------------------------
+
+pub struct ElementaryAtConst;
+
+impl RewriteRule for ElementaryAtConst {
+    fn name(&self) -> &'static str {
+        "elementary_at_const"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let (name, args) = match pool.get(expr) {
+            ExprData::Func { name, args } if args.len() == 1 => (name, args),
+            _ => return None,
+        };
+        let arg = args[0];
+        let after = match name.as_str() {
+            "exp" if is_zero(arg, pool) => pool.integer(1_i32),
+            "cos" if is_zero(arg, pool) => pool.integer(1_i32),
+            "cosh" if is_zero(arg, pool) => pool.integer(1_i32),
+            "sin" | "sinh" | "tan" | "atan" | "asin" if is_zero(arg, pool) => pool.integer(0_i32),
+            "log" | "ln" if is_one(arg, pool) => pool.integer(0_i32),
+            _ => return None,
+        };
+        if after == expr {
+            return None;
+        }
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ConstFold: numeric folding for Add/Mul (partial) and Pow (integer exponents)
 // Handles Integer, Rational (with promotion), and Float atoms.
 // ---------------------------------------------------------------------------
@@ -395,6 +451,17 @@ impl RewriteRule for ConstFold {
                 Some((after, one_step(self.name(), expr, after)))
             }
             ExprData::Pow { base, exp } => {
+                // 1^r = 1 for any literal rational (or integer) exponent `r`,
+                // including non-integer exponents like 1/2. This is sound
+                // unconditionally: 1^r = exp(r * log(1)) = exp(r * 0) = 1
+                // under the principal branch, with no branch-cut ambiguity.
+                if is_one(base, pool) && as_rational(exp, pool).is_some() {
+                    let after = pool.integer(1_i32);
+                    if after == expr {
+                        return None;
+                    }
+                    return Some((after, one_step(self.name(), expr, after)));
+                }
                 let b = as_integer(base, pool)?;
                 let e = as_integer(exp, pool)?;
                 // 1^e = 1 and (-1)^e = ±1 for any integer e (including negative)
@@ -414,7 +481,22 @@ impl RewriteRule for ConstFold {
                     return Some((after, one_step(self.name(), expr, after)));
                 }
                 if e < 0 {
-                    return None; // negative integer pow → rational; skip
+                    // b^e for nonzero integer base `b` and negative integer
+                    // exponent `e` is the rational `1 / b^|e|`. Sound for any
+                    // nonzero b (b == 0, ±1 handled above / 0 excluded since
+                    // 0^(negative) is undefined and `as_integer` would give 0
+                    // only for base literal 0, which we reject here).
+                    if b == 0 {
+                        return None; // 0^(negative) undefined
+                    }
+                    let e_u32 = (-e.clone()).to_u32()?;
+                    let denom: rug::Integer = b.pow(e_u32);
+                    let result = rug::Rational::from((rug::Integer::from(1), denom));
+                    let after = intern_rational(result, pool);
+                    if after == expr {
+                        return None;
+                    }
+                    return Some((after, one_step(self.name(), expr, after)));
                 }
                 let e_u32 = e.to_u32()?;
                 let result: rug::Integer = b.pow(e_u32);
@@ -426,6 +508,182 @@ impl RewriteRule for ConstFold {
             }
             _ => None,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PowOfPow: (x^a)^b → x^(a·b) for literal integer exponents a, b.
+//
+// Soundness: for *integer* a and b, integer exponentiation obeys the group
+// law `(x^a)^b = x^(ab)` for all x ≠ 0, and the b == 0 / a == 0 boundary
+// cases agree on both sides as well (both reduce via PowZero/PowOne). At
+// x == 0 the two sides are simultaneously defined or simultaneously
+// undefined (0^n is 0 for n > 0 and undefined for n ≤ 0), so no domain
+// violation is introduced.
+//
+// Fractional `a` is deliberately **not** handled: `(x^(p/q))^b = x^(pb/q)`
+// can fail for complex x because raising to a fractional power selects a
+// branch, and re-exponentiating that branch value need not coincide with
+// the principal branch of `x^(a·b)` (e.g. `((-1)^(1/3))^2 ≠ (-1)^(2/3)`
+// under some branch conventions). Restricting to integer `a` and `b` avoids
+// all such branch-cut ambiguity.
+// ---------------------------------------------------------------------------
+
+pub struct PowOfPow;
+
+impl RewriteRule for PowOfPow {
+    fn name(&self) -> &'static str {
+        "pow_of_pow"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let (outer_base, outer_exp) = match pool.get(expr) {
+            ExprData::Pow { base, exp } => (base, exp),
+            _ => return None,
+        };
+        let (inner_base, inner_exp) = match pool.get(outer_base) {
+            ExprData::Pow { base, exp } => (base, exp),
+            _ => return None,
+        };
+        let a = as_integer(inner_exp, pool)?;
+        let b = as_integer(outer_exp, pool)?;
+        let new_exp = a * b;
+        let new_exp_id = pool.integer(new_exp);
+        let after = pool.pow(inner_base, new_exp_id);
+        if after == expr {
+            return None;
+        }
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DistributePowOverLiteralCoeff: (c · rest)^n → c^n · rest^n for a literal
+// integer coefficient `c` (extracted from a Mul) and a literal integer
+// exponent `n`.
+//
+// Soundness: integer-power exponentiation distributes over multiplication
+// for *integer* exponents — `(c·rest)^n = c^n · rest^n` for all complex
+// `c, rest` and integer `n`, including negative `n` (where both sides are
+// simultaneously undefined iff `c·rest == 0`). This is the key step that
+// lets `π · (4π)^(-1)` reduce to `π · 4^(-1) · π^(-1)`, which `DivSelf` and
+// `ConstFold` then collapse to `1/4`.
+//
+// Only fires when `c` is a literal integer `!= ±1` (those cases are
+// already handled / no-ops) and `rest` is non-trivial, to avoid loops with
+// `PowOne`/`ConstFold`.
+// ---------------------------------------------------------------------------
+
+pub struct DistributePowOverLiteralCoeff;
+
+impl RewriteRule for DistributePowOverLiteralCoeff {
+    fn name(&self) -> &'static str {
+        "distribute_pow_literal_coeff"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let (base, exp) = match pool.get(expr) {
+            ExprData::Pow { base, exp } => (base, exp),
+            _ => return None,
+        };
+        let n = as_integer(exp, pool)?;
+        let (coeff, rest) = extract_int_coeff(base, pool);
+        if coeff == 1 || coeff == -1 || coeff == 0 {
+            return None;
+        }
+        if rest == pool.integer(1_i32) {
+            // base was purely numeric — leave to ConstFold.
+            return None;
+        }
+        let coeff_pow = pool.pow(pool.integer(coeff), pool.integer(n.clone()));
+        let rest_pow = pool.pow(rest, pool.integer(n));
+        let after = pool.mul(vec![coeff_pow, rest_pow]);
+        if after == expr {
+            return None;
+        }
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EvenPowerSignFold: (-1 · x)^n → x^n for literal even integer n.
+//
+// Soundness: for even integer n, (-y)^n = y^n for all y (real or complex),
+// since (-1)^n = 1. This holds unconditionally — no domain restriction on
+// x is needed.
+// ---------------------------------------------------------------------------
+
+pub struct EvenPowerSignFold;
+
+impl RewriteRule for EvenPowerSignFold {
+    fn name(&self) -> &'static str {
+        "even_power_sign_fold"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let (base, exp) = match pool.get(expr) {
+            ExprData::Pow { base, exp } => (base, exp),
+            _ => return None,
+        };
+        let n = as_integer(exp, pool)?;
+        if !n.is_even() || n == 0 {
+            return None;
+        }
+        let args = match pool.get(base) {
+            ExprData::Mul(v) => v,
+            _ => return None,
+        };
+        // Find a literal -1 factor.
+        let neg_pos = args
+            .iter()
+            .position(|&a| as_integer(a, pool).is_some_and(|i| i == -1))?;
+        let rest: Vec<ExprId> = args
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| i != neg_pos)
+            .map(|(_, &a)| a)
+            .collect();
+        let new_base = match rest.len() {
+            0 => pool.integer(1_i32),
+            1 => rest[0],
+            _ => pool.mul(rest),
+        };
+        let after = pool.pow(new_base, exp);
+        if after == expr {
+            return None;
+        }
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RationalCanon: Rational(n/1) → Integer(n)
+//
+// `ExprPool::rational` reduces to lowest terms but does not collapse a
+// denominator of 1 to an `Integer` node — such nodes can also arise from
+// un-collapsed arithmetic (see PR #147). Canonicalizing here ensures
+// `Rational` nodes always have denominator > 1, simplifying downstream
+// pattern matches (e.g. `as_integer`, polynomial coefficient extraction).
+// Always sound: the value is unchanged, only the representation changes.
+// ---------------------------------------------------------------------------
+
+pub struct RationalCanon;
+
+impl RewriteRule for RationalCanon {
+    fn name(&self) -> &'static str {
+        "rational_canon"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let r = match pool.get(expr) {
+            ExprData::Rational(r) => r.0,
+            _ => return None,
+        };
+        if *r.denom() != 1 {
+            return None;
+        }
+        let after = pool.integer(r.numer().clone());
+        Some((after, one_step(self.name(), expr, after)))
     }
 }
 
@@ -1079,5 +1337,337 @@ mod tests {
             result.is_none(),
             "CanonicalOrder should be a no-op when children are already sorted at construction"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // ElementaryAtConst
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn exp_zero_is_one() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("exp", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(1_i32));
+    }
+
+    #[test]
+    fn sin_zero_is_zero() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("sin", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn cos_zero_is_one() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("cos", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(1_i32));
+    }
+
+    #[test]
+    fn sinh_zero_is_zero() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("sinh", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn cosh_zero_is_one() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("cosh", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(1_i32));
+    }
+
+    #[test]
+    fn tan_zero_is_zero() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("tan", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn atan_zero_is_zero() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("atan", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn asin_zero_is_zero() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("asin", vec![zero]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn log_one_is_zero() {
+        let pool = p();
+        let one = pool.integer(1_i32);
+        let expr = pool.func("log", vec![one]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn ln_one_is_zero() {
+        let pool = p();
+        let one = pool.integer(1_i32);
+        let expr = pool.func("ln", vec![one]);
+        let (result, _) = ElementaryAtConst.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(0_i32));
+    }
+
+    #[test]
+    fn elementary_at_const_no_match_for_nonzero_arg() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("exp", vec![x]);
+        assert!(ElementaryAtConst.apply(expr, &pool).is_none());
+    }
+
+    #[test]
+    fn exp_zero_fires_via_full_simplify() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let expr = pool.func("exp", vec![zero]);
+        let r = crate::simplify::simplify(expr, &pool);
+        assert_eq!(r.value, pool.integer(1_i32));
+    }
+
+    // -------------------------------------------------------------------
+    // PowOne (x^1 → x) — already implemented; exercised via full simplify
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn pow_one_via_full_simplify() {
+        let pool = p();
+        let s = pool.symbol("s", Domain::Real);
+        let expr = pool.pow(s, pool.integer(1_i32));
+        let r = crate::simplify::simplify(expr, &pool);
+        assert_eq!(r.value, s);
+    }
+
+    // -------------------------------------------------------------------
+    // 1^r → 1 for literal rational exponents
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn one_pow_half_is_one() {
+        let pool = p();
+        let one = pool.integer(1_i32);
+        let half = pool.rational(1_i32, 2_i32);
+        let expr = pool.pow(one, half);
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(1_i32));
+    }
+
+    #[test]
+    fn one_pow_half_via_full_simplify() {
+        let pool = p();
+        let one = pool.integer(1_i32);
+        let half = pool.rational(1_i32, 2_i32);
+        let expr = pool.pow(one, half);
+        let r = crate::simplify::simplify(expr, &pool);
+        assert_eq!(r.value, pool.integer(1_i32));
+    }
+
+    // -------------------------------------------------------------------
+    // PowOfPow: (x^a)^b → x^(a*b) for literal integer a, b
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn pow_of_pow_combines_integer_exponents() {
+        // (s^4)^(-1) → s^(-4)
+        let pool = p();
+        let s = pool.symbol("s", Domain::Real);
+        let s4 = pool.pow(s, pool.integer(4_i32));
+        let expr = pool.pow(s4, pool.integer(-1_i32));
+        let (result, _) = PowOfPow.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.pow(s, pool.integer(-4_i32)));
+    }
+
+    #[test]
+    fn pow_of_pow_via_full_simplify() {
+        let pool = p();
+        let s = pool.symbol("s", Domain::Real);
+        let s4 = pool.pow(s, pool.integer(4_i32));
+        let expr = pool.pow(s4, pool.integer(-1_i32));
+        let r = crate::simplify::simplify(expr, &pool);
+        assert_eq!(r.value, pool.pow(s, pool.integer(-4_i32)));
+    }
+
+    #[test]
+    fn pow_of_pow_does_not_fire_for_fractional_inner_exponent() {
+        // (x^(1/2))^2 is NOT rewritten by PowOfPow (left for other rules /
+        // domain-aware identities) — branch-cut conservatism.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let half = pool.rational(1_i32, 2_i32);
+        let x_half = pool.pow(x, half);
+        let expr = pool.pow(x_half, pool.integer(2_i32));
+        assert!(PowOfPow.apply(expr, &pool).is_none());
+    }
+
+    // -------------------------------------------------------------------
+    // EvenPowerSignFold: (-1 * x)^n → x^n for literal even integer n
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn even_power_sign_fold_squares() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
+        let expr = pool.pow(neg_x, pool.integer(2_i32));
+        let (result, _) = EvenPowerSignFold.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.pow(x, pool.integer(2_i32)));
+    }
+
+    #[test]
+    fn even_power_sign_fold_via_full_simplify() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
+        let expr = pool.pow(neg_x, pool.integer(2_i32));
+        let r = crate::simplify::simplify(expr, &pool);
+        assert_eq!(r.value, pool.pow(x, pool.integer(2_i32)));
+    }
+
+    #[test]
+    fn odd_power_sign_fold_does_not_fire() {
+        // (-1 * x)^3 should NOT drop the sign (it's -x^3).
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
+        let expr = pool.pow(neg_x, pool.integer(3_i32));
+        assert!(EvenPowerSignFold.apply(expr, &pool).is_none());
+    }
+
+    // -------------------------------------------------------------------
+    // RationalCanon: Rational(n/1) → Integer(n)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn rational_with_denom_one_canonicalizes_to_integer() {
+        let pool = p();
+        // Build a Rational(3/1) node directly (bypassing ExprPool::rational's
+        // own reduction, which still leaves a Rational node for denom == 1).
+        let r = rug::Rational::from((rug::Integer::from(3), rug::Integer::from(1)));
+        let expr = pool.intern(ExprData::Rational(crate::kernel::expr::BigRat(r)));
+        let (result, _) = RationalCanon.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.integer(3_i32));
+    }
+
+    #[test]
+    fn rational_with_denom_gt_one_unchanged() {
+        let pool = p();
+        let half = pool.rational(1_i32, 2_i32);
+        assert!(RationalCanon.apply(half, &pool).is_none());
+    }
+
+    // -------------------------------------------------------------------
+    // Numeric cancellation across a product:
+    //   π · (4π)^(-1) → 1/4   (DistributePowOverLiteralCoeff + DivSelf +
+    //   ConstFold's new negative-integer-exponent fold)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn distribute_pow_over_literal_coeff() {
+        // (4*pi)^(-1) → 4^(-1) * pi^(-1)
+        let pool = p();
+        let pi = pool.symbol("pi", Domain::Real);
+        let four_pi = pool.mul(vec![pool.integer(4_i32), pi]);
+        let expr = pool.pow(four_pi, pool.integer(-1_i32));
+        let (result, _) = DistributePowOverLiteralCoeff.apply(expr, &pool).unwrap();
+        let expected = pool.mul(vec![
+            pool.pow(pool.integer(4_i32), pool.integer(-1_i32)),
+            pool.pow(pi, pool.integer(-1_i32)),
+        ]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn pi_times_inverse_four_pi_is_one_quarter() {
+        // pi * (4*pi)^(-1) → 1/4
+        let pool = p();
+        let pi = pool.symbol("pi", Domain::Real);
+        let four_pi = pool.mul(vec![pool.integer(4_i32), pi]);
+        let inv = pool.pow(four_pi, pool.integer(-1_i32));
+        let expr = pool.mul(vec![pi, inv]);
+        let r = crate::simplify::simplify(expr, &pool);
+        assert_eq!(r.value, pool.rational(1_i32, 4_i32));
+    }
+
+    #[test]
+    fn integer_to_negative_one_is_reciprocal_rational() {
+        // 4^(-1) → 1/4
+        let pool = p();
+        let expr = pool.pow(pool.integer(4_i32), pool.integer(-1_i32));
+        let (result, _) = ConstFold.apply(expr, &pool).unwrap();
+        assert_eq!(result, pool.rational(1_i32, 4_i32));
+    }
+
+    // -------------------------------------------------------------------
+    // Idempotency spot-checks on larger expressions
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn idempotent_on_combined_expression() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let pi = pool.symbol("pi", Domain::Real);
+
+        // Build: exp(0) + sin(0) + (1)^(1/2) + (s^4)^(-1) + (-1*x)^2
+        //        + pi * (4*pi)^(-1)
+        let s = pool.symbol("s", Domain::Real);
+        let exp0 = pool.func("exp", vec![pool.integer(0_i32)]);
+        let sin0 = pool.func("sin", vec![pool.integer(0_i32)]);
+        let one_pow_half = pool.pow(pool.integer(1_i32), pool.rational(1_i32, 2_i32));
+        let s_pow_pow = pool.pow(pool.pow(s, pool.integer(4_i32)), pool.integer(-1_i32));
+        let neg_x_sq = pool.pow(pool.mul(vec![pool.integer(-1_i32), x]), pool.integer(2_i32));
+        let four_pi = pool.mul(vec![pool.integer(4_i32), pi]);
+        let pi_cancel = pool.mul(vec![pi, pool.pow(four_pi, pool.integer(-1_i32))]);
+
+        let expr = pool.add(vec![
+            exp0,
+            sin0,
+            one_pow_half,
+            s_pow_pow,
+            neg_x_sq,
+            pi_cancel,
+        ]);
+
+        let r1 = crate::simplify::simplify(expr, &pool);
+        let r2 = crate::simplify::simplify(r1.value, &pool);
+        assert_eq!(r1.value, r2.value, "simplify should be idempotent");
+    }
+
+    #[test]
+    fn idempotent_on_rational_canon_node() {
+        let pool = p();
+        let r = rug::Rational::from((rug::Integer::from(5), rug::Integer::from(1)));
+        let rat_five = pool.intern(ExprData::Rational(crate::kernel::expr::BigRat(r)));
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![rat_five, x]);
+
+        let r1 = crate::simplify::simplify(expr, &pool);
+        let r2 = crate::simplify::simplify(r1.value, &pool);
+        assert_eq!(r1.value, r2.value);
+        assert_eq!(r1.value, pool.add(vec![pool.integer(5_i32), x]));
     }
 }


### PR DESCRIPTION
## Summary

Closes a batch of independently-rediscovered `simplify` gaps (each hit and worked around locally during PRs #152/#155/#158/#161):

1. **Elementary functions at known points** (`ElementaryAtConst`, new rule):
   `exp(0)→1`, `sin(0)→0`, `cos(0)→1`, `sinh(0)→0`, `cosh(0)→1`, `tan(0)→0`,
   `atan(0)→0`, `asin(0)→0`, `log(1)→0`, `ln(1)→0`.
   **Soundness:** all of these are exact values strictly inside the domain of
   analyticity of each function — no branch cuts, no poles, no sign/positivity
   assumptions needed.

2. **`x^1 → x`**: already implemented (`PowOne`) and registered in
   `rules_for_config` on `origin/main` — no change needed.

3. **`1^r → 1`** for any literal rational exponent `r` (e.g. `1^(1/2) → 1`),
   extending `ConstFold`'s `Pow` arm.
   **Soundness:** `1^r = exp(r·log(1)) = exp(r·0) = 1` under the principal
   branch for any `r`, real or complex — no ambiguity.

4. **`PowOfPow`**: `(x^a)^b → x^(a·b)` **only** when both `a` and `b` are
   literal integers (e.g. `(s^4)^(-1) → s^(-4)`).
   **Soundness:** integer exponentiation obeys the group law
   `(x^a)^b = x^(ab)` for all `x` (including `x = 0`, where both sides are
   simultaneously defined or undefined). Fractional `a` is **deliberately
   excluded** — `(x^(p/q))^b` can select a different branch than
   `x^((p/q)·b)` for complex `x` (e.g. `((-1)^(1/3))^2` vs `(-1)^(2/3)`),
   so this case is left unhandled.

5. **Numeric cancellation across a product** (`π·(4π)^(-1) → 1/4`):
   - New `DistributePowOverLiteralCoeff`: `(c·rest)^n → c^n · rest^n` for a
     literal integer coefficient `c` extracted from a `Mul` and literal
     integer exponent `n` (any sign). Sound via the integer-power
     distributive law over products.
   - Extended `ConstFold`'s `Pow` arm: `b^(-n) → 1/b^n` for nonzero literal
     integer base `b` and positive integer `n` (e.g. `4^(-1) → 1/4`).
   - Together with the existing `DivSelf`, `π·(4π)^(-1)` →
     `π · 4^(-1) · π^(-1)` → `4^(-1) · (π·π^(-1))` → `1/4 · 1` → `1/4`.

6. **`EvenPowerSignFold`**: `(-1·x)^n → x^n` for literal even integer `n`
   (e.g. `(-1·x)^2 → x^2`).
   **Soundness:** `(-y)^n = (-1)^n · y^n = y^n` for even `n`, unconditionally.

7. **`RationalCanon`**: `Rational(n/1) → Integer(n)`.
   **Soundness:** pure representation change (companion to the poly-side fix
   in #147); always value-preserving.

## Pre-existing bug fixed along the way

Fold (1) (`sin(0) → 0`) newly exposed a **pre-existing unsoundness** in
`MulZero`: `0 * 0^(-1) → 0` was previously reachable (e.g. via
`sin(x·y)·(x·y)^(-1)` evaluated along the path `y = 0`), but `0 * 0^(-1)` is
indeterminate (`0 * undefined`), not `0`. `MulZero` now refuses to fire when
another factor is a literal `0^(negative integer)`. This fixed a regression in
`calculus::multilimit::tests::sin_xy_over_xy_one_or_undecided`
(`sin(xy)/(xy)` was being certified `DoesNotExist` along `y=0` instead of
`Undecided`/`1`).

## Egraph path

Added a final post-extraction pass in `simplify_egraph_impl` that runs the
rule-based `simplify` over the extracted/canonicalized term, so all of the
above folds also apply to e-graph results (the egglog program itself only
models `Sin`/`Cos`/`Exp`/`Log`/`Sqrt`/`Pow` — `sinh`, `tan`, `atan`, `asin`,
and the new algebraic folds are not representable inside egglog, so a Rust
post-pass is the simplest correct approach). The extracted term is typically
already near normal form, so this is a cheap bounded pass.

## Assertion updates

None — no existing test assertions needed to change (the new forms are
strictly *more* simplified versions of previously-unsimplified expressions,
and no test asserted the old unsimplified shape as a final answer). One test
(`sin_xy_over_xy_one_or_undecided`) was failing due to the pre-existing
`MulZero` bug described above; fixed by tightening `MulZero`'s guard rather
than by changing the assertion.

## Test plan

- [x] `cargo test --workspace` — 1296 passed, 0 failed, 3 ignored (pre-existing)
- [x] `cargo test -p alkahest-cas --lib --features egraph` — all egraph tests pass
- [x] New unit tests per fold in `alkahest-core/src/simplify/rules.rs`
      (`elementary_at_const`, `one_pow_half_*`, `pow_of_pow_*`,
      `even_power_sign_fold_*`, `rational_with_denom_one_*`,
      `distribute_pow_over_literal_coeff`, `pi_times_inverse_four_pi_is_one_quarter`,
      `integer_to_negative_one_is_reciprocal_rational`)
- [x] Idempotency spot-checks (`idempotent_on_combined_expression`,
      `idempotent_on_rational_canon_node`)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p alkahest-cas --all-targets` — no new warnings
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p alkahest-cas --no-deps` clean

## Performance note

All new rules use only literal `Integer`/`Rational` pattern matches (cheap
`as_integer`/`as_rational`/`is_one`/`is_zero` checks), consistent with the
existing rule style. The egraph post-pass runs the existing bounded
fixed-point `simplify` loop on an already-near-normal-form term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a final lightweight constant-folding pass in the simplifier for more aggressive, safe local simplifications (powers, elementary functions, small arithmetic identities).
  * Extended power/rational simplifications (nested powers, sign folding, distributing integer coefficients).

* **Bug Fixes**
  * Avoid incorrect folding to zero in certain indeterminate product cases.

* **Tests**
  * Added coverage and a performance probe for the simplifier hot path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->