### PR TITLE
fix(jit): cover all numeric primitives in eval_interp (+ registry sync test)

### DIFF
--- a/alkahest-core/src/jit/cranelift_backend.rs
+++ b/alkahest-core/src/jit/cranelift_backend.rs
@@ -55,6 +55,43 @@ extern "C" fn tramp_abs(x: f64) -> f64 {
 extern "C" fn tramp_pow(base: f64, exp: f64) -> f64 {
     base.powf(exp)
 }
+extern "C" fn tramp_sinh(x: f64) -> f64 {
+    x.sinh()
+}
+extern "C" fn tramp_cosh(x: f64) -> f64 {
+    x.cosh()
+}
+extern "C" fn tramp_tanh(x: f64) -> f64 {
+    x.tanh()
+}
+extern "C" fn tramp_asin(x: f64) -> f64 {
+    x.asin()
+}
+extern "C" fn tramp_acos(x: f64) -> f64 {
+    x.acos()
+}
+extern "C" fn tramp_atan(x: f64) -> f64 {
+    x.atan()
+}
+extern "C" fn tramp_floor(x: f64) -> f64 {
+    x.floor()
+}
+extern "C" fn tramp_ceil(x: f64) -> f64 {
+    x.ceil()
+}
+extern "C" fn tramp_round(x: f64) -> f64 {
+    x.round()
+}
+/// Matches `SignPrimitive::numeric_f64`: `0` for `x == 0`, `±1` otherwise.
+extern "C" fn tramp_sign(x: f64) -> f64 {
+    if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Helper: declared function IDs for math imports
@@ -69,6 +106,16 @@ struct MathFuncIds {
     tan_id: FuncId,
     abs_id: FuncId,
     pow_id: FuncId,
+    sinh_id: FuncId,
+    cosh_id: FuncId,
+    tanh_id: FuncId,
+    asin_id: FuncId,
+    acos_id: FuncId,
+    atan_id: FuncId,
+    floor_id: FuncId,
+    ceil_id: FuncId,
+    round_id: FuncId,
+    sign_id: FuncId,
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +183,16 @@ fn codegen_node(
                 "sqrt" => math.sqrt_id,
                 "tan" => math.tan_id,
                 "abs" => math.abs_id,
+                "sinh" => math.sinh_id,
+                "cosh" => math.cosh_id,
+                "tanh" => math.tanh_id,
+                "asin" => math.asin_id,
+                "acos" => math.acos_id,
+                "atan" => math.atan_id,
+                "floor" => math.floor_id,
+                "ceil" => math.ceil_id,
+                "round" => math.round_id,
+                "sign" => math.sign_id,
                 other => {
                     return Err(JitError::UnsupportedNode(format!("function '{other}'")));
                 }
@@ -254,6 +311,16 @@ pub fn compile_cranelift(
     jit_builder.symbol("alkahest_tan", tramp_tan as *const u8);
     jit_builder.symbol("alkahest_abs", tramp_abs as *const u8);
     jit_builder.symbol("alkahest_pow", tramp_pow as *const u8);
+    jit_builder.symbol("alkahest_sinh", tramp_sinh as *const u8);
+    jit_builder.symbol("alkahest_cosh", tramp_cosh as *const u8);
+    jit_builder.symbol("alkahest_tanh", tramp_tanh as *const u8);
+    jit_builder.symbol("alkahest_asin", tramp_asin as *const u8);
+    jit_builder.symbol("alkahest_acos", tramp_acos as *const u8);
+    jit_builder.symbol("alkahest_atan", tramp_atan as *const u8);
+    jit_builder.symbol("alkahest_floor", tramp_floor as *const u8);
+    jit_builder.symbol("alkahest_ceil", tramp_ceil as *const u8);
+    jit_builder.symbol("alkahest_round", tramp_round as *const u8);
+    jit_builder.symbol("alkahest_sign", tramp_sign as *const u8);
 
     let mut module = JITModule::new(jit_builder);
 
@@ -284,6 +351,16 @@ pub fn compile_cranelift(
         tan_id: decl(&mut module, "alkahest_tan", &f1_sig)?,
         abs_id: decl(&mut module, "alkahest_abs", &f1_sig)?,
         pow_id: decl(&mut module, "alkahest_pow", &f2_sig)?,
+        sinh_id: decl(&mut module, "alkahest_sinh", &f1_sig)?,
+        cosh_id: decl(&mut module, "alkahest_cosh", &f1_sig)?,
+        tanh_id: decl(&mut module, "alkahest_tanh", &f1_sig)?,
+        asin_id: decl(&mut module, "alkahest_asin", &f1_sig)?,
+        acos_id: decl(&mut module, "alkahest_acos", &f1_sig)?,
+        atan_id: decl(&mut module, "alkahest_atan", &f1_sig)?,
+        floor_id: decl(&mut module, "alkahest_floor", &f1_sig)?,
+        ceil_id: decl(&mut module, "alkahest_ceil", &f1_sig)?,
+        round_id: decl(&mut module, "alkahest_round", &f1_sig)?,
+        sign_id: decl(&mut module, "alkahest_sign", &f1_sig)?,
     };
 
     // ------------------------------------------------------------------
@@ -540,5 +617,36 @@ mod tests {
         let x = pool.symbol("x", Domain::Real);
         let f = compile_cranelift(x, &[x], &pool).unwrap();
         f.call(&[]);
+    }
+
+    /// The newly-registered unary math trampolines (sinh, cosh, tanh, asin,
+    /// acos, atan, floor, ceil, round, sign) all compile and evaluate
+    /// correctly via the Cranelift backend.
+    #[test]
+    fn cranelift_unary_math_trampolines() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+
+        let cases: &[(&str, f64, f64)] = &[
+            ("sinh", 0.5, 0.5_f64.sinh()),
+            ("cosh", 0.5, 0.5_f64.cosh()),
+            ("tanh", 0.5, 0.5_f64.tanh()),
+            ("asin", 0.5, 0.5_f64.asin()),
+            ("acos", 0.5, 0.5_f64.acos()),
+            ("atan", 0.5, 0.5_f64.atan()),
+            ("floor", 1.7, 1.0),
+            ("ceil", 1.2, 2.0),
+            ("round", 1.5, 2.0),
+            ("sign", -3.0, -1.0),
+        ];
+        for &(name, input, expected) in cases {
+            let expr = pool.func(name, vec![x]);
+            let f = compile_cranelift(expr, &[x], &pool).unwrap();
+            let got = f.call(&[input]);
+            assert!(
+                (got - expected).abs() < 1e-12,
+                "{name}({input}): got {got}, expected {expected}"
+            );
+        }
     }
 }

--- a/alkahest-core/src/jit/mod.rs
+++ b/alkahest-core/src/jit/mod.rs
@@ -43,8 +43,26 @@
 use crate::kernel::eval_const::try_predicate_bool_from_expr;
 use crate::kernel::expr::PredicateKind;
 use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::primitive::PrimitiveRegistry;
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::OnceLock;
+
+// ---------------------------------------------------------------------------
+// Shared primitive registry — used to evaluate `ExprData::Func` nodes in the
+// tree-walking interpreters below.
+// ---------------------------------------------------------------------------
+
+/// Returns a lazily-initialised, process-wide [`PrimitiveRegistry`].
+///
+/// `eval_interp` and the snapshot interpreter dispatch every `Func { name,
+/// args }` node through `registry().numeric_f64(name, &vals)` so that *every*
+/// primitive with a `numeric_f64` kernel is automatically evaluable here —
+/// new primitives don't need a hand-written match arm in this module.
+fn registry() -> &'static PrimitiveRegistry {
+    static REGISTRY: OnceLock<PrimitiveRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(PrimitiveRegistry::default_registry)
+}
 
 #[cfg(feature = "cuda")]
 pub mod nvptx;
@@ -654,19 +672,12 @@ fn eval_interp_inner(
             let e = eval_interp_inner(exp, env, pool, memo)?;
             Some(b.powf(e))
         }
-        ExprData::Func { name, args } if args.len() == 1 => {
-            let x = eval_interp_inner(args[0], env, pool, memo)?;
-            Some(match name.as_str() {
-                "sin" => x.sin(),
-                "cos" => x.cos(),
-                "tan" => x.tan(),
-                "exp" => x.exp(),
-                "log" => x.ln(),
-                "sqrt" => x.sqrt(),
-                "gamma" => rug::Float::with_val(53, x).gamma().to_f64(),
-                "abs" => x.abs(),
-                _ => return None,
-            })
+        ExprData::Func { name, args } => {
+            let mut vals = Vec::with_capacity(args.len());
+            for &a in &args {
+                vals.push(eval_interp_inner(a, env, pool, memo)?);
+            }
+            registry().numeric_f64(name.as_str(), &vals)
         }
         ExprData::Piecewise { branches, default } => {
             for (c, v) in branches {
@@ -803,6 +814,13 @@ fn try_expr_f64_snap(
             try_expr_f64_snap(*base, snap, env, memo)?
                 .powf(try_expr_f64_snap(*exp, snap, env, memo)?),
         ),
+        ExprData::Func { name, args } => {
+            let mut vals = Vec::with_capacity(args.len());
+            for &a in args {
+                vals.push(try_expr_f64_snap(a, snap, env, memo)?);
+            }
+            registry().numeric_f64(name.as_str(), &vals)
+        }
         _ => None,
     };
     if let Some(v) = val {
@@ -914,20 +932,13 @@ fn eval_interp_snap(
             let (b, e) = (*base, *exp);
             Some(eval_interp_snap(b, env, snap, memo)?.powf(eval_interp_snap(e, env, snap, memo)?))
         }
-        ExprData::Func { name, args } if args.len() == 1 => {
-            let a = args[0];
-            let x = eval_interp_snap(a, env, snap, memo)?;
-            Some(match name.as_str() {
-                "sin" => x.sin(),
-                "cos" => x.cos(),
-                "tan" => x.tan(),
-                "exp" => x.exp(),
-                "log" => x.ln(),
-                "sqrt" => x.sqrt(),
-                "gamma" => rug::Float::with_val(53, x).gamma().to_f64(),
-                "abs" => x.abs(),
-                _ => return None,
-            })
+        ExprData::Func { name, args } => {
+            let args = args.clone();
+            let mut vals = Vec::with_capacity(args.len());
+            for a in args {
+                vals.push(eval_interp_snap(a, env, snap, memo)?);
+            }
+            registry().numeric_f64(name.as_str(), &vals)
         }
         ExprData::Piecewise { branches, default } => {
             for (c, v) in branches {
@@ -1343,6 +1354,17 @@ mod llvm_backend {
                     "log" => "llvm.log.f64",
                     "sqrt" => "llvm.sqrt.f64",
                     "abs" => "llvm.fabs.f64",
+                    "floor" => "llvm.floor.f64",
+                    "ceil" => "llvm.ceil.f64",
+                    "round" => "llvm.round.f64",
+                    // No dedicated LLVM intrinsic; declared as external libm
+                    // calls resolved by the JIT execution engine.
+                    "sinh" => "sinh",
+                    "cosh" => "cosh",
+                    "tanh" => "tanh",
+                    "asin" => "asin",
+                    "acos" => "acos",
+                    "atan" => "atan",
                     other => {
                         return Err(JitError::UnsupportedNode(format!("function '{other}'")));
                     }
@@ -1667,5 +1689,175 @@ mod tests {
         for (got, exp) in out.iter().zip(expected.iter()) {
             assert!((got - exp).abs() < 1e-10, "got {got}, expected {exp}");
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Registry / eval_interp sync test
+    // -----------------------------------------------------------------
+
+    /// Probe argument lists, ordered to prefer well-behaved (in-domain)
+    /// inputs for every registered primitive — mirrors the probe sets used
+    /// by `primitive::probe_caps`.
+    const PROBE_ARG_SETS: &[&[f64]] = &[
+        &[0.5],
+        &[0.5, 0.3],
+        &[0.2, 0.3, 0.4],
+        &[1.0],
+        &[1.0, 2.0],
+        &[1.0, 2.0, 3.0],
+    ];
+
+    /// Every primitive in [`PrimitiveRegistry::default_registry`] that has a
+    /// `numeric_f64` kernel must be evaluable through [`eval_interp`] when
+    /// expressed as `Func { name, args }`.
+    ///
+    /// `diracdelta` is the documented exception: it is a distribution with no
+    /// pointwise `f64` value (see the `primitive::mod` coverage doctest and
+    /// `tests/test_v10.py::test_primitive_registry_all_have_numeric_f64`).
+    #[test]
+    fn eval_interp_covers_all_numeric_f64_primitives() {
+        use crate::primitive::{Capabilities, PrimitiveRegistry};
+
+        let reg = PrimitiveRegistry::default_registry();
+        let pool = p();
+
+        let mut missing = Vec::new();
+
+        for (name, caps) in reg.iter() {
+            if !caps.contains(Capabilities::NUMERIC_F64) {
+                continue;
+            }
+            if name == "diracdelta" {
+                continue;
+            }
+
+            // Find an arg-count / value combination this primitive accepts.
+            let Some(probe) = PROBE_ARG_SETS
+                .iter()
+                .find(|args| reg.numeric_f64(name, args).is_some())
+            else {
+                // Registered as NUMERIC_F64 but none of our probe sets work —
+                // treat as a coverage gap to investigate rather than silently
+                // skipping.
+                missing.push(format!("{name} (no working probe args)"));
+                continue;
+            };
+
+            let expected = reg.numeric_f64(name, probe).unwrap();
+
+            let arg_ids: Vec<ExprId> = probe.iter().map(|&v| pool.float(v, 53)).collect();
+            let expr = pool.func(name, arg_ids);
+
+            let env = HashMap::new();
+            match eval_interp(expr, &env, &pool) {
+                Some(got) => {
+                    if (got - expected).abs() > 1e-9 {
+                        missing.push(format!(
+                            "{name}: eval_interp({probe:?}) = {got}, \
+                             registry.numeric_f64 = {expected}"
+                        ));
+                    }
+                }
+                None => missing.push(format!(
+                    "{name}: eval_interp returned None for {probe:?} \
+                     (registry.numeric_f64 = {expected})"
+                )),
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "eval_interp is missing coverage for registered NUMERIC_F64 \
+             primitives:\n{}",
+            missing.join("\n")
+        );
+    }
+
+    #[test]
+    fn eval_interp_unary_heads() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let mut env = HashMap::new();
+        env.insert(x, 0.5_f64);
+
+        let cases: &[(&str, f64)] = &[
+            ("sinh", 0.5_f64.sinh()),
+            ("cosh", 0.5_f64.cosh()),
+            ("tanh", 0.5_f64.tanh()),
+            ("asin", 0.5_f64.asin()),
+            ("acos", 0.5_f64.acos()),
+            ("atan", 0.5_f64.atan()),
+            ("sign", 1.0),
+            ("floor", 0.0),
+            ("ceil", 1.0),
+            ("round", 1.0),
+        ];
+        for &(name, expected) in cases {
+            let expr = pool.func(name, vec![x]);
+            let got = eval_interp(expr, &env, &pool)
+                .unwrap_or_else(|| panic!("eval_interp returned None for {name}"));
+            assert!(
+                (got - expected).abs() < 1e-12,
+                "{name}(0.5): got {got}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn eval_interp_erf_erfc_gamma() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let mut env = HashMap::new();
+        env.insert(x, 1.0_f64);
+
+        let erf = eval_interp(pool.func("erf", vec![x]), &env, &pool).unwrap();
+        let erfc = eval_interp(pool.func("erfc", vec![x]), &env, &pool).unwrap();
+        assert!((erf + erfc - 1.0).abs() < 1e-9, "erf+erfc should be 1");
+
+        let gamma = eval_interp(pool.func("gamma", vec![x]), &env, &pool).unwrap();
+        assert!((gamma - 1.0).abs() < 1e-9, "Γ(1) = 1, got {gamma}");
+    }
+
+    #[test]
+    fn eval_interp_heaviside() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+
+        // θ(−1) = 0, θ(0) = 1/2, θ(1) = 1 — matches `HeavisidePrimitive`.
+        for (xv, expected) in [(-1.0, 0.0), (0.0, 0.5), (1.0, 1.0)] {
+            let mut env = HashMap::new();
+            env.insert(x, xv);
+            let expr = pool.func("heaviside", vec![x]);
+            let got = eval_interp(expr, &env, &pool).unwrap();
+            assert_eq!(got, expected, "heaviside({xv})");
+        }
+    }
+
+    #[test]
+    fn eval_interp_binary_and_ternary_heads() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let mut env = HashMap::new();
+        env.insert(x, 1.0_f64);
+        env.insert(y, 2.0_f64);
+
+        let atan2 = eval_interp(pool.func("atan2", vec![x, y]), &env, &pool).unwrap();
+        assert!((atan2 - 1.0_f64.atan2(2.0)).abs() < 1e-12);
+
+        let min = eval_interp(pool.func("min", vec![x, y]), &env, &pool).unwrap();
+        assert_eq!(min, 1.0);
+
+        let max = eval_interp(pool.func("max", vec![x, y]), &env, &pool).unwrap();
+        assert_eq!(max, 2.0);
+
+        // EllipticK(0) = EllipticE(0) = π/2.
+        let zero = pool.integer(0_i32);
+        let env = HashMap::new();
+        let k0 = eval_interp(pool.func("EllipticK", vec![zero]), &env, &pool).unwrap();
+        let e0 = eval_interp(pool.func("EllipticE", vec![zero]), &env, &pool).unwrap();
+        let half_pi = std::f64::consts::PI / 2.0;
+        assert!((k0 - half_pi).abs() < 1e-9);
+        assert!((e0 - half_pi).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
## Summary

`jit::eval_interp` (and the snapshot-based interpreter used by the
interpreter compile tier) only handled a hardcoded subset of unary
`Func` nodes: `sin, cos, tan, exp, log, sqrt, gamma, abs`. Every other
registered `NUMERIC_F64` primitive — `sinh, cosh, tanh, asin, acos, atan,
erf, erfc, sign, floor, ceil, round, heaviside, atan2, min, max,
EllipticK, EllipticE, EllipticF, EllipticPi` — fell through to `None`,
forcing downstream code (e.g. the Laplace transform tests) to write
local ad-hoc evaluators.

## Changes

### `eval_interp` (interpreter path — primary fix)

- Added a lazily-initialised, process-wide `PrimitiveRegistry`
  (`std::sync::OnceLock`).
- Replaced the hand-written `sin/cos/tan/.../abs` match arm in
  `eval_interp_inner`, `eval_interp_snap`, and `try_expr_f64_snap` (used
  for Piecewise predicate operands) with a single generic arm: evaluate
  all `Func` args to `f64`, then call
  `registry().numeric_f64(name, &vals)`.
- This means **every** primitive with a `numeric_f64` kernel — present
  or future — is automatically evaluable through `eval_interp` without a
  new match arm, for any arity (unary `sinh`, binary `atan2`/`min`/`max`,
  ternary `EllipticPi`, etc.).
- `heaviside`: numeric semantics match `HeavisidePrimitive::numeric_f64`
  exactly — `θ(x) = 0` for `x<0`, `θ(0) = 1/2`, `θ(x) = 1` for `x>0`.
- `diracdelta` is the one documented exception (distribution, no
  pointwise value) — same exception already encoded in the
  `primitive::mod` coverage doctest and
  `tests/test_v10.py::test_primitive_registry_all_have_numeric_f64`.

### Durable sync test

`jit::tests::eval_interp_covers_all_numeric_f64_primitives` iterates
`PrimitiveRegistry::default_registry().iter()`, and for every primitive
with `Capabilities::NUMERIC_F64` (except `diracdelta`):

1. finds a probe argument list (from a small fixed set covering 1–3 args,
   matching the domains used by `primitive::probe_caps`) for which
   `numeric_f64` returns `Some`,
2. builds the corresponding `Func{name, args}` expression,
3. asserts `eval_interp` returns the *same* value as
   `registry.numeric_f64`.

Any future primitive registered with a `numeric_f64` kernel but missing
from `eval_interp`'s dispatch will fail this test — but since dispatch is
now registry-driven, that should only happen if `numeric_f64` itself
returns `None` for all probe sets (reported explicitly by the test).

Also added focused tests: `eval_interp_unary_heads` (sinh/cosh/tanh/
asin/acos/atan/sign/floor/ceil/round), `eval_interp_erf_erfc_gamma`,
`eval_interp_heaviside` (θ(-1)=0, θ(0)=½, θ(1)=1), and
`eval_interp_binary_and_ternary_heads` (atan2/min/max/EllipticK/E).

### Cranelift backend (`--features cranelift`)

Added `extern "C"` trampolines + Cranelift imports for `sinh, cosh,
tanh, asin, acos, atan, floor, ceil, round, sign` — same mechanical
pattern as the existing `sin/cos/tan/abs` trampolines. New test
`cranelift_unary_math_trampolines` compiles and evaluates each through
`compile_cranelift`.

### LLVM backend (`--features jit`)

- `floor`, `ceil`, `round` → wired to `llvm.floor.f64` / `llvm.ceil.f64`
  / `llvm.round.f64` intrinsics (same pattern as `sin`/`cos`/etc.).
- `sinh`, `cosh`, `tanh`, `asin`, `acos`, `atan` → declared as external
  libm calls (`sinh`, `cosh`, ... — no dedicated LLVM intrinsic exists),
  resolved by the JIT execution engine against the process's libm.

**Residual gap (LLVM path, documented not implemented):** `--features
jit` cannot be built in this sandbox (`llvm-sys` build script fails:
`fatal error: bits/wordsize.h: No such file or directory` — a
pre-existing glibc/LLVM-15-headers mismatch, reproducible on a clean
checkout of `origin/main` with no code changes). The LLVM-side edits
above are therefore **untested** — they follow the existing pattern
closely but should be exercised on a machine with working LLVM-15 dev
headers before relying on them.

**Residual gap (both Cranelift and LLVM):** `erf`, `erfc`, `gamma`,
`sign` (LLVM only — Cranelift has it), `atan2`, `min`, `max`,
`EllipticK/E/F/Pi`, and `heaviside` are still unsupported by the native
JIT codegen paths (`UnsupportedNode` → falls back to the interpreter tier,
which now fully supports them via the registry dispatch above). These
either need branchy codegen (`heaviside`, `sign`, `min`/`max`) or calls
into non-libm helper routines (`erf`/`erfc`/`gamma` use
`libm_erf`/`libm_gamma`, and the elliptic integrals use
AGM/adaptive-Simpson — none of which are `extern "C"`-exported from
`primitive::mod` today). Expressions using these primitives will simply
compile to the interpreter tier rather than native code; this is
existing/acceptable behavior (interpreter tier is always correct, just
slower) and out of scope for this PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` — 1273 passed, 0 failed (default features)
- [x] `cargo test --workspace --features cranelift` — 1284 passed, 0 failed
- [x] `cargo clippy -p alkahest-cas --all-targets [--features cranelift]` —
      no new warnings (pre-existing `too_many_arguments` /
      `needless_return` warnings in `jit/mod.rs` and
      `cranelift_backend.rs` predate this change)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p alkahest-cas
      [--features cranelift]` — clean
- [ ] `--features jit` — could not build in this sandbox (pre-existing
      LLVM-15 header issue unrelated to this change); LLVM-backend edits
      reviewed but not test-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional unary mathematical functions including trigonometric operations (`sinh`, `cosh`, `tanh`, `asin`, `acos`, `atan`) and rounding operations (`floor`, `ceil`, `round`, `sign`) in the JIT compiler.
  * Unified function evaluation across the interpreter through a shared registry for consistent behavior.

* **Tests**
  * Extended test suite to validate compatibility of all newly-supported functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->