### PR TITLE
feat(integrate): expose exact antiderivative verification

### DIFF
--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -2534,6 +2534,25 @@ fn is_zero(expr: ExprId, pool: &ExprPool) -> bool {
     as_integer(expr, pool) == Some(0)
 }
 
+/// Verify exactly that `d/dx(candidate) == integrand` after symbolic
+/// simplification.
+///
+/// This is an in-kernel symbolic check. It does not use numeric sampling and
+/// therefore returns `false` when equality cannot be established structurally.
+pub fn verify_antiderivative_exact(
+    candidate: ExprId,
+    integrand: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> bool {
+    let Ok(d_raw) = crate::diff::diff(candidate, var, pool) else {
+        return false;
+    };
+    let d = simplify(d_raw.value, pool).value;
+    let neg = pool.mul(vec![pool.integer(-1_i32), integrand]);
+    is_zero(simplify(pool.add(vec![d, neg]), pool).value, pool)
+}
+
 /// Soundness gate: verify `d/dx(candidate) == integrand`.
 ///
 /// Accepts when `d/dx(candidate) − integrand` simplifies structurally to zero,
@@ -2547,19 +2566,15 @@ fn verify_antiderivative(
     var: ExprId,
     pool: &ExprPool,
 ) -> bool {
-    let Ok(d_raw) = crate::diff::diff(candidate, var, pool) else {
-        return false;
-    };
-    let d = simplify(d_raw.value, pool).value;
-
-    // Structural check: d − integrand simplifies to zero.
-    let neg = pool.mul(vec![pool.integer(-1_i32), integrand]);
-    let diff_expr = simplify(pool.add(vec![d, neg]), pool).value;
-    if is_zero(diff_expr, pool) {
+    if verify_antiderivative_exact(candidate, integrand, var, pool) {
         return true;
     }
 
     // Numeric check at several sample points (irrational, to dodge poles).
+    let Ok(d_raw) = crate::diff::diff(candidate, var, pool) else {
+        return false;
+    };
+    let d = simplify(d_raw.value, pool).value;
     let samples = [0.3719_f64, 0.9137, 1.4231, 2.1719, 2.8123, 3.6411];
     let mut checked = 0_usize;
     for &xv in &samples {

--- a/alkahest-core/src/integrate/mod.rs
+++ b/alkahest-core/src/integrate/mod.rs
@@ -2,4 +2,4 @@ pub mod algebraic;
 pub mod engine;
 pub mod risch;
 
-pub use engine::{integrate, integrate_definite, IntegrationError};
+pub use engine::{integrate, integrate_definite, verify_antiderivative_exact, IntegrationError};

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -60,7 +60,7 @@ pub use deriv::{DerivationLog, DerivedExpr, RewriteStep, SideCondition};
 pub use diff::{diff, diff_forward, grad, DiffError, DualValue, ForwardDiffError};
 pub use flint::{FlintInteger, FlintPoly};
 pub use hybrid::{Event, GuardStructure, HybridODE};
-pub use integrate::{integrate, integrate_definite, IntegrationError};
+pub use integrate::{integrate, integrate_definite, verify_antiderivative_exact, IntegrationError};
 #[allow(deprecated)]
 pub use kernel::{
     expr_contains_noncommutative_symbol, load_from, mult_tree_is_commutative, open_persistent,

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1496,9 +1496,8 @@ struct PyDerivedResult {
     raw: DerivedExpr<ExprId>,
     /// Differentiation variable when this result comes from :func:`diff`.
     wrt: Option<ExprId>,
-    /// Exact symbolic antiderivative verification, when this result is from
-    /// indefinite integration.
-    integration_exactly_verified: Option<bool>,
+    /// Integrand and variable for lazy exact antiderivative verification.
+    integration_verification_input: Option<(ExprId, ExprId)>,
 }
 
 #[pymethods]
@@ -1551,7 +1550,11 @@ impl PyDerivedResult {
     fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
         let metadata = PyDict::new_bound(py);
         let has_certificate = !self.raw.log.is_empty();
-        let exactly_verified = self.integration_exactly_verified;
+        let exactly_verified = self.integration_verification_input.map(|(integrand, var)| {
+            let pool_py = self.value.pool.clone_ref(py);
+            let pool = pool_py.borrow(py);
+            core_verify_antiderivative_exact(self.raw.value, integrand, var, &pool.inner)
+        });
         metadata
             .set_item(
                 "status",
@@ -1665,7 +1668,7 @@ fn make_derived_result(
         steps_raw,
         raw: derived,
         wrt,
-        integration_exactly_verified: None,
+        integration_verification_input: None,
     }
 }
 
@@ -1689,7 +1692,7 @@ fn py_derived_result_context_simplify(
             steps_raw: dr.steps_raw.clone(),
             raw: dr.raw.clone(),
             wrt: dr.wrt,
-            integration_exactly_verified: dr.integration_exactly_verified,
+            integration_verification_input: dr.integration_verification_input,
         });
     }
     let mut log = dr.raw.log.clone();
@@ -2612,17 +2615,13 @@ fn py_integrate(
     expr: PyRef<PyExpr>,
     var: PyRef<PyExpr>,
 ) -> PyResult<PyDerivedResult> {
-    let (derived, exactly_verified) = {
+    let derived = {
         let pool = expr.pool.borrow(py);
-        let derived =
-            core_integrate(expr.id, var.id, &pool.inner).map_err(integrate_error_to_py)?;
-        let exactly_verified =
-            core_verify_antiderivative_exact(derived.value, expr.id, var.id, &pool.inner);
-        (derived, exactly_verified)
+        core_integrate(expr.id, var.id, &pool.inner).map_err(integrate_error_to_py)?
     };
     let pool_py = expr.pool.clone_ref(py);
     let mut result = make_derived_result(py, derived, pool_py, None);
-    result.integration_exactly_verified = Some(exactly_verified);
+    result.integration_verification_input = Some((expr.id, var.id));
     Ok(result)
 }
 

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -115,11 +115,12 @@ use alkahest_core::{
     simplify as core_simplify, simplify_batch as core_simplify_batch,
     simplify_egraph as core_simplify_egraph, simplify_egraph_with as core_simplify_egraph_with,
     simplify_trig_normal_form as core_simplify_trig_normal_form,
-    simplify_with as core_simplify_with, trig_rules, AlkahestError as AlkahestErrorTrait,
-    ApartError, DerivedExpr, DiffError, EgraphConfig, IntegrationError, IoError,
-    LimitDirection as CoreLimitDirection, LimitError, LinearRecurrenceError, PatternRule,
-    ProductError, ResultantError, RsolveError, SeriesError, SimplifyConfig, SizeCost,
-    SparseGcdError, SparseInterpError, SumError,
+    simplify_with as core_simplify_with, trig_rules,
+    verify_antiderivative_exact as core_verify_antiderivative_exact,
+    AlkahestError as AlkahestErrorTrait, ApartError, DerivedExpr, DiffError, EgraphConfig,
+    IntegrationError, IoError, LimitDirection as CoreLimitDirection, LimitError,
+    LinearRecurrenceError, PatternRule, ProductError, ResultantError, RsolveError, SeriesError,
+    SimplifyConfig, SizeCost, SparseGcdError, SparseInterpError, SumError,
 };
 // Experimental calculus / ODE / transform surface (PyO3 bindings deferred at
 // landing time — see PRs #152–#161). These mirror the Rust `experimental`
@@ -1495,6 +1496,9 @@ struct PyDerivedResult {
     raw: DerivedExpr<ExprId>,
     /// Differentiation variable when this result comes from :func:`diff`.
     wrt: Option<ExprId>,
+    /// Exact symbolic antiderivative verification, when this result is from
+    /// indefinite integration.
+    integration_exactly_verified: Option<bool>,
 }
 
 #[pymethods]
@@ -1541,15 +1545,21 @@ impl PyDerivedResult {
     /// Machine-readable evidence metadata for this derived result.
     ///
     /// A generated Lean source artifact is not a statement that Lean has
-    /// checked it.  External verification must be performed separately.
+    /// checked it. An indefinite integration result is ``exactly_verified``
+    /// only when its symbolic derivative residual simplifies to zero.
     #[getter]
     fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
         let metadata = PyDict::new_bound(py);
         let has_certificate = !self.raw.log.is_empty();
+        let exactly_verified = self.integration_exactly_verified;
         metadata
             .set_item(
                 "status",
-                if has_certificate {
+                if exactly_verified == Some(true) {
+                    "exactly_verified"
+                } else if exactly_verified == Some(false) {
+                    "unverified"
+                } else if has_certificate {
                     "certificate_available"
                 } else {
                     "unverified"
@@ -1559,7 +1569,9 @@ impl PyDerivedResult {
         metadata
             .set_item(
                 "evidence",
-                if has_certificate {
+                if exactly_verified == Some(true) {
+                    "antiderivative_derivative_identity"
+                } else if has_certificate {
                     "derivation_log"
                 } else {
                     "none"
@@ -1582,6 +1594,16 @@ impl PyDerivedResult {
         }
         metadata
             .set_item("side_conditions", side_conditions)
+            .unwrap();
+        metadata
+            .set_item(
+                "method",
+                if exactly_verified.is_some() {
+                    "in_kernel_symbolic_residual"
+                } else {
+                    "derivation_log"
+                },
+            )
             .unwrap();
         metadata
     }
@@ -1643,6 +1665,7 @@ fn make_derived_result(
         steps_raw,
         raw: derived,
         wrt,
+        integration_exactly_verified: None,
     }
 }
 
@@ -1666,6 +1689,7 @@ fn py_derived_result_context_simplify(
             steps_raw: dr.steps_raw.clone(),
             raw: dr.raw.clone(),
             wrt: dr.wrt,
+            integration_exactly_verified: dr.integration_exactly_verified,
         });
     }
     let mut log = dr.raw.log.clone();
@@ -2588,12 +2612,18 @@ fn py_integrate(
     expr: PyRef<PyExpr>,
     var: PyRef<PyExpr>,
 ) -> PyResult<PyDerivedResult> {
-    let derived = {
+    let (derived, exactly_verified) = {
         let pool = expr.pool.borrow(py);
-        core_integrate(expr.id, var.id, &pool.inner).map_err(integrate_error_to_py)?
+        let derived =
+            core_integrate(expr.id, var.id, &pool.inner).map_err(integrate_error_to_py)?;
+        let exactly_verified =
+            core_verify_antiderivative_exact(derived.value, expr.id, var.id, &pool.inner);
+        (derived, exactly_verified)
     };
     let pool_py = expr.pool.clone_ref(py);
-    Ok(make_derived_result(py, derived, pool_py, None))
+    let mut result = make_derived_result(py, derived, pool_py, None);
+    result.integration_exactly_verified = Some(exactly_verified);
+    Ok(result)
 }
 
 #[pyfunction]

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -667,6 +667,13 @@ def integrate(expr, var, a=None, b=None):
     between the bounds, and the residue-theorem route are not handled; in those
     cases the underlying integration error is propagated rather than guessed.
 
+    For an indefinite integral, ``result.verification`` reports
+    ``"exactly_verified"`` only when the kernel proves the symbolic residual
+    ``diff(result, var) - expr`` is zero. A successful result with
+    ``"unverified"`` may instead have passed the integrator's separate numeric
+    soundness gate. Definite integral results have no antiderivative
+    verification metadata.
+
     Example
     -------
     >>> p = ExprPool(); x = p.symbol("x")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -97,6 +97,26 @@ def test_integrate_constant():
     assert r.value is not None
 
 
+def test_integrate_exact_verification_metadata():
+    p = pool()
+    x = p.symbol("x")
+    r = integrate(x**2, x)
+
+    assert r.verification["status"] == "exactly_verified"
+    assert r.verification["evidence"] == "antiderivative_derivative_identity"
+    assert r.verification["method"] == "in_kernel_symbolic_residual"
+    assert r.verification["externally_verified"] is False
+
+
+def test_non_integration_retains_derivation_verification_metadata():
+    p = pool()
+    x = p.symbol("x")
+
+    verification = diff(x**2, x).verification
+    assert verification["status"] == "certificate_available"
+    assert verification["method"] == "derivation_log"
+
+
 # ---------------------------------------------------------------------------
 # Simplification (rule-based)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose a reusable in-kernel symbolic antiderivative residual check
- report exact integration verification through the shared metadata schema
- defer the check until callers request `.verification`, avoiding integration hot-path overhead

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `uv run maturin develop --manifest-path alkahest-py/Cargo.toml --release`
- [x] focused Python verification contract tests

Supersedes #201, which GitHub closed when its merged dependent base branch was deleted.

Made with [Cursor](https://cursor.com)