### PR TITLE
feat(py): bind acausal add_component/connect; surface Laplace in experimental

### DIFF
--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -2,6 +2,7 @@ use alkahest_core::{
     adjoint_system as core_adjoint_system,
     cad_lift as core_cad_lift,
     cad_project as core_cad_project,
+    capacitor as core_capacitor,
     // Phase 21 — JIT
     compile as core_compile,
     decide_expr as core_decide_expr,
@@ -42,12 +43,14 @@ use alkahest_core::{
     sum_definite as core_sum_definite,
     sum_indefinite as core_sum_indefinite,
     verify_wz_pair as core_verify_wz_pair,
+    voltage_source as core_voltage_source,
     // Phase 22 — Ball arithmetic
     ArbBall as CoreArbBall,
     // V2-9 — CAD / real QE
     CadError,
     Capabilities,
     CompileCache as CoreCompileCache,
+    Component,
     Domain,
     EigenError,
     Event,
@@ -4248,19 +4251,93 @@ impl PyPort {
     }
 }
 
+/// A physical component (resistor, capacitor, voltage source, …) with named
+/// :class:`Port` connectors and internal constitutive equations.
+///
+/// Construct components via :func:`resistor`, :func:`capacitor`, or
+/// :func:`voltage_source`, then register them on an :class:`AcausalSystem`
+/// with :meth:`AcausalSystem.add_component` and wire them together with
+/// :meth:`AcausalSystem.connect`.
+#[pyclass(name = "Component")]
+#[derive(Clone)]
+struct PyComponent {
+    inner: Component,
+    pool: Py<PyExprPool>,
+}
+
+#[pymethods]
+impl PyComponent {
+    #[getter]
+    fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// Number of constitutive equations contributed by this component.
+    fn n_equations(&self) -> usize {
+        self.inner.equations.len()
+    }
+
+    /// Number of external connection ports.
+    fn n_ports(&self) -> usize {
+        self.inner.ports.len()
+    }
+
+    /// All ports, in declaration order.
+    fn ports(&self, py: Python<'_>) -> Vec<PyPort> {
+        self.inner
+            .ports
+            .iter()
+            .map(|p| PyPort {
+                inner: p.clone(),
+                pool: self.pool.clone_ref(py),
+            })
+            .collect()
+    }
+
+    /// Look up a port by its full name (e.g. `"R1.p"`), or `None` if absent.
+    fn port(&self, py: Python<'_>, name: &str) -> Option<PyPort> {
+        self.inner.port(name).map(|p| PyPort {
+            inner: p.clone(),
+            pool: self.pool.clone_ref(py),
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Component(name={:?}, n_ports={}, n_equations={})",
+            self.inner.name,
+            self.inner.ports.len(),
+            self.inner.equations.len()
+        )
+    }
+}
+
 /// Acausal component-based modelling system.
 ///
 /// An :class:`AcausalSystem` aggregates components connected through
-/// :class:`Port` objects (potential/flow pairs).  Call :meth:`flatten` to
-/// convert the component network into an equivalent :class:`DAE` suitable
-/// for simulation or index reduction.
+/// :class:`Port` objects (potential/flow pairs).  Add components with
+/// :meth:`add_component`, wire ports together with :meth:`connect`, and
+/// call :meth:`flatten` to convert the component network into an equivalent
+/// :class:`DAE` suitable for simulation or index reduction.
 ///
-/// Example::
+/// Example (RC circuit)::
 ///
 ///     p = alkahest.ExprPool()
-///     sys = alkahest.AcausalSystem(p)
-///     r = alkahest.resistor("R1", p.rational(100, 1))
 ///     t = p.symbol("t")
+///
+///     src = alkahest.voltage_source("V1", p.symbol("Vs"))
+///     res = alkahest.resistor("R1", p.symbol("R"))
+///     cap = alkahest.capacitor("C1", p.symbol("C"))
+///
+///     sys = alkahest.AcausalSystem(p)
+///     sys.add_component(src["component"])
+///     sys.add_component(res["component"])
+///     sys.add_component(cap["component"])
+///
+///     sys.connect(src["component"].port("V1.p"), res["component"].port("R1.p"))
+///     sys.connect(res["component"].port("R1.n"), cap["component"].port("C1.p"))
+///     sys.connect(cap["component"].port("C1.n"), src["component"].port("V1.n"))
+///
 ///     dae = sys.flatten(t)
 #[pyclass(name = "AcausalSystem")]
 struct PyAcausalSystem {
@@ -4279,6 +4356,19 @@ impl PyAcausalSystem {
         }
     }
 
+    /// Add a component (e.g. from :func:`resistor`, :func:`capacitor`,
+    /// :func:`voltage_source`) to the system.
+    fn add_component(&mut self, component: PyRef<PyComponent>) {
+        self.inner.add_component(component.inner.clone());
+    }
+
+    /// Connect two ports: equates their potentials and balances their flows
+    /// (`a.potential == b.potential`, `a.flow + b.flow == 0`).
+    fn connect(&mut self, port_a: PyRef<PyPort>, port_b: PyRef<PyPort>) {
+        self.inner.connect(&port_a.inner, &port_b.inner);
+    }
+
+    /// Flatten all component and connection equations into a :class:`DAE`.
     fn flatten(&self, py: Python<'_>, time_var: PyRef<PyExpr>) -> PyDAE {
         let pool = self.pool.borrow(py);
         let dae = self.inner.flatten(time_var.id, &pool.inner);
@@ -4290,20 +4380,68 @@ impl PyAcausalSystem {
     }
 }
 
-/// `alkahest.resistor(name, resistance)` — create a resistor component.
-#[pyfunction]
-#[pyo3(name = "resistor")]
-fn py_resistor(py: Python<'_>, name: &str, resistance: PyRef<PyExpr>) -> PyResult<PyObject> {
-    // Return as a Python dict for simplicity
-    let pool = resistance.pool.borrow(py);
-    let comp = core_resistor(name, resistance.id, &pool.inner);
-    drop(pool);
-    // Pack as dict: {"name": name, "n_equations": N, "n_ports": M}
+/// Pack a core `Component` into the dict shape returned by `resistor`,
+/// `capacitor`, and `voltage_source`: `{"name", "n_equations", "n_ports",
+/// "component"}`, where `"component"` is a :class:`Component` instance that
+/// can be passed to `AcausalSystem.add_component` and `.port(name)`.
+fn component_to_pydict(
+    py: Python<'_>,
+    comp: Component,
+    pool: Py<PyExprPool>,
+) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("name", comp.name.clone())?;
     d.set_item("n_equations", comp.equations.len())?;
     d.set_item("n_ports", comp.ports.len())?;
+    d.set_item("component", PyComponent { inner: comp, pool }.into_py(py))?;
     Ok(d.into_py(py))
+}
+
+/// `alkahest.resistor(name, resistance)` — create a resistor component.
+///
+/// Returns a dict `{"name", "n_equations", "n_ports", "component"}`; the
+/// `"component"` entry is a :class:`Component` usable with
+/// `AcausalSystem.add_component` and `.port(name)`.
+#[pyfunction]
+#[pyo3(name = "resistor")]
+fn py_resistor(py: Python<'_>, name: &str, resistance: PyRef<PyExpr>) -> PyResult<PyObject> {
+    let pool_py = resistance.pool.clone_ref(py);
+    let pool = resistance.pool.borrow(py);
+    let comp = core_resistor(name, resistance.id, &pool.inner);
+    drop(pool);
+    component_to_pydict(py, comp, pool_py)
+}
+
+/// `alkahest.capacitor(name, capacitance)` — create an ideal capacitor
+/// component (`C * dv/dt = i`).
+///
+/// Returns a dict `{"name", "n_equations", "n_ports", "component"}`; the
+/// `"component"` entry is a :class:`Component` usable with
+/// `AcausalSystem.add_component` and `.port(name)`.
+#[pyfunction]
+#[pyo3(name = "capacitor")]
+fn py_capacitor(py: Python<'_>, name: &str, capacitance: PyRef<PyExpr>) -> PyResult<PyObject> {
+    let pool_py = capacitance.pool.clone_ref(py);
+    let pool = capacitance.pool.borrow(py);
+    let comp = core_capacitor(name, capacitance.id, &pool.inner);
+    drop(pool);
+    component_to_pydict(py, comp, pool_py)
+}
+
+/// `alkahest.voltage_source(name, voltage)` — create an ideal voltage
+/// source component (`v_p - v_n = V`).
+///
+/// Returns a dict `{"name", "n_equations", "n_ports", "component"}`; the
+/// `"component"` entry is a :class:`Component` usable with
+/// `AcausalSystem.add_component` and `.port(name)`.
+#[pyfunction]
+#[pyo3(name = "voltage_source")]
+fn py_voltage_source(py: Python<'_>, name: &str, voltage: PyRef<PyExpr>) -> PyResult<PyObject> {
+    let pool_py = voltage.pool.clone_ref(py);
+    let pool = voltage.pool.borrow(py);
+    let comp = core_voltage_source(name, voltage.id, &pool.inner);
+    drop(pool);
+    component_to_pydict(py, comp, pool_py)
 }
 
 // ---------------------------------------------------------------------------
@@ -7313,8 +7451,11 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_pantelides, m)?)?;
     // Phase 18
     m.add_class::<PyPort>()?;
