### PR TITLE
feat(py): coerce Python ints in Matrix.from_rows / series point / emit_c

### DIFF
--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -2519,13 +2519,14 @@ fn py_series(
     py: Python<'_>,
     expr: PyRef<PyExpr>,
     var: PyRef<PyExpr>,
-    point: PyRef<PyExpr>,
+    point: &Bound<'_, PyAny>,
     order: u32,
 ) -> PyResult<PySeries> {
     let pool_py = expr.pool.clone_ref(py);
+    let point_id = coerce_substituent(&pool_py, point, py)?;
     let id = {
         let pool = pool_py.borrow(py);
-        core_series(expr.id, var.id, point.id, order, &pool.inner)
+        core_series(expr.id, var.id, point_id, order, &pool.inner)
             .map_err(series_error_to_py)?
             .expr()
     };
@@ -3348,7 +3349,7 @@ fn py_grad(py: Python<'_>, expr: PyRef<PyExpr>, vars: Vec<PyRef<PyExpr>>) -> Vec
 // Phase 15: Matrix and jacobian
 // ---------------------------------------------------------------------------
 
-#[pyclass(name = "Matrix")]
+#[pyclass(name = "Matrix", subclass)]
 struct PyMatrix {
     inner: Matrix,
     pool: Py<PyExprPool>,
@@ -3358,22 +3359,60 @@ struct PyMatrix {
 impl PyMatrix {
     // Allow Matrix([[expr, expr], [expr, expr]]) in addition to from_rows.
     #[new]
-    fn __new__(py: Python<'_>, rows: Vec<Vec<PyRef<PyExpr>>>) -> PyResult<PyMatrix> {
+    fn __new__(py: Python<'_>, rows: Vec<Vec<Bound<'_, PyAny>>>) -> PyResult<PyMatrix> {
         PyMatrix::from_rows(py, rows)
     }
 
+    /// Build a matrix from a 2D list of entries.
+    ///
+    /// Each entry may be an :class:`Expr`, :class:`DerivedResult`, Python
+    /// ``int``, or Python ``float``. Bare numeric literals are coerced into
+    /// the same :class:`ExprPool` as the first :class:`Expr`/``DerivedResult``
+    /// found anywhere in `rows` (consistent with how arithmetic operators
+    /// coerce scalars). If `rows` contains no `Expr`/`DerivedResult` at all
+    /// (e.g. an all-integer matrix), the pool cannot be inferred and a
+    /// `TypeError` is raised — pass at least one `Expr`/`DerivedResult`
+    /// entry (or use `ExprPool.integer`/`pool.matrix_of(...)`-style helpers)
+    /// so the pool can be determined.
     #[staticmethod]
-    fn from_rows(py: Python<'_>, rows: Vec<Vec<PyRef<PyExpr>>>) -> PyResult<PyMatrix> {
+    fn from_rows(py: Python<'_>, rows: Vec<Vec<Bound<'_, PyAny>>>) -> PyResult<PyMatrix> {
         if rows.is_empty() {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "Matrix must have at least one row",
             ));
         }
-        let pool_py: Py<PyExprPool> = rows[0][0].pool.clone_ref(py);
+        // Find the pool from the first Expr/DerivedResult entry anywhere in `rows`.
+        let mut pool_py: Option<Py<PyExprPool>> = None;
+        for row in &rows {
+            for entry in row {
+                if let Ok(e) = entry.extract::<PyRef<PyExpr>>() {
+                    pool_py = Some(e.pool.clone_ref(py));
+                    break;
+                }
+                if let Ok(dr) = entry.downcast::<PyDerivedResult>() {
+                    pool_py = Some(dr.borrow().value.pool.clone_ref(py));
+                    break;
+                }
+            }
+            if pool_py.is_some() {
+                break;
+            }
+        }
+        let pool_py = pool_py.ok_or_else(|| {
+            PyTypeError::new_err(
+                "Matrix.from_rows could not determine an ExprPool: at least one entry must \
+                 be an Expr or DerivedResult (bare int/float entries are coerced into that \
+                 pool, but the pool cannot be inferred from numbers alone)",
+            )
+        })?;
         let data: Vec<Vec<ExprId>> = rows
             .iter()
-            .map(|row| row.iter().map(|e| e.id).collect())
-            .collect();
+            .map(|row| {
+                row.iter()
+                    .map(|entry| coerce_substituent(&pool_py, entry, py))
+                    .collect::<PyResult<Vec<ExprId>>>()
+            })
+            .collect::<PyResult<Vec<Vec<ExprId>>>>()?;
         let m = Matrix::new(data).map_err(matrix_error_to_py)?;
         Ok(PyMatrix {
             inner: m,
@@ -4996,8 +5035,10 @@ fn py_horner(py: Python<'_>, expr: PyRef<PyExpr>, var: PyRef<PyExpr>) -> PyResul
 /// ----------
 /// expr : Expr
 ///     A univariate polynomial in `var`.
-/// var : Expr
-///     The polynomial variable.
+/// var : Expr or list[Expr]
+///     The polynomial variable. `emit_c` only supports univariate
+///     polynomials, so a list/tuple is accepted as a convenience but must
+///     contain exactly one `Expr` (e.g. `[x]` is equivalent to `x`).
 /// var_name : str
 ///     The C variable name (default ``"x"``).
 /// fn_name : str
@@ -5008,13 +5049,37 @@ fn py_horner(py: Python<'_>, expr: PyRef<PyExpr>, var: PyRef<PyExpr>) -> PyResul
 fn py_emit_c(
     py: Python<'_>,
     expr: PyRef<PyExpr>,
-    var: PyRef<PyExpr>,
+    var: &Bound<'_, PyAny>,
     var_name: &str,
     fn_name: &str,
 ) -> PyResult<String> {
+    let var_id = extract_univariate_var(var)?;
     let pool = expr.pool.borrow(py);
-    core_emit_horner_c(expr.id, var.id, var_name, fn_name, &pool.inner)
+    core_emit_horner_c(expr.id, var_id, var_name, fn_name, &pool.inner)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+/// Extract a single `Expr`'s id from `var`, which may be an `Expr` directly
+/// or a one-element `list`/`tuple` containing an `Expr` (a common but
+/// incorrect guess for APIs that expect a single variable).
+fn extract_univariate_var(var: &Bound<'_, PyAny>) -> PyResult<ExprId> {
+    if let Ok(e) = var.extract::<PyRef<PyExpr>>() {
+        return Ok(e.id);
+    }
+    if let Ok(seq) = var.extract::<Vec<PyRef<PyExpr>>>() {
+        return match seq.len() {
+            1 => Ok(seq[0].id),
+            n => Err(PyTypeError::new_err(format!(
+                "var must be a single Expr (or a one-element list/tuple); \
+                 got a sequence of length {n}. emit_c only supports univariate \
+                 polynomials."
+            ))),
+        };
+    }
+    Err(PyTypeError::new_err(
+        "var must be an Expr (the polynomial variable), or a one-element \
+         list/tuple containing one, e.g. emit_c(expr, x) or emit_c(expr, [x])",
+    ))
 }
 
 // Phase 25 — NumPy / batch evaluation: call_batch_raw is merged into PyCompiledFn above.

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -547,9 +547,7 @@ def _coerce_matrix_rows(rows):
     fall back to :func:`active_pool` (set via ``with alkahest.context(pool=...)``)
     and lift each entry into that pool with ``pool.integer``/``pool.float``.
     """
-    has_expr = any(
-        isinstance(entry, (Expr, DerivedResult)) for row in rows for entry in row
-    )
+    has_expr = any(isinstance(entry, (Expr, DerivedResult)) for row in rows for entry in row)
     if has_expr:
         return rows
     pool = active_pool()

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -73,8 +73,6 @@ from .alkahest import (  # noqa: F401
     ExprPool,
     Forall,
     HybridODE,
-    # Phase 15: Symbolic matrices
-    Matrix as _NativeMatrix,
     # Polynomial types
     MultiPoly,
     MultiPolyFactorization,
@@ -199,6 +197,10 @@ from .alkahest import (  # noqa: F401
     verify_wz_pair,
     version,
     voltage_source,
+)
+from .alkahest import (
+    # Phase 15: Symbolic matrices
+    Matrix as _NativeMatrix,
 )
 from .alkahest import (
     # Phase 14: reverse-mode partials on Expr (native name `grad`; exported as symbolic_grad)

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -74,7 +74,7 @@ from .alkahest import (  # noqa: F401
     Forall,
     HybridODE,
     # Phase 15: Symbolic matrices
-    Matrix,
+    Matrix as _NativeMatrix,
     # Polynomial types
     MultiPoly,
     MultiPolyFactorization,
@@ -528,6 +528,63 @@ def _maybe_context_simplify(result):
     if not simplify_enabled() or not isinstance(result, DerivedResult):
         return result
     return _derived_result_context_simplify(result)
+
+
+# ---------------------------------------------------------------------------
+# Matrix — accept bare int/float entries in `Matrix(...)` / `Matrix.from_rows(...)`
+# ---------------------------------------------------------------------------
+
+
+def _coerce_matrix_rows(rows):
+    """Return *rows* unchanged unless every entry is a plain ``int``/``float``.
+
+    The native ``Matrix.from_rows`` can infer an :class:`ExprPool` and coerce
+    bare numbers as long as *some* entry in `rows` is already an
+    :class:`Expr`/:class:`DerivedResult`.  If `rows` is entirely numeric
+    (e.g. ``[[0, 1], [-1, 0]]``), there is no pool to infer it from, so we
+    fall back to :func:`active_pool` (set via ``with alkahest.context(pool=...)``)
+    and lift each entry into that pool with ``pool.integer``/``pool.float``.
+    """
+    has_expr = any(
+        isinstance(entry, (Expr, DerivedResult)) for row in rows for entry in row
+    )
+    if has_expr:
+        return rows
+    pool = active_pool()
+    if pool is None:
+        # No pool anywhere — let the native constructor raise its clear error.
+        return rows
+
+    def lift(entry):
+        if isinstance(entry, bool):
+            # bool is a subclass of int; treat as int (0/1).
+            return pool.integer(int(entry))
+        if isinstance(entry, int):
+            return pool.integer(entry)
+        if isinstance(entry, float):
+            return pool.float(entry)
+        return entry
+
+    return [[lift(entry) for entry in row] for row in rows]
+
+
+class Matrix(_NativeMatrix):
+    """Symbolic matrix.  See :class:`alkahest.alkahest.Matrix` for full docs.
+
+    This thin wrapper additionally accepts a fully-numeric ``rows`` (every
+    entry a Python ``int``/``float``, e.g. ``Matrix([[0, 1], [-1, 0]])``) by
+    coercing entries into :func:`active_pool` (the pool set via
+    ``with alkahest.context(pool=...)``).  Mixed int/``Expr`` rows already
+    work without this wrapper, since the native constructor infers the pool
+    from any :class:`Expr`/:class:`DerivedResult` entry.
+    """
+
+    def __new__(cls, rows):
+        return _NativeMatrix.__new__(cls, _coerce_matrix_rows(rows))
+
+    @staticmethod
+    def from_rows(rows):
+        return _NativeMatrix.from_rows(_coerce_matrix_rows(rows))
 
 
 # Wrap key calculus/simplification functions so they accept DerivedResult or

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -5,6 +5,26 @@ from __future__ import annotations
 import alkahest
 
 
+def test_matrix_from_rows_mixed_int_expr():
+    """from_rows accepts bare ints alongside Expr; pool is inferred from the Expr."""
+    pool = alkahest.ExprPool()
+    x = pool.symbol("x")
+    m = alkahest.Matrix.from_rows([[x, 1], [0, x]])
+    assert m.shape() == (2, 2)
+    assert m.get(0, 1).node() == pool.integer(1).node()
+
+
+def test_matrix_from_rows_all_int_with_active_pool():
+    """from_rows accepts an all-int matrix when an active pool is set via context()."""
+    pool = alkahest.ExprPool()
+    with alkahest.context(pool=pool):
+        m = alkahest.Matrix.from_rows([[0, 1], [-1, 0]])
+        m2 = alkahest.Matrix([[1, 0], [0, 1]])
+    assert m.shape() == (2, 2)
+    assert m2.shape() == (2, 2)
+    assert m.get(1, 0).node() == pool.integer(-1).node()
+
+
 def test_nullspace_rank_column_row_space():
     pool = alkahest.ExprPool()
     m = alkahest.Matrix([[pool.integer(1), pool.integer(2)]])

--- a/tests/test_series_v215.py
+++ b/tests/test_series_v215.py
@@ -52,3 +52,13 @@ def test_series_order_zero_raises():
     x = p.symbol("x")
     with pytest.raises(alkahest.SeriesError):
         alkahest.series(x, x, p.integer(0), 0)
+
+
+def test_series_accepts_bare_int_point():
+    """series()'s `point` accepts a bare Python int, coerced into expr's pool."""
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    cx = alkahest.cos(x)
+    s_int = alkahest.series(cx, x, 0, 6)
+    s_expr = alkahest.series(cx, x, p.integer(0), 6)
+    assert str(s_int.expr) == str(s_expr.expr)

--- a/tests/test_v04_phases.py
+++ b/tests/test_v04_phases.py
@@ -120,6 +120,24 @@ class TestHorner:
         with pytest.raises(ValueError):
             emit_c(expr, x)
 
+    def test_emit_c_accepts_one_element_list_var(self):
+        """`var` may be a single Expr or a one-element list/tuple containing one."""
+        p = pool()
+        x = p.symbol("x")
+        expr = x**2 + p.integer(2) * x + p.integer(1)
+        code_expr = emit_c(expr, x, "x", "eval_quad")
+        code_list = emit_c(expr, [x], "x", "eval_quad")
+        code_tuple = emit_c(expr, (x,), "x", "eval_quad")
+        assert code_expr == code_list == code_tuple
+
+    def test_emit_c_multi_element_list_var_raises_clear_error(self):
+        p = pool()
+        x = p.symbol("x")
+        y = p.symbol("y")
+        expr = x + y
+        with pytest.raises(TypeError, match="univariate"):
+            emit_c(expr, [x, y])
+
 
 # ===========================================================================
 # P-25 — NumPy / batch evaluation

--- a/verify_int_coercion.py
+++ b/verify_int_coercion.py
@@ -1,0 +1,45 @@
+"""Verification script for fix/expr-int-coercion.
+
+Demonstrates that Python `int` literals are now accepted where previously
+only `Expr` was accepted:
+
+1. ak.Matrix.from_rows([[0, 1], [-1, 0]]) — fully-numeric rows via active_pool().
+2. ak.Matrix.from_rows([[x, 1], [0, x]]) — mixed Expr/int rows (pool inferred from Expr).
+3. ak.series(ak.sin(x), x, 0, 5) — bare-int expansion point.
+4. ak.emit_c(expr, x) and ak.emit_c(expr, [x]) — single var and one-element list.
+"""
+
+import alkahest as ak
+
+p = ak.ExprPool()
+x = p.symbol("x")
+
+print("=== 1. Matrix.from_rows with fully-numeric rows (needs active_pool) ===")
+with ak.context(pool=p):
+    m = ak.Matrix.from_rows([[0, 1], [-1, 0]])
+print(m, "shape:", m.shape())
+
+print("\n=== 1b. Matrix(...) constructor with fully-numeric rows ===")
+with ak.context(pool=p):
+    m2 = ak.Matrix([[1, 0], [0, 1]])
+print(m2, "shape:", m2.shape())
+
+print("\n=== 2. Matrix.from_rows with mixed Expr/int rows (no context needed) ===")
+m3 = ak.Matrix.from_rows([[x, 1], [0, x]])
+print(m3, "shape:", m3.shape())
+
+print("\n=== 3. series with bare-int expansion point ===")
+s = ak.series(ak.sin(x), x, 0, 5)
+print(s)
+
+print("\n=== 4. emit_c with single Expr var ===")
+poly = x**2 + 2 * x + 1
+c_code = ak.emit_c(poly, x)
+print(c_code)
+
+print("\n=== 4b. emit_c with one-element list var ===")
+c_code2 = ak.emit_c(poly, [x])
+print(c_code2)
+assert c_code == c_code2
+
+print("\nAll checks passed.")


### PR DESCRIPTION
## Summary
- `Matrix.from_rows(...)` / `Matrix(...)` now accept bare `int`/`float` entries. If the rows contain any `Expr`/`DerivedResult`, the `ExprPool` is inferred from it (e.g. `Matrix.from_rows([[x, 1], [0, x]])`). If *all* entries are numeric (e.g. `Matrix.from_rows([[0, 1], [-1, 0]])`), there's no `Expr` to infer the pool from, so a thin Python `Matrix` subclass falls back to `alkahest.active_pool()` (set via `with alkahest.context(pool=p):`).
- `series(expr, var, point, order)`'s `point` argument now coerces Python `int`/`float` into `expr`'s pool via the same `coerce_substituent` helper used by arithmetic operators and `subs()` — `ak.series(ak.sin(x), x, 0, 5)` now works directly.
- `emit_c(expr, var, ...)`'s `var` now also accepts a one-element `list`/`tuple` containing the variable (e.g. `emit_c(expr, [x])`, equivalent to `emit_c(expr, x)`), with a clear `TypeError` mentioning "univariate" if more than one variable is passed.

All changes are additive — existing call patterns (`pool.integer(...)`-wrapped entries, `Expr` points, single-`Expr` `var`) continue to work unchanged.

## Test plan
- [x] `cargo fmt --all`
- [x] `maturin develop --manifest-path alkahest-py/Cargo.toml --features "egraph groebner"` builds cleanly
- [x] `verify_int_coercion.py` (new, repo root) demonstrates all three cases working with bare ints
- [x] New pytest cases in `tests/test_linear_algebra.py` (`test_matrix_from_rows_mixed_int_expr`, `test_matrix_from_rows_all_int_with_active_pool`), `tests/test_series_v215.py` (`test_series_accepts_bare_int_point`), `tests/test_v04_phases.py` (`test_emit_c_accepts_one_element_list_var`, `test_emit_c_multi_element_list_var_raises_clear_error`)
- [x] `pytest tests/` — 1159 passed, 42 skipped, 1 deselected (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * series() accepts bare numeric scalars for the point argument.
  * Matrix construction/from_rows accept mixed numeric and expression entries and support all-numeric rows when an active pool is present.
  * emit_c() accepts the variable as either a single expression or a one-element sequence.

* **Tests**
  * Added tests for matrix row coercion, series with bare int point, and emit_c var handling.

* **Tools**
  * Added a verification script demonstrating the new coercions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->