### PR TITLE
feat(real): parametric Routh-Hurwitz stability conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Real / decision procedures
+
+- **Parametric Routh–Hurwitz (`routh_hurwitz`):** symbolic stability analysis of a characteristic polynomial whose coefficients are free parameters. Builds the Routh array purely symbolically and returns the first-column entries plus the stability condition as a conjunction of strict-positivity predicates (e.g. `s²+a·s+b` → `a>0 ∧ b>0`; `s³+a·s²+b·s+c` → `a>0 ∧ a·b−c>0 ∧ c>0`). Exposed in Python as `alkahest.routh_hurwitz(poly, var)`.
+
 ## 3.5.1 — 2026-06-15
 
 ### Integration / Risch

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -65,7 +65,9 @@ pub use logic::{
     dpll_sat, formula_from_expr, satisfiable, BoolClause, BoolLit, Formula, LogicError,
     Satisfiability,
 };
-pub use real::{cad_lift, cad_project, decide, decide_expr, CadError, QeResult};
+pub use real::{
+    cad_lift, cad_project, decide, decide_expr, routh_hurwitz, CadError, QeResult, RouthHurwitz,
+};
 // V2-6 — LLL + integer relations (augmented lattice heuristic)
 pub use lattice::{
     lattice_reduce_rows, lattice_reduce_rows_with_delta, validate_lll_rows, LatticeError,
@@ -254,7 +256,9 @@ pub mod stable {
         SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP, UniPolyFactorization,
     };
     pub use crate::primitive::{Primitive, PrimitiveRegistry};
-    pub use crate::real::{cad_lift, cad_project, decide, decide_expr, CadError, QeResult};
+    pub use crate::real::{
+        cad_lift, cad_project, decide, decide_expr, routh_hurwitz, CadError, QeResult, RouthHurwitz,
+    };
     pub use crate::simplify::{
         simplify, simplify_egraph, simplify_egraph_with, simplify_with, DepthCost, EgraphConfig,
         EgraphCost, NoncommutativeCost, OpCost, SimplifyConfig, SizeCost, StabilityCost,

--- a/alkahest-core/src/real/mod.rs
+++ b/alkahest-core/src/real/mod.rs
@@ -4,5 +4,7 @@
 //! purely polynomial formulas in one quantified real variable).
 
 pub mod cad;
+pub mod routh;
 
 pub use cad::{cad_lift, cad_project, decide, decide_expr, CadError, QeResult};
+pub use routh::{routh_hurwitz, RouthHurwitz, ROUTH_MAX_DEGREE};

--- a/alkahest-core/src/real/routh.rs
+++ b/alkahest-core/src/real/routh.rs
@@ -1,0 +1,562 @@
+//! Symbolic / parametric Routh–Hurwitz stability analysis.
+//!
+//! Given a characteristic polynomial
+//!
+//! ```text
+//! p(s) = a_n s^n + a_{n-1} s^{n-1} + … + a_1 s + a_0
+//! ```
+//!
+//! whose coefficients may be *symbolic expressions in free parameters*, this
+//! module builds the Routh array and returns the stability condition: the
+//! conjunction of strict-positivity constraints on the entries of the first
+//! column. The continuous-time system is asymptotically stable (all roots have
+//! strictly negative real part) **iff** every first-column entry shares the
+//! sign of the leading coefficient (here taken positive) and none vanishes.
+//!
+//! Unlike [`crate::real::decide`], the body here is allowed to contain free
+//! parameters: the output is a *parametric* semialgebraic condition on those
+//! parameters rather than a single boolean. For the classic small cases this
+//! reproduces the textbook conditions, e.g.
+//!
+//! - `s^2 + a·s + b`         →  `a > 0 ∧ b > 0`
+//! - `s^3 + a·s^2 + b·s + c`  →  `a > 0 ∧ (a·b − c)/a > 0 ∧ c > 0`
+//!
+//! The construction is purely symbolic (no CAD lift), so it stays cheap even
+//! with many parameters; the only guard is a degree cap to bound the array size.
+
+use super::cad::CadError;
+use crate::kernel::expr::PredicateKind;
+use crate::kernel::{ExprId, ExprPool};
+use crate::logic::Formula;
+use crate::poly::{poly_normal, resultant, together_parts};
+
+/// Maximum polynomial degree accepted by [`routh_hurwitz`]. The Routh array is
+/// `O(n^2)` symbolic entries, each a `2x2` determinant of the row above, so the
+/// cost grows quickly with parametric coefficients; this cap bounds runtime.
+pub const ROUTH_MAX_DEGREE: usize = 24;
+
+/// Result of a symbolic Routh–Hurwitz analysis.
+#[derive(Debug, Clone)]
+pub struct RouthHurwitz {
+    /// Degree `n` of the characteristic polynomial in the analysis variable.
+    pub degree: usize,
+    /// Entries of the first column of the Routh array, top (`s^n`) to bottom
+    /// (`s^0`), each a (normalised) symbolic expression in the parameters.
+    pub first_column: Vec<ExprId>,
+    /// The full Routh array, row by row (row 0 corresponds to `s^n`). Rows are
+    /// padded with zeros to a common width; useful for inspection / display.
+    pub array: Vec<Vec<ExprId>>,
+    /// Stability condition: conjunction of `c > 0` over the non-trivial
+    /// first-column entries (a literal-`1` entry is omitted as vacuously
+    /// positive). [`Formula::True`] when the degree is `0`.
+    pub condition: Formula,
+}
+
+impl RouthHurwitz {
+    /// Intern [`RouthHurwitz::condition`] into the pool as a single predicate
+    /// [`ExprId`] (a conjunction of `> 0` atoms).
+    pub fn condition_expr(&self, pool: &ExprPool) -> ExprId {
+        self.condition.to_expr(pool)
+    }
+}
+
+/// Extract the dense coefficient vector of `expr` in `var`; index `i` holds the
+/// (canonicalised) coefficient of `var^i`. Parameters are treated as symbolic
+/// constants. Returns `Err` if `expr` is not a polynomial in `var` or exceeds
+/// [`ROUTH_MAX_DEGREE`].
+fn coeffs_in_var(expr: ExprId, var: ExprId, pool: &ExprPool) -> Result<Vec<ExprId>, CadError> {
+    let deg = poly_degree_in(expr, var, pool).ok_or(CadError::Unsupported(
+        "Routh: not a polynomial in the analysis variable",
+    ))?;
+    if deg as usize > ROUTH_MAX_DEGREE {
+        return Err(CadError::Unsupported(
+            "Routh: characteristic polynomial degree exceeds the supported cap",
+        ));
+    }
+    let zero = pool.integer(0_i32);
+    let mut coeffs = vec![zero; deg as usize + 1];
+    fill_coeffs(expr, var, &mut coeffs, pool)?;
+
+    // Canonicalise each coefficient as a multivariate polynomial in the free
+    // parameters (everything but `var`). This collapses e.g. `a*b + (-1)*c`
+    // into a single normalised term so downstream comparison / display is sane.
+    let params: Vec<ExprId> = collect_param_vars(expr, var, pool);
+    if !params.is_empty() {
+        for c in coeffs.iter_mut() {
+            *c = poly_normal(*c, params.clone(), pool)?;
+        }
+    }
+    Ok(coeffs)
+}
+
+/// Polynomial degree of `expr` in `var`, or `None` if not polynomial in `var`.
+fn poly_degree_in(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<u32> {
+    use crate::kernel::expr::ExprData;
+    if expr == var {
+        return Some(1);
+    }
+    if is_free_of(expr, var, pool) {
+        return Some(0);
+    }
+    match pool.get(expr) {
+        ExprData::Add(args) => {
+            let mut max_d = 0u32;
+            for a in &args {
+                max_d = max_d.max(poly_degree_in(*a, var, pool)?);
+            }
+            Some(max_d)
+        }
+        ExprData::Mul(args) => {
+            let mut total = 0u32;
+            for a in &args {
+                total = total.checked_add(poly_degree_in(*a, var, pool)?)?;
+            }
+            Some(total)
+        }
+        ExprData::Pow { base, exp } if base == var => match pool.get(exp) {
+            ExprData::Integer(n) => n.0.to_u32(),
+            _ => None,
+        },
+        ExprData::Pow { base, exp } if is_free_of(base, var, pool) => {
+            if is_free_of(exp, var, pool) {
+                Some(0)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_free_of(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    use crate::kernel::expr::ExprData;
+    if expr == var {
+        return false;
+    }
+    match pool.get(expr) {
+        ExprData::Add(args) | ExprData::Mul(args) => args.iter().all(|&a| is_free_of(a, var, pool)),
+        ExprData::Pow { base, exp } => is_free_of(base, var, pool) && is_free_of(exp, var, pool),
+        ExprData::Integer(_) | ExprData::Rational(_) => true,
+        ExprData::Symbol { .. } => expr != var,
+        _ => !resultant::collect_free_vars(expr, pool).contains(&var),
+    }
+}
+
+/// All free symbols of `expr` except `var`, sorted (for deterministic output).
+fn collect_param_vars(expr: ExprId, var: ExprId, pool: &ExprPool) -> Vec<ExprId> {
+    let mut v: Vec<ExprId> = resultant::collect_free_vars(expr, pool)
+        .into_iter()
+        .filter(|&s| s != var)
+        .collect();
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+/// Recursive coefficient accumulator: `coeffs[i]` gathers the coefficient of
+/// `var^i`.
+fn fill_coeffs(
+    expr: ExprId,
+    var: ExprId,
+    coeffs: &mut [ExprId],
+    pool: &ExprPool,
+) -> Result<(), CadError> {
+    use crate::kernel::expr::ExprData;
+
+    fn add_to_slot(slot: &mut ExprId, term: ExprId, pool: &ExprPool) {
+        if is_zero_int(*slot, pool) {
+            *slot = term;
+        } else {
+            *slot = pool.add(vec![*slot, term]);
+        }
+    }
+
+    match pool.get(expr) {
+        ExprData::Add(args) => {
+            for a in &args {
+                fill_coeffs(*a, var, coeffs, pool)?;
+            }
+            Ok(())
+        }
+        _ => {
+            // Single monomial: factor out the power of `var`.
+            let (power, rest) = split_var_power(expr, var, pool)?;
+            if power as usize >= coeffs.len() {
+                return Err(CadError::Unsupported(
+                    "Routh: internal degree miscount while collecting coefficients",
+                ));
+            }
+            add_to_slot(&mut coeffs[power as usize], rest, pool);
+            Ok(())
+        }
+    }
+}
+
+/// Given a monomial-like `expr`, return `(k, rest)` such that `expr = var^k *
+/// rest` and `rest` is free of `var`. Errors if `var` appears non-polynomially.
+fn split_var_power(expr: ExprId, var: ExprId, pool: &ExprPool) -> Result<(u32, ExprId), CadError> {
+    use crate::kernel::expr::ExprData;
+    if expr == var {
+        return Ok((1, pool.integer(1_i32)));
+    }
+    if is_free_of(expr, var, pool) {
+        return Ok((0, expr));
+    }
+    match pool.get(expr) {
+        ExprData::Pow { base, exp } if base == var => match pool.get(exp) {
+            ExprData::Integer(n) => {
+                let k = n.0.to_u32().ok_or(CadError::Unsupported(
+                    "Routh: exponent of analysis variable is not a small non-negative integer",
+                ))?;
+                Ok((k, pool.integer(1_i32)))
+            }
+            _ => Err(CadError::Unsupported(
+                "Routh: analysis variable raised to a non-integer power",
+            )),
+        },
+        ExprData::Mul(args) => {
+            let mut power = 0u32;
+            let mut rest: Vec<ExprId> = Vec::new();
+            for a in &args {
+                if is_free_of(*a, var, pool) {
+                    rest.push(*a);
+                } else {
+                    let (k, r) = split_var_power(*a, var, pool)?;
+                    power = power
+                        .checked_add(k)
+                        .ok_or(CadError::Unsupported("Routh: degree overflow in monomial"))?;
+                    if !is_one_int(r, pool) {
+                        rest.push(r);
+                    }
+                }
+            }
+            let rest_expr = if rest.is_empty() {
+                pool.integer(1_i32)
+            } else if rest.len() == 1 {
+                rest[0]
+            } else {
+                pool.mul(rest)
+            };
+            Ok((power, rest_expr))
+        }
+        _ => Err(CadError::Unsupported(
+            "Routh: characteristic polynomial is not polynomial in the analysis variable",
+        )),
+    }
+}
+
+fn is_zero_int(e: ExprId, pool: &ExprPool) -> bool {
+    use crate::kernel::expr::ExprData;
+    matches!(pool.get(e), ExprData::Integer(n) if n.0 == 0)
+}
+
+fn is_one_int(e: ExprId, pool: &ExprPool) -> bool {
+    use crate::kernel::expr::ExprData;
+    matches!(pool.get(e), ExprData::Integer(n) if n.0 == 1)
+}
+
+/// Build the symbolic Routh array and stability condition for the parametric
+/// characteristic polynomial `poly` in variable `var`.
+///
+/// The stability condition is the conjunction `c_0 > 0 ∧ c_1 > 0 ∧ …` over the
+/// non-trivial entries of the array's first column, expressed symbolically in
+/// the free parameters. (A leading entry equal to the integer `1` is omitted as
+/// vacuously positive.)
+///
+/// # Errors
+/// Returns [`CadError::Unsupported`] if `poly` is not polynomial in `var` or
+/// exceeds [`ROUTH_MAX_DEGREE`].
+pub fn routh_hurwitz(poly: ExprId, var: ExprId, pool: &ExprPool) -> Result<RouthHurwitz, CadError> {
+    let coeffs = coeffs_in_var(poly, var, pool)?;
+    let n = coeffs.len().saturating_sub(1);
+    if n == 0 {
+        return Ok(RouthHurwitz {
+            degree: 0,
+            first_column: coeffs.clone(),
+            array: vec![coeffs],
+            condition: Formula::True,
+        });
+    }
+
+    // coeffs[i] = coefficient of s^i; descending order is a_n .. a_0.
+    let desc: Vec<ExprId> = coeffs.iter().rev().copied().collect();
+
+    // Width of each row.
+    let width = n / 2 + 1;
+    let params = collect_param_vars(poly, var, pool);
+    let zero = pool.integer(0_i32);
+
+    // First two rows from the coefficients (even / odd index split).
+    let mut rows: Vec<Vec<ExprId>> = Vec::new();
+    let mut row0 = Vec::with_capacity(width);
+    let mut row1 = Vec::with_capacity(width);
+    let mut idx = 0usize;
+    while idx <= n {
+        row0.push(if idx < desc.len() { desc[idx] } else { zero });
+        let j = idx + 1;
+        row1.push(if j <= n && j < desc.len() {
+            desc[j]
+        } else {
+            zero
+        });
+        idx += 2;
+    }
+    while row0.len() < width {
+        row0.push(zero);
+    }
+    while row1.len() < width {
+        row1.push(zero);
+    }
+    rows.push(row0);
+    rows.push(row1);
+
+    // Remaining n-1 rows via the Routh recurrence.
+    for r in 2..=n {
+        let above = rows[r - 1].clone();
+        let above2 = rows[r - 2].clone();
+        let pivot = above[0];
+        let mut new_row = Vec::with_capacity(width);
+        for j in 0..width {
+            let a = above2[0];
+            let b = if j + 1 < above2.len() {
+                above2[j + 1]
+            } else {
+                zero
+            };
+            let c = pivot;
+            let d = if j + 1 < above.len() {
+                above[j + 1]
+            } else {
+                zero
+            };
+            // Routh entry = (c*b - a*d) / c.
+            let cb = pool.mul(vec![c, b]);
+            let ad = pool.mul(vec![a, d]);
+            let neg_ad = pool.mul(vec![pool.integer(-1_i32), ad]);
+            let num = pool.add(vec![cb, neg_ad]);
+            let entry = if is_one_int(pivot, pool) {
+                num
+            } else {
+                let inv = pool.pow(pivot, pool.integer(-1_i32));
+                pool.mul(vec![num, inv])
+            };
+            let entry = if params.is_empty() {
+                entry
+            } else {
+                // Best-effort canonicalisation; division can produce a rational
+                // function poly_normal cannot handle, so fall back to raw entry.
+                poly_normal(entry, params.clone(), pool).unwrap_or(entry)
+            };
+            new_row.push(entry);
+        }
+        rows.push(new_row);
+    }
+
+    // First column, top to bottom. Each divided Routh entry is a rational
+    // function whose denominator is a product of earlier (positive) pivots.
+    // Cancelling to a single fraction and taking the *numerator* yields the
+    // clean textbook stability polynomials (e.g. `a·b − c` for the cubic):
+    // since every pivot in the chain is required positive, `num/denom > 0`
+    // is equivalent to `num > 0` under the conjunction of prior conditions.
+    let mut first_column: Vec<ExprId> = Vec::with_capacity(rows.len());
+    let mut condition = Formula::True;
+    for row in &rows {
+        let entry = row[0];
+        if is_one_int(entry, pool) {
+            first_column.push(entry);
+            continue;
+        }
+        // Numerator of the cancelled fraction over the parameters. For numeric
+        // instances (`params` empty) this folds the divided entry into a single
+        // rational constant; the sign of the numerator is the sign of the entry
+        // (the denominator is a product of prior positive pivots).
+        let numer = match together_parts(entry, params.clone(), pool) {
+            Ok((numer, _denom)) => numer,
+            Err(_) => entry,
+        };
+        // Fold cosmetic artefacts such as `1 * a` into `a`.
+        let cond_lhs = crate::simplify::simplify(numer, pool).value;
+        first_column.push(cond_lhs);
+        if is_one_int(cond_lhs, pool) {
+            continue;
+        }
+        let atom = Formula::Atom {
+            kind: PredicateKind::Gt,
+            args: vec![cond_lhs, zero],
+        };
+        condition = match condition {
+            Formula::True => atom,
+            other => Formula::and(other, atom),
+        };
+    }
+
+    Ok(RouthHurwitz {
+        degree: n,
+        first_column,
+        array: rows,
+        condition,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+    use crate::poly::{real_roots, UniPoly};
+
+    // Helper: collect lhs of each `Gt(lhs, 0)` atom in a conjunction tree.
+    fn collect_gt_lhs(f: &Formula, out: &mut Vec<ExprId>) {
+        match f {
+            Formula::Atom {
+                kind: PredicateKind::Gt,
+                args,
+            } => out.push(args[0]),
+            Formula::And(a, b) => {
+                collect_gt_lhs(a, out);
+                collect_gt_lhs(b, out);
+            }
+            _ => {}
+        }
+    }
+
+    /// Count real roots strictly in the positive half-line (isolating interval
+    /// lower bound > 0). A positive real root is a definite instability witness.
+    fn count_positive_real_roots(poly: ExprId, var: ExprId, pool: &ExprPool) -> usize {
+        let up = UniPoly::from_symbolic(poly, var, pool).unwrap();
+        let sf = up.squarefree_part();
+        if sf.is_zero() {
+            return 0;
+        }
+        real_roots(&sf)
+            .unwrap()
+            .into_iter()
+            .filter(|iv| iv.lo > 0)
+            .count()
+    }
+
+    #[test]
+    fn quadratic_parametric_condition() {
+        let p = ExprPool::new();
+        let s = p.symbol("s", Domain::Real);
+        let a = p.symbol("a", Domain::Real);
+        let b = p.symbol("b", Domain::Real);
+        // s^2 + a*s + b
+        let poly = p.add(vec![p.pow(s, p.integer(2_i32)), p.mul(vec![a, s]), b]);
+        let rh = routh_hurwitz(poly, s, &p).unwrap();
+        assert_eq!(rh.degree, 2);
+        assert_eq!(rh.first_column.len(), 3);
+        // Condition: a > 0 ∧ b > 0
+        let mut atoms = Vec::new();
+        collect_gt_lhs(&rh.condition, &mut atoms);
+        assert_eq!(atoms.len(), 2);
+        assert!(atoms.contains(&a));
+        assert!(atoms.contains(&b));
+    }
+
+    #[test]
+    fn cubic_parametric_condition() {
+        let p = ExprPool::new();
+        let s = p.symbol("s", Domain::Real);
+        let a = p.symbol("a", Domain::Real);
+        let b = p.symbol("b", Domain::Real);
+        let c = p.symbol("c", Domain::Real);
+        // s^3 + a*s^2 + b*s + c
+        let poly = p.add(vec![
+            p.pow(s, p.integer(3_i32)),
+            p.mul(vec![a, p.pow(s, p.integer(2_i32))]),
+            p.mul(vec![b, s]),
+            c,
+        ]);
+        let rh = routh_hurwitz(poly, s, &p).unwrap();
+        assert_eq!(rh.degree, 3);
+        // first column: [1, a, (a*b - c)/a, c]; conditions a>0, (a*b-c)/a>0, c>0.
+        let mut atoms = Vec::new();
+        collect_gt_lhs(&rh.condition, &mut atoms);
+        assert_eq!(atoms.len(), 3);
+        assert!(atoms.contains(&a));
+        assert!(atoms.contains(&c));
+    }
+
+    #[test]
+    fn numeric_stable_instance_passes() {
+        // s^3 + 2 s^2 + 3 s + 1: a=2,b=3,c=1 -> a>0,c>0,ab-c=5>0 => STABLE.
+        let p = ExprPool::new();
+        let s = p.symbol("s", Domain::Real);
+        let poly = p.add(vec![
+            p.pow(s, p.integer(3_i32)),
+            p.mul(vec![p.integer(2_i32), p.pow(s, p.integer(2_i32))]),
+            p.mul(vec![p.integer(3_i32), s]),
+            p.integer(1_i32),
+        ]);
+        // Known-stable instance: no real root with a non-negative isolating
+        // interval lower bound (its single real root is strictly negative).
+        assert_eq!(count_positive_real_roots(poly, s, &p), 0);
+        let rh = routh_hurwitz(poly, s, &p).unwrap();
+        for &e in &rh.first_column {
+            let up = UniPoly::from_symbolic(e, s, &p).unwrap();
+            let val = up.eval_rational(&rug::Rational::from(0));
+            assert!(val > 0, "entry not positive: {val}");
+        }
+    }
+
+    #[test]
+    fn numeric_unstable_instance_excluded() {
+        // s^3 + s^2 + s + 6: a=1,b=1,c=6 -> ab-c = -5 < 0 => UNSTABLE.
+        let p = ExprPool::new();
+        let s = p.symbol("s", Domain::Real);
+        let poly = p.add(vec![
+            p.pow(s, p.integer(3_i32)),
+            p.pow(s, p.integer(2_i32)),
+            s,
+            p.integer(6_i32),
+        ]);
+        let rh = routh_hurwitz(poly, s, &p).unwrap();
+        let mut any_nonpos = false;
+        for &e in &rh.first_column {
+            let up = UniPoly::from_symbolic(e, s, &p).unwrap();
+            let val = up.eval_rational(&rug::Rational::from(0));
+            if val <= 0 {
+                any_nonpos = true;
+            }
+        }
+        assert!(
+            any_nonpos,
+            "unstable instance should violate a Routh condition"
+        );
+    }
+
+    #[test]
+    fn numeric_positive_root_instance_cross_check() {
+        // s^2 - 3 s + 2 = (s - 1)(s - 2): two positive real roots => UNSTABLE,
+        // and a = -3 < 0 so the Routh condition a > 0 is violated. This ties the
+        // symbolic condition to actual root locations.
+        let p = ExprPool::new();
+        let s = p.symbol("s", Domain::Real);
+        let poly = p.add(vec![
+            p.pow(s, p.integer(2_i32)),
+            p.mul(vec![p.integer(-3_i32), s]),
+            p.integer(2_i32),
+        ]);
+        // Two positive real roots => definitely unstable.
+        assert_eq!(count_positive_real_roots(poly, s, &p), 2);
+        let rh = routh_hurwitz(poly, s, &p).unwrap();
+        // First column is [1, -3, 2]; the entry -3 violates positivity.
+        let mut any_nonpos = false;
+        for &e in &rh.first_column {
+            let up = UniPoly::from_symbolic(e, s, &p).unwrap();
+            if up.eval_rational(&rug::Rational::from(0)) <= 0 {
+                any_nonpos = true;
+            }
+        }
+        assert!(any_nonpos, "positive-root instance must violate Routh");
+    }
+
+    #[test]
+    fn unsupported_non_polynomial_errors() {
+        let p = ExprPool::new();
+        let s = p.symbol("s", Domain::Real);
+        // 1/s is not polynomial in s.
+        let poly = p.add(vec![p.pow(s, p.integer(-1_i32)), p.integer(1_i32)]);
+        assert!(routh_hurwitz(poly, s, &p).is_err());
+    }
+}

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -34,6 +34,8 @@ use alkahest_core::{
     resistor as core_resistor,
     // V2-2 — Resultants and subresultant PRS
     resultant as core_resultant,
+    // Parametric Routh–Hurwitz stability conditions
+    routh_hurwitz as core_routh_hurwitz,
     // V3-3 — FOFormula / satisfiability
     satisfiable as core_satisfiable,
     sensitivity_system as core_sensitivity_system,
@@ -5853,6 +5855,59 @@ fn py_cad_lift(
     Ok(intervals.into_iter().map(core_interval_to_py).collect())
 }
 
+/// Symbolic / parametric Routh–Hurwitz stability analysis.
+///
+/// Given a characteristic polynomial ``poly`` in the analysis variable ``var``
+/// whose coefficients may be symbolic expressions in free parameters, returns a
+/// dict with:
+///
+/// - ``"degree"``: the degree of ``poly`` in ``var``;
+/// - ``"first_column"``: the Routh-array first-column entries (top to bottom) as
+///   ``Expr`` objects in the parameters;
+/// - ``"condition"``: the stability condition as a single predicate ``Expr`` — a
+///   conjunction of ``entry > 0`` over the non-trivial first-column entries.
+///
+/// For example ``s**2 + a*s + b`` yields the condition ``a > 0 ∧ b > 0`` and
+/// ``s**3 + a*s**2 + b*s + c`` yields ``a > 0 ∧ a*b - c > 0 ∧ c > 0``.
+#[pyfunction(name = "routh_hurwitz")]
+fn py_routh_hurwitz(py: Python<'_>, poly: PyRef<PyExpr>, var: PyRef<PyExpr>) -> PyResult<PyObject> {
+    let pool_py = poly.pool.clone_ref(py);
+    if !var.pool.is(&pool_py) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "routh_hurwitz expects poly and var in the same ExprPool",
+        ));
+    }
+    let rh = {
+        let bor = pool_py.borrow(py);
+        core_routh_hurwitz(poly.id, var.id, &bor.inner).map_err(cad_error_to_py)?
+    };
+    let first_column: Vec<PyObject> = rh
+        .first_column
+        .iter()
+        .map(|&id| {
+            PyExpr {
+                id,
+                pool: pool_py.clone_ref(py),
+            }
+            .into_py(py)
+        })
+        .collect();
+    let condition_id = {
+        let bor = pool_py.borrow(py);
+        rh.condition_expr(&bor.inner)
+    };
+    let condition = PyExpr {
+        id: condition_id,
+        pool: pool_py.clone_ref(py),
+    }
+    .into_py(py);
+    let d = PyDict::new_bound(py);
+    d.set_item("degree", rh.degree)?;
+    d.set_item("first_column", first_column)?;
+    d.set_item("condition", condition)?;
+    Ok(d.into_py(py))
+}
+
 // ---------------------------------------------------------------------------
 // PA-5 — Primitive registry Python bindings
 // ---------------------------------------------------------------------------
@@ -7625,6 +7680,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_decide, m)?)?;
     m.add_function(wrap_pyfunction!(py_cad_project, m)?)?;
     m.add_function(wrap_pyfunction!(py_cad_lift, m)?)?;
+    m.add_function(wrap_pyfunction!(py_routh_hurwitz, m)?)?;
     // V5-1 — Lean 4 certificate exporter
     m.add_function(wrap_pyfunction!(py_to_lean, m)?)?;
     // V5-2 — StableHLO/XLA bridge

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -164,6 +164,8 @@ from .alkahest import (  # noqa: F401
     # V2-2: Resultants and subresultant PRS
     resultant,
     round,  # symbolic round — use alkahest.round(expr)
+    # Parametric Routh–Hurwitz stability conditions
+    routh_hurwitz,
     rsolve,
     satisfiable,
     sensitivity_system,
@@ -1269,6 +1271,7 @@ __all__ = [
     # V2-13 — Differential algebra / Rosenfeld–Gröbner (groebner default feature)
     "rosenfeld_groebner",
     "round",
+    "routh_hurwitz",
     "rsolve",
     "satisfiable",
     "sensitivity_system",

--- a/tests/test_routh_hurwitz.py
+++ b/tests/test_routh_hurwitz.py
@@ -1,0 +1,76 @@
+"""Parametric Routh–Hurwitz stability conditions (pytest)."""
+
+
+def test_quadratic_parametric_condition():
+    import alkahest
+    from alkahest import ExprPool
+
+    pool = ExprPool()
+    s = pool.symbol("s")
+    a = pool.symbol("a")
+    b = pool.symbol("b")
+    # s^2 + a*s + b
+    poly = s**2 + a * s + b
+    res = alkahest.routh_hurwitz(poly, s)
+
+    assert res["degree"] == 2
+    # first column: [1, a, b]
+    assert len(res["first_column"]) == 3
+    cond = str(res["condition"])
+    # Condition is a > 0 ∧ b > 0
+    assert "a" in cond
+    assert "b" in cond
+    assert ">" in cond
+
+
+def test_cubic_parametric_condition():
+    import alkahest
+    from alkahest import ExprPool
+
+    pool = ExprPool()
+    s = pool.symbol("s")
+    a = pool.symbol("a")
+    b = pool.symbol("b")
+    c = pool.symbol("c")
+    # s^3 + a*s^2 + b*s + c -> a>0, c>0, a*b - c > 0
+    poly = s**3 + a * s**2 + b * s + c
+    res = alkahest.routh_hurwitz(poly, s)
+
+    assert res["degree"] == 3
+    cols = [str(e) for e in res["first_column"]]
+    # The middle first-column entry should encode a*b - c (textbook condition).
+    joined = " ".join(cols)
+    assert "a" in joined
+    assert "b" in joined
+    assert "c" in joined
+    cond = str(res["condition"])
+    assert cond.count(">") == 3
+
+
+def test_numeric_stable_instance_first_column_positive():
+    import alkahest
+    from alkahest import ExprPool
+
+    pool = ExprPool()
+    s = pool.symbol("s")
+    # s^3 + 2 s^2 + 3 s + 1: a=2,b=3,c=1 -> a*b - c = 5 > 0 => STABLE.
+    poly = s**3 + pool.integer(2) * s**2 + pool.integer(3) * s + pool.integer(1)
+    res = alkahest.routh_hurwitz(poly, s)
+    assert res["degree"] == 3
+    # All first-column entries are positive numeric constants.
+    vals = [float(str(e)) for e in res["first_column"]]
+    assert all(v > 0 for v in vals)
+
+
+def test_numeric_unstable_instance_violates_condition():
+    import alkahest
+    from alkahest import ExprPool
+
+    pool = ExprPool()
+    s = pool.symbol("s")
+    # s^3 + s^2 + s + 6: a*b - c = 1 - 6 = -5 < 0 => UNSTABLE.
+    poly = s**3 + s**2 + s + pool.integer(6)
+    res = alkahest.routh_hurwitz(poly, s)
+    vals = [float(str(e)) for e in res["first_column"]]
+    # At least one first-column entry is non-positive.
+    assert any(v <= 0 for v in vals)


### PR DESCRIPTION
## Summary

Implements issue #9b (parametric decide / Routh–Hurwitz): a symbolic
Routh–Hurwitz analysis (`routh_hurwitz`) that takes a characteristic
polynomial whose coefficients are *free parameters* and returns the
stability condition as a semialgebraic predicate on those parameters.

- `s² + a·s + b`         → `a > 0 ∧ b > 0`
- `s³ + a·s² + b·s + c`  → `a > 0 ∧ a·b − c > 0 ∧ c > 0`

The Routh array is built purely symbolically (no CAD lift), so it stays
cheap with many parameters; the only guard is a degree cap
(`ROUTH_MAX_DEGREE = 24`) bounding the O(n²) array size. Divided Routh
entries are reduced to their cancelled numerator via `together_parts`,
giving the clean textbook stability polynomials — valid under the
conjunction of the prior positive-pivot conditions.

## API (additive)

- Rust: `alkahest_core::routh_hurwitz`, `RouthHurwitz`, `ROUTH_MAX_DEGREE`,
  re-exported additively in `alkahest_core::stable`.
- Python: `alkahest.routh_hurwitz(poly, var)` → dict with `degree`,
  `first_column` (list of `Expr`), and `condition` (a single predicate
  `Expr`, conjunction of `> 0` atoms). Added to `__all__` (passes
  `check_api_freeze.py` as an addition).

Reuses the existing `CadError::Unsupported` variant for non-polynomial /
over-cap inputs rather than introducing a new error type.

## Scope boundary

- This adds a *dedicated* parametric stability primitive; it does **not**
  extend the general `decide` / CAD path to accept free parameters. The
  conditions are derived from the Routh first-column sign pattern (the
  standard controls criterion), not from full quantifier elimination.
- The numerator-only reduction of divided entries is correct under the
  conjunction of prior conditions (each denominator is a product of
  pivots already required positive); it is not a standalone per-entry
  equivalence.

## Tests

Rust (`alkahest-core/src/real/routh.rs`):
- parametric quadratic & cubic conditions (structure of the conjunction);
- numeric stable instance → entire first column positive;
- numeric unstable instance (`s³+s²+s+6`, `a·b−c=−5`) → a condition is
  violated;
- two-positive-root instance (`s²−3s+2`) cross-checked against
  `real_roots` (two roots > 0) and shown to violate `a > 0`;
- non-polynomial input (`1/s`) errors.

Python (`tests/test_routh_hurwitz.py`): parametric quadratic/cubic plus
numeric stable/unstable instances. (Not run locally — the shared env's
installed wheel predates this binding and rebuilding into it is out of
scope; CI builds the extension and runs them.)

## Gates run locally

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` — clean (fixed 4 `cmp_owned`
  warnings in the new tests)
- `cargo test -p alkahest-cas` — 6 new routh tests pass
- `cargo test --workspace` — 1356 + others passed, 0 failed
- `cargo build -p alkahest-py` — compiles
- `ruff check` + `ruff format --check` — clean
- `scripts/check_api_freeze.py main` — `routh_hurwitz` added (OK, additive)

### CI caveats

- `cargo-semver-checks` is not installed locally; changes are strictly
  additive (new `pub` items / re-exports), so the CI semver gate
  (`-p alkahest-cas`, baseline `origin/main`) should pass as a minor bump.
- Python tests require the extension to be rebuilt (CI does this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parametric Routh–Hurwitz symbolic stability analysis for characteristic polynomials via `alkahest.routh_hurwitz(poly, var)`, returning the first-column entries and stability condition as strict-positivity constraints.

* **Tests**
  * Added comprehensive test suite validating stability conditions for parametric and numeric polynomial instances.

* **Documentation**
  * Updated CHANGELOG with new feature entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->