### PR TITLE
feat(integrate): Coates' algorithm — genus≥2 hyperelliptic log output

### DIFF
--- a/alkahest-core/src/integrate/algebraic/coates.rs
+++ b/alkahest-core/src/integrate/algebraic/coates.rs
@@ -1,0 +1,531 @@
+//! Coates' algorithm (hyperelliptic case): construct a function `u` on the curve
+//! `y² = a(x)` with a prescribed **principal** divisor `D`.
+//!
+//! For `∫ B(x)·√a dx` on a genus ≥ 2 hyperelliptic curve whose residue divisor
+//! `δ` is torsion of order `N` ([`super::jacobian_torsion`] decides this), the
+//! integral is elementary and equals `g + (1/N)·log(u)` where `u ∈ ℚ(x)(y)` has
+//! `div(u) = N·δ` (a principal divisor).  Emitting the log part therefore needs
+//! a **constructive** step — the decision procedure only certifies principality.
+//!
+//! Davenport's presentation of Coates' algorithm (COATES + INTEGRAL_BASIS_ and
+//! NORMAL_BASIS_REDUCTION) builds a basis for the space of functions with poles
+//! bounded by a divisor and then imposes the zeros.  For the hyperelliptic case
+//! `n = 2` we use the equivalent — and much more direct — **Cantor/Mumford**
+//! realisation: a principal divisor on `y² = F(X)` (monic, odd degree) is the
+//! divisor of a product of the elementary functions `(Y − v(X))` and `(X − α)`
+//! that appear as Cantor's reduction and the hyperelliptic involution act on the
+//! Mumford representation.  Concretely we fold the divisor into the Jacobian one
+//! place at a time, keeping the running class **reduced** (Cantor) and tracking
+//! the realising function; when the total divisor is principal the running class
+//! collapses to the identity and the accumulated function is `u`.
+//!
+//! # Invariant
+//!
+//! Throughout, `(u, v)` is a semi-reduced Mumford pair (`v² ≡ F (mod u)`) and
+//! `ans` a function on the curve with
+//!
+//! ```text
+//!     T_partial  =  div(u, v)  +  div(ans)
+//! ```
+//!
+//! where `T_partial` is the sum of the divisor units processed so far and
+//! `div(u, v) = Σ_{roots α of u} (α, v(α)) − deg(u)·∞`.  When every unit of the
+//! (principal) target `T` has been folded in, `[T] = 0`, so the reduced running
+//! class is the identity `(1, 0)` and `div(ans) = T`.  The result is returned as
+//! a symbolic function of `x` and `√a`; **its correctness is additionally gated
+//! numerically** at the call site (`d/dx F = integrand`), so a construction that
+//! ever produced a wrong `u` would be declined rather than emitted.
+//!
+//! Scope: `n = 2`, `a` squarefree of **odd** degree `2g+1` (imaginary model, a
+//! single place at infinity).  Even-degree (real) models and `n > 2` return
+//! `None` (the caller then declines soundly).
+
+use rug::{Integer, Rational};
+
+use super::super::risch::poly_rde::{
+    degree, poly_add, poly_mul, poly_scale, qpoly_to_expr, trim, QPoly,
+};
+use super::super::risch::rational_rde::{poly_divrem, poly_monic, poly_sub};
+use crate::kernel::{ExprId, ExprPool};
+
+/// A finite place `(x, y)` of `y² = a(x)` with an integer multiplicity.
+#[derive(Clone, Debug)]
+pub(crate) struct CoatesPlace {
+    pub x: Rational,
+    /// Sheet value: `y² = a(x)`.  `y = 0` marks a branch (ramified) place.
+    pub y: Rational,
+    pub coeff: Integer,
+}
+
+// ---------------------------------------------------------------------------
+// Small ℚ[x] helpers
+// ---------------------------------------------------------------------------
+
+fn q_is_zero(p: &QPoly) -> bool {
+    degree(p) < 0
+}
+
+fn poly_rem(a: &QPoly, b: &QPoly) -> QPoly {
+    trim(poly_divrem(a, b).1)
+}
+
+fn poly_eval(p: &QPoly, x: &Rational) -> Rational {
+    let mut acc = Rational::from(0);
+    for c in p.iter().rev() {
+        acc = acc * x + c;
+    }
+    acc
+}
+
+/// `r^e` for a rational base and (possibly negative) integer exponent.
+fn pow_rat(r: &Rational, e: i64) -> Rational {
+    let mut acc = Rational::from(1);
+    if e >= 0 {
+        for _ in 0..e {
+            acc *= r;
+        }
+        acc
+    } else {
+        for _ in 0..(-e) {
+            acc *= r;
+        }
+        Rational::from(1) / acc
+    }
+}
+
+/// Substitute `X = lc·x` into `p(X)`, returning `p(lc·x)` as a polynomial in `x`.
+fn subst_lc(p: &QPoly, lc: &Rational) -> QPoly {
+    let mut out = p.clone();
+    let mut s = Rational::from(1);
+    for c in out.iter_mut() {
+        *c *= &s;
+        s *= lc;
+    }
+    trim(out)
+}
+
+/// Linear factor `X − α`.
+fn linear(alpha: &Rational) -> QPoly {
+    trim(vec![-alpha.clone(), Rational::from(1)])
+}
+
+// ---------------------------------------------------------------------------
+// The running state: reduced Mumford class + tracked realising function.
+// ---------------------------------------------------------------------------
+
+/// `ans = (num_x(X) / den_x(X)) · Π_j (Y − yfac_j(X))`.  Only the numerator ever
+/// carries the algebraic generator `Y`, so `ans ∈ ℚ(X)[Y]`.
+struct Coates<'a> {
+    f: &'a QPoly, // monic curve, deg 2g+1
+    g: usize,
+    u: QPoly,
+    v: QPoly,
+    num_x: QPoly,
+    den_x: QPoly,
+    yfac: Vec<QPoly>,
+}
+
+impl<'a> Coates<'a> {
+    fn new(f: &'a QPoly, g: usize) -> Self {
+        Coates {
+            f,
+            g,
+            u: vec![Rational::from(1)],
+            v: vec![],
+            num_x: vec![Rational::from(1)],
+            den_x: vec![Rational::from(1)],
+            yfac: Vec::new(),
+        }
+    }
+
+    /// Cantor reduction with function tracking: while `deg u > g`, replace
+    /// `(u, v)` by the reduced `(w, −v mod w)` and multiply `ans` by
+    /// `(Y − v)/w`, which keeps `T_partial = div(u,v) + div(ans)` invariant
+    /// because `div(u_old, v_old) = div(w, −v mod w) + div((Y − v_old)/w)`.
+    fn reduce(&mut self) -> Option<()> {
+        while degree(&self.u) > self.g as i64 {
+            let v2 = poly_mul(&self.v, &self.v);
+            let num = poly_sub(self.f, &v2);
+            let (w, r) = poly_divrem(&num, &self.u);
+            if !q_is_zero(&r) {
+                return None; // not semi-reduced — should not happen
+            }
+            let w = poly_monic(&w);
+            // ans *= (Y − v)/w
+            self.yfac.push(self.v.clone());
+            self.den_x = poly_mul(&self.den_x, &w);
+            // step
+            let nv = poly_scale(&self.v, &Rational::from(-1));
+            let vp = if degree(&w) <= 0 {
+                vec![]
+            } else {
+                poly_rem(&nv, &w)
+            };
+            self.u = w;
+            self.v = vp;
+        }
+        Some(())
+    }
+
+    /// Append a point `(α, β)` to the Mumford pair, increasing its multiplicity
+    /// there by one: `u ← u·(X−α)`, `v ← v + u_old·t` with `t` chosen so the
+    /// pair stays semi-reduced.  Requires `β² = F(α)`.  (α may already be a root
+    /// of `u` on the *same* sheet — a multiplicity bump.)
+    fn mumford_append(&mut self, alpha: &Rational, beta: &Rational) -> Option<()> {
+        let u_old = self.u.clone();
+        let ua = poly_eval(&u_old, alpha);
+        let t = if ua != 0 {
+            // v(α) + u(α)·t = β
+            (beta.clone() - poly_eval(&self.v, alpha)) / ua
+        } else {
+            // α is a root of u with v(α)=β (same sheet).  Bump multiplicity:
+            // q = (v²−F)/u, t = −q(α)/(2β).  (β ≠ 0 here — branch points never
+            // reach this path.)
+            if *beta == 0 {
+                return None;
+            }
+            let v2 = poly_mul(&self.v, &self.v);
+            let num = poly_sub(&v2, self.f);
+            let (q, r) = poly_divrem(&num, &u_old);
+            if !q_is_zero(&r) {
+                return None;
+            }
+            -poly_eval(&q, alpha) / (Rational::from(2) * beta)
+        };
+        self.u = poly_mul(&u_old, &linear(alpha));
+        self.v = trim(poly_add(&self.v, &poly_scale(&u_old, &t)));
+        Some(())
+    }
+
+    /// Remove one copy of the point `(α, v(α))` from the Mumford pair.
+    fn mumford_remove(&mut self, alpha: &Rational) {
+        let (q, _r) = poly_divrem(&self.u, &linear(alpha));
+        self.u = poly_monic(&trim(q));
+        self.v = if degree(&self.u) <= 0 {
+            vec![]
+        } else {
+            poly_rem(&self.v, &self.u)
+        };
+    }
+
+    /// Fold in `+[(α, β) − ∞]` (one unit).  Handles the three configurations:
+    /// append (α not a root), same-sheet multiplicity bump, and opposite-sheet
+    /// (or branch) cancellation `(α,β)+(α,−β) = div(X−α)`.
+    fn add_point(&mut self, alpha: &Rational, beta: &Rational) -> Option<()> {
+        let on_u = degree(&self.u) >= 0 && poly_eval(&self.u, alpha) == 0;
+        if on_u {
+            let vat = poly_eval(&self.v, alpha);
+            if *beta != 0 && vat == *beta {
+                // same sheet → bump multiplicity
+                self.mumford_append(alpha, beta)?;
+                self.reduce()?;
+            } else {
+                // opposite sheet, or branch pair → cancel, ans *= (X−α)
+                self.mumford_remove(alpha);
+                self.num_x = poly_mul(&self.num_x, &linear(alpha));
+            }
+        } else {
+            self.mumford_append(alpha, beta)?;
+            self.reduce()?;
+        }
+        Some(())
+    }
+
+    /// Fold in `sign·[(α, β) − ∞]` (one unit, `sign = ±1`).
+    fn apply_unit(&mut self, sign: i32, alpha: &Rational, beta: &Rational) -> Option<()> {
+        if sign > 0 {
+            self.add_point(alpha, beta)
+        } else {
+            // −[(α,β)−∞]: if (α,β) is present, just remove it; otherwise use
+            // −[(α,β)−∞] = +[(α,−β)−∞] − div(X−α).
+            let on_u = degree(&self.u) >= 0 && poly_eval(&self.u, alpha) == 0;
+            if on_u && poly_eval(&self.v, alpha) == *beta {
+                self.mumford_remove(alpha);
+            } else {
+                self.add_point(alpha, &(-beta.clone()))?;
+                self.den_x = poly_mul(&self.den_x, &linear(alpha));
+            }
+            Some(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+/// Construct `u ∈ ℚ(x)(y)` with `div(u) = Σ places` on `y² = a(x)`, or `None` if
+/// the divisor is not principal in the handled scope.
+///
+/// `places` is a **degree-0** divisor of finite places; the (single, ramified)
+/// place at infinity is implied by degree balance `Σ coeff·(−∞)`.  `a` must be
+/// squarefree of **odd** degree `≥ 3`.  The returned expression is a symbolic
+/// function of `var` and `sqrt(a)`.
+pub(crate) fn coates_hyperelliptic(
+    a: &QPoly,
+    places: &[CoatesPlace],
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    let a = trim(a.clone());
+    let d = degree(&a);
+    if d < 3 || d % 2 == 0 {
+        return None; // odd model only
+    }
+    let dd = d as usize;
+    let g = (dd - 1) / 2;
+
+    // Monic curve F(X): X = lc·x, Y = lc^g·y, F_k = a_k·lc^{d-1-k}.
+    let lc = a[dd].clone();
+    let mut f = vec![Rational::from(0); dd + 1];
+    for (k, slot) in f.iter_mut().enumerate() {
+        let e = dd as i64 - 1 - k as i64;
+        *slot = a[k].clone() * pow_rat(&lc, e);
+    }
+    let f = trim(f);
+    let lc_g = pow_rat(&lc, g as i64);
+
+    let mut st = Coates::new(&f, g);
+    for pl in places {
+        if pl.coeff == 0 {
+            continue;
+        }
+        let big_x = lc.clone() * &pl.x;
+        let big_y = lc_g.clone() * &pl.y;
+        // On-curve sanity: Y² = F(X).
+        if big_y.clone() * &big_y != poly_eval(&f, &big_x) {
+            return None;
+        }
+        let sign = if pl.coeff < 0 { -1 } else { 1 };
+        let reps = pl.coeff.clone().abs().to_u64()?;
+        for _ in 0..reps {
+            st.apply_unit(sign, &big_x, &big_y)?;
+        }
+    }
+
+    // Principal ⇒ the running class must have collapsed to the identity.
+    if degree(&st.u) != 0 {
+        return None;
+    }
+
+    // Assemble ans = (num_x/den_x)·Π(Y − yfac_j), substituting X = lc·x,
+    // Y = lc^g·y.
+    let y_expr = pool.func("sqrt", vec![qpoly_to_expr(&a, var, pool)]);
+    let big_y_expr = if lc_g == 1 {
+        y_expr
+    } else {
+        pool.mul(vec![rat_expr(&lc_g, pool), y_expr])
+    };
+
+    let mut num_terms: Vec<ExprId> = Vec::new();
+    let num_poly_x = subst_lc(&st.num_x, &lc);
+    if !(degree(&num_poly_x) == 0 && num_poly_x[0] == 1) {
+        num_terms.push(qpoly_to_expr(&num_poly_x, var, pool));
+    }
+    for vj in &st.yfac {
+        let vpoly_x = subst_lc(vj, &lc);
+        let factor = pool.add(vec![
+            big_y_expr,
+            pool.mul(vec![
+                pool.integer(-1_i32),
+                qpoly_to_expr(&vpoly_x, var, pool),
+            ]),
+        ]);
+        num_terms.push(factor);
+    }
+    let num_expr = match num_terms.len() {
+        0 => pool.integer(1_i32),
+        1 => num_terms.remove(0),
+        _ => pool.mul(num_terms),
+    };
+
+    let den_poly_x = subst_lc(&st.den_x, &lc);
+    let u_expr = if degree(&den_poly_x) == 0 && den_poly_x[0] == 1 {
+        num_expr
+    } else {
+        let den_expr = qpoly_to_expr(&den_poly_x, var, pool);
+        pool.mul(vec![num_expr, pool.pow(den_expr, pool.integer(-1_i32))])
+    };
+    Some(u_expr)
+}
+
+fn rat_expr(r: &Rational, pool: &ExprPool) -> ExprId {
+    super::super::risch::poly_rde::rational_to_expr(r, pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+    use crate::simplify::engine::simplify;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+
+    fn place(x: i64, y: i64, c: i64) -> CoatesPlace {
+        CoatesPlace {
+            x: Rational::from(x),
+            y: Rational::from(y),
+            coeff: Integer::from(c),
+        }
+    }
+
+    /// Numeric eval of an ExprId at `x = xv`, `sqrt(a) = +√a`.
+    fn eval(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> Option<f64> {
+        use crate::kernel::ExprData;
+        if expr == x {
+            return Some(xv);
+        }
+        match pool.get(expr) {
+            ExprData::Integer(n) => Some(n.0.to_f64()),
+            ExprData::Rational(r) => Some(r.0.to_f64()),
+            ExprData::Add(args) => args
+                .iter()
+                .try_fold(0.0, |s, &a| Some(s + eval(a, x, xv, pool)?)),
+            ExprData::Mul(args) => args
+                .iter()
+                .try_fold(1.0, |s, &a| Some(s * eval(a, x, xv, pool)?)),
+            ExprData::Pow { base, exp } => {
+                Some(eval(base, x, xv, pool)?.powf(eval(exp, x, xv, pool)?))
+            }
+            ExprData::Func { ref name, ref args } if args.len() == 1 => {
+                let v = eval(args[0], x, xv, pool)?;
+                match name.as_str() {
+                    "sqrt" => Some(v.sqrt()),
+                    "log" => Some(v.ln()),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn eval_qp(p: &QPoly, xv: f64) -> f64 {
+        p.iter().rev().fold(0.0, |acc, c| acc * xv + c.to_f64())
+    }
+
+    /// Check `div(u_coates) = div(ref_fn)` by confirming `u/ref` is constant (a
+    /// function is determined by its divisor up to a nonzero scalar).
+    fn assert_constant_ratio(u: ExprId, ref_fn: ExprId, a: &QPoly, x: ExprId, pool: &ExprPool) {
+        let u = simplify(u, pool).value;
+        let mut ratios = Vec::new();
+        for &xv in &[0.31_f64, 1.27, 2.73, 3.61, 4.19, 5.53] {
+            let av = eval_qp(a, xv);
+            if av <= 1e-6 {
+                continue;
+            }
+            let (Some(uu), Some(rr)) = (eval(u, x, xv, pool), eval(ref_fn, x, xv, pool)) else {
+                continue;
+            };
+            if !uu.is_finite() || !rr.is_finite() || rr.abs() < 1e-9 {
+                continue;
+            }
+            ratios.push(uu / rr);
+        }
+        assert!(ratios.len() >= 3, "too few sample points: {ratios:?}");
+        let r0 = ratios[0];
+        assert!(r0.abs() > 1e-9, "reference/u vanished");
+        for r in &ratios {
+            assert!(
+                (r - r0).abs() < 1e-6 * (1.0 + r0.abs()),
+                "u/ref not constant: {ratios:?}"
+            );
+        }
+    }
+
+    /// Asymmetric principal divisor `div(y − v)` on a genus-2 quintic.  Pick five
+    /// rational roots and a linear `v = x + 1`, set `a = v² + Π(x − rᵢ)`.  Then
+    /// `div(y − v) = Σ (rᵢ, v(rᵢ)) − 5∞`, and Coates must recover `u ∝ (y − v)`.
+    #[test]
+    fn recover_y_minus_v() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let roots = [-2_i64, -1, 3, 4, 5];
+        let mut prod = qp(&[1]);
+        for &r in &roots {
+            prod = poly_mul(&prod, &qp(&[-r, 1]));
+        }
+        let v = qp(&[1, 1]); // x + 1
+        let a = trim(poly_add(&poly_mul(&v, &v), &prod));
+        assert_eq!(degree(&a), 5);
+        let places: Vec<CoatesPlace> = roots
+            .iter()
+            .map(|&r| place(r, eval_qp(&v, r as f64) as i64, 1))
+            .collect();
+        let u = coates_hyperelliptic(&a, &places, x, &pool).expect("principal");
+        let y = pool.func("sqrt", vec![qpoly_to_expr(&a, x, &pool)]);
+        let ref_fn = pool.add(vec![
+            y,
+            pool.mul(vec![pool.integer(-1_i32), qpoly_to_expr(&v, x, &pool)]),
+        ]);
+        assert_constant_ratio(u, ref_fn, &a, x, &pool);
+    }
+
+    /// Anti-symmetric principal divisor `div((y − v)/(y + v))` (the pure
+    /// logarithmic-derivative / pseudo-elliptic shape): zeros `(rᵢ, v(rᵢ))`,
+    /// poles `(rᵢ, −v(rᵢ))`.  Coates must recover `u ∝ (y − v)/(y + v)`.
+    #[test]
+    fn recover_antisymmetric_unit() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let roots = [-2_i64, -1, 3, 4, 5];
+        let mut prod = qp(&[1]);
+        for &r in &roots {
+            prod = poly_mul(&prod, &qp(&[-r, 1]));
+        }
+        let v = qp(&[1, 1]);
+        let a = trim(poly_add(&poly_mul(&v, &v), &prod));
+        let mut places: Vec<CoatesPlace> = Vec::new();
+        for &r in &roots {
+            let vr = eval_qp(&v, r as f64) as i64;
+            places.push(place(r, vr, 1)); // zero
+            places.push(place(r, -vr, -1)); // pole (opposite sheet)
+        }
+        let u = coates_hyperelliptic(&a, &places, x, &pool).expect("principal");
+        let y = pool.func("sqrt", vec![qpoly_to_expr(&a, x, &pool)]);
+        let vexpr = qpoly_to_expr(&v, x, &pool);
+        let num = pool.add(vec![y, pool.mul(vec![pool.integer(-1_i32), vexpr])]);
+        let den = pool.add(vec![y, vexpr]);
+        let ref_fn = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+        assert_constant_ratio(u, ref_fn, &a, x, &pool);
+    }
+
+    /// Symmetric principal divisor `div((x − 1)/(x − 2))` (a rational function of
+    /// `x`): both sheets over `x=1` are zeros, both over `x=2` poles.  On
+    /// `y² = x⁵ + x + 2` (`a(1)=4`, `a(2)=36`).  Coates recovers `(x−1)/(x−2)`.
+    #[test]
+    fn recover_rational_x_function() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let a = qp(&[2, 1, 0, 0, 0, 1]); // x⁵ + x + 2
+        assert_eq!(eval_qp(&a, 1.0), 4.0);
+        assert_eq!(eval_qp(&a, 2.0), 36.0);
+        let places = vec![
+            place(1, 2, 1),
+            place(1, -2, 1),
+            place(2, 6, -1),
+            place(2, -6, -1),
+        ];
+        let u = coates_hyperelliptic(&a, &places, x, &pool).expect("principal");
+        let ref_fn = pool.mul(vec![
+            pool.add(vec![x, pool.integer(-1_i32)]),
+            pool.pow(
+                pool.add(vec![x, pool.integer(-2_i32)]),
+                pool.integer(-1_i32),
+            ),
+        ]);
+        assert_constant_ratio(u, ref_fn, &a, x, &pool);
+    }
+
+    /// A non-principal divisor must return `None`: `(0,1) − ∞` alone on
+    /// `y² = x⁵ + x + 1` is non-torsion, so no function has that divisor.
+    #[test]
+    fn non_principal_returns_none() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let a = qp(&[1, 1, 0, 0, 0, 1]); // x⁵ + x + 1
+        let places = vec![place(0, 1, 1)];
+        assert!(coates_hyperelliptic(&a, &places, x, &pool).is_none());
+    }
+}

--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -16,18 +16,22 @@ use crate::integrate::engine::IntegrationError;
 use crate::integrate::risch::alg_field::{AlgElem, RatFn};
 use crate::integrate::risch::number_field::KElem;
 use crate::integrate::risch::poly_rde::{
-    degree, expr_to_qpoly, poly_add, poly_deriv, poly_mul, poly_scale, qpoly_to_expr, trim, QPoly,
+    degree, expr_to_qpoly, poly_add, poly_deriv, poly_mul, poly_scale, qpoly_to_expr,
+    rational_to_expr, trim, QPoly,
 };
 use crate::integrate::risch::rational_rde::{
     expr_to_qrational, poly_divrem, poly_gcd, solve_rational_rde_generalized,
 };
 use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::simplify::engine::simplify;
 use rug::{Integer, Rational};
 
+use super::coates::{coates_hyperelliptic, CoatesPlace};
 use super::find_order::{find_order_placed, FindOrder};
 use super::jacobian_torsion::AlgPlace;
 use super::residues::{
     finite_residues_algebraic, residue_divisor_placed, residue_sum_complete, AlgResidue,
+    PlacedResidue,
 };
 use super::trager_log::trager_log_criterion_alg;
 
@@ -707,6 +711,11 @@ fn integrate_b_sqrt_high_degree(
 ) -> Result<ExprId, IntegrationError> {
     let nonelem = |msg: &str| IntegrationError::NonElementary(msg.to_string());
     let notimpl = |msg: &str| IntegrationError::NotImplemented(msg.to_string());
+    // FIND-ORDER could not settle elementarity (torsion undecided, or the Coates
+    // construction did not yield a gate-verified argument).  Surfaced as a
+    // NotImplemented with a "NotDecided" marker rather than a new public enum
+    // variant — honest "cannot decide", never a wrong answer.
+    let notdecided = |msg: &str| IntegrationError::NotImplemented(format!("NotDecided: {msg}"));
 
     let p_poly = expr_to_qpoly(p, var, pool)
         .ok_or_else(|| notimpl("radicand P is not a polynomial in the variable"))?;
@@ -759,9 +768,22 @@ fn integrate_b_sqrt_high_degree(
             FindOrder::NonElementary => Err(nonelem(
                 "residue divisor is non-torsion (FIND-ORDER): no elementary log part",
             )),
-            _ => Err(notimpl(
-                "genus ≥ 2 logarithmic part: torsion/undecided, log argument not \
-                 yet constructible (Coates)",
+            FindOrder::Principal { order } => {
+                // Torsion log part.  Construct `u` with `div(u) = N·δ` (Coates)
+                // and emit `(gg/(L·N))·log(u)`, but only if it passes the numeric
+                // `d/dx F = B·√P` gate — else decline honestly.
+                match try_emit_genus2_coates_log(&p_poly, &divisor, order, &h, var, pool, log) {
+                    Some(f) => Ok(f),
+                    None => Err(notdecided(
+                        "genus ≥ 2 torsion log part: Coates construction did not yield \
+                         a gate-verified antiderivative in the handled scope (even-\
+                         degree/real model, or an unverified argument)",
+                    )),
+                }
+            }
+            FindOrder::NotDecided => Err(notdecided(
+                "genus ≥ 2 residue divisor: torsion order could not be decided \
+                 (FIND-ORDER undecided) — elementarity unknown",
             )),
         };
     }
@@ -785,6 +807,168 @@ fn integrate_b_sqrt_high_degree(
              (torsion log not yet emittable, or out of the handled scope — \
              non-Galois tower / base degree ≥ 3)",
         )),
+    }
+}
+
+/// Construct and **gate-verify** the genus ≥ 2 torsion logarithmic part.
+///
+/// Given the rational residue divisor `δ` and its torsion order `N`
+/// (`FindOrder::Principal{N}`), primitivize `δ = (gg/L)·δ_prim` (integer
+/// `δ_prim`), build `u` with `div(u) = N·δ_prim` via Coates
+/// ([`super::coates`]), and return `(gg/(L·N))·log(u)` — but **only if** it
+/// passes the numeric `d/dx F = B·√P` gate.  Returns `None` outside the
+/// constructible scope (even-degree/real model, unverified argument), so the
+/// caller declines soundly.  A wrong `u` never escapes the gate.
+fn try_emit_genus2_coates_log(
+    a: &QPoly,
+    divisor: &[PlacedResidue],
+    order: u32,
+    h: &AlgElem,
+    var: ExprId,
+    pool: &ExprPool,
+    log: &mut DerivationLog,
+) -> Option<ExprId> {
+    if degree(a) % 2 == 0 {
+        return None; // Coates here handles the odd (imaginary) model only.
+    }
+    let finite: Vec<&PlacedResidue> = divisor.iter().filter(|r| !r.residue.at_infinity).collect();
+    if finite.is_empty() {
+        return None;
+    }
+    // Primitivize: L = lcm of residue denominators, coeffs = numer(value·L),
+    // gg = gcd(coeffs); δ_prim coeff = coeffs/gg.
+    let mut l = Integer::from(1);
+    for r in &finite {
+        l = l.lcm(r.residue.value.denom());
+    }
+    let coeffs: Vec<Integer> = finite
+        .iter()
+        .map(|r| {
+            (r.residue.value.clone() * Rational::from(l.clone()))
+                .numer()
+                .clone()
+        })
+        .collect();
+    let mut gg = Integer::from(0);
+    for c in &coeffs {
+        gg = gg.gcd(c);
+    }
+    if gg == 0 {
+        return None;
+    }
+    let n = Integer::from(order);
+    // The principal divisor `N·δ_prim` as Coates places.
+    let places: Vec<CoatesPlace> = finite
+        .iter()
+        .zip(&coeffs)
+        .filter_map(|(r, c)| {
+            let cprim = c.clone() / &gg;
+            if cprim == 0 {
+                return None;
+            }
+            Some(CoatesPlace {
+                x: r.residue.point.clone(),
+                y: r.y_coord.clone(),
+                coeff: cprim * &n,
+            })
+        })
+        .collect();
+    if places.is_empty() {
+        return None;
+    }
+    let u = coates_hyperelliptic(a, &places, var, pool)?;
+
+    // ω = B·√P dx has residue divisor δ; dlog(u) has residue divisor N·δ_prim;
+    // δ = (gg/L)·δ_prim, so ω = (gg/(L·N))·dlog(u) as third-kind differentials.
+    let coeff = Rational::from((gg.clone(), l.clone() * &n));
+    let log_u = pool.func("log", vec![u]);
+    let f = simplify(pool.mul(vec![rational_to_expr(&coeff, pool), log_u]), pool).value;
+
+    // Soundness gate: d/dx F = B·√P numerically (where a(x) > 0).
+    if verify_bsqrt_derivative(f, h, a, var, pool) {
+        let from = pool.func("sqrt", vec![qpoly_to_expr(a, var, pool)]);
+        log.push(RewriteStep::simple("genus2_coates_torsion_log", from, f));
+        Some(f)
+    } else {
+        None
+    }
+}
+
+/// Numeric gate: `d/dx F == (h as B·√a)` at several real samples with `a(x)>0`.
+/// `h = c₀ + c₁·y` (`y = √a`) is the integrand's algebraic form.
+fn verify_bsqrt_derivative(
+    f: ExprId,
+    h: &AlgElem,
+    a: &QPoly,
+    var: ExprId,
+    pool: &ExprPool,
+) -> bool {
+    let Ok(df) = crate::diff::diff(f, var, pool) else {
+        return false;
+    };
+    let ds = simplify(df.value, pool).value;
+    let mut checked = 0;
+    for &xv in &[0.3_f64, 1.4, 2.7, 3.6, 4.9, 5.8] {
+        let av = eval_qpoly_f64(a, xv);
+        if av <= 1e-6 {
+            continue; // need √a real
+        }
+        let ya = av.sqrt();
+        let Some(lhs) = eval_f64(ds, var, xv, pool) else {
+            return false;
+        };
+        let rhs = eval_alg_f64(h, xv, ya);
+        if !lhs.is_finite() || !rhs.is_finite() || (lhs - rhs).abs() > 1e-6 * (1.0 + rhs.abs()) {
+            return false;
+        }
+        checked += 1;
+    }
+    checked >= 2
+}
+
+fn eval_qpoly_f64(p: &QPoly, xv: f64) -> f64 {
+    p.iter().rev().fold(0.0, |acc, c| acc * xv + c.to_f64())
+}
+
+fn eval_alg_f64(g: &AlgElem, xv: f64, yv: f64) -> f64 {
+    g.iter()
+        .enumerate()
+        .map(|(j, c)| {
+            let num = eval_qpoly_f64(c.numer(), xv);
+            let den = eval_qpoly_f64(c.denom(), xv);
+            (num / den) * yv.powi(j as i32)
+        })
+        .sum()
+}
+
+/// Numeric eval; `sqrt`/`cbrt` take the principal real branch (matching `+√a`).
+fn eval_f64(expr: ExprId, x: ExprId, xv: f64, pool: &ExprPool) -> Option<f64> {
+    if expr == x {
+        return Some(xv);
+    }
+    match pool.get(expr) {
+        ExprData::Integer(n) => Some(n.0.to_f64()),
+        ExprData::Rational(r) => Some(r.0.to_f64()),
+        ExprData::Add(args) => args
+            .iter()
+            .try_fold(0.0, |s, &a| Some(s + eval_f64(a, x, xv, pool)?)),
+        ExprData::Mul(args) => args
+            .iter()
+            .try_fold(1.0, |s, &a| Some(s * eval_f64(a, x, xv, pool)?)),
+        ExprData::Pow { base, exp } => {
+            Some(eval_f64(base, x, xv, pool)?.powf(eval_f64(exp, x, xv, pool)?))
+        }
+        ExprData::Func { ref name, ref args } if args.len() == 1 => {
+            let v = eval_f64(args[0], x, xv, pool)?;
+            match name.as_str() {
+                "exp" => Some(v.exp()),
+                "log" => Some(v.ln()),
+                "sqrt" => Some(v.sqrt()),
+                "cbrt" => Some(v.cbrt()),
+                _ => None,
+            }
+        }
+        _ => None,
     }
 }
 
@@ -1121,5 +1305,138 @@ fn neg_c_power(c: &rug::Integer, n: i64) -> rug::Integer {
         // negative power: for integer arithmetic this requires the value to be ±1
         // (for general use, fallback to 0 if not invertible)
         rug::Integer::from(0)
+    }
+}
+
+#[cfg(test)]
+mod genus2_log_tests {
+    use super::*;
+    use crate::integrate::algebraic::residues::{PlacedResidue, Residue};
+    use crate::integrate::risch::rational_rde::poly_sub;
+    use crate::kernel::Domain;
+
+    fn qp(cs: &[i64]) -> QPoly {
+        cs.iter().map(|&c| Rational::from(c)).collect()
+    }
+
+    fn sqrt_of(a: &QPoly, x: ExprId, pool: &ExprPool) -> ExprId {
+        pool.func("sqrt", vec![qpoly_to_expr(a, x, pool)])
+    }
+
+    /// End-to-end genus-2 (odd quintic) **torsion logarithmic part**: the
+    /// FIND-ORDER (MC2) decision + Coates construction + numeric gate.
+    ///
+    /// With `v = x+1` and `a = v² + Π(x−rᵢ)` (roots `−2,−1,3,4,5`), the function
+    /// `u = (y−v)/(y+v)` has norm `u·ū = 1`, so `ω = dlog(u) = B·√a dx` is a pure
+    /// second-/third-kind differential with the **anti-symmetric** residue divisor
+    /// `δ = Σ (rᵢ, v(rᵢ)) − (rᵢ, −v(rᵢ))`, which is principal (`N=1`).
+    /// `find_order_placed` must certify `Principal{1}`, and the wired Coates path
+    /// must emit a gate-verified `F` with `d/dx F = B·√a`.
+    ///
+    /// The residue divisor is built directly here: the AST-level residue
+    /// *extraction* (`residues::finite_residues_placed`) is slow for a degree-10
+    /// pole denominator — a pre-existing Puiseux-stack cost, orthogonal to the
+    /// FIND-ORDER→Coates→gate emission this test exercises.
+    #[test]
+    fn genus2_coates_torsion_log_emitted() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let roots = [-2_i64, -1, 3, 4, 5];
+        let mut prod = qp(&[1]);
+        for &r in &roots {
+            prod = poly_mul(&prod, &qp(&[-r, 1]));
+        }
+        let v = qp(&[1, 1]); // x + 1
+        let a = trim(poly_add(&poly_mul(&v, &v), &prod));
+        assert_eq!(degree(&a), 5);
+        assert_eq!(super::super::find_order::genus(2, &a), Some(2));
+
+        // ω = dlog((y−v)/(y+v)) = B·√a with B = (a'·v − 2a)/(a·(a − v²)).
+        let a_prime = poly_deriv(&a);
+        let b_num = poly_sub(&poly_mul(&a_prime, &v), &poly_scale(&a, &Rational::from(2)));
+        let b_den = poly_mul(&a, &poly_sub(&a, &poly_mul(&v, &v)));
+        let h: AlgElem = vec![RatFn::int(0), RatFn::new(b_num, b_den)];
+
+        // Anti-symmetric residue divisor δ = Σ (rᵢ, v(rᵢ)) − (rᵢ, −v(rᵢ)).
+        let mut divisor: Vec<PlacedResidue> = Vec::new();
+        for &r in &roots {
+            let vr = eval_qpoly_f64(&v, r as f64) as i64;
+            for (beta, val) in [(vr, 1_i64), (-vr, -1)] {
+                divisor.push(PlacedResidue {
+                    residue: Residue {
+                        point: Rational::from(r),
+                        at_infinity: false,
+                        sheet: 0,
+                        ramification: 1,
+                        value: Rational::from(val),
+                    },
+                    y_coord: Rational::from(beta),
+                });
+            }
+        }
+
+        // MC2 FIND-ORDER must certify the divisor principal.
+        let order = match find_order_placed(2, &a, &divisor) {
+            FindOrder::Principal { order } => order,
+            other => panic!("expected Principal, got {other:?}"),
+        };
+        assert_eq!(order, 1);
+
+        // Wired emission: Coates → (gg/(L·N))·log(u), gate-verified.
+        let mut logd = crate::deriv::log::DerivationLog::new();
+        let f = try_emit_genus2_coates_log(&a, &divisor, order, &h, x, &pool, &mut logd)
+            .expect("Coates torsion log must be emitted (gate-verified)");
+
+        // Independently re-confirm d/dx F = B·√a numerically.
+        let df = simplify(crate::diff::diff(f, x, &pool).unwrap().value, &pool).value;
+        let mut checked = 0;
+        for &xv in &[0.31_f64, 1.27, 2.73, 3.61, 4.19, 5.53] {
+            let av = eval_qpoly_f64(&a, xv);
+            if av <= 1e-6 {
+                continue;
+            }
+            let lhs = eval_f64(df, x, xv, &pool).unwrap();
+            let rhs = eval_alg_f64(&h, xv, av.sqrt());
+            assert!(
+                (lhs - rhs).abs() < 1e-6 * (1.0 + rhs.abs()),
+                "x={xv}: d/dx F = {lhs}, integrand = {rhs}"
+            );
+            checked += 1;
+        }
+        assert!(checked >= 3, "too few verified sample points");
+    }
+
+    /// A genus-2 **non-torsion** pure `B·√a` differential stays declined (never a
+    /// wrong answer): `∫ √a/x dx` on `y² = x⁵ + x + 1` has residue divisor
+    /// `(0,1) − (0,−1)`, whose class is non-torsion ⇒ certified non-elementary.
+    #[test]
+    fn genus2_non_torsion_declines() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let a = qp(&[1, 1, 0, 0, 0, 1]); // x⁵ + x + 1
+        let integrand = pool.mul(vec![
+            sqrt_of(&a, x, &pool),
+            pool.pow(x, pool.integer(-1_i32)),
+        ]);
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "expected NonElementary, got {res:?}"
+        );
+    }
+
+    /// `∫ dx/√(x⁵+1)` — the genus-2 first-kind headline — is unchanged: no log
+    /// part, no algebraic primitive ⇒ non-elementary.
+    #[test]
+    fn genus2_first_kind_unchanged() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let a = qp(&[1, 0, 0, 0, 0, 1]); // x⁵ + 1
+        let integrand = pool.pow(sqrt_of(&a, x, &pool), pool.integer(-1_i32));
+        let res = crate::integrate::engine::integrate(integrand, x, &pool);
+        assert!(
+            matches!(res, Err(IntegrationError::NonElementary(_))),
+            "expected NonElementary, got {res:?}"
+        );
     }
 }