+    m.add_class::<PyComponent>()?;
     m.add_class::<PyAcausalSystem>()?;
     m.add_function(wrap_pyfunction!(py_resistor, m)?)?;
+    m.add_function(wrap_pyfunction!(py_capacitor, m)?)?;
+    m.add_function(wrap_pyfunction!(py_voltage_source, m)?)?;
     // Phase 19
     m.add_class::<PySensitivitySystem>()?;
     m.add_function(wrap_pyfunction!(py_sensitivity_system, m)?)?;

--- a/docs/features.md
+++ b/docs/features.md
@@ -123,7 +123,8 @@ Current stable feature surface.
 - Symbolic matrices (`Matrix`), determinant, inverse, transpose, Jacobian
 - ODE representation and first-order lowering (`ODE`, `lower_to_first_order`)
 - DAE structural analysis: Pantelides index reduction (`DAE`, `pantelides`)
-- Acausal component modeling (`AcausalSystem`, `Port`, `resistor`)
+- Acausal component modeling (`AcausalSystem`, `Port`, `Component`, `resistor`, `capacitor`, `voltage_source`)
+- Laplace transform (`alkahest.experimental.laplace_transform` / `inverse_laplace_transform`)
 - Sensitivity analysis: forward (`sensitivity_system`) and adjoint (`adjoint_system`)
 - Hybrid systems with events (`HybridODE`, `Event`)
 - Piecewise expressions and predicates

