### PR TITLE
feat(eval): add unified experimental evaluation API

### DIFF
--- a/alkahest-core/src/ball/mod.rs
+++ b/alkahest-core/src/ball/mod.rs
@@ -62,7 +62,6 @@
 // bindings, gate with `#[cfg(feature = "flint3")]`, verify all ball::tests
 // pass, then confirm rad is tighter than the MPFR path on exp/sin tests.
 
-use crate::kernel::eval_const::try_predicate_bool_from_expr;
 use crate::kernel::expr::PredicateKind;
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use rug::{ops::Pow, Float};
@@ -761,18 +760,18 @@ impl IntervalEval {
         self.eval_node(expr, pool)
     }
 
+    /// Evaluate a predicate only when its truth value is uniform throughout
+    /// every bound input ball.  `None` means the predicate changes (or may
+    /// change) within an interval, so choosing a `Piecewise` branch would be
+    /// unsound.
     fn eval_predicate(&self, pred: ExprId, pool: &ExprPool) -> Option<bool> {
-        if let Some(b) = try_predicate_bool_from_expr(pred, pool) {
-            return Some(b);
-        }
         let ExprData::Predicate { kind, args } = pool.get(pred) else {
             return None;
         };
-        let mid = |id: ExprId| self.eval_node(id, pool).map(|b| b.mid.to_f64());
         match kind {
             PredicateKind::True => Some(true),
             PredicateKind::False => Some(false),
-            PredicateKind::Not => Some(!self.eval_predicate(args[0], pool)?),
+            PredicateKind::Not => Some(!self.eval_predicate(*args.first()?, pool)?),
             PredicateKind::And => {
                 for &a in &args {
                     if !self.eval_predicate(a, pool)? {
@@ -789,12 +788,50 @@ impl IntervalEval {
                 }
                 Some(false)
             }
-            PredicateKind::Lt => Some(mid(args[0])? < mid(args[1])?),
-            PredicateKind::Le => Some(mid(args[0])? <= mid(args[1])?),
-            PredicateKind::Gt => Some(mid(args[0])? > mid(args[1])?),
-            PredicateKind::Ge => Some(mid(args[0])? >= mid(args[1])?),
-            PredicateKind::Eq => Some(mid(args[0])? == mid(args[1])?),
-            PredicateKind::Ne => Some(mid(args[0])? != mid(args[1])?),
+            PredicateKind::Lt
+            | PredicateKind::Le
+            | PredicateKind::Gt
+            | PredicateKind::Ge
+            | PredicateKind::Eq
+            | PredicateKind::Ne => {
+                let [lhs, rhs] = args.as_slice() else {
+                    return None;
+                };
+                let lhs = self.eval_node(*lhs, pool)?;
+                let rhs = self.eval_node(*rhs, pool)?;
+                let lhs_lo = lhs.lo();
+                let lhs_hi = lhs.hi();
+                let rhs_lo = rhs.lo();
+                let rhs_hi = rhs.hi();
+
+                match kind {
+                    // A strict ordering is uniform only when the two closed
+                    // balls are separated.  In particular, do not inspect
+                    // their midpoints: a midpoint can select the wrong
+                    // Piecewise branch when an interval crosses a threshold.
+                    PredicateKind::Lt if lhs_hi < rhs_lo => Some(true),
+                    PredicateKind::Lt if lhs_lo >= rhs_hi => Some(false),
+                    PredicateKind::Le if lhs_hi <= rhs_lo => Some(true),
+                    PredicateKind::Le if lhs_lo > rhs_hi => Some(false),
+                    PredicateKind::Gt if lhs_lo > rhs_hi => Some(true),
+                    PredicateKind::Gt if lhs_hi <= rhs_lo => Some(false),
+                    PredicateKind::Ge if lhs_lo >= rhs_hi => Some(true),
+                    PredicateKind::Ge if lhs_hi < rhs_lo => Some(false),
+                    // Equality is uniformly true only for the same singleton
+                    // interval.  It is uniformly false for disjoint balls.
+                    PredicateKind::Eq if lhs.is_exact() && rhs.is_exact() && lhs.mid == rhs.mid => {
+                        Some(true)
+                    }
+                    PredicateKind::Eq if lhs_hi < rhs_lo || lhs_lo > rhs_hi => Some(false),
+                    // Inequality is the converse only in the cases we can
+                    // prove uniformly; overlap remains indeterminate.
+                    PredicateKind::Ne if lhs_hi < rhs_lo || lhs_lo > rhs_hi => Some(true),
+                    PredicateKind::Ne if lhs.is_exact() && rhs.is_exact() && lhs.mid == rhs.mid => {
+                        Some(false)
+                    }
+                    _ => None,
+                }
+            }
         }
     }
 
@@ -970,6 +1007,22 @@ mod tests {
         ev.bind(x, ArbBall::from_midpoint_radius(1.0, 1e-6, 128));
         let r = ev.eval(pw, &pool).unwrap();
         assert!(r.contains(1.0));
+    }
+
+    #[test]
+    fn interval_eval_refuses_piecewise_threshold_spanning_binding() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let pw = pool.piecewise(
+            vec![(pool.pred_gt(x, pool.integer(0_i32)), pool.integer(1_i32))],
+            pool.integer(-1_i32),
+        );
+        let mut ev = IntervalEval::new(128);
+        ev.bind(x, ArbBall::from_midpoint_radius(0.1, 0.2, 128));
+
+        // The interval contains both negative and positive values.  Selecting
+        // the positive branch from the midpoint would exclude -1.
+        assert!(ev.eval(pw, &pool).is_none());
     }
 
     #[test]

--- a/alkahest-core/src/eval/mod.rs
+++ b/alkahest-core/src/eval/mod.rs
@@ -1,0 +1,487 @@
+//! Unified expression evaluation facade.
+//!
+//! The underlying evaluators deliberately retain their native representations:
+//! exact rationals stay exact, `f64` remains a fast approximate mode, and
+//! [`IntervalEval`] provides rigorous enclosures.  This module gives callers a
+//! single dispatch point and reports unsupported constructs structurally.
+
+use crate::ball::{ArbBall, IntervalEval};
+use crate::kernel::expr::PredicateKind;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use rug::Rational;
+use std::collections::HashMap;
+use std::fmt;
+
+/// Input bindings and representation selected for an evaluation.
+pub enum EvalMode<'a> {
+    /// Exact evaluation over rational numbers.  Float literals and
+    /// transcendental functions are rejected.
+    ExactRational(&'a HashMap<ExprId, Rational>),
+    /// Fast approximate evaluation using IEEE-754 double precision.
+    F64(&'a HashMap<ExprId, f64>),
+    /// Rigorous ball evaluation through the existing [`IntervalEval`] engine.
+    Interval(&'a IntervalEval),
+}
+
+/// Value returned by [`evaluate`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum EvalValue {
+    Rational(Rational),
+    F64(f64),
+    Interval(ArbBall),
+}
+
+/// A structured reason why an expression cannot be evaluated in a mode.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnsupportedReason {
+    UnboundSymbol {
+        symbol: ExprId,
+    },
+    FloatLiteralInExactMode,
+    NonIntegerExponent,
+    ZeroToNegativePower,
+    UnsupportedFunction {
+        name: String,
+    },
+    UnsupportedExpression {
+        kind: &'static str,
+    },
+    InvalidPredicateArity {
+        kind: PredicateKind,
+        expected: usize,
+        actual: usize,
+    },
+    IndeterminatePredicate,
+    NonFiniteResult,
+    IntervalEvaluationFailed,
+}
+
+impl UnsupportedReason {
+    /// Stable machine-readable code for an unsupported evaluation outcome.
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::UnboundSymbol { .. } => "E-EVAL-001",
+            Self::FloatLiteralInExactMode => "E-EVAL-002",
+            Self::NonIntegerExponent => "E-EVAL-003",
+            Self::ZeroToNegativePower => "E-EVAL-004",
+            Self::UnsupportedFunction { .. } => "E-EVAL-005",
+            Self::UnsupportedExpression { .. } => "E-EVAL-006",
+            Self::InvalidPredicateArity { .. } => "E-EVAL-007",
+            Self::IndeterminatePredicate => "E-EVAL-008",
+            Self::NonFiniteResult => "E-EVAL-009",
+            Self::IntervalEvaluationFailed => "E-EVAL-010",
+        }
+    }
+}
+
+/// Evaluation failed because the requested mode cannot represent an operation
+/// or establish a required precondition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvalError {
+    pub reason: UnsupportedReason,
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "evaluation unsupported: {:?}", self.reason)
+    }
+}
+
+impl std::error::Error for EvalError {}
+
+/// Evaluate an expression in the representation selected by `mode`.
+pub fn evaluate(expr: ExprId, pool: &ExprPool, mode: EvalMode<'_>) -> Result<EvalValue, EvalError> {
+    match mode {
+        EvalMode::ExactRational(bindings) => {
+            eval_exact_rational(expr, pool, bindings).map(EvalValue::Rational)
+        }
+        EvalMode::F64(bindings) => eval_f64(expr, pool, bindings).map(EvalValue::F64),
+        EvalMode::Interval(eval) => eval
+            .eval(expr, pool)
+            .map(EvalValue::Interval)
+            .ok_or_else(|| error(UnsupportedReason::IntervalEvaluationFailed)),
+    }
+}
+
+/// Evaluate using exact rational arithmetic.
+pub fn eval_exact_rational(
+    expr: ExprId,
+    pool: &ExprPool,
+    bindings: &HashMap<ExprId, Rational>,
+) -> Result<Rational, EvalError> {
+    eval_rational_node(expr, pool, bindings)
+}
+
+/// Evaluate using IEEE-754 double precision.
+pub fn eval_f64(
+    expr: ExprId,
+    pool: &ExprPool,
+    bindings: &HashMap<ExprId, f64>,
+) -> Result<f64, EvalError> {
+    let result = eval_f64_node(expr, pool, bindings)?;
+    if result.is_finite() {
+        Ok(result)
+    } else {
+        Err(error(UnsupportedReason::NonFiniteResult))
+    }
+}
+
+/// Evaluate using the existing rigorous interval evaluator.
+pub fn eval_interval(
+    expr: ExprId,
+    pool: &ExprPool,
+    eval: &IntervalEval,
+) -> Result<ArbBall, EvalError> {
+    evaluate(expr, pool, EvalMode::Interval(eval)).and_then(|value| match value {
+        EvalValue::Interval(ball) => Ok(ball),
+        _ => unreachable!("interval mode always returns an interval"),
+    })
+}
+
+fn error(reason: UnsupportedReason) -> EvalError {
+    EvalError { reason }
+}
+
+fn eval_rational_node(
+    expr: ExprId,
+    pool: &ExprPool,
+    bindings: &HashMap<ExprId, Rational>,
+) -> Result<Rational, EvalError> {
+    match pool.get(expr) {
+        ExprData::Integer(n) => Ok(Rational::from(n.0.clone())),
+        ExprData::Rational(r) => Ok(r.0.clone()),
+        ExprData::Float(_) => Err(error(UnsupportedReason::FloatLiteralInExactMode)),
+        ExprData::Symbol { .. } => bindings
+            .get(&expr)
+            .cloned()
+            .ok_or_else(|| error(UnsupportedReason::UnboundSymbol { symbol: expr })),
+        ExprData::Add(args) => {
+            let mut sum = Rational::from(0);
+            for arg in args {
+                sum += eval_rational_node(arg, pool, bindings)?;
+            }
+            Ok(sum)
+        }
+        ExprData::Mul(args) => {
+            let mut product = Rational::from(1);
+            for arg in args {
+                product *= eval_rational_node(arg, pool, bindings)?;
+            }
+            Ok(product)
+        }
+        ExprData::Pow { base, exp } => {
+            let base = eval_rational_node(base, pool, bindings)?;
+            let exponent = integer_exponent(exp, pool)?;
+            rational_pow(base, exponent)
+        }
+        ExprData::Piecewise { branches, default } => {
+            for (condition, value) in branches {
+                if eval_rational_predicate(condition, pool, bindings)? {
+                    return eval_rational_node(value, pool, bindings);
+                }
+            }
+            eval_rational_node(default, pool, bindings)
+        }
+        ExprData::Predicate { .. } => Ok(Rational::from(eval_rational_predicate(
+            expr, pool, bindings,
+        )? as i32)),
+        ExprData::Func { name, .. } => Err(error(UnsupportedReason::UnsupportedFunction {
+            name: name.clone(),
+        })),
+        other => Err(error(UnsupportedReason::UnsupportedExpression {
+            kind: expr_kind(&other),
+        })),
+    }
+}
+
+fn integer_exponent(expr: ExprId, pool: &ExprPool) -> Result<i64, EvalError> {
+    match pool.get(expr) {
+        ExprData::Integer(n) => {
+            n.0.to_i64()
+                .ok_or_else(|| error(UnsupportedReason::NonIntegerExponent))
+        }
+        ExprData::Rational(r) if *r.0.denom() == 1 => {
+            r.0.numer()
+                .to_i64()
+                .ok_or_else(|| error(UnsupportedReason::NonIntegerExponent))
+        }
+        _ => Err(error(UnsupportedReason::NonIntegerExponent)),
+    }
+}
+
+fn rational_pow(mut base: Rational, exponent: i64) -> Result<Rational, EvalError> {
+    if exponent < 0 && base == 0 {
+        return Err(error(UnsupportedReason::ZeroToNegativePower));
+    }
+    let mut result = Rational::from(1);
+    let mut power = exponent.unsigned_abs();
+    while power != 0 {
+        if power & 1 == 1 {
+            result *= &base;
+        }
+        power >>= 1;
+        if power != 0 {
+            base *= base.clone();
+        }
+    }
+    if exponent < 0 {
+        Ok(Rational::from(1) / result)
+    } else {
+        Ok(result)
+    }
+}
+
+fn eval_rational_predicate(
+    expr: ExprId,
+    pool: &ExprPool,
+    bindings: &HashMap<ExprId, Rational>,
+) -> Result<bool, EvalError> {
+    let ExprData::Predicate { kind, args } = pool.get(expr) else {
+        return Err(error(UnsupportedReason::IndeterminatePredicate));
+    };
+    match kind {
+        PredicateKind::True => check_arity(&kind, &args, 0).map(|_| true),
+        PredicateKind::False => check_arity(&kind, &args, 0).map(|_| false),
+        PredicateKind::Not => Ok(!eval_rational_predicate(
+            predicate_arg(&kind, &args, 0)?,
+            pool,
+            bindings,
+        )?),
+        PredicateKind::And => {
+            for &arg in &args {
+                if !eval_rational_predicate(arg, pool, bindings)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        PredicateKind::Or => {
+            for &arg in &args {
+                if eval_rational_predicate(arg, pool, bindings)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        PredicateKind::Lt
+        | PredicateKind::Le
+        | PredicateKind::Gt
+        | PredicateKind::Ge
+        | PredicateKind::Eq
+        | PredicateKind::Ne => {
+            check_arity(&kind, &args, 2)?;
+            let lhs = eval_rational_node(args[0], pool, bindings)?;
+            let rhs = eval_rational_node(args[1], pool, bindings)?;
+            Ok(match kind {
+                PredicateKind::Lt => lhs < rhs,
+                PredicateKind::Le => lhs <= rhs,
+                PredicateKind::Gt => lhs > rhs,
+                PredicateKind::Ge => lhs >= rhs,
+                PredicateKind::Eq => lhs == rhs,
+                PredicateKind::Ne => lhs != rhs,
+                _ => unreachable!(),
+            })
+        }
+    }
+}
+
+fn eval_f64_node(
+    expr: ExprId,
+    pool: &ExprPool,
+    bindings: &HashMap<ExprId, f64>,
+) -> Result<f64, EvalError> {
+    match pool.get(expr) {
+        ExprData::Integer(n) => Ok(n.0.to_f64()),
+        ExprData::Rational(r) => Ok(r.0.to_f64()),
+        ExprData::Float(f) => Ok(f.inner.to_f64()),
+        ExprData::Symbol { .. } => bindings
+            .get(&expr)
+            .copied()
+            .ok_or_else(|| error(UnsupportedReason::UnboundSymbol { symbol: expr })),
+        ExprData::Add(args) => {
+            let mut sum = 0.0;
+            for arg in args {
+                sum += eval_f64_node(arg, pool, bindings)?;
+            }
+            Ok(sum)
+        }
+        ExprData::Mul(args) => {
+            let mut product = 1.0;
+            for arg in args {
+                product *= eval_f64_node(arg, pool, bindings)?;
+            }
+            Ok(product)
+        }
+        ExprData::Pow { base, exp } => {
+            Ok(eval_f64_node(base, pool, bindings)?.powf(eval_f64_node(exp, pool, bindings)?))
+        }
+        ExprData::Func { name, args } if args.len() == 1 => {
+            let arg = eval_f64_node(args[0], pool, bindings)?;
+            match name.as_str() {
+                "sin" => Ok(arg.sin()),
+                "cos" => Ok(arg.cos()),
+                "exp" => Ok(arg.exp()),
+                "log" => Ok(arg.ln()),
+                "sqrt" => Ok(arg.sqrt()),
+                _ => Err(error(UnsupportedReason::UnsupportedFunction {
+                    name: name.clone(),
+                })),
+            }
+        }
+        ExprData::Func { name, .. } => Err(error(UnsupportedReason::UnsupportedFunction {
+            name: name.clone(),
+        })),
+        ExprData::Piecewise { branches, default } => {
+            for (condition, value) in branches {
+                if eval_f64_predicate(condition, pool, bindings)? {
+                    return eval_f64_node(value, pool, bindings);
+                }
+            }
+            eval_f64_node(default, pool, bindings)
+        }
+        ExprData::Predicate { .. } => Ok(eval_f64_predicate(expr, pool, bindings)? as i32 as f64),
+        other => Err(error(UnsupportedReason::UnsupportedExpression {
+            kind: expr_kind(&other),
+        })),
+    }
+}
+
+fn eval_f64_predicate(
+    expr: ExprId,
+    pool: &ExprPool,
+    bindings: &HashMap<ExprId, f64>,
+) -> Result<bool, EvalError> {
+    let ExprData::Predicate { kind, args } = pool.get(expr) else {
+        return Err(error(UnsupportedReason::IndeterminatePredicate));
+    };
+    match kind {
+        PredicateKind::True => check_arity(&kind, &args, 0).map(|_| true),
+        PredicateKind::False => check_arity(&kind, &args, 0).map(|_| false),
+        PredicateKind::Not => Ok(!eval_f64_predicate(
+            predicate_arg(&kind, &args, 0)?,
+            pool,
+            bindings,
+        )?),
+        PredicateKind::And => {
+            for &arg in &args {
+                if !eval_f64_predicate(arg, pool, bindings)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        PredicateKind::Or => {
+            for &arg in &args {
+                if eval_f64_predicate(arg, pool, bindings)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        PredicateKind::Lt
+        | PredicateKind::Le
+        | PredicateKind::Gt
+        | PredicateKind::Ge
+        | PredicateKind::Eq
+        | PredicateKind::Ne => {
+            check_arity(&kind, &args, 2)?;
+            let lhs = eval_f64_node(args[0], pool, bindings)?;
+            let rhs = eval_f64_node(args[1], pool, bindings)?;
+            Ok(match kind {
+                PredicateKind::Lt => lhs < rhs,
+                PredicateKind::Le => lhs <= rhs,
+                PredicateKind::Gt => lhs > rhs,
+                PredicateKind::Ge => lhs >= rhs,
+                PredicateKind::Eq => lhs == rhs,
+                PredicateKind::Ne => lhs != rhs,
+                _ => unreachable!(),
+            })
+        }
+    }
+}
+
+fn check_arity(kind: &PredicateKind, args: &[ExprId], expected: usize) -> Result<(), EvalError> {
+    if args.len() == expected {
+        Ok(())
+    } else {
+        Err(error(UnsupportedReason::InvalidPredicateArity {
+            kind: kind.clone(),
+            expected,
+            actual: args.len(),
+        }))
+    }
+}
+
+fn predicate_arg(kind: &PredicateKind, args: &[ExprId], index: usize) -> Result<ExprId, EvalError> {
+    check_arity(kind, args, 1)?;
+    Ok(args[index])
+}
+
+fn expr_kind(expr: &ExprData) -> &'static str {
+    match expr {
+        ExprData::Forall { .. } => "Forall",
+        ExprData::Exists { .. } => "Exists",
+        ExprData::BigO(_) => "BigO",
+        ExprData::RootSum { .. } => "RootSum",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ball::ArbBall;
+    use crate::kernel::Domain;
+
+    #[test]
+    fn exact_rational_mode_preserves_fractional_result() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![pool.rational(1, 3), x]);
+        let bindings = HashMap::from([(x, Rational::from((1, 6)))]);
+
+        assert_eq!(
+            eval_exact_rational(expr, &pool, &bindings).unwrap(),
+            Rational::from((1, 2))
+        );
+    }
+
+    #[test]
+    fn f64_mode_evaluates_transcendental_function() {
+        let pool = ExprPool::new();
+        let expr = pool.func("sqrt", vec![pool.integer(9_i32)]);
+
+        let result = eval_f64(expr, &pool, &HashMap::new()).unwrap();
+        assert_eq!(result, 3.0);
+    }
+
+    #[test]
+    fn exact_mode_rejects_float_literal_structurally() {
+        let pool = ExprPool::new();
+        let expr = pool.float(0.5, 53);
+
+        assert_eq!(
+            eval_exact_rational(expr, &pool, &HashMap::new())
+                .unwrap_err()
+                .reason,
+            UnsupportedReason::FloatLiteralInExactMode
+        );
+    }
+
+    #[test]
+    fn facade_interval_mode_refuses_threshold_spanning_piecewise() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.piecewise(
+            vec![(pool.pred_ge(x, pool.integer(0_i32)), pool.integer(1_i32))],
+            pool.integer(-1_i32),
+        );
+        let mut interval = IntervalEval::new(128);
+        interval.bind(x, ArbBall::from_midpoint_radius(0.0, 1.0, 128));
+
+        assert_eq!(
+            eval_interval(expr, &pool, &interval).unwrap_err().reason,
+            UnsupportedReason::IntervalEvaluationFailed
+        );
+    }
+}

--- a/alkahest-core/src/eval/mod.rs
+++ b/alkahest-core/src/eval/mod.rs
@@ -99,7 +99,7 @@ pub fn evaluate(expr: ExprId, pool: &ExprPool, mode: EvalMode<'_>) -> Result<Eva
         EvalMode::Interval(eval) => eval
             .eval(expr, pool)
             .map(EvalValue::Interval)
-            .ok_or_else(|| error(UnsupportedReason::IntervalEvaluationFailed)),
+            .ok_or(error(UnsupportedReason::IntervalEvaluationFailed)),
     }
 }
 
@@ -132,8 +132,8 @@ pub fn eval_interval(
     pool: &ExprPool,
     eval: &IntervalEval,
 ) -> Result<ArbBall, EvalError> {
-    evaluate(expr, pool, EvalMode::Interval(eval)).and_then(|value| match value {
-        EvalValue::Interval(ball) => Ok(ball),
+    evaluate(expr, pool, EvalMode::Interval(eval)).map(|value| match value {
+        EvalValue::Interval(ball) => ball,
         _ => unreachable!("interval mode always returns an interval"),
     })
 }
@@ -154,7 +154,7 @@ fn eval_rational_node(
         ExprData::Symbol { .. } => bindings
             .get(&expr)
             .cloned()
-            .ok_or_else(|| error(UnsupportedReason::UnboundSymbol { symbol: expr })),
+            .ok_or(error(UnsupportedReason::UnboundSymbol { symbol: expr })),
         ExprData::Add(args) => {
             let mut sum = Rational::from(0);
             for arg in args {
@@ -198,12 +198,12 @@ fn integer_exponent(expr: ExprId, pool: &ExprPool) -> Result<i64, EvalError> {
     match pool.get(expr) {
         ExprData::Integer(n) => {
             n.0.to_i64()
-                .ok_or_else(|| error(UnsupportedReason::NonIntegerExponent))
+                .ok_or(error(UnsupportedReason::NonIntegerExponent))
         }
         ExprData::Rational(r) if *r.0.denom() == 1 => {
             r.0.numer()
                 .to_i64()
-                .ok_or_else(|| error(UnsupportedReason::NonIntegerExponent))
+                .ok_or(error(UnsupportedReason::NonIntegerExponent))
         }
         _ => Err(error(UnsupportedReason::NonIntegerExponent)),
     }
@@ -297,7 +297,7 @@ fn eval_f64_node(
         ExprData::Symbol { .. } => bindings
             .get(&expr)
             .copied()
-            .ok_or_else(|| error(UnsupportedReason::UnboundSymbol { symbol: expr })),
+            .ok_or(error(UnsupportedReason::UnboundSymbol { symbol: expr })),
         ExprData::Add(args) => {
             let mut sum = 0.0;
             for arg in args {

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod dae;
 pub mod deriv;
 pub mod diff;
 pub mod errors;
+pub mod eval;
 pub mod flint;
 pub mod horner;
 pub mod hybrid;
@@ -58,6 +59,10 @@ pub use dae::{pantelides, DaeError, PantelidesResult, DAE};
 pub use deriv::{DerivationLog, DerivedExpr, RewriteStep, SideCondition};
 #[allow(deprecated)]
 pub use diff::{diff, diff_forward, grad, DiffError, DualValue, ForwardDiffError};
+pub use eval::{
+    eval_exact_rational, eval_f64, eval_interval, evaluate, EvalError, EvalMode, EvalValue,
+    UnsupportedReason,
+};
 pub use flint::{FlintInteger, FlintPoly};
 pub use hybrid::{Event, GuardStructure, HybridODE};
 pub use integrate::{integrate, integrate_definite, verify_antiderivative_exact, IntegrationError};
@@ -306,6 +311,10 @@ pub mod experimental {
     pub use crate::calculus::fps::{Fps, FpsError};
     pub use crate::calculus::multilimit::{multilimit, MultiLimit, PathWitness};
     pub use crate::deriv::{DerivationLog, DerivedExpr, RewriteStep, SideCondition};
+    pub use crate::eval::{
+        eval_exact_rational, eval_f64, eval_interval, evaluate, EvalError, EvalMode, EvalValue,
+        UnsupportedReason,
+    };
     pub use crate::horner::{emit_expr_c, emit_expr_c_vec, emit_horner_c, horner, EmitCError};
     pub use crate::hybrid::{Event, GuardStructure, HybridODE};
     pub use crate::lean::emit_lean_expr as emit_lean;

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -5548,7 +5548,7 @@ fn py_evaluate(
                     let fraction = py
                         .import_bound("fractions")?
                         .getattr("Fraction")?
-                        .call1((value.numer().to_string(), value.denom().to_string()))?;
+                        .call1((format!("{}/{}", value.numer(), value.denom()),))?;
                     PyEvaluationResult {
                         value: fraction.into_py(py),
                         status: "ok".into(),

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -110,10 +110,12 @@ use alkahest_core::modular::{
 };
 use alkahest_core::{
     apart as core_apart, diff as core_diff, diff_forward as core_diff_forward,
-    integrate as core_integrate, integrate_definite as core_integrate_definite,
-    limit as core_limit, load_from, log_exp_rules, rsolve as core_rsolve, series as core_series,
-    simplify as core_simplify, simplify_batch as core_simplify_batch,
-    simplify_egraph as core_simplify_egraph, simplify_egraph_with as core_simplify_egraph_with,
+    eval_exact_rational as core_eval_exact_rational, eval_f64 as core_eval_f64,
+    eval_interval as core_eval_interval, integrate as core_integrate,
+    integrate_definite as core_integrate_definite, limit as core_limit, load_from, log_exp_rules,
+    rsolve as core_rsolve, series as core_series, simplify as core_simplify,
+    simplify_batch as core_simplify_batch, simplify_egraph as core_simplify_egraph,
+    simplify_egraph_with as core_simplify_egraph_with,
     simplify_trig_normal_form as core_simplify_trig_normal_form,
     simplify_with as core_simplify_with, trig_rules,
     verify_antiderivative_exact as core_verify_antiderivative_exact,
@@ -161,7 +163,7 @@ use alkahest_core::number_theory::{
 use pyo3::exceptions::{PyOverflowError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyInt, PyList, PyTuple};
-use rug::{Integer, Rational};
+use rug::{Complete, Integer, Rational};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -5390,6 +5392,216 @@ fn py_interval_eval(
     Ok(PyArbBall { inner: result })
 }
 
+/// Structured result returned by the experimental unified evaluator.
+#[pyclass(name = "EvaluationResult")]
+struct PyEvaluationResult {
+    value: PyObject,
+    status: String,
+    backend: String,
+    requested_mode: String,
+    requested_precision_bits: Option<u32>,
+    achieved_precision_bits: Option<u32>,
+    enclosure: Option<Py<PyArbBall>>,
+    reason: Option<String>,
+}
+
+#[pymethods]
+impl PyEvaluationResult {
+    #[getter]
+    fn value(&self, py: Python<'_>) -> PyObject {
+        self.value.clone_ref(py)
+    }
+    #[getter]
+    fn status(&self) -> &str {
+        &self.status
+    }
+    #[getter]
+    fn backend(&self) -> &str {
+        &self.backend
+    }
+    #[getter]
+    fn requested_mode(&self) -> &str {
+        &self.requested_mode
+    }
+    #[getter]
+    fn requested_precision_bits(&self) -> Option<u32> {
+        self.requested_precision_bits
+    }
+    #[getter]
+    fn achieved_precision_bits(&self) -> Option<u32> {
+        self.achieved_precision_bits
+    }
+    #[getter]
+    fn enclosure(&self, py: Python<'_>) -> Option<Py<PyArbBall>> {
+        self.enclosure.as_ref().map(|ball| ball.clone_ref(py))
+    }
+    #[getter]
+    fn reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+    #[getter]
+    fn is_enclosure(&self) -> bool {
+        self.enclosure.is_some()
+    }
+}
+
+fn exact_binding(value: &Bound<'_, PyAny>) -> PyResult<Rational> {
+    if let Ok(integer) = value.extract::<i64>() {
+        return Ok(Rational::from(integer));
+    }
+    let numerator: String = value.getattr("numerator")?.str()?.extract()?;
+    let denominator: String = value.getattr("denominator")?.str()?.extract()?;
+    let numerator = Integer::parse(numerator)
+        .map_err(|_| PyTypeError::new_err("exact bindings must be int or fractions.Fraction"))?
+        .complete();
+    let denominator = Integer::parse(denominator)
+        .map_err(|_| PyTypeError::new_err("exact bindings must be int or fractions.Fraction"))?
+        .complete();
+    if denominator == 0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "exact binding denominator must be non-zero",
+        ));
+    }
+    Ok(Rational::from((numerator, denominator)))
+}
+
+#[pyfunction]
+#[pyo3(name = "evaluate", signature = (expr, bindings, *, mode = "auto", precision_bits = None))]
+fn py_evaluate(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    bindings: &Bound<'_, PyDict>,
+    mode: &str,
+    precision_bits: Option<u32>,
+) -> PyResult<PyEvaluationResult> {
+    if !matches!(mode, "auto" | "exact" | "f64" | "interval") {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "mode must be 'auto', 'exact', 'f64', or 'interval'",
+        ));
+    }
+    if precision_bits == Some(0) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "precision_bits must be positive",
+        ));
+    }
+    let pool = expr.pool.borrow(py);
+    let wants_interval = mode == "interval"
+        || (mode == "auto"
+            && (precision_bits.is_some()
+                || bindings
+                    .iter()
+                    .any(|(_, v)| v.is_instance_of::<PyArbBall>())));
+    if wants_interval {
+        let precision = precision_bits.unwrap_or(128);
+        let mut evaluator = CoreIntervalEval::new(precision);
+        for (key, value) in bindings.iter() {
+            let var: PyRef<PyExpr> = key.extract()?;
+            let ball: PyRef<PyArbBall> = value
+                .extract()
+                .map_err(|_| PyTypeError::new_err("interval bindings must be ArbBall values"))?;
+            evaluator.bind(var.id, ball.inner.clone());
+        }
+        return Ok(match core_eval_interval(expr.id, &pool.inner, &evaluator) {
+            Ok(ball) => {
+                let py_ball = Py::new(py, PyArbBall { inner: ball })?;
+                PyEvaluationResult {
+                    value: py_ball.clone_ref(py).into_py(py),
+                    status: "ok".into(),
+                    backend: "mpfr_ball".into(),
+                    requested_mode: mode.into(),
+                    requested_precision_bits: precision_bits,
+                    achieved_precision_bits: Some(precision),
+                    enclosure: Some(py_ball),
+                    reason: None,
+                }
+            }
+            Err(error) => PyEvaluationResult {
+                value: py.None(),
+                status: "unsupported".into(),
+                backend: "none".into(),
+                requested_mode: mode.into(),
+                requested_precision_bits: precision_bits,
+                achieved_precision_bits: None,
+                enclosure: None,
+                reason: Some(error.reason.code().to_owned()),
+            },
+        });
+    }
+    let mut exact = std::collections::HashMap::new();
+    let mut exact_possible = true;
+    for (key, value) in bindings.iter() {
+        let var: PyRef<PyExpr> = key.extract()?;
+        match exact_binding(&value) {
+            Ok(v) => {
+                exact.insert(var.id, v);
+            }
+            Err(_) => {
+                exact_possible = false;
+                break;
+            }
+        }
+    }
+    if mode == "exact" || (mode == "auto" && exact_possible) {
+        return Ok(
+            match core_eval_exact_rational(expr.id, &pool.inner, &exact) {
+                Ok(value) => {
+                    let fraction = py
+                        .import_bound("fractions")?
+                        .getattr("Fraction")?
+                        .call1((value.numer().to_string(), value.denom().to_string()))?;
+                    PyEvaluationResult {
+                        value: fraction.into_py(py),
+                        status: "ok".into(),
+                        backend: "exact_rational".into(),
+                        requested_mode: mode.into(),
+                        requested_precision_bits: precision_bits,
+                        achieved_precision_bits: None,
+                        enclosure: None,
+                        reason: None,
+                    }
+                }
+                Err(error) => PyEvaluationResult {
+                    value: py.None(),
+                    status: "unsupported".into(),
+                    backend: "none".into(),
+                    requested_mode: mode.into(),
+                    requested_precision_bits: precision_bits,
+                    achieved_precision_bits: None,
+                    enclosure: None,
+                    reason: Some(error.reason.code().to_owned()),
+                },
+            },
+        );
+    }
+    let mut env = std::collections::HashMap::new();
+    for (key, value) in bindings.iter() {
+        let var: PyRef<PyExpr> = key.extract()?;
+        env.insert(var.id, value.extract::<f64>()?);
+    }
+    Ok(match core_eval_f64(expr.id, &pool.inner, &env) {
+        Ok(value) => PyEvaluationResult {
+            value: value.into_py(py),
+            status: "ok".into(),
+            backend: "interpreter_f64".into(),
+            requested_mode: mode.into(),
+            requested_precision_bits: precision_bits,
+            achieved_precision_bits: Some(53),
+            enclosure: None,
+            reason: None,
+        },
+        Err(error) => PyEvaluationResult {
+            value: py.None(),
+            status: "unsupported".into(),
+            backend: "none".into(),
+            requested_mode: mode.into(),
+            requested_precision_bits: precision_bits,
+            achieved_precision_bits: None,
+            enclosure: None,
+            reason: Some(error.reason.code().to_owned()),
+        },
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Phase 23 — Parallel simplification
 // ---------------------------------------------------------------------------
@@ -8194,6 +8406,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_simplify_trig, m)?)?;
     m.add_function(wrap_pyfunction!(py_simplify_trig_normal_form, m)?)?;
     m.add_function(wrap_pyfunction!(py_simplify_log_exp, m)?)?;
+    m.add_function(wrap_pyfunction!(py_evaluate, m)?)?;
     m.add_function(wrap_pyfunction!(py_diff, m)?)?;
     m.add_function(wrap_pyfunction!(py_diff_forward, m)?)?;
     m.add_function(wrap_pyfunction!(py_integrate, m)?)?;
@@ -8259,6 +8472,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDomain>()?;
     m.add_class::<PyExprPool>()?;
     m.add_class::<PyExpr>()?;
+    m.add_class::<PyEvaluationResult>()?;
     m.add_class::<PyDerivedResult>()?;
     m.add_class::<PySeries>()?;
     m.add_class::<PyUniPoly>()?;

--- a/docs/mdbook/src/ball-arithmetic.md
+++ b/docs/mdbook/src/ball-arithmetic.md
@@ -1,5 +1,33 @@
 # Ball arithmetic
 
+## Unified evaluation (experimental)
+
+`alkahest.experimental.evaluate` provides one result contract for exact
+rational, `f64`, and rigorous interval evaluation. It returns an
+`EvaluationResult`; mathematically unsupported inputs return
+`status == "unsupported"` and a stable `E-EVAL-*` reason code rather than raising.
+Invalid API input, such as an invalid mode or zero precision, still raises
+`ValueError`.
+
+```python
+from fractions import Fraction
+import alkahest as ak
+from alkahest.experimental import evaluate
+
+p = ak.ExprPool()
+x = p.symbol("x")
+result = evaluate(x + p.rational(1, 3), {x: Fraction(1, 6)})
+assert result.value == Fraction(1, 2)
+assert result.backend == "exact_rational"
+```
+
+Use `mode="f64"` for ordinary floating-point evaluation and
+`mode="interval"` with `ArbBall` bindings for an enclosure. In interval mode,
+`result.value` and `result.enclosure` are the same `ArbBall`; its `lo` and
+`hi` bound the true result. `mode="auto"` selects intervals for `ArbBall`
+bindings (or an explicit precision), exact rationals when possible, and
+otherwise falls back to `f64`.
+
 Ball arithmetic provides rigorous enclosures: every operation produces an interval guaranteed to contain the true result. Alkahest uses FLINT's Arb library as the backend.
 
 ## ArbBall

--- a/python/alkahest/experimental/__init__.py
+++ b/python/alkahest/experimental/__init__.py
@@ -15,6 +15,7 @@ Other experimental surface:
 - :func:`to_lean` — Lean 4 certificate export (V5-1)
 - :func:`to_stablehlo` — StableHLO / XLA bridge (V5-2)
 - :func:`to_jax` — JAX primitive integration (V5-7, requires JAX)
+- :func:`evaluate` — unified exact, f64, and interval evaluation
 - :class:`GroebnerBasis`, :class:`GbPoly` — parallel F4 Gröbner basis (V5-11,
   requires ``groebner`` feature)
 - :func:`solve` — polynomial system solver (V1-4, requires ``groebner`` feature)
@@ -50,11 +51,13 @@ from alkahest import to_stablehlo
 
 # Calculus / ODE / transform surface (always built into the extension).
 from alkahest.alkahest import (
+    EvaluationResult,
     Fps,
     OdeTrajectory,
     asymptotic_expand,
     dirac_delta,
     dsolve,
+    evaluate,
     fourier_transform,
     heaviside,
     inverse_fourier_transform,
@@ -82,6 +85,7 @@ with contextlib.suppress(ImportError):
 
 __all__ = [
     "CudaCompiledFn",
+    "EvaluationResult",
     "Fps",
     "GbPoly",
     "GroebnerBasis",
@@ -90,6 +94,7 @@ __all__ = [
     "compile_cuda",
     "dirac_delta",
     "dsolve",
+    "evaluate",
     "fourier_transform",
     "heaviside",
     "inverse_fourier_transform",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,50 @@
+from fractions import Fraction
+
+import alkahest as ak
+from alkahest.experimental import evaluate
+
+
+def test_auto_evaluate_prefers_exact_rational_results():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    result = evaluate(x + pool.rational(1, 3), {x: Fraction(1, 6)})
+
+    assert result.status == "ok"
+    assert result.backend == "exact_rational"
+    assert result.value == Fraction(1, 2)
+    assert result.enclosure is None
+
+
+def test_evaluate_f64_reports_backend():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    result = evaluate(ak.sin(x), {x: 0.0}, mode="f64")
+
+    assert result.status == "ok"
+    assert result.backend == "interpreter_f64"
+    assert result.value == 0.0
+
+
+def test_evaluate_interval_returns_enclosure():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    result = evaluate(x * x, {x: ak.ArbBall(2.0, 0.1)}, mode="interval", precision_bits=128)
+
+    assert result.status == "ok"
+    assert result.is_enclosure
+    assert result.value.contains(4.0)
+    assert result.requested_precision_bits == 128
+
+
+def test_unsupported_evaluation_returns_stable_status():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    result = evaluate(ak.log(x), {}, mode="exact")
+
+    assert result.status == "unsupported"
+    assert result.value is None
+    assert result.reason == "E-EVAL-001"

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -43,7 +43,7 @@ def test_unsupported_evaluation_returns_stable_status():
     pool = ak.ExprPool()
     x = pool.symbol("x")
 
-    result = evaluate(ak.log(x), {}, mode="exact")
+    result = evaluate(x, {}, mode="exact")
 
     assert result.status == "unsupported"
     assert result.value is None


### PR DESCRIPTION
## Summary
- add one core facade for exact rational, f64, and ball-interval evaluation
- expose `alkahest.experimental.evaluate` with backend, precision, enclosure, and stable `E-EVAL-*` metadata
- refuse interval piecewise predicates that span a branch threshold rather than selecting a midpoint branch

## Test plan
- [x] `cargo test -p alkahest-cas eval`
- [x] `cargo test -p alkahest-py`
- [x] `ruff check python/alkahest/experimental/__init__.py tests/test_evaluate.py`
- [x] `cargo test --workspace`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified experimental evaluation API supporting exact rational, floating-point, and rigorous interval calculations.
  * Added automatic mode selection (based on inputs and requested precision) and structured results (backend, precision, optional interval enclosure, and stable “unsupported” codes).
  * Exposed the evaluator through the Python experimental interface.
* **Bug Fixes**
  * Improved interval predicate evaluation to avoid unsound decisions when truth can vary within a bound.
* **Documentation**
  * Documented the unified evaluation API, including behavior for unsupported inputs and example usage.
* **Tests**
  * Added tests covering mode selection, exact/f64/interval outputs, and deterministic unsupported results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->