### PR TITLE
feat(poly): cancel/together for rational expressions

### DIFF
--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -88,12 +88,12 @@ pub use ode::{
 pub use parse::{parse, ParseError};
 pub use pattern::{match_pattern, Pattern, Substitution};
 pub use poly::{
-    apart, factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z, gcd_sparse_modular,
-    poly_normal, real_roots, real_roots_symbolic, refine_root, resultant, sparse_interpolate,
-    sparse_interpolate_univariate, subresultant_prs, ApartError, ConversionError, FactorError,
-    MultiPoly, MultiPolyFactorization, RationalFunction, RealRootError, ResultantError,
-    RootInterval, SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP,
-    UniPolyFactorization,
+    apart, cancel, factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z,
+    gcd_sparse_modular, poly_normal, real_roots, real_roots_symbolic, refine_root, resultant,
+    sparse_interpolate, sparse_interpolate_univariate, subresultant_prs, together, together_parts,
+    ApartError, ConversionError, FactorError, MultiPoly, MultiPolyFactorization, RationalFunction,
+    RealRootError, ResultantError, RootInterval, SparseGcdError, SparseInterpError, UniPoly,
+    UniPolyFactorModP, UniPolyFactorization,
 };
 
 // §3.3 — Laplace transform and inverse (experimental surface; see `experimental`)
@@ -246,12 +246,12 @@ pub mod stable {
     pub use crate::parse::{parse, ParseError};
     pub use crate::pattern::{match_pattern, Pattern, Substitution};
     pub use crate::poly::{
-        apart, factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z,
+        apart, cancel, factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z,
         gcd_sparse_modular, poly_normal, real_roots, real_roots_symbolic, refine_root, resultant,
-        sparse_interpolate, sparse_interpolate_univariate, subresultant_prs, ApartError,
-        ConversionError, FactorError, MultiPoly, MultiPolyFactorization, RationalFunction,
-        RealRootError, ResultantError, RootInterval, SparseGcdError, SparseInterpError, UniPoly,
-        UniPolyFactorModP, UniPolyFactorization,
+        sparse_interpolate, sparse_interpolate_univariate, subresultant_prs, together,
+        together_parts, ApartError, ConversionError, FactorError, MultiPoly,
+        MultiPolyFactorization, RationalFunction, RealRootError, ResultantError, RootInterval,
+        SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP, UniPolyFactorization,
     };
     pub use crate::primitive::{Primitive, PrimitiveRegistry};
     pub use crate::real::{cad_lift, cad_project, decide, decide_expr, CadError, QeResult};

--- a/alkahest-core/src/poly/cancel.rs
+++ b/alkahest-core/src/poly/cancel.rs
@@ -1,0 +1,408 @@
+//! Rational-function `cancel` / `together` normalization.
+//!
+//! These routines take an expression built from `+`, `-`, `*`, `/` and
+//! **integer**-power nodes of polynomials in `vars`, combine it over a common
+//! denominator, and divide the numerator and denominator by their polynomial
+//! GCD (via [`RationalFunction::new`], which performs the GCD reduction).
+//!
+//! Any sub-expression that is *not* a polynomial in `vars` — a function call
+//! such as `sin(x)`, a symbol that is not in `vars`, or a base raised to a
+//! non-integer / negative exponent that is not otherwise reducible — is treated
+//! as an **opaque generator**: a fresh polynomial variable. This lets `cancel`
+//! operate on expressions like `(sin(x)**2 - 1) / (sin(x) - 1)` and on matrix
+//! entries containing unrelated symbols, collapsing common factors structurally.
+//!
+//! ## Limitations
+//! * Generators are matched **structurally**: `sin(x)` and `sin(2*x/2)` are
+//!   distinct generators (no simplification of arguments is performed first).
+//! * A base raised to a *symbolic* exponent (e.g. `x**n`) is opaque as a whole.
+//! * Negative integer powers of opaque generators are supported (they go into
+//!   the denominator), but a negative power of a *non-atomic* opaque base
+//!   (e.g. `sin(x)**-2`) is handled by treating `sin(x)` as a generator and
+//!   inverting it.
+
+use super::error::ConversionError;
+use super::multipoly::MultiPoly;
+use super::rational::RationalFunction;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+
+/// Convert *expr* into a single normalized rational function over *vars*
+/// (plus any opaque generators discovered inside it), returning the cancelled
+/// `(numerator, denominator)` expression pair.
+///
+/// The numerator and denominator are returned as separate `ExprId`s so callers
+/// can decide how to present the quotient; see [`cancel`] for the combined form.
+pub fn together_parts(
+    expr: ExprId,
+    vars: Vec<ExprId>,
+    pool: &ExprPool,
+) -> Result<(ExprId, ExprId), ConversionError> {
+    // Discover opaque generators and build the full generator list.
+    let mut gens: Vec<ExprId> = vars.clone();
+    collect_generators(expr, &vars, pool, &mut gens);
+
+    let rf = expr_to_rational(expr, &gens, pool)?;
+    let numer = rf.numer.to_expr(pool);
+    let denom = rf.denom.to_expr(pool);
+    Ok((numer, denom))
+}
+
+/// Combine *expr* over a common denominator and cancel common polynomial
+/// factors, returning a single symbolic expression.
+///
+/// If the resulting denominator is the constant `1`, the bare numerator is
+/// returned; otherwise `numerator / denominator` (i.e. `numerator *
+/// denominator**-1`) is returned.
+///
+/// Because [`RationalFunction::new`] already divides out the numerator/
+/// denominator GCD, `cancel` and [`together`] share this implementation; they
+/// differ only in intent (`cancel` emphasises factor removal). `together`
+/// is provided as a thin alias.
+pub fn cancel(expr: ExprId, vars: Vec<ExprId>, pool: &ExprPool) -> Result<ExprId, ConversionError> {
+    let (numer, denom) = together_parts(expr, vars, pool)?;
+    Ok(combine(numer, denom, pool))
+}
+
+/// Alias of [`cancel`]: combine over a common denominator with GCD reduction.
+pub fn together(
+    expr: ExprId,
+    vars: Vec<ExprId>,
+    pool: &ExprPool,
+) -> Result<ExprId, ConversionError> {
+    cancel(expr, vars, pool)
+}
+
+/// Build `numer / denom` as a symbolic expression, simplifying `denom == 1`.
+fn combine(numer: ExprId, denom: ExprId, pool: &ExprPool) -> ExprId {
+    // A zero numerator collapses the whole quotient to 0 (denom is non-zero by
+    // RationalFunction's invariant).
+    let numer_is_zero = pool.with(numer, |n| matches!(n, ExprData::Integer(z) if z.0 == 0));
+    if numer_is_zero {
+        return pool.integer(0_i32);
+    }
+    let denom_is_one = pool.with(denom, |d| matches!(d, ExprData::Integer(n) if n.0 == 1));
+    if denom_is_one {
+        return numer;
+    }
+    let inv = pool.pow(denom, pool.integer(-1_i32));
+    pool.mul(vec![numer, inv])
+}
+
+/// Walk *expr*, appending any opaque generator atoms (not already present in
+/// `acc`) to `acc`. A node is opaque when it is a symbol outside `vars`, a
+/// function call, or a power whose exponent is not a constant integer.
+fn collect_generators(expr: ExprId, vars: &[ExprId], pool: &ExprPool, acc: &mut Vec<ExprId>) {
+    enum Kind {
+        Var,
+        Opaque,
+        Recurse(Vec<ExprId>),
+        PowIntExp(ExprId),
+        Skip,
+    }
+
+    let kind = pool.with(expr, |data| match data {
+        ExprData::Symbol { .. } => {
+            if vars.contains(&expr) {
+                Kind::Var
+            } else {
+                Kind::Opaque
+            }
+        }
+        ExprData::Integer(_) => Kind::Skip,
+        ExprData::Rational(_) | ExprData::Float(_) => Kind::Skip,
+        ExprData::Add(args) | ExprData::Mul(args) => Kind::Recurse(args.clone()),
+        ExprData::Pow { base, exp } => {
+            let int_exp = pool.with(*exp, |e| matches!(e, ExprData::Integer(_)));
+            if int_exp {
+                Kind::PowIntExp(*base)
+            } else {
+                Kind::Opaque
+            }
+        }
+        ExprData::Func { .. } => Kind::Opaque,
+        _ => Kind::Opaque,
+    });
+
+    match kind {
+        Kind::Var | Kind::Skip => {}
+        Kind::Opaque => {
+            if !acc.contains(&expr) {
+                acc.push(expr);
+            }
+        }
+        Kind::Recurse(args) => {
+            for a in args {
+                collect_generators(a, vars, pool, acc);
+            }
+        }
+        Kind::PowIntExp(base) => collect_generators(base, vars, pool, acc),
+    }
+}
+
+/// Recursively convert *expr* into a [`RationalFunction`] over generator list
+/// `gens`. Division and negative integer powers are honoured; opaque atoms in
+/// `gens` are treated as polynomial variables.
+fn expr_to_rational(
+    expr: ExprId,
+    gens: &[ExprId],
+    pool: &ExprPool,
+) -> Result<RationalFunction, ConversionError> {
+    // If this whole node is one of our generators, emit it directly. This
+    // short-circuits opaque atoms (functions, foreign symbols, symbolic
+    // powers) before we try to interpret their internal structure.
+    if gens.contains(&expr) {
+        return generator_rf(expr, gens, pool);
+    }
+
+    enum Node {
+        Poly,
+        Add(Vec<ExprId>),
+        Mul(Vec<ExprId>),
+        Pow { base: ExprId, exp_i64: Option<i64> },
+    }
+
+    let node = pool.with(expr, |data| match data {
+        ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Symbol { .. } => Node::Poly,
+        ExprData::Add(args) => Node::Add(args.clone()),
+        ExprData::Mul(args) => Node::Mul(args.clone()),
+        ExprData::Pow { base, exp } => {
+            let exp_i64 = pool.with(*exp, |e| match e {
+                ExprData::Integer(n) => n.0.to_i64(),
+                _ => None,
+            });
+            Node::Pow {
+                base: *base,
+                exp_i64,
+            }
+        }
+        _ => Node::Poly,
+    });
+
+    match node {
+        // A polynomial leaf/atom: convert directly to a poly-over-1 rational.
+        Node::Poly => poly_rf(expr, gens, pool),
+        Node::Add(args) => {
+            let mut acc = const_rf(0, gens);
+            for a in args {
+                let r = expr_to_rational(a, gens, pool)?;
+                acc = (acc + r)?;
+            }
+            Ok(acc)
+        }
+        Node::Mul(args) => {
+            let mut acc = const_rf(1, gens);
+            for a in args {
+                let r = expr_to_rational(a, gens, pool)?;
+                acc = (acc * r)?;
+            }
+            Ok(acc)
+        }
+        Node::Pow { base, exp_i64 } => {
+            let n = exp_i64.ok_or(ConversionError::NonConstantExponent)?;
+            let base_rf = expr_to_rational(base, gens, pool)?;
+            pow_rf(base_rf, n, gens)
+        }
+    }
+}
+
+/// Build the rational function `g / 1` for a single generator `g`.
+fn generator_rf(
+    g: ExprId,
+    gens: &[ExprId],
+    _pool: &ExprPool,
+) -> Result<RationalFunction, ConversionError> {
+    let idx = gens
+        .iter()
+        .position(|&v| v == g)
+        .expect("generator present");
+    let mut exp = vec![0u32; idx + 1];
+    exp[idx] = 1;
+    let mut terms = std::collections::BTreeMap::new();
+    terms.insert(exp, rug::Integer::from(1));
+    let numer = MultiPoly {
+        vars: gens.to_vec(),
+        terms,
+    };
+    let denom = MultiPoly::constant(gens.to_vec(), 1);
+    RationalFunction::new(numer, denom)
+}
+
+/// Convert a polynomial expression (no division, only integer powers) over
+/// `gens` into a `poly / 1` rational function.
+fn poly_rf(
+    expr: ExprId,
+    gens: &[ExprId],
+    pool: &ExprPool,
+) -> Result<RationalFunction, ConversionError> {
+    let numer = MultiPoly::from_symbolic(expr, gens.to_vec(), pool)?;
+    let denom = MultiPoly::constant(gens.to_vec(), 1);
+    RationalFunction::new(numer, denom)
+}
+
+/// The constant rational function `c / 1`.
+fn const_rf(c: i64, gens: &[ExprId]) -> RationalFunction {
+    RationalFunction {
+        numer: MultiPoly::constant(gens.to_vec(), c),
+        denom: MultiPoly::constant(gens.to_vec(), 1),
+    }
+}
+
+/// Raise a rational function to an integer power `n` (negative inverts).
+fn pow_rf(
+    base: RationalFunction,
+    n: i64,
+    gens: &[ExprId],
+) -> Result<RationalFunction, ConversionError> {
+    if n == 0 {
+        return Ok(const_rf(1, gens));
+    }
+    let (b, exp) = if n < 0 {
+        // Invert: (num/den)^-1 = den/num.
+        if base.numer.is_zero() {
+            return Err(ConversionError::ZeroDenominator);
+        }
+        (
+            RationalFunction::new(base.denom.clone(), base.numer.clone())?,
+            (-n) as u64,
+        )
+    } else {
+        (base, n as u64)
+    };
+    let mut acc = const_rf(1, gens);
+    for _ in 0..exp {
+        acc = (acc * b.clone())?;
+    }
+    Ok(acc)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::{Domain, ExprPool};
+    use crate::matrix::Matrix;
+
+    fn is_int(pool: &ExprPool, e: ExprId, val: i64) -> bool {
+        pool.with(e, |d| matches!(d, ExprData::Integer(n) if n.0 == val))
+    }
+
+    #[test]
+    fn cancels_difference_of_squares() {
+        // (x^2 - 1)/(x - 1) -> x + 1
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let num = p.add(vec![p.pow(x, p.integer(2_i32)), p.integer(-1_i32)]);
+        let den = p.add(vec![x, p.integer(-1_i32)]);
+        let expr = p.mul(vec![num, p.pow(den, p.integer(-1_i32))]);
+        let out = cancel(expr, vec![x], &p).unwrap();
+        // Expect x + 1 (denominator gone). Normalize via poly_normal-style check.
+        let mp = MultiPoly::from_symbolic(out, vec![x], &p).unwrap();
+        assert_eq!(mp.terms.get(&vec![1]).cloned(), Some(rug::Integer::from(1)));
+        assert_eq!(mp.terms.get(&vec![]).cloned(), Some(rug::Integer::from(1)));
+        assert_eq!(mp.terms.len(), 2, "should be exactly x + 1: {mp:?}");
+    }
+
+    #[test]
+    fn sum_of_two_fractions() {
+        // 1/x + 1/(x+1) -> (2x + 1) / (x^2 + x)
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let inv_x = p.pow(x, p.integer(-1_i32));
+        let xp1 = p.add(vec![x, p.integer(1_i32)]);
+        let inv_xp1 = p.pow(xp1, p.integer(-1_i32));
+        let expr = p.add(vec![inv_x, inv_xp1]);
+        let (numer, denom) = together_parts(expr, vec![x], &p).unwrap();
+        let n = MultiPoly::from_symbolic(numer, vec![x], &p).unwrap();
+        let d = MultiPoly::from_symbolic(denom, vec![x], &p).unwrap();
+        // numerator 2x + 1
+        assert_eq!(n.terms.get(&vec![1]).cloned(), Some(rug::Integer::from(2)));
+        assert_eq!(n.terms.get(&vec![]).cloned(), Some(rug::Integer::from(1)));
+        // denominator x^2 + x
+        assert_eq!(d.terms.get(&vec![2]).cloned(), Some(rug::Integer::from(1)));
+        assert_eq!(d.terms.get(&vec![1]).cloned(), Some(rug::Integer::from(1)));
+        assert_eq!(d.terms.len(), 2, "denominator should be x^2 + x: {d:?}");
+    }
+
+    #[test]
+    fn constant_quotient_collapses() {
+        // x / x -> 1
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let expr = p.mul(vec![x, p.pow(x, p.integer(-1_i32))]);
+        let out = cancel(expr, vec![x], &p).unwrap();
+        assert!(is_int(&p, out, 1), "x/x should cancel to 1");
+    }
+
+    #[test]
+    fn opaque_generator_cancellation() {
+        // (sin(x)^2 - 1)/(sin(x) - 1) -> sin(x) + 1, with vars = [x].
+        // sin(x) is opaque (a function), so it becomes a generator.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let s = p.func("sin", vec![x]);
+        let num = p.add(vec![p.pow(s, p.integer(2_i32)), p.integer(-1_i32)]);
+        let den = p.add(vec![s, p.integer(-1_i32)]);
+        let expr = p.mul(vec![num, p.pow(den, p.integer(-1_i32))]);
+        let out = cancel(expr, vec![x], &p).unwrap();
+        // Result should be sin(x) + 1: a poly in the opaque generator sin(x).
+        // Re-run cancel treating sin(x) as a generator to extract numer/denom,
+        // since MultiPoly::from_symbolic does not recognise composite generators.
+        let (numer, denom) = together_parts(out, vec![x], &p).unwrap();
+        // denominator should be 1
+        assert!(
+            is_int(&p, denom, 1),
+            "denominator should collapse to 1: {}",
+            p.display(denom)
+        );
+        // numerator is sin(x) + 1 — confirm structurally via display.
+        let s_disp = p.display(numer).to_string();
+        assert!(
+            s_disp.contains("sin") && s_disp.contains("1"),
+            "numerator should be sin(x) + 1, got {s_disp}"
+        );
+    }
+
+    #[test]
+    fn foreign_symbol_is_opaque() {
+        // (y^2 - 1)/(y - 1) with vars = [x] -> y + 1 (y opaque).
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let y = p.symbol("y", Domain::Real);
+        let num = p.add(vec![p.pow(y, p.integer(2_i32)), p.integer(-1_i32)]);
+        let den = p.add(vec![y, p.integer(-1_i32)]);
+        let expr = p.mul(vec![num, p.pow(den, p.integer(-1_i32))]);
+        let out = cancel(expr, vec![x], &p).unwrap();
+        let mp = MultiPoly::from_symbolic(out, vec![y], &p).unwrap();
+        assert_eq!(mp.terms.get(&vec![1]).cloned(), Some(rug::Integer::from(1)));
+        assert_eq!(mp.terms.get(&vec![]).cloned(), Some(rug::Integer::from(1)));
+    }
+
+    #[test]
+    fn matrix_inverse_product_is_identity() {
+        // For a symbolic 2x2 A, cancel applied entrywise to A * A^-1 yields I.
+        let p = ExprPool::new();
+        let a = p.symbol("a", Domain::Real);
+        let b = p.symbol("b", Domain::Real);
+        let c = p.symbol("c", Domain::Real);
+        let d = p.symbol("d", Domain::Real);
+        let m = Matrix::new(vec![vec![a, b], vec![c, d]]).unwrap();
+        let inv = m.inverse(&p).unwrap();
+        let prod = m.mul(&inv, &p).unwrap();
+        let vars = vec![a, b, c, d];
+        for r in 0..2 {
+            for col in 0..2 {
+                let entry = prod.get(r, col);
+                let reduced = cancel(entry, vars.clone(), &p).unwrap();
+                let expect = if r == col { 1 } else { 0 };
+                assert!(
+                    is_int(&p, reduced, expect),
+                    "entry ({r},{col}) should cancel to {expect}, got {}",
+                    p.display(reduced)
+                );
+            }
+        }
+    }
+}

--- a/alkahest-core/src/poly/mod.rs
+++ b/alkahest-core/src/poly/mod.rs
@@ -1,3 +1,5 @@
+// Rational-function cancel/together normalization
+pub mod cancel;
 pub mod error;
 // V2-7 — Polynomial factorization
 pub mod factor;
@@ -21,6 +23,7 @@ pub mod groebner;
 #[cfg(test)]
 mod proptests;
 
+pub use cancel::{cancel, together, together_parts};
 pub use error::{ConversionError, FactorError};
 pub use factor::{
     factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z, MultiPolyFactorization,

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -2,6 +2,8 @@ use alkahest_core::{
     adjoint_system as core_adjoint_system,
     cad_lift as core_cad_lift,
     cad_project as core_cad_project,
+    // Rational-function cancel/together
+    cancel as core_cancel,
     capacitor as core_capacitor,
     // Phase 21 — JIT
     compile as core_compile,
@@ -42,6 +44,7 @@ use alkahest_core::{
     subs as core_subs,
     sum_definite as core_sum_definite,
     sum_indefinite as core_sum_indefinite,
+    together as core_together,
     verify_wz_pair as core_verify_wz_pair,
     voltage_source as core_voltage_source,
     // Phase 22 — Ball arithmetic
@@ -5176,6 +5179,63 @@ fn py_poly_normal(
     })
 }
 
+/// Cancel common polynomial factors in a rational expression.
+///
+/// Combines an expression built from ``+``, ``-``, ``*``, ``/`` and integer
+/// powers of polynomials in *vars* over a common denominator, then divides the
+/// numerator and denominator by their polynomial GCD.  Any sub-expression that
+/// is not a polynomial in *vars* (a function call like ``sin(x)``, a symbol not
+/// listed in *vars*, or a base with a symbolic exponent) is treated as an
+/// opaque generator.
+///
+/// Examples::
+///
+///     cancel((x**2 - 1) / (x - 1), [x])   # -> x + 1
+///     cancel(1/x + 1/(x + 1), [x])         # -> (2*x + 1) / (x**2 + x)
+///     cancel(x / x, [x])                   # -> 1
+///
+/// Limitations: generators are matched structurally (``sin(x)`` and
+/// ``sin(2*x/2)`` are distinct), and bases raised to symbolic exponents are
+/// opaque as a whole.
+#[pyfunction]
+#[pyo3(name = "cancel")]
+fn py_cancel(py: Python<'_>, expr: PyRef<PyExpr>, vars: Vec<PyRef<PyExpr>>) -> PyResult<PyExpr> {
+    let pool_py = expr.pool.clone_ref(py);
+    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
+    let result = {
+        let pool = pool_py.borrow(py);
+        core_cancel(expr.id, var_ids, &pool.inner).map_err(conv_error_to_py)?
+    };
+    Ok(PyExpr {
+        id: result,
+        pool: pool_py,
+    })
+}
+
+/// Combine a rational expression over a single common denominator.
+///
+/// Behaves like :func:`cancel` (the numerator/denominator GCD is divided out by
+/// the underlying rational-function constructor); provided as a companion name
+/// for callers that want the explicit "put over a common denominator" intent.
+///
+/// Example::
+///
+///     together(1/x + 1/(x + 1), [x])   # -> (2*x + 1) / (x**2 + x)
+#[pyfunction]
+#[pyo3(name = "together")]
+fn py_together(py: Python<'_>, expr: PyRef<PyExpr>, vars: Vec<PyRef<PyExpr>>) -> PyResult<PyExpr> {
+    let pool_py = expr.pool.clone_ref(py);
+    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
+    let result = {
+        let pool = pool_py.borrow(py);
+        core_together(expr.id, var_ids, &pool.inner).map_err(conv_error_to_py)?
+    };
+    Ok(PyExpr {
+        id: result,
+        pool: pool_py,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // V2-2 — Resultants and subresultant PRS
 // ---------------------------------------------------------------------------
@@ -7549,6 +7609,9 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_simplify_clifford_orthogonal, m)?)?;
     // Phase 27 — poly_normal
     m.add_function(wrap_pyfunction!(py_poly_normal, m)?)?;
+    // Rational-function cancel/together
+    m.add_function(wrap_pyfunction!(py_cancel, m)?)?;
+    m.add_function(wrap_pyfunction!(py_together, m)?)?;
     // PA-5 — Primitive registry
     m.add_class::<PyPrimitiveRegistry>()?;
     // PA-9 — Piecewise

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -154,6 +154,9 @@ from .alkahest import (  # noqa: F401
     piecewise,
     # Phase 27: poly_normal
     poly_normal,
+    # Rational-function cancel/together
+    cancel,
+    together,
     product_definite,
     product_indefinite,
     real_roots,
@@ -962,6 +965,24 @@ def poly_normal(expr, vars):
     return _native_poly_normal(_coerce_expr(expr), [_coerce_expr(v) for v in vars])
 
 
+_native_cancel = cancel
+_native_together = together
+
+
+def cancel(expr, vars):
+    """Combine *expr* over a common denominator and cancel common polynomial factors.
+
+    Non-polynomial sub-expressions (e.g. ``sin(x)`` or symbols not in *vars*) are
+    treated as opaque generators. Accepts :class:`DerivedResult` as *expr*.
+    """
+    return _native_cancel(_coerce_expr(expr), [_coerce_expr(v) for v in vars])
+
+
+def together(expr, vars):
+    """Combine *expr* over a single common denominator (alias of :func:`cancel`)."""
+    return _native_together(_coerce_expr(expr), [_coerce_expr(v) for v in vars])
+
+
 _native_eval_expr = eval_expr
 
 
@@ -1234,6 +1255,8 @@ __all__ = [
     "plot_svg",
     # Phase 27
     "poly_normal",
+    "cancel",
+    "together",
     "primary_decomposition",
     "product_definite",
     "product_indefinite",

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -106,6 +106,8 @@ from .alkahest import (  # noqa: F401
     atan2,
     cad_lift,
     cad_project,
+    # Rational-function cancel/together
+    cancel,
     # Phase 18: Acausal modelling (component constructors)
     capacitor,
     ceil,
@@ -154,9 +156,6 @@ from .alkahest import (  # noqa: F401
     piecewise,
     # Phase 27: poly_normal
     poly_normal,
-    # Rational-function cancel/together
-    cancel,
-    together,
     product_definite,
     product_indefinite,
     real_roots,
@@ -197,6 +196,7 @@ from .alkahest import (  # noqa: F401
     to_lean,
     # V5-2: StableHLO/XLA bridge
     to_stablehlo,
+    together,
     verify_wz_pair,
     version,
     voltage_source,
@@ -1183,6 +1183,7 @@ __all__ = [
     "atan",
     "cad_lift",
     "cad_project",
+    "cancel",
     "capabilities",
     "capacitor",
     "ceil",
@@ -1255,8 +1256,6 @@ __all__ = [
     "plot_svg",
     # Phase 27
     "poly_normal",
-    "cancel",
-    "together",
     "primary_decomposition",
     "product_definite",
     "product_indefinite",
@@ -1311,6 +1310,7 @@ __all__ = [
     "to_lean",
     # V5-2
     "to_stablehlo",
+    "together",
     "trace",
     "trace_fn",
     # V2-11 — Regular chains / triangular decomposition

--- a/tests/test_v04_phases.py
+++ b/tests/test_v04_phases.py
@@ -11,6 +11,7 @@ Covers:
 import pytest
 from alkahest import (
     ExprPool,
+    cancel,
     collect_like_terms,
     compile_expr,
     emit_c,
@@ -18,6 +19,7 @@ from alkahest import (
     numpy_eval,
     poly_normal,
     sin,
+    together,
 )
 
 # ===========================================================================
@@ -403,6 +405,57 @@ class TestPolyNormal:
         for v in [-2.0, -1.0, 0.0, 1.0, 2.0]:
             expected = 3 * v**2 + 2 * v + 1
             assert abs(f([v]) - expected) < 1e-10
+
+
+# ===========================================================================
+# Rational-function cancel / together
+# ===========================================================================
+
+
+class TestCancel:
+    def test_difference_of_squares(self):
+        # (x^2 - 1)/(x - 1) -> x + 1
+        p = pool()
+        x = p.symbol("x")
+        result = cancel((x**2 - 1) / (x - 1), [x])
+        f = compile_expr(result, [x])
+        for v in [0.0, 2.0, 3.0, -4.0]:
+            assert abs(f([v]) - (v + 1.0)) < 1e-10
+
+    def test_sum_of_fractions(self):
+        # 1/x + 1/(x+1) -> (2x + 1)/(x^2 + x)
+        p = pool()
+        x = p.symbol("x")
+        result = together(1 / x + 1 / (x + 1), [x])
+        f = compile_expr(result, [x])
+        for v in [1.0, 2.0, 3.5, -2.0]:
+            expected = 1.0 / v + 1.0 / (v + 1.0)
+            assert abs(f([v]) - expected) < 1e-9
+
+    def test_constant_quotient(self):
+        # x / x -> 1
+        p = pool()
+        x = p.symbol("x")
+        result = cancel(x / x, [x])
+        f = compile_expr(result, [x])
+        for v in [1.0, 2.0, -3.0]:
+            assert abs(f([v]) - 1.0) < 1e-10
+
+    def test_matrix_inverse_product_is_identity(self):
+        # cancel applied entrywise to A * A^-1 collapses to the identity.
+        from alkahest import Matrix
+
+        p = pool()
+        a, b, c, d = (p.symbol(s) for s in ("a", "b", "c", "d"))
+        m = Matrix([[a, b], [c, d]])
+        prod = m @ m.inverse()
+        for r in range(2):
+            for col in range(2):
+                reduced = cancel(prod.get(r, col), [a, b, c, d])
+                f = compile_expr(reduced, [a, b, c, d])
+                val = f([2.0, 1.0, 1.0, 3.0])  # det = 5, nonsingular
+                expected = 1.0 if r == col else 0.0
+                assert abs(val - expected) < 1e-9, (r, col, val)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds `cancel(expr, vars)` and `together(expr, vars)` — the first
rational-function normalization in the CAS. They combine an expression
built from `+`, `-`, `*`, `/` and integer powers of polynomials in
`vars` over a common denominator, then divide numerator and denominator
by their polynomial GCD. This reuses the existing `RationalFunction`
type (GCD-normalizing constructor) and `MultiPoly`/FLINT GCD machinery
rather than reinventing them.

Non-polynomial sub-expressions — function calls like `sin(x)`, symbols
not listed in `vars`, or bases with symbolic exponents — are treated as
**opaque polynomial generators**. This makes cancellation work
structurally, including entrywise on a symbolic matrix product `A·A⁻¹`,
which now collapses to the identity (the motivating gap for verifying
the recently merged symbolic matrix inverse).

`cancel` and `together` share one implementation (the GCD reduction
happens in `RationalFunction::new`); `together_parts` exposes the
`(numerator, denominator)` pair in core.

## Examples
```
cancel((x**2 - 1) / (x - 1), [x])   # -> x + 1
cancel(1/x + 1/(x + 1), [x])         # -> (2*x + 1) / (x**2 + x)
cancel(x / x, [x])                   # -> 1
```
Before this PR, `poly_normal((x**2-1)/(x-1), [x])` errored on the
negative exponent; there was no way to collapse a sum of rational terms.

## Changes
- `alkahest-core/src/poly/cancel.rs` (new): `cancel`, `together`,
  `together_parts`, generator discovery, recursive expr→RationalFunction.
- Re-exports in `poly/mod.rs` and `alkahest-core/src/lib.rs` (+ prelude).
- PyO3 bindings + Python wrappers; `__all__` updated (append-only — the
  `__all__` freeze check passes additively).
- Rust unit tests (all 6 pass): difference of squares, sum of fractions,
  `x/x → 1`, opaque generator (`sin`), foreign symbol, and the
  **`A·A⁻¹ → I` entrywise collapse** using the `Matrix` API.
- Python tests: `TestCancel` in `tests/test_v04_phases.py` (4 pass,
  including the matrix-identity case).

## Testing
- `cargo test -p alkahest-cas --lib poly::` — 197 pass
- `cargo test -p alkahest-cas --lib` — 1331 pass, 0 fail (no regressions)
- `cargo fmt --all --check` — clean
- `pytest tests/ -k "poly or rational or cancel"` — 264 pass

## Documented limitations
- Generators are matched **structurally**: `sin(x)` and `sin(2*x/2)` are
  distinct generators (arguments are not pre-simplified).
- A base raised to a *symbolic* exponent (e.g. `x**n`) is opaque as a
  whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `cancel()` to simplify rational expressions by canceling common factors and reducing to lowest terms.
  * Added `together()` to combine fractions into a single normalized rational form.
  * Added `together_parts()` to expose numerator/denominator decomposition for more control over the normalized result.
  * Available across the core library and the Python API (with convenient `vars` handling).

* **Tests**
  * Added coverage for cancellation/combination behavior and an entrywise matrix inverse correctness check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->