--- a/alkahest-core/src/integrate/algebraic/mod.rs
+++ b/alkahest-core/src/integrate/algebraic/mod.rs
@@ -21,6 +21,7 @@
 // and `galois_quartic` its automorphisms, consumed by
 // `genus_zero::try_alg_base_log` (the conjugate-divisor reduction).
 mod alg_tower;
+mod coates;
 pub(super) mod decompose;
 pub mod elliptic;
 pub mod elliptic_output;


### PR DESCRIPTION
## What (Register C headline — research)
Implements **Coates' algorithm** (Davenport; Coates 1970) to construct a function `u` with a prescribed principal divisor `N·δ` on a hyperelliptic curve `y²=a(x)`, so the `∫ B·√P` path can emit the elementary **logarithmic part `(1/N)·log(u)`** for a **genus ≥ 2 torsion** residue divisor — previously this case declined. The torsion *decision* already existed (`jacobian_torsion.rs`, Cantor + good-prime reduction); this adds the missing *function construction*.

## How
- New `algebraic/coates.rs`: `coates_hyperelliptic(a, places, …)` builds `u = c(x)+d(x)·y` from the residue places via Mumford/Cantor-style reduction. Unit-tested by **recovering known functions from their divisors** (`y−v`, an antisymmetric unit, a rational-in-`x` function) and rejecting non-principal divisors.
- Wired into `integrate_b_sqrt_high_degree` (`genus_zero.rs`): a genus≥2 `FindOrder::Principal{N}` case constructs `u` and emits `g + (1/N)log(u)`.

## Soundness (gate-only — cannot emit a wrong answer)
The log form is returned **only if it passes a numeric `d/dx F = B·√P` gate** (`verify_bsqrt_derivative`, sampled where `a(x)>0`); otherwise it declines. An imperfect/partial construction declines, never emits an unverified argument. Non-torsion genus≥2 still certifies `NonElementary`; first-kind output is unchanged. Undecided cases surface an honest `NotDecided: …` (as `NotImplemented`, no new public enum variant — additive).

## Scope (honest)
Handles the **odd-degree (imaginary) hyperelliptic model** with finite residue places; even-degree/real models and unverified constructions **decline** (gate-safe). This lands rungs 1–2 (Coates module + wiring) of the research task; broader models are follow-up.

Tests: 4 `coates.rs` unit tests + genus-2 end-to-end (`genus2_coates_torsion_log_emitted`, plus `genus2_non_torsion_declines` / `genus2_first_kind_unchanged` soundness guards). Full `alkahest-cas` lib suite green (1477).

🤖 Generated with [Claude Code](https://claude.com/claude-code)