### PR TITLE
fix(diff): differentiate atan2 (chain rule)

### DIFF
--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -1838,6 +1838,31 @@ pub mod builtins {
             }
         }
 
+        fn diff_forward(&self, args: &[ExprId], wrt: ExprId, pool: &ExprPool) -> Option<ExprId> {
+            // d/dt atan2(y, x) = (x·y' − y·x') / (x² + y²)
+            if args.len() != 2 {
+                return None;
+            }
+            let y = args[0];
+            let x = args[1];
+            let dy = crate::diff::diff(y, wrt, pool).ok()?.value;
+            let dx = crate::diff::diff(x, wrt, pool).ok()?.value;
+
+            let neg_one = pool.integer(-1_i32);
+            let neg_dx = pool.mul(vec![neg_one, dx]);
+
+            let x_dy = pool.mul(vec![x, dy]);
+            let y_dx = pool.mul(vec![y, neg_dx]);
+            let numerator = pool.add(vec![x_dy, y_dx]);
+
+            let two = pool.integer(2_i32);
+            let x2 = pool.pow(x, two);
+            let y2 = pool.pow(y, two);
+            let denominator = pool.add(vec![x2, y2]);
+
+            Some(pool.mul(vec![numerator, pool.pow(denominator, neg_one)]))
+        }
+
         fn lean_theorem(&self) -> Option<&'static str> {
             Some("Real.arctan2")
         }
@@ -2016,6 +2041,63 @@ mod tests {
         let x = pool.symbol("x", Domain::Real);
         let result = reg.diff_forward("sin", &[x], x, &pool);
         assert!(result.is_some(), "sin diff_forward returned None");
+    }
+
+    #[test]
+    fn diff_atan2_full_chain_rule() {
+        // d/dx atan2(y, x) = (x·y' - y·x') / (x² + y²), evaluated numerically
+        // against a finite-difference approximation for y = x^2, var = x.
+        use crate::jit::eval_interp;
+        use std::collections::HashMap;
+
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.pow(x, pool.integer(2_i32));
+        let expr = pool.func("atan2", vec![y, x]);
+
+        let derived = crate::diff::diff(expr, x, &pool).expect("atan2 should be differentiable");
+
+        let h = 1e-6;
+        for &xv in &[0.5_f64, 1.0, 2.0, -1.5] {
+            let f = |xv: f64| xv.powi(2).atan2(xv);
+            let numeric = (f(xv + h) - f(xv - h)) / (2.0 * h);
+
+            let mut env = HashMap::new();
+            env.insert(x, xv);
+            let analytic = eval_interp(derived.value, &env, &pool)
+                .expect("derivative should evaluate numerically");
+
+            assert!(
+                (numeric - analytic).abs() < 1e-4,
+                "atan2 derivative mismatch at x={xv}: numeric={numeric}, analytic={analytic}"
+            );
+        }
+    }
+
+    #[test]
+    fn diff_atan2_simple_case_x_over_constant() {
+        // atan2(x, c) for constant c: d/dx atan2(x, c) = c / (c² + x²)
+        use crate::jit::eval_interp;
+        use std::collections::HashMap;
+
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let c = pool.integer(2_i32);
+        let expr = pool.func("atan2", vec![x, c]);
+
+        let derived = crate::diff::diff(expr, x, &pool).expect("atan2 should be differentiable");
+
+        for &xv in &[0.0_f64, 1.0, -3.0, 5.0] {
+            let expected = 2.0 / (4.0 + xv * xv);
+            let mut env = HashMap::new();
+            env.insert(x, xv);
+            let got = eval_interp(derived.value, &env, &pool)
+                .expect("derivative should evaluate numerically");
+            assert!(
+                (got - expected).abs() < 1e-9,
+                "atan2(x,2) derivative mismatch at x={xv}: got={got}, expected={expected}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`atan2` is registered as a primitive (`ak.atan2(y, x)` works) but had no
`diff_forward` implementation. Calling `diff(atan2(y, x), x)` raised
`DiffError::UnknownFunction("atan2")` ("cannot differentiate unknown
function 'atan2'"). This blocked range/bearing EKF measurement models, a
common robotics/aerospace workflow.

## Fix

Added `diff_forward` to `Atan2Primitive` in
`alkahest-core/src/primitive/mod.rs`, implementing the full chain rule:

```
d/dt atan2(y, x) = (x*y' - y*x') / (x^2 + y^2)
```

Both arguments are recursed into via `crate::diff::diff(arg, var, pool)`,
so derivatives are correct even when both `y` and `x` depend on the
differentiation variable (the EKF range/bearing case). This is purely
additive — no existing public signatures changed.

## Tests

- `alkahest-core/src/primitive/mod.rs`:
  - `diff_atan2_full_chain_rule` — for `y = x^2`, checks the analytic
    derivative of `atan2(y, x)` w.r.t. `x` against a finite-difference
    approximation at several points.
  - `diff_atan2_simple_case_x_over_constant` — checks
    `d/dx atan2(x, 2) = 2 / (x^2 + 4)` exactly.
- `cargo test -p alkahest-cas` (primitive + diff modules): all pass.

## End-to-end evidence (Python)

Before (on `main`):
```
>>> ak.diff(ak.atan2(y, x), x).value
ERROR: cannot differentiate unknown function 'atan2'
Remediation: register the function in PrimitiveRegistry, or use diff_forward with a custom rule
```

After (this branch):
```
>>> ak.diff(ak.atan2(y, x), x).value
(y * -1 * (x^2 + y^2)^-1)          # i.e. -y/(x^2+y^2)
>>> ak.diff(ak.atan2(y, x), y).value
(x * (x^2 + y^2)^-1)               # i.e. x/(x^2+y^2)
>>> ak.diff(ak.atan2(x, 2), x).value
(2 * (x^2 + 4)^-1)                  # i.e. 2/(x^2+4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forward-mode automatic differentiation support for the arctangent of two variables function.

* **Tests**
  * Expanded test coverage with new unit tests validating differentiation behavior across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->