### PR TITLE
feat(verify): distinguish exact and numeric integration checks

### DIFF
--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -2553,6 +2553,18 @@ pub fn verify_antiderivative_exact(
     is_zero(simplify(pool.add(vec![d, neg]), pool).value, pool)
 }
 
+/// Evidence established by the antiderivative soundness gate.
+///
+/// Numeric sampling is a useful acceptance screen, but is deliberately distinct
+/// from an in-kernel symbolic derivative identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AntiderivativeVerification {
+    /// The symbolic residual `d/dx(candidate) - integrand` simplified to zero.
+    Exact,
+    /// Several finite floating-point samples agreed, but no exact identity was found.
+    Numeric,
+}
+
 /// Soundness gate: verify `d/dx(candidate) == integrand`.
 ///
 /// Accepts when `d/dx(candidate) − integrand` simplifies structurally to zero,
@@ -2560,19 +2572,19 @@ pub fn verify_antiderivative_exact(
 /// (skipping points where either side is non-finite, e.g. singularities).  A
 /// `candidate` whose derivative cannot be confirmed equal is rejected, so the
 /// integrator never returns a wrong antiderivative.
-fn verify_antiderivative(
+pub fn verify_antiderivative_status(
     candidate: ExprId,
     integrand: ExprId,
     var: ExprId,
     pool: &ExprPool,
-) -> bool {
+) -> Option<AntiderivativeVerification> {
     if verify_antiderivative_exact(candidate, integrand, var, pool) {
-        return true;
+        return Some(AntiderivativeVerification::Exact);
     }
 
     // Numeric check at several sample points (irrational, to dodge poles).
     let Ok(d_raw) = crate::diff::diff(candidate, var, pool) else {
-        return false;
+        return None;
     };
     let d = simplify(d_raw.value, pool).value;
     let samples = [0.3719_f64, 0.9137, 1.4231, 2.1719, 2.8123, 3.6411];
@@ -2585,21 +2597,30 @@ fn verify_antiderivative(
             crate::jit::eval_interp(integrand, &env, pool),
         ) else {
             // Unevaluable expression — cannot certify numerically.
-            return false;
+            return None;
         };
         if !dv.is_finite() || !fv.is_finite() {
             continue; // near a singularity; skip this sample
         }
         let tol = 1e-7 * (1.0 + dv.abs().max(fv.abs()));
         if (dv - fv).abs() > tol {
-            return false;
+            return None;
         }
         checked += 1;
     }
 
     // Require at least a couple of usable samples so an all-singular set cannot
     // vacuously pass.
-    checked >= 2
+    (checked >= 2).then_some(AntiderivativeVerification::Numeric)
+}
+
+fn verify_antiderivative(
+    candidate: ExprId,
+    integrand: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> bool {
+    verify_antiderivative_status(candidate, integrand, var, pool).is_some()
 }
 
 // ---------------------------------------------------------------------------
@@ -2615,6 +2636,19 @@ mod tests {
 
     fn p() -> ExprPool {
         ExprPool::new()
+    }
+
+    #[test]
+    fn antiderivative_verification_distinguishes_numeric_evidence() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let candidate = pool.func("sqrt", vec![pool.pow(x, pool.integer(2_i32))]);
+        let one = pool.integer(1_i32);
+
+        assert_eq!(
+            verify_antiderivative_status(candidate, one, x, &pool),
+            Some(AntiderivativeVerification::Numeric)
+        );
     }
 
     fn coeffs_equal(a: ExprId, b: ExprId, x: ExprId, pool: &ExprPool) -> bool {

--- a/alkahest-core/src/integrate/mod.rs
+++ b/alkahest-core/src/integrate/mod.rs
@@ -2,4 +2,7 @@ pub mod algebraic;
 pub mod engine;
 pub mod risch;
 
-pub use engine::{integrate, integrate_definite, verify_antiderivative_exact, IntegrationError};
+pub use engine::{
+    integrate, integrate_definite, verify_antiderivative_exact, verify_antiderivative_status,
+    AntiderivativeVerification, IntegrationError,
+};

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -60,7 +60,10 @@ pub use deriv::{DerivationLog, DerivedExpr, RewriteStep, SideCondition};
 pub use diff::{diff, diff_forward, grad, DiffError, DualValue, ForwardDiffError};
 pub use flint::{FlintInteger, FlintPoly};
 pub use hybrid::{Event, GuardStructure, HybridODE};
-pub use integrate::{integrate, integrate_definite, verify_antiderivative_exact, IntegrationError};
+pub use integrate::{
+    integrate, integrate_definite, verify_antiderivative_exact, verify_antiderivative_status,
+    AntiderivativeVerification, IntegrationError,
+};
 #[allow(deprecated)]
 pub use kernel::{
     expr_contains_noncommutative_symbol, load_from, mult_tree_is_commutative, open_persistent,

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -116,11 +116,11 @@ use alkahest_core::{
     simplify_egraph as core_simplify_egraph, simplify_egraph_with as core_simplify_egraph_with,
     simplify_trig_normal_form as core_simplify_trig_normal_form,
     simplify_with as core_simplify_with, trig_rules,
-    verify_antiderivative_exact as core_verify_antiderivative_exact,
-    AlkahestError as AlkahestErrorTrait, ApartError, DerivedExpr, DiffError, EgraphConfig,
-    IntegrationError, IoError, LimitDirection as CoreLimitDirection, LimitError,
-    LinearRecurrenceError, PatternRule, ProductError, ResultantError, RsolveError, SeriesError,
-    SimplifyConfig, SizeCost, SparseGcdError, SparseInterpError, SumError,
+    verify_antiderivative_status as core_verify_antiderivative_status,
+    AlkahestError as AlkahestErrorTrait, AntiderivativeVerification, ApartError, DerivedExpr,
+    DiffError, EgraphConfig, IntegrationError, IoError, LimitDirection as CoreLimitDirection,
+    LimitError, LinearRecurrenceError, PatternRule, ProductError, ResultantError, RsolveError,
+    SeriesError, SimplifyConfig, SizeCost, SparseGcdError, SparseInterpError, SumError,
 };
 // Experimental calculus / ODE / transform surface (PyO3 bindings deferred at
 // landing time — see PRs #152–#161). These mirror the Rust `experimental`
@@ -1550,18 +1550,20 @@ impl PyDerivedResult {
     fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
         let metadata = PyDict::new_bound(py);
         let has_certificate = !self.raw.log.is_empty();
-        let exactly_verified = self.integration_verification_input.map(|(integrand, var)| {
-            let pool_py = self.value.pool.clone_ref(py);
-            let pool = pool_py.borrow(py);
-            core_verify_antiderivative_exact(self.raw.value, integrand, var, &pool.inner)
-        });
+        let integration_verification =
+            self.integration_verification_input
+                .and_then(|(integrand, var)| {
+                    let pool_py = self.value.pool.clone_ref(py);
+                    let pool = pool_py.borrow(py);
+                    core_verify_antiderivative_status(self.raw.value, integrand, var, &pool.inner)
+                });
         metadata
             .set_item(
                 "status",
-                if exactly_verified == Some(true) {
+                if integration_verification == Some(AntiderivativeVerification::Exact) {
                     "exactly_verified"
-                } else if exactly_verified == Some(false) {
-                    "unverified"
+                } else if integration_verification == Some(AntiderivativeVerification::Numeric) {
+                    "numerically_checked"
                 } else if has_certificate {
                     "certificate_available"
                 } else {
@@ -1572,8 +1574,10 @@ impl PyDerivedResult {
         metadata
             .set_item(
                 "evidence",
-                if exactly_verified == Some(true) {
+                if integration_verification == Some(AntiderivativeVerification::Exact) {
                     "antiderivative_derivative_identity"
+                } else if integration_verification == Some(AntiderivativeVerification::Numeric) {
+                    "antiderivative_numeric_samples"
                 } else if has_certificate {
                     "derivation_log"
                 } else {
@@ -1601,8 +1605,10 @@ impl PyDerivedResult {
         metadata
             .set_item(
                 "method",
-                if exactly_verified.is_some() {
+                if integration_verification == Some(AntiderivativeVerification::Exact) {
                     "in_kernel_symbolic_residual"
+                } else if integration_verification == Some(AntiderivativeVerification::Numeric) {
+                    "floating_point_samples"
                 } else {
                     "derivation_log"
                 },
@@ -1705,7 +1711,9 @@ fn py_derived_result_context_simplify(
         value: simplified.value,
         log: log.merge(simplified.log),
     };
-    Ok(make_derived_result(py, merged, pool_py, dr.wrt))
+    let mut result = make_derived_result(py, merged, pool_py, dr.wrt);
+    result.integration_verification_input = dr.integration_verification_input;
+    Ok(result)
 }
 
 // ---------------------------------------------------------------------------

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -186,6 +186,11 @@ if evidence["status"] == "certificate_available":
     print(result.certificate)  # Lean source; check it with Lean separately
 ```
 
+For indefinite integrals, distinguish `"exactly_verified"` (the symbolic
+derivative residual is zero) from `"numerically_checked"` (the integration
+gate passed floating-point samples only). Never treat the latter as an exact
+or Lean-checked proof.
+
 ---
 
 ## Simplification

--- a/docs/mdbook/src/derivations.md
+++ b/docs/mdbook/src/derivations.md
@@ -51,6 +51,12 @@ A side condition is a predicate that must hold for a rewrite to be sound:
 
 Side conditions propagate into the derivation log as `SideCondition` entries and are aggregated in `dr.verification["side_conditions"]`. A generated Lean source artifact is evidence that can be checked; it is not a claim that the project has checked the artifact with Lean.
 
+For antiderivatives, `exactly_verified` means that the in-kernel symbolic
+residual `d/dx(F) - f` simplified to zero. `numerically_checked` means only
+that the integration soundness gate found agreement at several floating-point
+samples; it is useful evidence, but it is not an exact proof. `lean_checked`
+remains reserved for an actual completed external Lean check.
+
 ```python
 evidence = dr.verification
 if evidence["status"] == "certificate_available":

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1133,6 +1133,7 @@ def capabilities() -> dict:
                 "lean_checked",
                 "certificate_available",
                 "exactly_verified",
+                "numerically_checked",
                 "unverified",
             ],
             "artifacts": {"lean4_source": True},

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -51,6 +51,7 @@ def test_capabilities_describes_verification_boundary():
         "lean_checked",
         "certificate_available",
         "exactly_verified",
+        "numerically_checked",
         "unverified",
     ]
     assert verification["artifacts"] == {"lean4_source": True}


### PR DESCRIPTION
## Summary
- expose exact-versus-numeric evidence from the antiderivative soundness gate
- label sampled antiderivative agreement as `numerically_checked`, never as exact proof
- preserve integration evidence through context simplification and document the contract

## Test plan
- [x] `cargo fmt --all --check`
- [x] focused exact/numeric antiderivative evidence tests
- [x] `cargo test -p alkahest-py`
- [x] `pytest tests/test_smoke.py tests/test_agent_contract.py`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

Made with [Cursor](https://cursor.com)