### PR TITLE
feat(parse): desugar reciprocal trig/hyperbolic functions (sec, csc, cot, sech, csch, coth)

### DIFF
--- a/alkahest-core/src/parse.rs
+++ b/alkahest-core/src/parse.rs
@@ -105,7 +105,7 @@ impl AlkahestError for ParseError {
         match self.code_idx {
             1 => Some("only ASCII arithmetic expressions are supported"),
             2 => Some("check parentheses and operator placement"),
-            _ => Some("use a known function: sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, atan2, exp, log, sqrt, abs, sign, floor, ceil, round, erf, erfc, gamma"),
+            _ => Some("use a known function: sin, cos, tan, sec, csc, cot, sinh, cosh, tanh, sech, csch, coth, asin, acos, atan, atan2, exp, log, sqrt, abs, sign, floor, ceil, round, erf, erfc, gamma"),
         }
     }
 
@@ -285,10 +285,37 @@ const KNOWN_FUNCS: &[&str] = &[
     "EllipticE",
     "EllipticF",
     "EllipticPi",
+    // Reciprocal trig / hyperbolic functions.  These are *desugared* in
+    // `parse_funcall` to their elementary reciprocal definitions (e.g.
+    // `sec(x) → cos(x)^(-1)`); no `sec`/`csc`/… node ever enters the pool.
+    "sec",
+    "csc",
+    "cot",
+    "sech",
+    "csch",
+    "coth",
 ];
 
 fn is_known_func(name: &str) -> bool {
     KNOWN_FUNCS.contains(&name)
+}
+
+/// If `name` is a reciprocal trig/hyperbolic function, return the elementary
+/// primitive it is the reciprocal of (`sec → cos`, `csc → sin`, `cot → tan`,
+/// and the hyperbolic analogues).  These are desugared to `base(x)^(-1)` at
+/// parse time so every downstream stage (diff, eval, integrate, simplify)
+/// operates purely on the existing `cos`/`sin`/`tan`/`cosh`/`sinh`/`tanh`
+/// primitives.
+fn reciprocal_base(name: &str) -> Option<&'static str> {
+    match name {
+        "sec" => Some("cos"),
+        "csc" => Some("sin"),
+        "cot" => Some("tan"),
+        "sech" => Some("cosh"),
+        "csch" => Some("sinh"),
+        "coth" => Some("tanh"),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -481,6 +508,23 @@ impl<'a> Parser<'a> {
             }
         }
         self.expect(&Tok::RParen)?;
+
+        // Desugar reciprocal trig/hyperbolic calls to `base(x)^(-1)` so no
+        // `sec`/`csc`/… node ever reaches the pool.  Only the single-argument
+        // form is meaningful; any other arity is a syntax error, mirroring how
+        // the other unary functions reject extra arguments downstream.
+        if let Some(base) = reciprocal_base(name) {
+            if args.len() != 1 {
+                return Err(ParseError::syntax(
+                    format!("{name} takes exactly 1 argument, got {}", args.len()),
+                    (offset, offset + name.len()),
+                ));
+            }
+            let inner = self.pool.func(base, args);
+            let neg1 = self.pool.integer(-1_i64);
+            return Ok(self.pool.pow(inner, neg1));
+        }
+
         Ok(self.pool.func(name, args))
     }
 }
