### PR TITLE
feat(api): add agent capability and verification contract

### DIFF
--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1538,6 +1538,54 @@ impl PyDerivedResult {
         ))
     }
 
+    /// Machine-readable evidence metadata for this derived result.
+    ///
+    /// A generated Lean source artifact is not a statement that Lean has
+    /// checked it.  External verification must be performed separately.
+    #[getter]
+    fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
+        let metadata = PyDict::new_bound(py);
+        let has_certificate = !self.raw.log.is_empty();
+        metadata
+            .set_item(
+                "status",
+                if has_certificate {
+                    "certificate_available"
+                } else {
+                    "unverified"
+                },
+            )
+            .unwrap();
+        metadata
+            .set_item(
+                "evidence",
+                if has_certificate {
+                    "derivation_log"
+                } else {
+                    "none"
+                },
+            )
+            .unwrap();
+        metadata.set_item("externally_verified", false).unwrap();
+        metadata
+            .set_item(
+                "artifact_format",
+                if has_certificate { Some("lean4") } else { None },
+            )
+            .unwrap();
+
+        let side_conditions = PyList::empty_bound(py);
+        for (_, _, _, conditions) in &self.steps_raw {
+            for condition in conditions {
+                side_conditions.append(condition).unwrap();
+            }
+        }
+        metadata
+            .set_item("side_conditions", side_conditions)
+            .unwrap();
+        metadata
+    }
+
     fn __repr__(&self, py: Python<'_>) -> String {
         format!("DerivedResult(value={})", self.value.__repr__(py))
     }
@@ -4853,6 +4901,28 @@ fn py_compile_expr(
 #[pyo3(name = "jit_is_available")]
 fn py_jit_is_available() -> bool {
     core_jit_available()
+}
+
+/// Return the Cargo feature flags compiled into this extension.
+///
+/// This reports the installed artifact, not the project defaults or the
+/// availability of Python fallback functions.
+#[pyfunction]
+#[pyo3(name = "_build_features")]
+fn py_build_features() -> std::collections::HashMap<String, bool> {
+    [
+        ("egraph", cfg!(feature = "egraph")),
+        ("groebner", cfg!(feature = "groebner")),
+        ("jit", cfg!(feature = "jit")),
+        ("cranelift", cfg!(feature = "cranelift")),
+        ("parallel", cfg!(feature = "parallel")),
+        ("numpy", cfg!(feature = "numpy")),
+        ("cuda", cfg!(feature = "cuda")),
+        ("groebner_cuda", cfg!(feature = "groebner-cuda")),
+    ]
+    .into_iter()
+    .map(|(name, enabled)| (name.to_string(), enabled))
+    .collect()
 }
 
 /// Evaluate a symbolic expression numerically using the interpreter.
@@ -8202,6 +8272,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_compile_expr, m)?)?;
     m.add_function(wrap_pyfunction!(py_eval_expr, m)?)?;
     m.add_function(wrap_pyfunction!(py_jit_is_available, m)?)?;
+    m.add_function(wrap_pyfunction!(py_build_features, m)?)?;
     m.add_class::<PyCompiledFn>()?;
     m.add_class::<PyCompileCache>()?;
     // Phase 22 — Ball arithmetic

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -168,14 +168,22 @@ Every top-level operation returns a `DerivedResult`:
 |-----------|------|-------------|
 | `.value` | `Expr` | The result expression |
 | `.steps` | `list[dict]` | Rewrite log; each step has `"rule"`, `"before"`, `"after"` keys |