--- a/docs/mdbook/src/ode-dae.md
+++ b/docs/mdbook/src/ode-dae.md
@@ -91,22 +91,43 @@ adj = adjoint_system(ode, output_expr, [p])
 Acausal component modeling lets you describe physical systems by their component equations without manually choosing which direction information flows:
 
 ```python
-from alkahest import AcausalSystem, Port, resistor
+from alkahest import AcausalSystem, ExprPool, capacitor, resistor, voltage_source
 
-# Build a simple RC circuit symbolically
 pool = ExprPool()
-circuit = AcausalSystem()
+t = pool.symbol("t")
 
-R = resistor(pool, resistance=pool.symbol("R"))
-# Connect components via ports
-circuit.add(R)
-circuit.connect(R.port_pos, ...)
+# Component constructors return {"name", "n_equations", "n_ports", "component"}.
+src = voltage_source("V1", pool.symbol("Vs"))["component"]
+res = resistor("R1", pool.symbol("R"))["component"]
+cap = capacitor("C1", pool.symbol("C"))["component"]
 
-# Extract the DAE from the connected system
-dae = circuit.to_dae()
+circuit = AcausalSystem(pool)
+circuit.add_component(src)
+circuit.add_component(res)
+circuit.add_component(cap)
+
+# Wire the loop: Vs.p -> R.p, R.n -> C.p, C.n -> Vs.n
+circuit.connect(src.port("V1.p"), res.port("R1.p"))
+circuit.connect(res.port("R1.n"), cap.port("C1.p"))
+circuit.connect(cap.port("C1.n"), src.port("V1.n"))
+
+# Flatten into a DAE
+dae = circuit.flatten(t)
 ```
 
-Built-in components (`resistor`, and others registered via the component API) generate their constitutive equations automatically. The system then assembles them into a DAE that Pantelides can reduce.
+Built-in components (`resistor`, `capacitor`, `voltage_source`, and others registered via the component API) generate their constitutive equations automatically. `AcausalSystem.flatten` assembles them, plus the Kirchhoff-style connection equations, into a `DAE` that Pantelides can reduce. See `examples/acausal_and_laplace.py` for a runnable end-to-end example.
+
+## Laplace transform
+
+The Laplace transform lives in `alkahest.experimental` (the calculus/ODE/transform surface is not yet semver-frozen):
+
+```python
+from alkahest.experimental import inverse_laplace_transform, laplace_transform
+
+s, t = pool.symbol("s"), pool.symbol("t")
+F = laplace_transform(pool.integer(1), t, s)            # 1/s
+f = inverse_laplace_transform(F, s, t)                   # back to 1 (Heaviside(t))
+```
 
 ## Hybrid systems
 

