### PR TITLE
feat(poly): verify integer factorization products

### DIFF
--- a/alkahest-core/src/poly/factor/mod.rs
+++ b/alkahest-core/src/poly/factor/mod.rs
@@ -46,6 +46,14 @@ impl UniPolyFactorization {
         }
         UniPoly { var, coeffs: acc }
     }
+
+    /// Check exactly that this factorization reconstructs `original`.
+    ///
+    /// This verifies the represented product over the integer coefficient
+    /// ring. It does not establish irreducibility of the returned factors.
+    pub fn verifies_product(&self, original: &UniPoly) -> bool {
+        self.expand_with_var(original.var) == *original
+    }
 }
 
 impl MultiPolyFactorization {
@@ -67,6 +75,30 @@ impl MultiPolyFactorization {
             acc = acc * powered;
         }
         acc
+    }
+
+    /// Check exactly that this factorization reconstructs `original`.
+    ///
+    /// The variable list comes from `original` so constant multivariate
+    /// factorizations retain their ambient polynomial ring.
+    pub fn verifies_product(&self, original: &MultiPoly) -> bool {
+        let mut terms = std::collections::BTreeMap::new();
+        terms.insert(vec![], self.unit.clone());
+        let mut acc = MultiPoly {
+            vars: original.vars.clone(),
+            terms,
+        };
+        for (factor, exponent) in &self.factors {
+            if factor.vars != original.vars {
+                return false;
+            }
+            let mut powered = MultiPoly::constant(original.vars.clone(), 1);
+            for _ in 0..*exponent {
+                powered = powered * factor.clone();
+            }
+            acc = acc * powered;
+        }
+        acc == *original
     }
 }
 
@@ -193,6 +225,7 @@ mod tests {
         assert_eq!(fac.factors.len(), 2);
         let prod = fac.expand_with_var(x);
         assert_eq!(prod, p);
+        assert!(fac.verifies_product(&p));
     }
 
     #[test]
@@ -249,5 +282,6 @@ mod tests {
         let fac = product.factor_z().unwrap();
         let expanded = fac.expand_clone_vars();
         assert_eq!(expanded, product);
+        assert!(fac.verifies_product(&product));
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -2033,6 +2033,7 @@ fn merge_mp_pool(a: &Option<Py<PyExprPool>>, b: &Option<Py<PyExprPool>>) -> Opti
 #[pyclass(name = "UniPolyFactorization")]
 struct PyUniPolyFactorization {
     inner: UniPolyFactorization,
+    original: UniPoly,
 }
 
 #[pymethods]
@@ -2049,11 +2050,18 @@ impl PyUniPolyFactorization {
             .map(|(p, e)| (PyUniPoly { inner: p.clone() }, *e))
             .collect()
     }
+
+    /// Exact in-kernel reconstruction evidence for this factorization.
+    #[getter]
+    fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
+        factor_verification_dict(py, self.inner.verifies_product(&self.original))
+    }
 }
 
 #[pyclass(name = "MultiPolyFactorization")]
 struct PyMultiPolyFactorization {
     inner: MultiPolyFactorization,
+    original: MultiPoly,
 }
 
 #[pymethods]
@@ -2078,6 +2086,32 @@ impl PyMultiPolyFactorization {
             })
             .collect()
     }
+
+    /// Exact in-kernel reconstruction evidence for this factorization.
+    #[getter]
+    fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
+        factor_verification_dict(py, self.inner.verifies_product(&self.original))
+    }
+}
+
+fn factor_verification_dict<'py>(py: Python<'py>, verified: bool) -> Bound<'py, PyDict> {
+    let result = PyDict::new_bound(py);
+    result
+        .set_item(
+            "status",
+            if verified {
+                "exactly_verified"
+            } else {
+                "unverified"
+            },
+        )
+        .unwrap();
+    result.set_item("evidence", "factor_product").unwrap();
+    result
+        .set_item("method", "in_kernel_exact_reconstruction")
+        .unwrap();
+    result.set_item("lean_checked", false).unwrap();
+    result
 }
 
 #[pyclass(name = "UniPolyFactorModP")]