-| `.certificate` | `str \| None` | Lean 4 `.lean` source (Mathlib proof file), when steps are certifiable |
+| `.verification` | `dict` | Evidence status, emitted artifact format, external-check status, and side conditions |
+| `.certificate` | `str \| None` | Generated Lean 4 `.lean` source; generation is not Lean proof checking |
 | `to_lean(result)` | `str` | Same as `.certificate`; also accepts `Expr` (runs `simplify` first) |
 
 ```python
+caps = ak.capabilities()
+if not caps["groebner"]:
+    # Select a non-Gröbner strategy before calling solve().
+    pass
+
 result = diff(sin(x**2), x)
 print(result.value)   # 2*x*cos(x^2)
 print(result.steps)   # list of rewrite-rule dicts
-print(result.certificate)  # or: to_lean(result)
+evidence = result.verification
+if evidence["status"] == "certificate_available":
+    print(result.certificate)  # Lean source; check it with Lean separately
 ```
 
 ---

--- a/docs/mdbook/src/derivations.md
+++ b/docs/mdbook/src/derivations.md
@@ -21,9 +21,8 @@ dr = diff(sin(x**2), x)
 |---|---|---|
 | `.value` | `Expr` | The result expression |
 | `.steps` | `list[dict]` | Ordered list of rewrite steps |
-| `.certificate` | `str \| None` | Lean 4 proof term, if exported |
-| `.assumptions` | `list` | Side conditions that were verified |
-| `.warnings` | `list[str]` | Non-fatal issues (e.g. branch cut warning) |
+| `.verification` | `dict` | Evidence status, artifact format, external-check status, and side conditions |
+| `.certificate` | `str \| None` | Generated Lean 4 source, when a derivation log exists |
 
 ## Rewrite steps
 
@@ -34,8 +33,7 @@ Each step in `.steps` is a dict with:
 | `rule` | Rule name (string) |
 | `before` | Expression before the rewrite |
 | `after` | Expression after the rewrite |
-| `subst` | Variable substitution, if any |
-| `side_condition` | Side condition that was checked |
+| `side_conditions` | Side conditions recorded for the rewrite |
 
 ```python
 for step in dr.steps:
@@ -51,7 +49,15 @@ A side condition is a predicate that must hold for a rewrite to be sound:
 - `Integer(n)` — `n` must be an integer (e.g. for some power rules)
 - `BranchCut(f, x)` — records that `f` may have a branch cut at `x`
 
-Side conditions propagate into the derivation log as `SideCondition` entries. When a side condition is not provable from the symbol's domain, the step is still recorded but flagged. Lean export only produces a verifiable proof for steps where all side conditions are proved.
+Side conditions propagate into the derivation log as `SideCondition` entries and are aggregated in `dr.verification["side_conditions"]`. A generated Lean source artifact is evidence that can be checked; it is not a claim that the project has checked the artifact with Lean.
+
+```python
+evidence = dr.verification
+if evidence["status"] == "certificate_available":
+    assert not evidence["externally_verified"]
+    lean_source = dr.certificate
+    # Invoke a pinned Lean/Mathlib checker before treating this as lean_checked.
+```
 
 ## Inspecting a derivation
 
@@ -65,8 +71,8 @@ for step in dr.steps[:5]:
     before = step['before']
     after = step['after']
     print(f"  [{rule}]: {before} → {after}")
-    if step.get('side_condition'):
-        print(f"    side_condition: {step['side_condition']}")
+    for condition in step["side_conditions"]:
+        print(f"    side condition: {condition}")
 ```
 
 ## DerivationLog overhead

--- a/docs/sphinx/api/core.rst
+++ b/docs/sphinx/api/core.rst
@@ -118,20 +118,19 @@ DerivedResult
       - ``rule`` (str) — rule name
       - ``before`` (str) — expression before the rewrite
       - ``after`` (str) — expression after the rewrite
-      - ``subst`` (dict, optional) — variable substitution
-      - ``side_condition`` (str, optional) — side condition checked
+      - ``side_conditions`` (list[str]) — conditions recorded for the rewrite
 
    .. attribute:: certificate
 
-      Lean 4 proof term as a string, or ``None`` if not exported.
+      Generated Lean 4 source as a string, or ``None`` for an empty derivation
+      log. Generation is not proof checking.
 
-   .. attribute:: assumptions
+   .. attribute:: verification
 