--- a/docs/sphinx/api/ode.rst
+++ b/docs/sphinx/api/ode.rst
@@ -75,32 +75,60 @@ Sensitivity analysis
 Acausal modeling
 ----------------
 
-.. class:: AcausalSystem
+.. class:: AcausalSystem(pool: ExprPool)
 
-   An acausal component model. Components are added via :meth:`add` and
-   connected via :meth:`connect`. The system is compiled to a :class:`DAE`
-   via :meth:`to_dae`.
+   An acausal component model. Components are added via
+   :meth:`add_component` and connected via :meth:`connect`. The system is
+   compiled to a :class:`DAE` via :meth:`flatten`.
 
-   .. method:: add(component) -> None
+   .. method:: add_component(component: Component) -> None
 
       Add a component to the system.
 
    .. method:: connect(port_a: Port, port_b: Port) -> None
 
-      Connect two component ports.
+      Connect two component ports (equates potentials, balances flows).
 
-   .. method:: to_dae() -> DAE
+   .. method:: flatten(time_var: Expr) -> DAE
 
-      Assemble the component equations into a DAE.
+      Assemble the component and connection equations into a DAE.
+
+.. class:: Component
+
+   A physical component (resistor, capacitor, voltage source, …) with named
+   :class:`Port` connectors and constitutive equations. Returned inside the
+   ``"component"`` key of the dicts produced by :func:`resistor`,
+   :func:`capacitor`, and :func:`voltage_source`.
+
+   .. method:: port(name: str) -> Port | None
+
+      Look up a port by its full name (e.g. ``"R1.p"``).
+
+   .. method:: ports() -> list[Port]
+
+      All ports, in declaration order.
 
 .. class:: Port
 
    A connection port on a component (e.g. positive/negative terminals
-   of a resistor).
+   of a resistor), exposing ``potential`` and ``flow`` :class:`Expr`
+   attributes.
 
-.. function:: resistor(pool: ExprPool, resistance: Expr) -> object
+.. function:: resistor(name: str, resistance: Expr) -> dict
 
-   Create a resistor component with the given resistance expression.
+   Create a resistor component (``v - R*i = 0``). Returns a dict with keys
+   ``"name"``, ``"n_equations"``, ``"n_ports"``, and ``"component"`` (a
+   :class:`Component`).
+
+.. function:: capacitor(name: str, capacitance: Expr) -> dict
+
+   Create an ideal capacitor component (``C * dv/dt - i = 0``). Same return
+   shape as :func:`resistor`.
+
+.. function:: voltage_source(name: str, voltage: Expr) -> dict
+
+   Create an ideal voltage source component (``v_p - v_n = V``). Same return
+   shape as :func:`resistor`.
 
 Hybrid systems
 --------------