@@ -2217,7 +2251,10 @@ impl PyUniPoly {
     fn factor_z(&self) -> PyResult<PyUniPolyFactorization> {
         self.inner
             .factor_z()
-            .map(|inner| PyUniPolyFactorization { inner })
+            .map(|inner| PyUniPolyFactorization {
+                inner,
+                original: self.inner.clone(),
+            })
             .map_err(factor_error_to_py)
     }
 
@@ -2326,7 +2363,10 @@ impl PyMultiPoly {
     fn factor_z(&self) -> PyResult<PyMultiPolyFactorization> {
         self.inner
             .factor_z()
-            .map(|inner| PyMultiPolyFactorization { inner })
+            .map(|inner| PyMultiPolyFactorization {
+                inner,
+                original: self.inner.clone(),
+            })
             .map_err(factor_error_to_py)
     }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -108,7 +108,13 @@ The library produces proof artifacts at three levels of rigor:
 
 **Lean certificate export.** Each rewrite rule is tagged with a corresponding Lean 4 / Mathlib theorem name. For operations expressible as sequences of rewrites, the library emits a `.lean` file containing a proof term that Lean can verify independently. Side conditions (non-zero denominators, branch cuts, domain constraints) are tracked and propagated into the Lean output.
 
-**Algorithmic certificates.** For operations where rewrite sequences don't work (polynomial factoring, Risch integration), the library emits verifiable witnesses instead of proof traces. For factoring, the witness is the claimed factorization — Lean verifies it by multiplying out. For integration, the witness is the claimed antiderivative, verified by differentiating.
+**Algorithmic evidence.** For operations where rewrite sequences do not work,
+the library can expose an operation-specific witness or exact checker. Integer
+factorization results carry an in-kernel reconstruction check: the unit and
+powered factors are multiplied in the exact coefficient ring and compared with
+the input. This establishes the represented factor product, not irreducibility
+or a Lean-checked certificate. Risch integration verification remains a
+separate, narrower effort.
 
 ### Statelessness
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -35,7 +35,7 @@ Current stable feature surface.
 - `RationalFunction`: quotient with automatic GCD normalization
 - Horner-form rewriting (`horner`); SIMD batch f64 Horner eval (`eval_horner_f64_batch`, Rust)
 - C code emission (`emit_c`)
-- Polynomial factorization over ℤ, ℤ[x₁,...,xₙ], and 𝔽ₚ (Zassenhaus, van Hoeij, Berlekamp, Cantor–Zassenhaus via FLINT)
+- Polynomial factorization over ℤ, ℤ[x₁,...,xₙ], and 𝔽ₚ (Zassenhaus, van Hoeij, Berlekamp, Cantor–Zassenhaus via FLINT); integer factorization outputs include exact in-kernel factor-product reconstruction metadata
 - Hermite and Smith normal forms for integer matrices and polynomial matrices over ℚ[x]
 - LLL lattice reduction over ℤ (`alkahest.lattice`)
 - Approximate integer-relation finding (`guess_relation`)

--- a/tests/test_poly_factor.py
+++ b/tests/test_poly_factor.py
@@ -15,6 +15,12 @@ def test_unipoly_factor_quadratic():
     for base, exp in fac.factor_list():
         assert exp == 1
         assert base.degree() == 1
+    assert fac.verification == {
+        "status": "exactly_verified",
+        "evidence": "factor_product",
+        "method": "in_kernel_exact_reconstruction",
+        "lean_checked": False,
+    }
 
 
 def test_multipoly_factor_product():
@@ -28,6 +34,9 @@ def test_multipoly_factor_product():
     mp = alkahest.MultiPoly.from_symbolic(e, [x, y])
     fac = mp.factor_z()
     assert len(fac.factor_list()) >= 2
+    assert fac.verification["status"] == "exactly_verified"
+    assert fac.verification["evidence"] == "factor_product"
+    assert fac.verification["lean_checked"] is False
 
 
 def test_factor_univariate_mod_p_x_squared_plus_one_char2():


### PR DESCRIPTION
## Summary
- add exact core reconstruction checks for integer univariate and multivariate factorization products
- expose additive factorization verification metadata using the shared `exactly_verified` vocabulary
- document the boundary between in-kernel reconstruction and Lean verification

## Test plan
- [x] cargo fmt --all
- [x] cargo test -p alkahest-cas poly::factor::tests
- [x] cargo clippy -p alkahest-py -- -D warnings
- [x] uv run maturin develop --manifest-path alkahest-py/Cargo.toml --release
- [x] uv run pytest tests/test_poly_factor.py
- [x] uv run ruff check tests/test_poly_factor.py
- [x] uv run ruff format --check tests/test_poly_factor.py


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification metadata for polynomial factorization results.
  * Python factorization results now expose a `.verification` property with reconstruction status, evidence, and verification method.
  * Added exact checks confirming that computed factors reconstruct the original polynomial.

* **Documentation**
  * Clarified factorization evidence and reconstruction checks in the documentation.
  * Documented reconstruction metadata for integer polynomial factorization.

* **Tests**
  * Expanded coverage to validate factorization verification details and reconstruction results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->