-      List of side conditions that were verified during derivation.
-
-   .. attribute:: warnings
-
-      List of non-fatal warning strings (e.g. branch-cut warnings).
+      A mapping with the evidence ``status``, ``artifact_format``,
+      ``externally_verified`` flag, and recorded ``side_conditions``. A result
+      with ``status == "certificate_available"`` has generated Lean source but
+      has not been checked by Lean in this execution.
 
    Example::
 

--- a/examples/agent_workflow.py
+++ b/examples/agent_workflow.py
@@ -33,6 +33,10 @@ print("=" * 62)
 print("1. Expression Construction")
 print("=" * 62)
 
+capabilities = ak.capabilities()
+print(f"agent contract: v{capabilities['contract_version']}")
+print(f"build features: {capabilities['features']}")
+
 pool = ExprPool()
 x = pool.symbol("x")
 y = pool.symbol("y")
@@ -63,6 +67,7 @@ print("=" * 62)
 
 r = simplify(x + pool.integer(0))
 print(f"x + 0              → {r.value}  ({len(r.steps)} steps)")
+print(f"verification status: {r.verification['status']}")
 
 r = simplify_trig(sin(x)**2 + cos(x)**2)
 print(f"sin²+cos²          → {r.value}")

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -95,6 +95,7 @@ from .alkahest import (  # noqa: F401
     UniPolyFactorization,
     # V2-7: Polynomial factorization
     UniPolyFactorModP,
+    _build_features,
     _derived_result_context_simplify,
     abs,  # symbolic abs — use alkahest.abs(expr); shadows Python builtin within this module
     acos,
@@ -1082,16 +1083,21 @@ if "solve" not in dir():
 
 
 def capabilities() -> dict:
-    """Return a dict of feature capability flags for this alkahest build.
+    """Return the versioned agent contract for this installed build.
 
-    Agents should call this once at session start to know which APIs are
-    available before attempting to use them.
+    Agents should call this once at session start before selecting an
+    operation. The ``features`` mapping is authoritative for the installed
+    extension; it does not infer availability from project defaults or Python
+    fallback functions.
 
     Returns
     -------
     dict
-        Keys: ``"groebner"``, ``"jit"``, ``"egraph"``, ``"parallel"``.
-        Each value is a :class:`bool`.
+        ``contract_version`` identifies this schema. ``groebner``, ``jit``,
+        ``egraph``, and ``parallel`` are compatibility feature booleans.
+        ``features`` contains installed Cargo features, ``primitives`` is
+        deterministic per-primitive implementation coverage, and
+        ``verification`` describes available evidence artifacts and checkers.
 
     Example
     -------
@@ -1102,17 +1108,29 @@ def capabilities() -> dict:
     >>> if not caps["jit"]:
     ...     print("JIT unavailable; compile_expr will run in interpreter mode")
     """
-    import sys as _sys
-
-    _mod = _sys.modules[__name__]
-    # groebner: solve must be the real Rust binding, not our stub above
-    _solve = getattr(_mod, "solve", None)
-    _groebner_real = _solve is not None and getattr(_solve, "__module__", None) != __name__
+    features = _build_features()
+    primitive_rows = PrimitiveRegistry.default_registry().coverage_report()
+    primitive_rows.sort(key=lambda row: row["name"])
     return {
-        "groebner": _groebner_real,
-        "jit": bool(jit_is_available()),
-        "egraph": bool(HAS_EGRAPH),
-        "parallel": hasattr(_mod, "simplify_par") and callable(_mod.simplify_par),
+        "contract_version": 1,
+        # Compatibility keys: report what this extension was compiled with,
+        # even where a Python-level fallback exists.
+        "groebner": features["groebner"],
+        "jit": features["jit"] or features["cranelift"],
+        "egraph": features["egraph"],
+        "parallel": features["parallel"],
+        "features": features,
+        "primitives": primitive_rows,
+        "verification": {
+            "statuses": [
+                "lean_checked",
+                "certificate_available",
+                "exactly_verified",
+                "unverified",
+            ],
+            "artifacts": {"lean4_source": True},
+            "checkers": {"lean4": "external"},
+        },
     }
 
 

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -1,0 +1,71 @@
+"""Machine-readable agent contract tests."""
+
+import alkahest
+
+
+def test_capabilities_reports_installed_build_features():
+    caps = alkahest.capabilities()
+
+    assert caps["contract_version"] == 1
+    assert {"groebner", "jit", "egraph", "parallel", "features", "primitives", "verification"} <= (
+        caps.keys()
+    )
+    assert {
+        "egraph",
+        "groebner",
+        "jit",
+        "cranelift",
+        "parallel",
+        "numpy",
+        "cuda",
+        "groebner_cuda",
+    } == caps["features"].keys()
+    assert caps["groebner"] is caps["features"]["groebner"]
+    assert caps["egraph"] is caps["features"]["egraph"]
+    assert caps["parallel"] is caps["features"]["parallel"]
+    assert caps["jit"] is (caps["features"]["jit"] or caps["features"]["cranelift"])
+    assert caps["jit"] is alkahest.jit_is_available()
+
+
+def test_capabilities_primitive_rows_are_deterministic():
+    primitives = alkahest.capabilities()["primitives"]
+
+    assert primitives
+    assert [row["name"] for row in primitives] == sorted(row["name"] for row in primitives)
+    assert {
+        "name",
+        "simplify",
+        "diff_forward",
+        "diff_reverse",
+        "numeric_f64",
+        "numeric_ball",
+        "lower_llvm",
+        "lean_theorem",
+    } == primitives[0].keys()
+
+
+def test_capabilities_describes_verification_boundary():
+    verification = alkahest.capabilities()["verification"]
+
+    assert verification["statuses"] == [
+        "lean_checked",
+        "certificate_available",
+        "exactly_verified",
+        "unverified",
+    ]
+    assert verification["artifacts"] == {"lean4_source": True}
+    assert verification["checkers"] == {"lean4": "external"}
+
+
+def test_derived_result_labels_emitted_lean_source_as_unchecked_evidence():
+    pool = alkahest.ExprPool()
+    x = pool.symbol("x")
+    result = alkahest.simplify(x + pool.integer(0))
+
+    verification = result.verification
+    assert verification["status"] == "certificate_available"
+    assert verification["evidence"] == "derivation_log"
+    assert verification["artifact_format"] == "lean4"
+    assert verification["externally_verified"] is False
+    assert isinstance(verification["side_conditions"], list)
+    assert isinstance(result.certificate, str)


### PR DESCRIPTION
## Summary
- expose versioned capabilities from the extension's actual compiled feature set, including deterministic primitive coverage
- add explicit DerivedResult verification evidence that distinguishes generated Lean source from externally checked proof
- document the agent workflow and cover the schema with regression tests

## Test plan
- [x] cargo fmt --all
- [x] cargo test -p alkahest-py
- [x] cargo clippy -p alkahest-py -- -D warnings
- [x] uv run pytest tests/test_agent_contract.py tests/test_api.py
- [x] uv run ruff check python/alkahest/__init__.py tests/test_agent_contract.py
- [x] uv run ruff format --check python/alkahest/__init__.py tests/test_agent_contract.py
- [ ] Full example-file Ruff check (blocked by 13 pre-existing violations in examples/agent_workflow.py)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a machine-readable `verification` summary on derived results, including evidence/status, artifact format, external verification flag, and aggregated `side_conditions`.
  * Enhanced runtime `capabilities()` to report a versioned contract with deterministic feature/primitive coverage and verification metadata.
* **Documentation**
  * Updated derivation and API docs to describe the new `verification` field, revised `certificate` wording (generated Lean 4 source, not proof checking), and the `side_conditions` step schema.
  * Refreshed examples to display verification and capability information.
* **Tests**
  * Added/extended contract tests for capabilities, verification fields, and deterministic output ordering/schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->