@@ -498,6 +542,12 @@ impl<'a> Parser<'a> {
 /// `sin`, `cos`, `tan`, `sinh`, `cosh`, `tanh`, `asin`, `acos`, `atan`,
 /// `atan2`, `exp`, `log`, `sqrt`, `abs`, `sign`, `floor`, `ceil`, `round`,
 /// `erf`, `erfc`, `gamma`.
+///
+/// The reciprocal trig/hyperbolic functions `sec`, `csc`, `cot`, `sech`,
+/// `csch`, and `coth` are also accepted; they are desugared at parse time to
+/// their elementary reciprocal definitions (`sec(x) → cos(x)^(-1)`,
+/// `csc(x) → sin(x)^(-1)`, `cot(x) → tan(x)^(-1)`, and the hyperbolic
+/// analogues), so no dedicated node for them exists in the pool.
 ///
 /// `symbols` maps identifier names to pre-existing [`ExprId`]s.  Identifiers
 /// not in the map are interned as new `Domain::Real` symbols and added to the
@@ -655,5 +705,99 @@ mod tests {
         let mut syms = HashMap::new();
         parse("y + 1", &pool, &mut syms).unwrap();
         assert!(syms.contains_key("y"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Reciprocal trig / hyperbolic desugaring
+    // -----------------------------------------------------------------------
+
+    /// Each reciprocal function desugars to `base(x)^(-1)`; no `sec`/`csc`/…
+    /// node is ever produced.
+    #[test]
+    fn reciprocal_trig_desugar_structure() {
+        let cases = [
+            ("sec(x)", "cos"),
+            ("csc(x)", "sin"),
+            ("cot(x)", "tan"),
+            ("sech(x)", "cosh"),
+            ("csch(x)", "sinh"),
+            ("coth(x)", "tanh"),
+        ];
+        for (src, base) in cases {
+            let (pool, x, mut syms) = pool_and_x();
+            let e = parse(src, &pool, &mut syms).unwrap();
+            let neg1 = pool.integer(-1i64);
+            let expected = pool.pow(pool.func(base, vec![x]), neg1);
+            assert_eq!(e, expected, "{src} should desugar to {base}(x)^(-1)");
+        }
+    }
+
+    /// The desugared argument is threaded through, not just a bare symbol.
+    #[test]
+    fn reciprocal_trig_desugar_with_expression_arg() {
+        let (pool, x, mut syms) = pool_and_x();
+        let e = parse("sec(2*x)", &pool, &mut syms).unwrap();
+        let two_x = pool.mul(vec![pool.integer(2i64), x]);
+        let neg1 = pool.integer(-1i64);
+        let expected = pool.pow(pool.func("cos", vec![two_x]), neg1);
+        assert_eq!(e, expected);
+    }
+
+    /// Differentiating a reciprocal function succeeds (routes through the
+    /// existing `cos`/`sin`/… diff rules via the `^(-1)` desugar).
+    #[test]
+    fn reciprocal_trig_diff_closes() {
+        let (pool, x, mut syms) = pool_and_x();
+        let e = parse("sec(x)", &pool, &mut syms).unwrap();
+        let d = crate::diff::diff(e, x, &pool);
+        assert!(d.is_ok(), "d/dx sec(x) should differentiate");
+    }
+
+    /// `∫ sec(x)² dx` closes (== tan(x)) and routes through the reciprocal-square
+    /// trig rule: `sec(x)^2` parses to `(cos(x)^(-1))^2`, which `simplify`
+    /// canonicalizes to `cos(x)^(-2)` — the exact shape the integrator's
+    /// `∫ 1/cos² = tan` rule matches.  Like every integrand, it must be in
+    /// canonical (simplified) form; the integrator's internal soundness gate then
+    /// guarantees `d/dx(result) == sec(x)²`.
+    #[test]
+    fn reciprocal_trig_integrate_sec_squared() {
+        let (pool, x, mut syms) = pool_and_x();
+        let e =
+            crate::simplify::simplify(parse("sec(x)^2", &pool, &mut syms).unwrap(), &pool).value;
+        let r = crate::integrate::integrate(e, x, &pool);
+        assert!(r.is_ok(), "∫ sec(x)² dx should close (== tan(x))");
+    }
+
+    /// `∫ csc(x)² dx` closes (== −cot(x)); `csc(x)^2` simplifies to `sin(x)^(-2)`.
+    #[test]
+    fn reciprocal_trig_integrate_csc_squared() {
+        let (pool, x, mut syms) = pool_and_x();
+        let e =
+            crate::simplify::simplify(parse("csc(x)^2", &pool, &mut syms).unwrap(), &pool).value;
+        let r = crate::integrate::integrate(e, x, &pool);
+        assert!(r.is_ok(), "∫ csc(x)² dx should close");
+    }
+
+    /// A reciprocal function called with the wrong arity is a syntax error.
+    #[test]
+    fn reciprocal_trig_wrong_arity_errors() {
+        let (pool, _x, mut syms) = pool_and_x();
+        let err = parse("sec(x, x)", &pool, &mut syms).unwrap_err();
+        assert_eq!(err.code(), "E-PARSE-002");
+    }
+
+    /// Regression: the base trig/hyperbolic functions and `atan2` still parse
+    /// to plain `Func` nodes (unaffected by the desugar).
+    #[test]
+    fn base_trig_functions_unchanged() {
+        for src in [
+            "sin(x)", "cos(x)", "tan(x)", "sinh(x)", "cosh(x)", "tanh(x)",
+        ] {
+            let (pool, _x, mut syms) = pool_and_x();
+            parse(src, &pool, &mut syms).unwrap();
+        }
+        let pool = ExprPool::new();
+        let mut syms = HashMap::new();
+        parse("atan2(1, 2)", &pool, &mut syms).unwrap();
     }
 }

--- a/python/alkahest/_parse.py
+++ b/python/alkahest/_parse.py
@@ -61,8 +61,29 @@ _FUNC_NAMES = frozenset(
         "erf",
         "erfc",
         "gamma",
+        # Reciprocal trig / hyperbolic functions (desugared to base(x) ** -1).
+        "sec",
+        "csc",
+        "cot",
+        "sech",
+        "csch",
+        "coth",
     }
 )
+
+# Reciprocal trig / hyperbolic functions map to the elementary primitive they
+# are the reciprocal of; a call ``f(x)`` is desugared to ``base(x) ** -1`` so no
+# dedicated ``sec``/``csc``/… node is ever built and everything downstream
+# (diff, eval, integrate, simplify) runs on the existing cos/sin/tan/cosh/sinh/
+# tanh primitives.  Mirrors the desugar in ``alkahest-core/src/parse.rs``.
+_RECIPROCAL_BASE: dict[str, str] = {
+    "sec": "cos",
+    "csc": "sin",
+    "cot": "tan",
+    "sech": "cosh",
+    "csch": "sinh",
+    "coth": "tanh",
+}
 
 # ---------------------------------------------------------------------------
 # Lexer
@@ -304,12 +325,25 @@ def _apply_func(name: str, args: list, offset: int):
         "EllipticF": _ak.elliptic_f,
         "EllipticPi": _ak.elliptic_pi,
     }
+    # Desugar reciprocal trig/hyperbolic calls to ``base(x) ** -1``.  Only the
+    # single-argument form is meaningful; any other arity is a parse error.
+    base = _RECIPROCAL_BASE.get(name)
+    if base is not None:
+        if len(args) != 1:
+            raise ParseError(
+                f"{name} takes exactly 1 argument, got {len(args)}",
+                span=(offset, offset + len(name)),
+            )
+        return _funcs[base](*args) ** -1
+
     fn = _funcs.get(name)
     if fn is None:
         raise ParseError(
             f"unknown function {name!r}",
             span=(offset, offset + len(name)),
-            remediation=f"known functions: {', '.join(sorted(_funcs))}",
+            remediation=(
+                f"known functions: {', '.join(sorted(set(_funcs) | set(_RECIPROCAL_BASE)))}"
+            ),
         )
     return fn(*args)
 

--- a/tests/test_reciprocal_trig_parse.py
+++ b/tests/test_reciprocal_trig_parse.py
@@ -1,0 +1,93 @@
+"""Parsing of the reciprocal trig / hyperbolic functions.
+
+``sec``, ``csc``, ``cot``, ``sech``, ``csch`` and ``coth`` are not primitives;
+the parser desugars each single-argument call ``f(x)`` to its elementary
+reciprocal definition ``base(x) ** -1`` (``sec -> cos``, ``csc -> sin``,
+``cot -> tan`` and the hyperbolic analogues).  No dedicated ``sec``/``csc``/…
+node is ever built, so differentiation, evaluation, integration and
+simplification all run on the existing cos/sin/tan/cosh/sinh/tanh primitives.
+"""
+
+import alkahest
+import pytest
+from alkahest.alkahest import (
+    ExprPool,
+    cos,
+    cosh,
+    diff,
+    integrate,
+    simplify,
+    sin,
+    sinh,
+    tan,
+    tanh,
+)
+from alkahest.exceptions import ParseError
+
+_CASES = [
+    ("sec", cos),
+    ("csc", sin),
+    ("cot", tan),
+    ("sech", cosh),
+    ("csch", sinh),
+    ("coth", tanh),
+]
+
+
+@pytest.mark.parametrize(("name", "base"), _CASES)
+def test_reciprocal_desugars_to_base_pow_neg_one(name, base):
+    """``f(x)`` parses to exactly ``base(x) ** -1`` (hash-consed equality)."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    parsed = alkahest.parse(f"{name}(x)", pool, {"x": x})
+    expected = base(x) ** -1
+    assert parsed == expected, f"{name}(x) should desugar to {base.__name__}(x)^-1"
+
+
+def test_reciprocal_desugars_with_expression_argument():
+    """The argument is threaded through the desugar, not just a bare symbol."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    parsed = alkahest.parse("sec(2*x)", pool, {"x": x})
+    assert parsed == cos(2 * x) ** -1
+
+
+def test_base_trig_and_atan2_still_parse():
+    """Regression: base trig/hyperbolic funcs and atan2 are unaffected."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    syms = {"x": x}
+    for src in ("sin(x)", "cos(x)", "tan(x)", "sinh(x)", "cosh(x)", "tanh(x)"):
+        alkahest.parse(src, pool, syms)
+    assert alkahest.parse("atan2(1, 2)", pool, syms) is not None
+
+
+def test_wrong_arity_is_parse_error():
+    """A reciprocal function with the wrong arity raises ParseError."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    with pytest.raises(ParseError):
+        alkahest.parse("sec(x, x)", pool, {"x": x})
+
+
+def test_diff_of_sec_closes():
+    """d/dx sec(x) differentiates via the cos(x)^-1 desugar."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    e = alkahest.parse("sec(x)", pool, {"x": x})
+    d = diff(e, x)
+    assert d.value is not None
+
+
+def test_integrate_sec_squared_equals_tan():
+    """∫ sec(x)² dx = tan(x).
+
+    ``sec(x)^2`` parses to ``(cos(x)^-1)^2``; ``simplify`` canonicalises it to
+    ``cos(x)^-2`` (the shape the reciprocal-square trig rule matches).  The
+    integrator's soundness gate then guarantees d/dx(result) == sec(x)².
+    """
+    pool = ExprPool()
+    x = pool.symbol("x")
+    integrand = simplify(alkahest.parse("sec(x)^2", pool, {"x": x})).value
+    result = integrate(integrand, x)
+    assert result.value is not None


### PR DESCRIPTION
## What

Adds parser support for the six reciprocal trig/hyperbolic functions that previously failed with `unknown function '...'` (E-PARSE-003):

`sec`, `csc`, `cot`, `sech`, `csch`, `coth`.

## Why

`sin/cos/tan/sinh/cosh/tanh` parsed fine, but their reciprocals didn't. Rather than register six new primitives (each needing numeric/ball evaluators, forward/reverse diff rules, MLIR lowering, Lean tags), they are **desugared in the parser** to their elementary reciprocal definitions. No `sec`/`csc`/… node ever enters the pool, so diff, eval, integrate, and simplify all work for free via the existing primitives.

## Desugarings (single-argument only)

| input | desugars to | | input | desugars to |
|---|---|---|---|---|
| `sec(x)` | `cos(x)^(-1)` | | `sech(x)` | `cosh(x)^(-1)` |
| `csc(x)` | `sin(x)^(-1)` | | `csch(x)` | `sinh(x)^(-1)` |
| `cot(x)` | `tan(x)^(-1)` | | `coth(x)` | `tanh(x)^(-1)` |

A wrong arity raises a parse error. `atan2` (2-arg) and the base trig/hyperbolic functions are untouched.

The change is mirrored in both the Rust parser (`alkahest-core/src/parse.rs`) and the pure-Python parser (`python/alkahest/_parse.py`), which are parallel implementations.

## Downstream behavior

- `d/dx sec(x)` differentiates (via `cos(x)^(-1)`).
- `sec(x)^2` parses to `(cos(x)^-1)^2`; after `simplify` it canonicalizes to `cos(x)^(-2)`, which the reciprocal-square trig rule (PR #190) integrates: `∫ sec(x)² dx = tan(x)`, `∫ csc(x)² dx = −cot(x)`. Like every integrand, it must be in canonical (simplified) form; the integrator's soundness gate then guarantees `d/dx(result) == integrand`.

## Tests

- Rust (`parse.rs`): desugar structure for all six, expression-argument threading, `diff` of `sec(x)`, `∫ sec² / ∫ csc²` closing, wrong-arity error, and a regression that base trig + `atan2` are unchanged.
- Python (`tests/test_reciprocal_trig_parse.py`, ruff-formatted): parse/desugar for all six, diff, and the `∫ sec²` integral.

## Additive-only

Only **private** items change: names added to the private `const KNOWN_FUNCS`, a new private helper, and new logic/match arms in the private `parse_funcall`. No public type/fn/field shape is altered, so `cargo semver-checks` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reciprocal trig and hyperbolic functions like `sec`, `csc`, `cot`, `sech`, `csch`, and `coth`.
  * These functions now parse correctly in expressions and are handled automatically during parsing.

* **Bug Fixes**
  * Improved error messages for unknown functions to include the newly supported names.
  * Added validation so reciprocal functions require exactly one argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->