--- a/examples/acausal_and_laplace.py
+++ b/examples/acausal_and_laplace.py
@@ -1,0 +1,94 @@
+"""Demo: acausal RC-circuit modeling + Laplace transform (experimental).
+
+Part 1 — Acausal (Modelica-like) modeling
+------------------------------------------
+Builds a simple RC circuit (ideal voltage source, resistor, capacitor) by
+creating components, registering them on an :class:`alkahest.AcausalSystem`,
+wiring up the ports with :meth:`AcausalSystem.connect`, and flattening the
+network into a :class:`alkahest.DAE`.
+
+Part 2 — Laplace transform (experimental)
+------------------------------------------
+Shows that ``laplace_transform`` / ``inverse_laplace_transform`` are
+discoverable from ``alkahest.experimental`` and compute textbook results:
+
+    L{1}(s)        = 1/s
+    L{exp(-a t)}(s) = 1/(s + a)
+
+Run with::
+
+    PYTHONPATH=python python examples/acausal_and_laplace.py
+"""
+
+from __future__ import annotations
+
+import alkahest as ak
+from alkahest.experimental import inverse_laplace_transform, laplace_transform
+
+
+def part1_acausal_rc_circuit() -> None:
+    print("=" * 70)
+    print("Part 1: Acausal RC circuit")
+    print("=" * 70)
+
+    pool = ak.ExprPool()
+    t = pool.symbol("t")
+
+    # Component constructors return {"name", "n_equations", "n_ports",
+    # "component"}; "component" is an alkahest.Component.
+    src = ak.voltage_source("V1", pool.symbol("Vs"))
+    res = ak.resistor("R1", pool.symbol("R"))
+    cap = ak.capacitor("C1", pool.symbol("C"))
+
+    src_comp = src["component"]
+    res_comp = res["component"]
+    cap_comp = cap["component"]
+
+    print(f"voltage_source -> {src_comp!r}")
+    print(f"resistor       -> {res_comp!r}")
+    print(f"capacitor      -> {cap_comp!r}")
+
+    sys = ak.AcausalSystem(pool)
+    sys.add_component(src_comp)
+    sys.add_component(res_comp)
+    sys.add_component(cap_comp)
+
+    # Wire: Vs.p -> R1.p, R1.n -> C1.p, C1.n -> Vs.n (ground loop)
+    sys.connect(src_comp.port("V1.p"), res_comp.port("R1.p"))
+    sys.connect(res_comp.port("R1.n"), cap_comp.port("C1.p"))
+    sys.connect(cap_comp.port("C1.n"), src_comp.port("V1.n"))
+
+    dae = sys.flatten(t)
+
+    print(f"\nFlattened DAE: {dae.n_equations()} equations, "
+          f"{dae.n_variables()} variables")
+    print(dae)
+
+
+def part2_laplace_transform() -> None:
+    print()
+    print("=" * 70)
+    print("Part 2: Laplace transform (alkahest.experimental)")
+    print("=" * 70)
+
+    pool = ak.ExprPool()
+    t = pool.symbol("t")
+    s = pool.symbol("s")
+    a = pool.symbol("a")
+
+    one = pool.integer(1)
+    L_one = laplace_transform(one, t, s)
+    print(f"L{{1}}(s)          = {L_one}")  # expect 1/s
+
+    exp_neg_at = ak.exp(pool.mul([pool.integer(-1), a, t]))
+    L_exp = laplace_transform(exp_neg_at, t, s)
+    print(f"L{{exp(-a t)}}(s)  = {L_exp}")  # expect 1/(s + a)
+
+    # Round trip: inverse Laplace of 1/s should give back 1 (Heaviside(t)).
+    inv = inverse_laplace_transform(L_one, s, t)
+    print(f"L^-1{{1/s}}(t)     = {inv}")
+
+
+if __name__ == "__main__":
+    part1_acausal_rc_circuit()
+    part2_laplace_transform()

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -60,6 +60,7 @@ from .alkahest import (  # noqa: F401
     CompileCache,
     # Phase 21: JIT compiled evaluation
     CompiledFn,
+    Component,
     # Core expression types
     DerivedResult,
     Domain,
@@ -107,6 +108,8 @@ from .alkahest import (  # noqa: F401
     atan2,
     cad_lift,
     cad_project,
+    # Phase 18: Acausal modelling (component constructors)
+    capacitor,
     ceil,
     # Phase 26: collect_like_terms
     collect_like_terms,
@@ -195,6 +198,7 @@ from .alkahest import (  # noqa: F401
     to_stablehlo,
     verify_wz_pair,
     version,
+    voltage_source,
 )
 from .alkahest import (
     # Phase 14: reverse-mode partials on Expr (native name `grad`; exported as symbolic_grad)
@@ -1016,6 +1020,7 @@ __all__ = [
     "CompiledFn",
     "CompiledGradTracedFn",
     "CompiledTracedFn",
+    "Component",
     "ConversionError",
     "DaeError",
     "DaeIndexReduction",
@@ -1101,6 +1106,7 @@ __all__ = [
     "cad_lift",
     "cad_project",
     "capabilities",
+    "capacitor",
     "ceil",
     # Phase 26
     "collect_like_terms",
@@ -1233,4 +1239,5 @@ __all__ = [
     "unicode_str",
     "verify_wz_pair",
     "version",
+    "voltage_source",
 ]

--- a/tests/test_v03.py
+++ b/tests/test_v03.py
@@ -15,12 +15,14 @@ from alkahest.alkahest import (
     DAE,
     ODE,
     AcausalSystem,
+    Component,
     Event,
     ExprPool,
     HybridODE,
     Matrix,
     SensitivitySystem,
     adjoint_system,
+    capacitor,
     cos,
     diff,
     exp,
@@ -31,6 +33,7 @@ from alkahest.alkahest import (
     resistor,
     sensitivity_system,
     sin,
+    voltage_source,
 )
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -361,6 +364,52 @@ class TestAcausal:
         dae = sys.flatten(self.t)
         # Empty system → empty DAE
         assert dae.n_equations() == 0
+
+    def test_component_accessible_from_dict(self):
+        R = self.pool.symbol("R")
+        comp = resistor("R1", R)["component"]
+        assert isinstance(comp, Component)
+        assert comp.name == "R1"
+        assert comp.n_equations() == 1
+        assert comp.n_ports() == 2
+        port = comp.port("R1.p")
+        assert port is not None
+        assert port.name == "R1.p"
+        assert comp.port("does.not.exist") is None
+        assert len(comp.ports()) == 2
+
+    def test_capacitor_and_voltage_source_dicts(self):
+        C = self.pool.symbol("C")
+        Vs = self.pool.symbol("Vs")
+        cap = capacitor("C1", C)
+        src = voltage_source("V1", Vs)
+        assert cap["n_equations"] == 2
+        assert cap["n_ports"] == 2
+        assert src["n_equations"] == 1
+        assert src["n_ports"] == 2
+
+    def test_acausal_rc_circuit_add_component_and_connect(self):
+        R = self.pool.symbol("R")
+        C = self.pool.symbol("C")
+        Vs = self.pool.symbol("Vs")
+
+        src = voltage_source("V1", Vs)["component"]
+        res = resistor("R1", R)["component"]
+        cap = capacitor("C1", C)["component"]
+
+        sys = AcausalSystem(self.pool)
+        sys.add_component(src)
+        sys.add_component(res)
+        sys.add_component(cap)
+
+        sys.connect(src.port("V1.p"), res.port("R1.p"))
+        sys.connect(res.port("R1.n"), cap.port("C1.p"))
+        sys.connect(cap.port("C1.n"), src.port("V1.n"))
+
+        dae = sys.flatten(self.t)
+        # 1 (source) + 1 (resistor) + 2 (capacitor) + 2*3 (connections) = 10
+        assert dae.n_equations() == 10
+        assert dae.n_variables() > 0
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Part 1 — Acausal modeling Python bindings**
- New `alkahest.Component` pyclass wrapping the core `Component` (ports, equations, internal vars).
- `AcausalSystem.add_component(component)` and `AcausalSystem.connect(port_a, port_b)` now bound, mirroring the existing Rust `System::add_component` / `System::connect`.
- `resistor`, and new `capacitor` / `voltage_source` constructors, now return `{"name", "n_equations", "n_ports", "component"}` — the `"component"` key is a `Component` with `.port(name)` / `.ports()` accessors. The existing `resistor(...)["n_equations"]` etc. dict shape is preserved (additive only).
- Updated `docs/mdbook/src/ode-dae.md` and `docs/sphinx/api/ode.rst` (previously showed a non-working sketch API: `AcausalSystem()`, `.add`, `.to_dae`) to the real, working API.

**Part 2 — Laplace transform discoverability**
- `laplace_transform` / `inverse_laplace_transform` were already imported and in `alkahest.experimental.__all__` — no code change needed there.
- Added a one-line pointer + example in `docs/mdbook/src/ode-dae.md` and `docs/features.md` so users searching for Laplace find it under `alkahest.experimental`.

**New example**: `examples/acausal_and_laplace.py` builds an RC circuit (voltage source + resistor + capacitor), connects ports, flattens to a `DAE`, and computes `L{1}=1/s` and `L{exp(-a t)}=1/(s+a)`.

## Test plan
- [x] `maturin develop --manifest-path alkahest-py/Cargo.toml --features "egraph groebner"` builds cleanly
- [x] `cargo test --workspace` passes (incl. existing `acausal::tests::*`)
- [x] `cargo fmt --all -- --check` passes
- [x] `pytest tests/` — 1157 passed, 42 skipped
- [x] `python examples/acausal_and_laplace.py` runs end-to-end, prints flattened RC-circuit DAE (10 equations, 13 variables) and Laplace results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Component` class for acausal physical components with port management
  * Added `AcausalSystem.add_component()` and `AcausalSystem.connect()` methods for component registration and wiring
  * Expanded component library: `resistor`, `capacitor`, and `voltage_source` now return unified dictionary format with component objects
  * Added Laplace transform support via `alkahest.experimental`

* **Documentation**
  * Provided complete acausal RC circuit modeling example with runnable code
  * Updated API documentation with new component and system signatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->