### PR TITLE
fix(lean): close diff certificate goals after simp with ring

### DIFF
--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -69,10 +69,10 @@ fn diff_rule_to_tactic(rule_name: &str) -> &'static str {
     match rule_name {
         "diff_identity" => "by simp [deriv_id]",
         "diff_const" => "by simp [deriv_const]",
-        "diff_univariate_poly" => "by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]",
-        "sum_rule" => "by simp [deriv_add]",
-        "product_rule" => "by simp [deriv_mul]",
-        "power_rule" | "power_rule_n1" => "by simp [deriv_pow, deriv_mul]",
+        "diff_univariate_poly" => "by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]; ring",
+        "sum_rule" => "by simp [deriv_add]; ring",
+        "product_rule" => "by simp [deriv_mul]; ring",
+        "power_rule" | "power_rule_n1" => "by simp [deriv_pow, deriv_mul]; ring",
         "power_rule_n0" => "by simp [deriv_const]",
         "diff_sin" | "diff_cos" | "diff_exp" | "diff_log" | "diff_sqrt" => "by sorry",
         "diff_forward" | "diff_primitive_registry" | "diff_piecewise" | "diff_root_sum" => {
@@ -546,6 +546,10 @@ mod tests {
         assert!(
             lean.contains("deriv_pow"),
             "expected deriv_pow tactic, got: {lean}"
+        );
+        assert!(
+            lean.contains("; ring"),
+            "expected ring to close mul-order goals, got: {lean}"
         );
         assert!(
             !lean.contains("= (((x : ℝ)) ^ (2 : ℕ) * (3 : ℝ)) :=") || lean.contains("deriv"),

--- a/demo-playground/server/playground_helpers.py
+++ b/demo-playground/server/playground_helpers.py
@@ -28,14 +28,17 @@ _DIFF_HEADER = (
     "open Real\n\n"
 )
 
+# Close goals when Alkahest's canonical mul order differs from Mathlib (e.g. x^2 * 3 vs 3 * x^2).
+_DIFF_RING = "; ring"
+
 _DIFF_RULE_TACTICS: dict[str, str] = {
     "diff_identity": "by simp [deriv_id]",
     "diff_const": "by simp [deriv_const]",
-    "diff_univariate_poly": "by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]",
-    "sum_rule": "by simp [deriv_add]",
-    "product_rule": "by simp [deriv_mul]",
-    "power_rule": "by simp [deriv_pow, deriv_mul]",
-    "power_rule_n1": "by simp [deriv_pow, deriv_mul]",
+    "diff_univariate_poly": f"by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]{_DIFF_RING}",
+    "sum_rule": f"by simp [deriv_add]{_DIFF_RING}",
+    "product_rule": f"by simp [deriv_mul]{_DIFF_RING}",
+    "power_rule": f"by simp [deriv_pow, deriv_mul]{_DIFF_RING}",
+    "power_rule_n1": f"by simp [deriv_pow, deriv_mul]{_DIFF_RING}",
     "power_rule_n0": "by simp [deriv_const]",
 }
 

--- a/demo-playground/server/test_playground_helpers.py
+++ b/demo-playground/server/test_playground_helpers.py
@@ -20,6 +20,7 @@ def test_fix_legacy_diff_rewrites_deriv_goal():
     fixed = fix_legacy_diff_lean(_LEGACY_DIFF_X3)
     assert "deriv (fun (x : ℝ)" in fixed
     assert "deriv_pow" in fixed
+    assert "; ring" in fixed
     assert "MeasureTheory" not in fixed
     assert "ring_nf" not in fixed
     assert "((x : ℝ)) ^ (3 : ℕ) = ((3 : ℝ)" not in fixed


### PR DESCRIPTION
## Summary
- Append `ring` after `simp` on diff Lean certificate tactics so goals like `3 * x^2 = x^2 * 3` close when Alkahest's canonical mul order differs from Mathlib.
- Mirror the same tactic update in demo-playground `fix_legacy_diff_lean` for older wheels.

## Test plan
- [x] `cargo test -p alkahest-cas lean::`
- [x] `pytest demo-playground/server/test_playground_helpers.py`
- [ ] CI green (including Lean job if triggered)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved proof generation for differentiation operations (sum, product, power rules) with more robust handling of arithmetic expressions in the proof system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->