### PR TITLE
feat(api): report native build feature parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,11 @@ jobs:
       - name: maturin develop
         run: maturin develop --manifest-path alkahest-py/Cargo.toml --features "groebner egraph"
 
+      - name: Cranelift capability smoke test
+        run: |
+          maturin develop --manifest-path alkahest-py/Cargo.toml --features "groebner egraph cranelift"
+          python -c "import alkahest as ak; f = ak.capabilities()['features']; assert f['cranelift_jit'] and not f['llvm_jit'] and not f['parallel']"
+
       - name: ty check
         run: ty check python/alkahest/
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -75,6 +75,12 @@ jobs:
           print(ak.simplify(x + 0).value)
           print(ak.simplify_egraph(x + 0).value)
           assert hasattr(ak, 'solve'), 'expected groebner APIs in default wheel'
+          assert ak.capabilities()["features"] == {
+              "egraph": True, "groebner": True, "jit": False,
+              "cranelift": False, "llvm_jit": False, "cranelift_jit": False,
+              "parallel": False, "numpy": False, "cuda": False,
+              "groebner_cuda": False,
+          }
           print('groebner ok')
           "
 
@@ -153,7 +159,7 @@ jobs:
           if [ -n "$SITE_LIBS" ]; then
             export LD_LIBRARY_PATH="${SITE_LIBS}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           fi
-          python -c "import alkahest as ak; assert ak.jit_is_available(), 'expected LLVM JIT in +jit wheel'"
+          python -c "import alkahest as ak; caps = ak.capabilities(); assert caps['features']['llvm_jit'] and not caps['features']['parallel'], 'expected LLVM-only JIT in +jit wheel'"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -224,7 +230,7 @@ jobs:
           if [ -n "$SITE_LIBS" ]; then
             export LD_LIBRARY_PATH="${SITE_LIBS}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           fi
-          python -c "import alkahest as ak; assert ak.jit_is_available(); assert hasattr(ak, 'solve'), 'expected groebner APIs in +full wheel'"
+          python -c "import alkahest as ak; caps = ak.capabilities(); assert caps['features']['llvm_jit'] and caps['features']['parallel']; assert hasattr(ak, 'solve'), 'expected groebner APIs in +full wheel'"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -322,7 +328,7 @@ jobs:
       - name: Smoke test
         run: |
           pip install --no-index --find-links dist alkahest
-          python -c "import alkahest; p = alkahest.ExprPool(); x = p.symbol('x'); print(alkahest.simplify(x + 0))"
+          python -c "import alkahest; p = alkahest.ExprPool(); x = p.symbol('x'); print(alkahest.simplify(x + 0)); caps = alkahest.capabilities(); assert caps['features']['egraph'] and caps['features']['groebner']; assert not caps['features']['jit'] and not caps['features']['parallel']"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -4922,7 +4922,7 @@ fn py_compile_expr(
     })
 }
 
-/// Return True if LLVM JIT compilation is available in this build.
+/// Return True if any native JIT backend is available in this build.
 ///
 /// When False, `compile_expr` falls back to the tree-walking interpreter and
 /// emits a RuntimeWarning.
