### PR TITLE
ci(lean): reject admitted generated certificates

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -7,14 +7,34 @@ on:
     branches: [main]
     paths:
       - 'alkahest-core/src/lean/**'
+      - 'alkahest-core/src/deriv/**'
+      - 'alkahest-core/src/diff/**'
+      - 'alkahest-core/src/simplify/**'
+      - 'alkahest-core/src/kernel/**'
+      - 'alkahest-py/src/lib.rs'
       - 'tests/lean_corpus.py'
+      - 'tests/test_smoke.py'
+      - 'lean/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'alkahest-py/Cargo.toml'
       - '.github/workflows/lean.yml'
   pull_request:
     branches: [main]
     paths:
       - 'alkahest-core/src/lean/**'
+      - 'alkahest-core/src/deriv/**'
+      - 'alkahest-core/src/diff/**'
+      - 'alkahest-core/src/simplify/**'
+      - 'alkahest-core/src/kernel/**'
+      - 'alkahest-py/src/lib.rs'
       - 'tests/lean_corpus.py'
+      - 'tests/test_smoke.py'
       - 'lean/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'alkahest-py/Cargo.toml'
+      - '.github/workflows/lean.yml'
 
 jobs:
   lean-verify:
@@ -37,7 +57,7 @@ jobs:
           path: |
             ~/.elan
             lean/.lake
-          key: lean-${{ runner.os }}-${{ hashFiles('lean/lean-toolchain', 'lean/lakefile.lean') }}-v1
+          key: lean-${{ runner.os }}-${{ hashFiles('lean/lean-toolchain', 'lean/lakefile.lean', 'lean/lake-manifest.json') }}-v2
           restore-keys: |
             lean-${{ runner.os }}-
 
@@ -68,12 +88,24 @@ jobs:
           lake update
           lake exe cache get
 
