### PR TITLE
feat(matrix): symbolic eigenvalues / matrix_exp over free symbols

### DIFF
--- a/alkahest-core/src/matrix/eigen.rs
+++ b/alkahest-core/src/matrix/eigen.rs
@@ -125,10 +125,95 @@ pub fn characteristic_polynomial_lambda_minus_m(
     Ok((simplify(det, pool).value, lam))
 }
 
-/// multiset of eigenvalue Expr → algebraic multiplicity  
+/// multiset of eigenvalue Expr → algebraic multiplicity
 pub fn eigenvalues(m: &Matrix, pool: &ExprPool) -> Result<Vec<(ExprId, usize)>, EigenError> {
     let (poly_e, lam) = characteristic_polynomial_lambda_minus_m(m, pool)?;
-    eigenvalues_from_char_poly(poly_e, lam, pool)
+    match eigenvalues_from_char_poly(poly_e, lam, pool) {
+        Ok(v) => Ok(v),
+        Err(EigenError::CharPolyConversion(_)) => {
+            // The characteristic polynomial has non-rational (free-symbol) coefficients,
+            // so it cannot be cleared to ℤ[λ]. For 2×2 matrices the eigenvalues are still
+            // available in closed form via the quadratic formula, fully symbolically.
+            symbolic_eigenvalues_2x2(m, pool)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Closed-form eigenvalues of a 2×2 matrix `[[a, b], [c, d]]` over arbitrary symbolic
+/// entries: roots of `λ² − (a+d)λ + (ad − bc)`. Returns the two roots
+/// `(tr ± √(tr² − 4·det)) / 2`, collapsing to a single eigenvalue of multiplicity 2
+/// when the discriminant simplifies to exactly zero.
+///
+/// This deliberately covers only the 2×2 case — higher-dimensional symbolic spectra
+/// need general radical/algebraic-number machinery and are out of scope here.
+fn symbolic_eigenvalues_2x2(
+    m: &Matrix,
+    pool: &ExprPool,
+) -> Result<Vec<(ExprId, usize)>, EigenError> {
+    if m.rows != m.cols {
+        return Err(EigenError::NonSquare);
+    }
+    if m.rows != 2 {
+        // No general symbolic spectrum for n ≥ 3 yet.
+        return Err(EigenError::UnsupportedIrreducibleDegree { degree: m.rows });
+    }
+    let a = m.get(0, 0);
+    let b = m.get(0, 1);
+    let c = m.get(1, 0);
+    let d = m.get(1, 1);
+    let neg_one = pool.integer(-1_i32);
+
+    // trace = a + d
+    let trace = simplify(pool.add(vec![a, d]), pool).value;
+    // det = a*d - b*c
+    let ad = pool.mul(vec![a, d]);
+    let bc = pool.mul(vec![b, c]);
+    let det = simplify(pool.add(vec![ad, pool.mul(vec![neg_one, bc])]), pool).value;
+
+    // discriminant = trace² - 4*det
+    let trace_sq = pool.pow(trace, pool.integer(2_i32));
+    let four_det = pool.mul(vec![pool.integer(4_i32), det]);
+    let disc = simplify(
+        pool.add(vec![trace_sq, pool.mul(vec![neg_one, four_det])]),
+        pool,
+    )
+    .value;
+
+    let half = pool.rational(rug::Integer::from(1), rug::Integer::from(2));
+
+    // Repeated root when the discriminant is exactly zero: λ = trace/2 (mult 2).
+    if expr_is_exactly_zero(pool, disc) {
+        let lam = simplify(pool.mul(vec![half, trace]), pool).value;
+        return Ok(vec![(lam, 2)]);
+    }
+
+    let sqrt_disc = simplify(pool.func("sqrt", vec![disc]), pool).value;
+    let neg_sqrt = simplify(pool.mul(vec![neg_one, sqrt_disc]), pool).value;
+    let lam_plus = simplify(
+        pool.mul(vec![
+            half,
+            simplify(pool.add(vec![trace, sqrt_disc]), pool).value,
+        ]),
+        pool,
+    )
+    .value;
+    let lam_minus = simplify(
+        pool.mul(vec![
+            half,
+            simplify(pool.add(vec![trace, neg_sqrt]), pool).value,
+        ]),
+        pool,
+    )
+    .value;
+
+    // If the two roots collapse after simplification (e.g. discriminant simplified to a
+    // perfect square that the zero-check missed), treat as a repeated eigenvalue.
+    if lam_plus == lam_minus {
+        return Ok(vec![(lam_plus, 2)]);
+    }
+    let (x, y) = order_two_roots(lam_plus, lam_minus, pool);
+    Ok(vec![(x, 1), (y, 1)])
 }
 
 /// `(value, multiplicity, column eigenvectors)`
@@ -973,6 +1058,270 @@ mod tests {
         ])
         .unwrap();
         eigenvalues(&m, &p).unwrap();
+    }
+
+    /// Complex number for numeric verification of symbolic eigenvalues.
+    #[derive(Clone, Copy)]
+    struct C {
+        re: f64,
+        im: f64,
+    }
+    impl C {
+        fn new(re: f64, im: f64) -> Self {
+            C { re, im }
+        }
+        fn add(self, o: C) -> C {
+            C::new(self.re + o.re, self.im + o.im)
+        }
+        fn mul(self, o: C) -> C {
+            C::new(
+                self.re * o.re - self.im * o.im,
+                self.re * o.im + self.im * o.re,
+            )
+        }
+        fn powi(self, n: i64) -> C {
+            if n == 0 {
+                return C::new(1.0, 0.0);
+            }
+            if n < 0 {
+                let p = self.powi(-n);
+                let den = p.re * p.re + p.im * p.im;
+                return C::new(p.re / den, -p.im / den);
+            }
+            let mut acc = C::new(1.0, 0.0);
+            for _ in 0..n {
+                acc = acc.mul(self);
+            }
+            acc
+        }
+        fn sqrt(self) -> C {
+            // Principal square root of a complex number.
+            let r = (self.re * self.re + self.im * self.im).sqrt();
+            let re = ((r + self.re) / 2.0).max(0.0).sqrt();
+            let mut im = ((r - self.re) / 2.0).max(0.0).sqrt();
+            if self.im < 0.0 {
+                im = -im;
+            }
+            C::new(re, im)
+        }
+        fn near(self, o: C) -> bool {
+            (self.re - o.re).abs() < 1e-7 && (self.im - o.im).abs() < 1e-7
+        }
+    }
+
+    /// Numerically evaluate `e` under a symbol→value map (complex), used purely to verify
+    /// closed-form symbolic eigenvalues without fighting the simplifier over nested radicals.
+    fn eval_c(e: ExprId, env: &[(ExprId, C)], pool: &ExprPool) -> C {
+        match pool.get(e) {
+            ExprData::Integer(n) => C::new(n.0.to_f64(), 0.0),
+            ExprData::Rational(r) => {
+                let (num, den) = r.0.clone().into_numer_denom();
+                C::new(num.to_f64() / den.to_f64(), 0.0)
+            }
+            ExprData::Symbol { .. } => env
+                .iter()
+                .find(|(s, _)| *s == e)
+                .map(|(_, v)| *v)
+                .unwrap_or(C::new(0.0, 0.0)),
+            ExprData::Add(args) => args
+                .iter()
+                .fold(C::new(0.0, 0.0), |acc, &a| acc.add(eval_c(a, env, pool))),
+            ExprData::Mul(args) => args
+                .iter()
+                .fold(C::new(1.0, 0.0), |acc, &a| acc.mul(eval_c(a, env, pool))),
+            ExprData::Pow { base, exp } => {
+                let b = eval_c(base, env, pool);
+                if let ExprData::Integer(n) = pool.get(exp) {
+                    b.powi(n.0.to_i64().unwrap_or(0))
+                } else if let ExprData::Rational(r) = pool.get(exp) {
+                    // handle ^(1/2) and ^(-1/2) which appear via sqrt lowering
+                    let (num, den) = r.0.clone().into_numer_denom();
+                    if den == 1 {
+                        b.powi(num.to_i64().unwrap_or(0))
+                    } else if den == 2 {
+                        let s = b.sqrt();
+                        s.powi(num.to_i64().unwrap_or(1))
+                    } else {
+                        C::new(f64::NAN, f64::NAN)
+                    }
+                } else {
+                    C::new(f64::NAN, f64::NAN)
+                }
+            }
+            ExprData::Func { name, args } if name == "sqrt" && args.len() == 1 => {
+                eval_c(args[0], env, pool).sqrt()
+            }
+            _ => C::new(f64::NAN, f64::NAN),
+        }
+    }
+
+    /// True iff every returned eigenvalue satisfies `λ² − tr·λ + det = 0` for the 2×2 `m`,
+    /// checked numerically at several random rational substitutions for the free symbols.
+    fn eigvals_satisfy_2x2_charpoly(m: &Matrix, vals: &[(ExprId, usize)], p: &ExprPool) -> bool {
+        let a = m.get(0, 0);
+        let b = m.get(0, 1);
+        let c = m.get(1, 0);
+        let d = m.get(1, 1);
+        let tr = p.add(vec![a, d]);
+        let det = p.add(vec![
+            p.mul(vec![a, d]),
+            p.mul(vec![p.integer(-1), p.mul(vec![b, c])]),
+        ]);
+        // Collect free symbols present in the matrix.
+        let mut syms: Vec<ExprId> = Vec::new();
+        for &e in m.entries() {
+            collect_symbols(e, p, &mut syms);
+        }
+        // A handful of generic substitution points (avoid trivial coincidences).
+        let points: [&[f64]; 3] = [
+            &[2.0, 3.0, 5.0, 7.0, 11.0, 13.0],
+            &[1.5, -2.0, 4.0, 0.5, -3.0, 6.0],
+            &[-1.0, 2.0, -3.0, 5.0, 1.0, -4.0],
+        ];
+        for pt in points.iter() {
+            let env: Vec<(ExprId, C)> = syms
+                .iter()
+                .enumerate()
+                .map(|(i, &s)| (s, C::new(pt[i % pt.len()], 0.0)))
+                .collect();
+            let tr_v = eval_c(tr, &env, p);
+            let det_v = eval_c(det, &env, p);
+            for (lam, _) in vals {
+                let l = eval_c(*lam, &env, p);
+                // λ² − tr·λ + det
+                let lhs = l.powi(2).add(tr_v.mul(l).mul(C::new(-1.0, 0.0))).add(det_v);
+                if !lhs.near(C::new(0.0, 0.0)) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn collect_symbols(e: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
+        match pool.get(e) {
+            ExprData::Symbol { .. } if !out.contains(&e) => {
+                out.push(e);
+            }
+            ExprData::Add(args) | ExprData::Mul(args) => {
+                for a in args.iter() {
+                    collect_symbols(*a, pool, out);
+                }
+            }
+            ExprData::Pow { base, exp } => {
+                collect_symbols(base, pool, out);
+                collect_symbols(exp, pool, out);
+            }
+            ExprData::Func { args, .. } => {
+                for a in args.iter() {
+                    collect_symbols(*a, pool, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn symbolic_eigenvalues_harmonic_oscillator() {
+        // [[0, 1], [-w^2, 0]] — undamped oscillator companion matrix.
+        // char poly: λ² + w² → eigenvalues ± w·√(-1)  (i.e. ±iw).
+        let p = pool();
+        let w = p.symbol("w", Domain::Real);
+        let zero = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let w2 = p.pow(w, p.integer(2_i32));
+        let neg_w2 = p.mul(vec![p.integer(-1_i32), w2]);
+        let m = Matrix::new(vec![vec![zero, one], vec![neg_w2, zero]]).unwrap();
+        let vals = eigenvalues(&m, &p).unwrap();
+        assert_eq!(vals.len(), 2, "two distinct eigenvalues");
+        for (_lam, mult) in &vals {
+            assert_eq!(*mult, 1);
+        }
+        // Both satisfy λ² + w² = 0 (verified numerically over the free symbol w).
+        assert!(eigvals_satisfy_2x2_charpoly(&m, &vals, &p));
+    }
+
+    #[test]
+    fn symbolic_eigenvalues_diagonal_free_symbols() {
+        // [[a, 0], [0, b]] → eigenvalues solve (λ−a)(λ−b)=0; both roots satisfy char poly.
+        let p = pool();
+        let a = p.symbol("a", Domain::Real);
+        let b = p.symbol("b", Domain::Real);
+        let zero = p.integer(0_i32);
+        let m = Matrix::new(vec![vec![a, zero], vec![zero, b]]).unwrap();
+        let vals = eigenvalues(&m, &p).unwrap();
+        assert_eq!(vals.len(), 2);
+        assert!(eigvals_satisfy_2x2_charpoly(&m, &vals, &p));
+    }
+
+    #[test]
+    fn symbolic_eigenvalues_repeated_scalar_matrix() {
+        // [[k, 0], [0, k]] → single eigenvalue k with algebraic multiplicity 2.
+        let p = pool();
+        let k = p.symbol("k", Domain::Real);
+        let zero = p.integer(0_i32);
+        let m = Matrix::new(vec![vec![k, zero], vec![zero, k]]).unwrap();
+        let vals = eigenvalues(&m, &p).unwrap();
+        assert_eq!(vals.len(), 1);
+        assert_eq!(vals[0].1, 2);
+        assert_eq!(vals[0].0, k);
+    }
+
+    #[test]
+    fn symbolic_eigenvalues_satisfy_char_poly() {
+        // General symbolic 2×2 — every returned eigenvalue must satisfy λ²−tr·λ+det = 0.
+        let p = pool();
+        let a = p.symbol("a", Domain::Real);
+        let b = p.symbol("b", Domain::Real);
+        let c = p.symbol("c", Domain::Real);
+        let d = p.symbol("d", Domain::Real);
+        let m = Matrix::new(vec![vec![a, b], vec![c, d]]).unwrap();
+        let vals = eigenvalues(&m, &p).unwrap();
+        assert_eq!(vals.len(), 2);
+        assert!(
+            eigvals_satisfy_2x2_charpoly(&m, &vals, &p),
+            "eigenvalues do not satisfy the characteristic polynomial"
+        );
+    }
+
+    #[test]
+    fn symbolic_eigenvectors_satisfy_definition() {
+        // For a symbolic 2×2 with distinct eigenvalues, each returned eigenvector v must
+        // satisfy A·v = λ·v. Verified numerically over random rational substitutions of the
+        // free symbol, since the closed-form vectors involve nested radicals.
+        let p = pool();
+        let w = p.symbol("w", Domain::Real);
+        let zero = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let w2 = p.pow(w, p.integer(2_i32));
+        let neg_w2 = p.mul(vec![p.integer(-1_i32), w2]);
+        // [[0, 1], [-w², 0]] — undamped oscillator companion matrix.
+        let m = Matrix::new(vec![vec![zero, one], vec![neg_w2, zero]]).unwrap();
+        let triples = eigenvectors(&m, &p).unwrap();
+        assert_eq!(triples.len(), 2, "two distinct symbolic eigenpairs");
+
+        let a = m.get(0, 0);
+        let b = m.get(0, 1);
+        let c = m.get(1, 0);
+        let d = m.get(1, 1);
+        let points: [f64; 3] = [2.0, 3.5, 5.0];
+        for (lambda, _mult, vecs) in &triples {
+            assert!(!vecs.is_empty(), "eigenvalue must have ≥1 eigenvector");
+            for v in vecs {
+                let v0 = v.get(0, 0);
+                let v1 = v.get(1, 0);
+                for &wv in points.iter() {
+                    let env = [(w, C::new(wv, 0.0))];
+                    let lam = eval_c(*lambda, &env, &p);
+                    let x0 = eval_c(v0, &env, &p);
+                    let x1 = eval_c(v1, &env, &p);
+                    let av0 = eval_c(a, &env, &p).mul(x0).add(eval_c(b, &env, &p).mul(x1));
+                    let av1 = eval_c(c, &env, &p).mul(x0).add(eval_c(d, &env, &p).mul(x1));
+                    assert!(av0.near(lam.mul(x0)), "row0: A·v ≠ λ·v at w={wv}");
+                    assert!(av1.near(lam.mul(x1)), "row1: A·v ≠ λ·v at w={wv}");
+                }
+            }
+        }
     }
 
     #[test]

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -974,6 +974,13 @@ pub fn matrix_exponential(m: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearA
     if m.rows != m.cols {
         return Err(LinearAlgebraError::NonSquare);
     }
+    // A diagonal matrix (possibly with free-symbol entries) exponentiates entrywise:
+    // exp(diag(d₀, …, dₙ)) = diag(e^{d₀}, …, e^{dₙ}). Short-circuit so symbolic diagonal /
+    // decoupled state matrices succeed without invoking the eigenvector machinery, whose
+    // radical eigenvalues can collapse the eigenbasis for these cases.
+    if is_diagonal(m, pool) {
+        return diagonal_matrix_exp(m, pool);
+    }
     if let Ok((p, d)) = eigen::diagonalize(m, pool) {
         let exp_d = diagonal_matrix_exp(&d, pool)?;
         let inv_p = matrix_inverse(&p, pool).map_err(|_| LinearAlgebraError::SingularTransform)?;
@@ -990,6 +997,21 @@ pub fn matrix_exponential(m: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearA
         .map_err(|_| LinearAlgebraError::KernelFailed)?
         .mul(&inv_p, pool)
         .map_err(|_| LinearAlgebraError::KernelFailed)
+}
+
+/// True iff every off-diagonal entry simplifies to exactly zero.
+fn is_diagonal(m: &Matrix, pool: &ExprPool) -> bool {
+    if m.rows != m.cols {
+        return false;
+    }
+    for r in 0..m.rows {
+        for c in 0..m.cols {
+            if r != c && !expr_is_zero(pool, simplify(m.get(r, c), pool).value) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 fn diagonal_matrix_exp(d: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
@@ -1388,6 +1410,66 @@ mod tests {
         assert_eq!(expm.cols, 2);
         assert!(!expr_is_zero(&p, expm.get(0, 0)));
         assert!(!expr_is_zero(&p, expm.get(1, 1)));
+    }
+
+    #[test]
+    fn matrix_exp_symbolic_diagonal() {
+        // exp(diag(a, b)) = diag(e^a, e^b) for free symbols a ≠ b.
+        let p = pool();
+        let a = p.symbol("a", Domain::Real);
+        let b = p.symbol("b", Domain::Real);
+        let z = p.integer(0_i32);
+        let m = Matrix::new(vec![vec![a, z], vec![z, b]]).unwrap();
+        let expm = matrix_exponential(&m, &p).unwrap().simplify_entries(&p);
+        let ea = simplify(p.func("exp", vec![a]), &p).value;
+        let eb = simplify(p.func("exp", vec![b]), &p).value;
+        let expected = Matrix::new(vec![vec![ea, z], vec![z, eb]]).unwrap();
+        assert!(
+            eigen::matrix_eq_simplified(&expm, &expected, &p),
+            "got {}",
+            expm.display(&p)
+        );
+    }
+
+    #[test]
+    fn matrix_exp_symbolic_oscillator_has_closed_form() {
+        // The headline probe: a state matrix with a FREE SYMBOL now yields e^{A} in closed
+        // form (previously errored "entries must simplify to rationals"). A = [[0,1],[-w²,0]].
+        let p = pool();
+        let w = p.symbol("w", Domain::Real);
+        let z = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let w2 = p.pow(w, p.integer(2_i32));
+        let neg_w2 = p.mul(vec![p.integer(-1_i32), w2]);
+        let a = Matrix::new(vec![vec![z, one], vec![neg_w2, z]]).unwrap();
+        let expm = matrix_exponential(&a, &p).expect("symbolic e^A closed form");
+        assert_eq!(expm.rows, 2);
+        assert_eq!(expm.cols, 2);
+        // Every entry depends on w (via exp(±√(−4w²)/2)) — i.e. genuinely symbolic.
+        let s = expm.display(&p);
+        assert!(s.contains("exp"), "expected exponential entries: {s}");
+        assert!(s.contains('w'), "expected dependence on free symbol w: {s}");
+    }
+
+    #[test]
+    fn matrix_exp_symbolic_state_matrix_t_zero_is_identity() {
+        // For a symbolic state matrix A(parameter), exp(0·A) must be the identity.
+        // Build A = [[0, 1], [-k, 0]] (oscillator with symbolic stiffness k) scaled by 0.
+        let p = pool();
+        let k = p.symbol("k", Domain::Real);
+        let z = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let neg_k = p.mul(vec![p.integer(-1_i32), k]);
+        let a = Matrix::new(vec![vec![z, one], vec![neg_k, z]]).unwrap();
+        let zero_a = a.scale(z, &p);
+        let expm = matrix_exponential(&zero_a, &p)
+            .unwrap()
+            .simplify_entries(&p);
+        assert!(
+            eigen::matrix_eq_simplified(&expm, &Matrix::identity(2, &p), &p),
+            "exp(0) should be I, got {}",
+            expm.display(&p)
+        );
     }
 
     #[test]

--- a/tests/test_eigen_v217.py
+++ b/tests/test_eigen_v217.py
@@ -109,6 +109,101 @@ def test_similar_integer_diagonal_random3x3():
         assert sum(len(vs) for (_, _, vs) in triples) == 3
 
 
+def test_symbolic_eigenvals_2x2_free_symbol():
+    """Issue #3 — eigenvalues of a 2×2 matrix with a FREE SYMBOL (no longer requires
+    rational entries). [[0, 1], [-w², 0]] is the undamped-oscillator companion matrix."""
+    pool = alkahest.ExprPool()
+    w = pool.symbol("w")
+    z = pool.integer(0)
+    one = pool.integer(1)
+    neg_w2 = -(w**2)
+    m = alkahest.Matrix([[z, one], [neg_w2, z]])
+    vals = m.eigenvals()
+    assert len(vals) == 2
+    # Every eigenvalue must satisfy the characteristic polynomial λ² + w² = 0.
+    sw = sympy.Symbol("w")
+    for ev, mult in vals.items():
+        assert mult == 1
+        lam = _expr_to_sympy(ev)
+        assert sympy.simplify(lam**2 + sw**2) == 0
+
+
+def test_symbolic_eigenvals_general_2x2():
+    """A fully symbolic 2×2 [[a, b], [c, d]] returns radical eigenvalues that satisfy
+    λ² − (a+d)λ + (ad − bc) = 0."""
+    pool = alkahest.ExprPool()
+    a = pool.symbol("a")
+    b = pool.symbol("b")
+    c = pool.symbol("c")
+    d = pool.symbol("d")
+    m = alkahest.Matrix([[a, b], [c, d]])
+    vals = m.eigenvals()
+    assert len(vals) == 2
+    sa, sb, sc, sd = sympy.symbols("a b c d")
+    tr, det = sa + sd, sa * sd - sb * sc
+    for ev, _mult in vals.items():
+        lam = _expr_to_sympy(ev)
+        assert sympy.simplify(lam**2 - tr * lam + det) == 0
+
+
+def test_symbolic_eigenvects_2x2_free_symbol():
+    """Issue #3 — eigenvectors of a 2×2 matrix with a FREE SYMBOL. Each eigenpair (λ, v)
+    must satisfy A·v = λ·v, checked symbolically via SymPy on [[0, 1], [-w², 0]]."""
+    pool = alkahest.ExprPool()
+    w = pool.symbol("w")
+    z = pool.integer(0)
+    one = pool.integer(1)
+    neg_w2 = -(w**2)
+    m = alkahest.Matrix([[z, one], [neg_w2, z]])
+    triples = m.eigenvects()
+    assert len(triples) == 2
+    sw = sympy.Symbol("w")
+    sa = sympy.Matrix([[0, 1], [-(sw**2), 0]])
+    for ev, _mult, vecs in triples:
+        lam = _expr_to_sympy(ev)
+        assert len(vecs) >= 1
+        for v in vecs:
+            col = v.to_list()
+            sv = sympy.Matrix([[_expr_to_sympy(col[i][0])] for i in range(len(col))])
+            # A·v − λ·v must vanish identically in w.
+            assert sympy.simplify(sa * sv - lam * sv) == sympy.zeros(2, 1)
+
+
+def test_symbolic_matrix_exp_diagonal():
+    """exp(diag(a, b)) = diag(e^a, e^b) for free symbols — previously errored."""
+    pool = alkahest.ExprPool()
+    a = pool.symbol("a")
+    b = pool.symbol("b")
+    z = pool.integer(0)
+    m = alkahest.Matrix([[a, z], [z, b]])
+    expm = m.matrix_exp().simplify().to_list()
+    sa, sb = sympy.symbols("a b")
+    assert sympy.simplify(_expr_to_sympy(expm[0][0]) - sympy.exp(sa)) == 0
+    assert sympy.simplify(_expr_to_sympy(expm[1][1]) - sympy.exp(sb)) == 0
+    assert sympy.simplify(_expr_to_sympy(expm[0][1])) == 0
+    assert sympy.simplify(_expr_to_sympy(expm[1][0])) == 0
+
+
+def test_symbolic_matrix_exp_oscillator_state_matrix():
+    """The headline probe: e^{A} for a state matrix A = [[0,1],[-w²,0]] with a free symbol
+    now returns a closed form instead of erroring on rationals. Verify numerically at w=2
+    against SymPy's matrix exponential."""
+    pool = alkahest.ExprPool()
+    w = pool.symbol("w")
+    z = pool.integer(0)
+    one = pool.integer(1)
+    neg_w2 = -(w**2)
+    a = alkahest.Matrix([[z, one], [neg_w2, z]])
+    expm = a.matrix_exp().to_list()
+    sw = sympy.Symbol("w")
+    got = sympy.Matrix([[_expr_to_sympy(expm[i][j]) for j in range(2)] for i in range(2)])
+    want = sympy.exp(sympy.Matrix([[0, 1], [-(sw**2), 0]]))
+    diff = sympy.simplify((got - want).subs(sw, 2))
+    for i in range(2):
+        for j in range(2):
+            assert abs(complex(diff[i, j])) < 1e-9, (i, j, diff[i, j])
+
+
 def test_rotation_diagonalizes():
     pool = alkahest.ExprPool()
     z = pool.integer(0)


### PR DESCRIPTION
## Summary

Fixes #3. `eigenvalues` / `eigenvectors` / `matrix_exp` now work on 2×2 matrices with free symbols (e.g. `e^{At}` for a symbolic state matrix). Previously these errored with *"entries must simplify to rationals"* whenever the characteristic polynomial couldn't be cleared to ℤ[λ].

## What changed

**`alkahest-core/src/matrix/eigen.rs`**
- `eigenvalues()` falls back to a closed-form 2×2 solver on `CharPolyConversion` (the error raised when coefficients are non-rational). The new private `symbolic_eigenvalues_2x2` returns the quadratic-formula roots `(tr ± √(tr² − 4·det)) / 2` fully symbolically, collapsing to a single eigenvalue of multiplicity 2 when the discriminant is exactly zero or the two roots coincide after simplification.
- `eigenvectors()` inherits symbolic support transitively — the existing `kernel_2x2` / `gauss_nullspace_expr` paths handle the radical eigenvalues, so no change was needed there.

**`alkahest-core/src/matrix/linear_algebra.rs`**
- `matrix_exponential()` short-circuits diagonal matrices (including free-symbol diagonals) to entrywise `exp`, avoiding the eigenbasis collapse that radical eigenvalues can cause for decoupled / diagonal state matrices. Non-diagonal symbolic matrices still go through `diagonalize()`.

## Tests

Rust unit tests (in-module):
- symbolic eigenvalues satisfy the characteristic polynomial `λ² − tr·λ + det = 0`
- symbolic eigenvectors satisfy `A·v = λ·v`
- diagonal / repeated-scalar / `exp(0·A) = I` cases
- numeric verification over several random rational substitutions of the free symbols (avoids fighting the simplifier over nested radicals)

Python tests (`tests/test_eigen_v217.py`) cross-check eigenvalues, eigenvectors, and `matrix_exp` against SymPy.

## Prior-agent work vs added here

Already present in the worktree: the `symbolic_eigenvalues_2x2` fallback, the `matrix_exponential` diagonal short-circuit, and Rust/Python tests for eigenvalues + matrix_exp.

Added in this session: a Rust unit test and a Python test for **symbolic eigenvectors** (`A·v = λ·v`), since #3 names `eigenvectors` explicitly and it was previously only exercised transitively via `matrix_exp`. Verified the full build/clippy/test gates pass and tidied formatting.

## Scope boundary

- Symbolic spectra are supported for **2×2 only**. For `n ≥ 3` the behavior is unchanged: `eigenvalues` still returns `UnsupportedIrreducibleDegree`, because general n-dimensional symbolic spectra need radical/algebraic-number machinery that is out of scope here.
- The `matrix_exp` diagonal short-circuit benefits any-size symbolic *diagonal* matrices; general (non-diagonal) symbolic `matrix_exp` is effectively 2×2-bound via the eigenvalue path.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo test -p alkahest-cas --lib` — 1358 passed, 0 failed, 4 ignored
- `cargo test --workspace` — all green
- `cargo build -p alkahest-py` — compiles
- `ruff check` + `ruff format` on `tests/test_eigen_v217.py` — clean
- Semver: only additive **private** helpers added; no public/released signature or enum changed. No `pub` items added to the diff. Reused the existing `CharPolyConversion` / `UnsupportedIrreducibleDegree` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved eigenvalue computation with enhanced symbolic matrix handling and fallback mechanisms for robust results
  * Added fast-path optimization for diagonal matrix exponential calculations

* **Tests**
  * Extended test coverage for symbolic eigenvalue, eigenvector, and matrix exponential operations with comprehensive validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->