@@ -4942,8 +4942,12 @@ fn py_build_features() -> std::collections::HashMap<String, bool> {
     [
         ("egraph", cfg!(feature = "egraph")),
         ("groebner", cfg!(feature = "groebner")),
+        // Retain the Cargo feature names for compatibility and expose
+        // backend-specific names so callers need not infer what `jit` means.
         ("jit", cfg!(feature = "jit")),
         ("cranelift", cfg!(feature = "cranelift")),
+        ("llvm_jit", cfg!(feature = "jit")),
+        ("cranelift_jit", cfg!(feature = "cranelift")),
         ("parallel", cfg!(feature = "parallel")),
         ("numpy", cfg!(feature = "numpy")),
         ("cuda", cfg!(feature = "cuda")),

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -133,7 +133,8 @@ Every expression lives in an **`ExprPool`** (a hash-consed DAG). You must create
 import alkahest as ak
 from alkahest import sin, cos, exp, log, sqrt, diff, integrate, simplify, simplify_trig
 
-caps = ak.capabilities()  # groebner, jit, egraph, parallel — probe once per session
+caps = ak.capabilities()  # probe the installed native build once per session
+features = caps["features"]  # includes llvm_jit, cranelift_jit, cuda, and parallel
 
 pool = ak.ExprPool()
 x = pool.symbol("x", ak.Domain.Real)   # or domain="real"

--- a/docs/mdbook/src/getting-started.md
+++ b/docs/mdbook/src/getting-started.md
@@ -34,11 +34,11 @@ Tagged releases attach **`linux_x86_64`** wheels on [GitHub Releases](https://gi
 | `+jit` | `egraph groebner jit` | LLVM CPU JIT (smaller than `+full`; groebner and egraph are already in the default PyPI wheel). |
 | `+full` | `egraph groebner jit parallel` | JIT plus parallel F4 S-polynomial reduction (largest wheel). |
 
-Example direct installs (replace **version**, tag, and wheel name using the release asset list):
+Example direct installs (replace `<version>` and the wheel name using the release asset list):
 
 ```bash
-pip install "https://github.com/alkahest-cas/alkahest/releases/download/v2.0.2/alkahest-2.0.2+full-cp311-cp311-linux_x86_64.whl"
-pip install "https://github.com/alkahest-cas/alkahest/releases/download/v2.0.2/alkahest-2.0.2+jit-cp311-cp311-linux_x86_64.whl"
+pip install "https://github.com/alkahest-cas/alkahest/releases/download/v<version>/alkahest-<version>+full-cp311-cp311-linux_x86_64.whl"
+pip install "https://github.com/alkahest-cas/alkahest/releases/download/v<version>/alkahest-<version>+jit-cp311-cp311-linux_x86_64.whl"
 ```
 
 These wheels vendor LLVM and related `.so` files under `site-packages/alkahest.libs/`. If `import alkahest` fails with a missing `libLLVM-*.so` or `libffi-*.so`, prepend that directory to `LD_LIBRARY_PATH` (or install matching system packages).
@@ -50,6 +50,30 @@ After `+jit` or `+full`, `alkahest.jit_is_available()` should be `True`. Gröbne
 macOS and Windows `+jit` / `+full` wheels are **not** produced in CI yet; use [building from source](#from-source) there.
 
 **Roadmap:** a small PEP 503 **extras index** URL hosting only `+jit` / `+full` wheels (PyTorch-style `--extra-index-url`). Until then, use PyPI for the default wheel or direct URLs / asset downloads from Releases.
+
+### Build-profile verification
+
+Every published wheel runs an import-and-capability smoke test in release CI.
+After installing, inspect the exact native build rather than inferring features
+from available Python functions:
+
+```python
+import alkahest as ak
+
+features = ak.capabilities()["features"]
+print(features)
+```
+
+| Distribution | Tested platforms | Native feature profile |
+|---|---|---|
+| Default PyPI wheel | Linux x86_64, macOS arm64, Windows x86_64 | `egraph`, `groebner` |
+| Release `+jit` | Linux x86_64 | Default profile plus `llvm_jit` |
+| Release `+full` | Linux x86_64 | `+jit` profile plus `parallel` |
+
+`jit` and `cranelift` remain compatibility names in this mapping. Prefer
+`llvm_jit` and `cranelift_jit` when selecting a backend explicitly. CUDA and
+`groebner_cuda` indicate that the extension was compiled with those features;
+they do not claim that a usable GPU is present at runtime.
 
 ### Optional: RL environments (`alkahest[rl]`)
 

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1102,7 +1102,8 @@ def capabilities() -> dict:
     dict
         ``contract_version`` identifies this schema. ``groebner``, ``jit``,
         ``egraph``, and ``parallel`` are compatibility feature booleans.
-        ``features`` contains installed Cargo features, ``primitives`` is
+        ``features`` contains installed Cargo features and explicit
+        ``llvm_jit`` / ``cranelift_jit`` backend flags; ``primitives`` is
         deterministic per-primitive implementation coverage, and
         ``verification`` describes available evidence artifacts and checkers.
 
@@ -1123,7 +1124,7 @@ def capabilities() -> dict:
         # Compatibility keys: report what this extension was compiled with,
         # even where a Python-level fallback exists.
         "groebner": features["groebner"],
-        "jit": features["jit"] or features["cranelift"],
+        "jit": features["llvm_jit"] or features["cranelift_jit"],
         "egraph": features["egraph"],
         "parallel": features["parallel"],
         "features": features,

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -15,6 +15,8 @@ def test_capabilities_reports_installed_build_features():
         "groebner",
         "jit",
         "cranelift",
+        "llvm_jit",
+        "cranelift_jit",
         "parallel",
         "numpy",
         "cuda",
@@ -23,7 +25,9 @@ def test_capabilities_reports_installed_build_features():
     assert caps["groebner"] is caps["features"]["groebner"]
     assert caps["egraph"] is caps["features"]["egraph"]
     assert caps["parallel"] is caps["features"]["parallel"]
-    assert caps["jit"] is (caps["features"]["jit"] or caps["features"]["cranelift"])
+    assert caps["features"]["jit"] is caps["features"]["llvm_jit"]
+    assert caps["features"]["cranelift"] is caps["features"]["cranelift_jit"]
+    assert caps["jit"] is (caps["features"]["llvm_jit"] or caps["features"]["cranelift_jit"])
     assert caps["jit"] is alkahest.jit_is_available()
 
 


### PR DESCRIPTION
## Summary
- expose backend-specific LLVM and Cranelift build metadata through `capabilities()`
- assert the expected native profile in default, `+jit`, and `+full` release-wheel smoke tests
- document tested distributions and add a Cranelift capability smoke test to CI

## Test plan
- [x] `cargo clippy -p alkahest-py --all-targets -- -D warnings`
- [x] `cargo test -p alkahest-py`
- [x] `cargo test -p alkahest-cas`
- [x] default-profile `tests/test_agent_contract.py`
- [x] Cranelift-profile capability smoke and `tests/test_agent_contract.py`

Made with [Cursor](https://cursor.com)