-      - name: Verify proofs with Lean
+      - name: Verify proofs with Lean without admissions
         run: |
           cd lean
           for f in /tmp/lean_proofs/*.lean; do
             fname=$(basename "$f")
             echo "Verifying $fname..."
-            lake env lean "$f" || { echo "FAILED: $fname"; exit 1; }
+            if grep -Eq '\b(sorry|admit|axiom)\b' "$f"; then
+              echo "FAILED: $fname contains an admission"
+              exit 1
+            fi
+            lake env lean -DwarningAsError=true "$f" || { echo "FAILED: $fname"; exit 1; }
           done
-          echo "All Lean proofs verified."
+          echo "All generated Lean proofs verified without admissions."
+
+      - name: Upload generated Lean proofs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated-lean-proofs
+          path: /tmp/lean_proofs
+          if-no-files-found: ignore

--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -69,7 +69,7 @@ fn diff_rule_to_tactic(rule_name: &str) -> &'static str {
     match rule_name {
         "diff_identity" => "by simp [deriv_id]",
         "diff_const" => "by simp [deriv_const]",
-        "diff_univariate_poly" => "by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]; ring",
+        "diff_univariate_poly" => "by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]",
         "sum_rule" => "by simp [deriv_add]; ring",
         "product_rule" => "by simp [deriv_mul]; ring",
         "power_rule" | "power_rule_n1" => "by simp [deriv_pow, deriv_mul]; ring",
@@ -548,8 +548,8 @@ mod tests {
             "expected deriv_pow tactic, got: {lean}"
         );
         assert!(
-            lean.contains("; ring"),
-            "expected ring to close mul-order goals, got: {lean}"
+            !lean.contains("sorry"),
+            "polynomial derivative certificate must not use an admission: {lean}"
         );
         assert!(
             !lean.contains("= (((x : ℝ)) ^ (2 : ℕ) * (3 : ℝ)) :=") || lean.contains("deriv"),

--- a/docs/mdbook/src/lean-certs.md
+++ b/docs/mdbook/src/lean-certs.md
@@ -1,14 +1,25 @@
 # Lean certificates
 
-Alkahest can export machine-checkable Lean 4 proofs for a subset of computations.
+Alkahest can emit Lean 4 source for derivations. Generated source becomes a
+machine-checked proof only after it typechecks with the pinned Lean/Mathlib
+toolchain and without admitted placeholders.
 
 ## Three levels of evidence
 
 **Derivation logs** — always on, always cheap. Records every rewrite rule applied, with rule name and arguments. Human-readable; machine-parseable; forms the basis for Lean export.
 
-**Lean certificate export** — for computations expressible as sequences of rewrites tagged with Lean theorem names. The library emits a `.lean` file containing a proof term. Lean checks it independently.
+**Lean certificate export** — for computations expressible as sequences of
+rewrites tagged with Lean theorem names. The library emits a `.lean` file
+containing a proof term. Emission makes a certificate *available*; it does not
+by itself mean Lean has checked the source.
 
-**Algorithmic certificates** — for operations where rewrite sequences do not work (polynomial factoring, integration by the Risch algorithm). The library emits a verifiable witness instead. For factoring, the witness is the claimed factorization, which Lean verifies by multiplying out.
+In the agent contract, `certificate_available` has this same meaning. Only a
+corpus artifact compiled by pinned Lean/Mathlib without admissions can be
+described as `lean_checked`.
+
+**Algorithmic certificates** — planned evidence for operations where rewrite
+sequences do not work. Do not treat a derivation log as an independently
+verified witness.
 
 ## Theorem mapping
 
@@ -55,35 +66,40 @@ theorem alkahest_diff_sin_sq (x : ℝ) :
   exact (Real.hasDerivAt_sin _).comp x h1
 ```
 
-## Lean CI
+## Strict Lean CI
 
-The CI pipeline (`.github/workflows/lean.yml`) runs on every change to `lean/`-tagged files:
+The CI pipeline (`.github/workflows/lean.yml`) generates a deliberately small,
+strict corpus of basic arithmetic rewrites and `d/dx x³`. Every corpus entry
+must have the expected non-empty derivation log, must contain no `sorry`,
+`admit`, or `axiom`, and must typecheck with warnings treated as errors. The
+pinned Lean 4.9 compiler does not provide a `--no-sorries` command-line flag,
+so the source admission check is explicit in both the generator and CI.
 
 1. Generates proof files via `tests/lean_corpus.py`
-2. Compiles them with the `lean` compiler (with Mathlib cached)
-3. Fails the build if any proof does not typecheck
+2. Compiles them with the pinned Lean/Mathlib toolchain (with Mathlib cached)
+3. Fails the build if a proof contains an admission or does not typecheck
 
 ## Coverage
 
-Lean export works for computations that decompose into the tagged primitive set. Operations that currently produce certificates:
+The strict CI corpus currently covers:
 
-- Polynomial differentiation (all degrees)
-- Trigonometric differentiation (`sin`, `cos`, `tan`, and chain compositions)
-- Exponential and logarithm differentiation
-- Basic arithmetic rewrites (`add_zero`, `mul_one`, `mul_comm`, etc.)
+- Basic arithmetic rewrites (`add_zero`, `mul_one`, `mul_zero`, constant
+  folding, and `pow_one`)
+- The polynomial differentiation fast path for `d/dx x³`
 
-Operations that use algorithmic certificates (witness-based):
+Other exports are generated source, not CI-qualified Lean proofs. In
+particular, non-polynomial differentiation, conditional logarithm/power
+rewrites, integration, limits, and unsupported expression forms can require
+side conditions or currently use a placeholder tactic. They must remain
+unverified until their proof encoding and strict corpus coverage are added.
 
-- Polynomial factoring — the claimed factorization is verified by `ring_nf` in Lean
-- Polynomial GCD — verified by showing `gcd` divides both inputs and is a linear combination
+Planned algorithmic certificates include:
 
-Operations without Lean certificates (Lean theorem not yet mapped, or algorithm not expressible as rewrites):
-
-- Integration by the Risch algorithm
-- E-graph extraction steps
-
-**Upcoming (v2.0):** Deeper Mathlib coverage including limits (`Filter.Tendsto`), series (`HasSum`), and real algebraic geometry (`Polynomial.roots`).
+- Polynomial factoring
+- Polynomial GCD
 
 ## Side conditions in proofs
 
-Side conditions (domain constraints, branch cut restrictions) are propagated into the emitted Lean proof as hypotheses. A certificate that depends on `x > 0` will include `hx : 0 < x` as an assumption in the proof term. This makes the trust boundary explicit: the certificate is only verifiable when the side conditions hold.
+Side conditions (domain constraints and branch-cut restrictions) are recorded in
+the derivation log. They are not yet translated into Lean hypotheses by the
+exporter, so conditional rewrites are excluded from the strict corpus.

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -2,8 +2,8 @@
 """
 Lean corpus generator — V5-8.
 
-Generates .lean proof files for a curated set of algebraic identities
-and writes them to the output directory. Used by the Lean CI job.
+Generates a strict, no-admission Lean proof corpus for a curated set of
+deterministic derivations. Used by the Lean CI job.
 
 Usage::
 
@@ -19,29 +19,62 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import alkahest
 
-IDENTITIES = [
-    # (description, expr_builder)
-    ("add_zero", lambda pool: pool.symbol("x") + pool.integer(0)),
-    ("mul_one", lambda pool: pool.symbol("x") * pool.integer(1)),
-    ("mul_zero", lambda pool: pool.symbol("x") * pool.integer(0)),
-    ("const_fold_2_plus_3", lambda pool: pool.integer(2) + pool.integer(3)),
-    ("const_fold_3_times_4", lambda pool: pool.integer(3) * pool.integer(4)),
-    ("pow_one", lambda pool: pool.symbol("x") ** 1),
+STRICT_CASES = [
+    # (name, expected_rule, DerivedResult builder)
     (
-        "sin_neg_x",
-        lambda pool: pool.func("sin", [pool.integer(-1) * pool.symbol("x")]),
+        "add_zero",
+        "add_zero",
+        lambda pool: alkahest.simplify(pool.symbol("x") + pool.integer(0)),
     ),
     (
-        "cos_neg_x",
-        lambda pool: pool.func("cos", [pool.integer(-1) * pool.symbol("x")]),
+        "mul_one",
+        "mul_one",
+        lambda pool: alkahest.simplify(pool.symbol("x") * pool.integer(1)),
+    ),
+    (
+        "mul_zero",
+        "mul_zero",
+        lambda pool: alkahest.simplify(pool.symbol("x") * pool.integer(0)),
+    ),
+    (
+        "const_fold_2_plus_3",
+        "const_fold",
+        lambda pool: alkahest.simplify(pool.integer(2) + pool.integer(3)),
+    ),
+    (
+        "const_fold_3_times_4",
+        "const_fold",
+        lambda pool: alkahest.simplify(pool.integer(3) * pool.integer(4)),
+    ),
+    (
+        "pow_one",
+        "pow_one",
+        lambda pool: alkahest.simplify(pool.symbol("x") ** 1),
+    ),
+    (
+        "diff_x_cubed",
+        "diff_univariate_poly",
+        lambda pool: alkahest.diff(pool.symbol("x") ** 3, pool.symbol("x")),
     ),
 ]
 
+FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")
 
-def generate_proof(name: str, expr_builder, pool) -> str:
-    """Generate a Lean proof for one identity."""
-    expr = expr_builder(pool)
-    return alkahest.to_lean(expr)
+
+def generate_proof(name: str, expected_rule: str, result_builder, pool) -> str:
+    """Generate one strict Lean proof from a non-empty expected derivation."""
+    result = result_builder(pool)
+    rules = [step["rule"] for step in result.steps]
+    if not rules:
+        raise ValueError(f"{name}: derivation log is empty")
+    if expected_rule not in rules:
+        raise ValueError(f"{name}: expected rule {expected_rule!r}, got {rules!r}")
+
+    lean_src = alkahest.to_lean(result)
+    for token in FORBIDDEN_TOKENS:
+        if token in lean_src:
+            raise ValueError(f"{name}: generated Lean source contains {token!r}")
+    return lean_src
 
 
 def main():
@@ -53,9 +86,9 @@ def main():
 
     pool = alkahest.ExprPool()
     success = 0
-    for name, builder in IDENTITIES:
+    for name, expected_rule, builder in STRICT_CASES:
         try:
-            lean_src = generate_proof(name, builder, pool)
+            lean_src = generate_proof(name, expected_rule, builder, pool)
             out_path = os.path.join(args.output, f"{name}.lean")
             with open(out_path, "w") as f:
                 f.write(lean_src)
@@ -64,8 +97,8 @@ def main():
         except Exception as e:
             print(f"ERROR generating {name}: {e}", file=sys.stderr)
 
-    print(f"\n{success}/{len(IDENTITIES)} proofs generated in {args.output}")
-    return 0 if success == len(IDENTITIES) else 1
+    print(f"\n{success}/{len(STRICT_CASES)} strict proofs generated in {args.output}")
+    return 0 if success == len(STRICT_CASES) else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -294,6 +294,9 @@ def test_lean_diff_export():
     assert "deriv (fun" in lean
     assert "deriv_pow" in lean
     assert "MeasureTheory" not in lean
+    assert "sorry" not in lean
+    assert "admit" not in lean
+    assert any(step["rule"] == "diff_univariate_poly" for step in result.steps)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make the generated Lean corpus require non-empty, expected derivations and reject admitted source
- typecheck the strict arithmetic and polynomial-derivative corpus with warnings treated as errors, and upload artifacts on CI failure
- document the distinction between generated Lean source and strict corpus validation

The pinned Lean 4.9 compiler does not implement `--no-sorries`; CI therefore rejects `sorry`, `admit`, and `axiom` explicitly before typechecking. The documentation terminology complements #196's agent verification metadata.

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy -p alkahest-cas -- -D warnings
- [x] cargo test -p alkahest-cas lean::tests
- [x] uv run pytest tests/test_smoke.py -k lean
- [x] uv run ruff check tests/lean_corpus.py tests/test_smoke.py
- [x] uv run ruff format --check tests/lean_corpus.py tests/test_smoke.py
- [x] Generate and typecheck all seven strict corpus files with pinned Lean 4.9 and `-DwarningAsError=true`


Made with [Cursor](https://cursor.com)