### PR TITLE
feat(complex): add principal Arg with branch-safe folds

### DIFF
--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -35,7 +35,10 @@
 //! // exceptions are the Dirac delta `δ` and symbolic complex constructors,
 //! // which deliberately have no pointwise real `f64` value.
 //! for row in &report.rows {
-//!     if matches!(row.name.as_str(), "diracdelta" | "conjugate" | "re" | "im") {
+//!     if matches!(
+//!         row.name.as_str(),
+//!         "diracdelta" | "conjugate" | "re" | "im" | "arg"
+//!     ) {
 //!         continue;
 //!     }
 //!     assert!(row.caps.contains(Capabilities::NUMERIC_F64));
@@ -336,6 +339,7 @@ impl PrimitiveRegistry {
         reg.register(Box::new(builtins::ConjugatePrimitive));
         reg.register(Box::new(builtins::RePrimitive));
         reg.register(Box::new(builtins::ImPrimitive));
+        reg.register(Box::new(builtins::ArgPrimitive));
         reg
     }
 
@@ -455,6 +459,7 @@ pub mod builtins {
     symbolic_complex_primitive!(ConjugatePrimitive, "conjugate");
     symbolic_complex_primitive!(RePrimitive, "re");
     symbolic_complex_primitive!(ImPrimitive, "im");
+    symbolic_complex_primitive!(ArgPrimitive, "arg");
 
     // ── sin ──────────────────────────────────────────────────────────────────
 

--- a/alkahest-core/src/simplify/rules.rs
+++ b/alkahest-core/src/simplify/rules.rs
@@ -1,5 +1,5 @@
 use crate::deriv::log::{DerivationLog, RewriteStep, SideCondition};
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
 use rug::ops::Pow;
 use std::collections::{HashMap, HashSet};
 
@@ -34,6 +34,35 @@ fn as_integer(expr: ExprId, pool: &ExprPool) -> Option<rug::Integer> {
         ExprData::Integer(n) => Some(n.0.clone()),
         _ => None,
     }
+}
+
+fn is_neg_imaginary_unit(expr: ExprId, pool: &ExprPool) -> bool {
+    match pool.get(expr) {
+        ExprData::Mul(args) if args.len() == 2 => {
+            (as_integer(args[0], pool).is_some_and(|n| n == -1) && pool.is_imaginary_unit(args[1]))
+                || (as_integer(args[1], pool).is_some_and(|n| n == -1)
+                    && pool.is_imaginary_unit(args[0]))
+        }
+        _ => false,
+    }
+}
+
+fn is_strictly_positive_literal(expr: ExprId, pool: &ExprPool) -> bool {
+    match pool.get(expr) {
+        ExprData::Integer(n) => n.0 > 0,
+        ExprData::Rational(r) => r.0 > 0,
+        _ => false,
+    }
+}
+
+fn is_positive_domain_symbol(expr: ExprId, pool: &ExprPool) -> bool {
+    matches!(
+        pool.get(expr),
+        ExprData::Symbol {
+            domain: Domain::Positive,
+            ..
+        }
+    )
 }
 
 fn is_zero(expr: ExprId, pool: &ExprPool) -> bool {
@@ -654,6 +683,24 @@ impl RewriteRule for ConstFold {
                     ) =>
                     {
                         pool.integer(0_i32)
+                    }
+                    // Principal Arg ∈ (−π, π]: only literal/domain-safe cases.
+                    // Leave arg(0), negative reals, and generic complex inputs
+                    // unevaluated — no atan2/log/sqrt rewrites.
+                    "arg" => {
+                        let pi = pool.symbol("pi", Domain::Positive);
+                        let half_pi = pool.mul(vec![pool.rational(1, 2), pi]);
+                        if pool.is_imaginary_unit(arg) {
+                            half_pi
+                        } else if is_neg_imaginary_unit(arg, pool) {
+                            pool.mul(vec![pool.integer(-1_i32), half_pi])
+                        } else if is_strictly_positive_literal(arg, pool)
+                            || is_positive_domain_symbol(arg, pool)
+                        {
+                            pool.integer(0_i32)
+                        } else {
+                            return None;
+                        }
                     }
                     "exp" if is_zero(arg, pool) => pool.integer(1_i32),
                     "cos" if is_zero(arg, pool) => pool.integer(1_i32),
@@ -1870,5 +1917,41 @@ mod tests {
             crate::simplify::simplify(d, &pool).value,
             pool.integer(0_i32)
         );
+    }
+
+    #[test]
+    fn principal_arg_safe_cases_and_branch_cut_refusal() {
+        let pool = p();
+        let i = pool.imaginary_unit();
+        let neg_i = pool.mul(vec![pool.integer(-1_i32), i]);
+        let pos = pool.symbol("x", Domain::Positive);
+        let z = pool.symbol("z", Domain::Complex);
+        let pi = pool.symbol("pi", Domain::Positive);
+        let half_pi = pool.mul(vec![pool.rational(1, 2), pi]);
+        let neg_half_pi = pool.mul(vec![pool.integer(-1_i32), half_pi]);
+
+        assert_eq!(
+            crate::simplify::simplify(pool.func("arg", vec![pool.integer(3_i32)]), &pool).value,
+            pool.integer(0_i32)
+        );
+        assert_eq!(
+            crate::simplify::simplify(pool.func("arg", vec![pos]), &pool).value,
+            pool.integer(0_i32)
+        );
+        assert_eq!(
+            crate::simplify::simplify(pool.func("arg", vec![i]), &pool).value,
+            crate::simplify::simplify(half_pi, &pool).value
+        );
+        assert_eq!(
+            crate::simplify::simplify(pool.func("arg", vec![neg_i]), &pool).value,
+            crate::simplify::simplify(neg_half_pi, &pool).value
+        );
+        // Zero, negatives, and generic complex stay unevaluated.
+        let arg0 = pool.func("arg", vec![pool.integer(0_i32)]);
+        assert_eq!(crate::simplify::simplify(arg0, &pool).value, arg0);
+        let arg_neg = pool.func("arg", vec![pool.integer(-1_i32)]);
+        assert_eq!(crate::simplify::simplify(arg_neg, &pool).value, arg_neg);
+        let arg_z = pool.func("arg", vec![z]);
+        assert_eq!(crate::simplify::simplify(arg_z, &pool).value, arg_z);
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1763,6 +1763,15 @@ fn im(py: Python<'_>, expr: PyRef<PyExpr>) -> PyExpr {
     make_func(py, "im", expr)
 }
 
+/// Experimental principal argument (`Arg ∈ (−π, π]`).
+///
+/// Only domain-safe literal simplifications are applied; branch-cut cases
+/// remain symbolic.
+#[pyfunction]
+fn arg(py: Python<'_>, expr: PyRef<PyExpr>) -> PyExpr {
+    make_func(py, "arg", expr)
+}
+
 // V1-12: expanded primitive registry
 #[pyfunction]
 fn tan(py: Python<'_>, expr: PyRef<PyExpr>) -> PyExpr {
@@ -8454,6 +8463,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(conjugate, m)?)?;
     m.add_function(wrap_pyfunction!(re, m)?)?;
     m.add_function(wrap_pyfunction!(im, m)?)?;
+    m.add_function(wrap_pyfunction!(arg, m)?)?;
     // V1-12: expanded primitive registry
     m.add_function(wrap_pyfunction!(tan, m)?)?;
     m.add_function(wrap_pyfunction!(sinh, m)?)?;

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -707,6 +707,10 @@ env = load_environment(difficulty_tier=0, n_train=1000, n_eval=100, adaptive=Tru
 
 Alkahest follows semantic versioning from `1.0`. The stable surface is everything re-exported from `alkahest_cas::stable` (Rust) and `alkahest.__all__` (Python). Experimental APIs live under `alkahest_cas::experimental` and `alkahest.experimental` and may change in minor releases—prefer top-level exports for agent-written code unless the user asks for experimental features.
 
+Symbolic complex constructors (`conjugate`, `re`, `im`, `arg`) are experimental.
+Principal `arg` only folds domain-safe literals (`arg(Positive)`, `arg(I)`);
+leave `arg(0)`, negative reals, and branch-cut expressions unevaluated.
+
 ---
 
 ## Primitive registry

--- a/docs/mdbook/src/simplification.md
+++ b/docs/mdbook/src/simplification.md
@@ -110,3 +110,16 @@ r = collect_like_terms(pool.integer(2) * x + pool.integer(3) * x)
 # Normalize to canonical polynomial form over given variables
 r = poly_normal(x**2 + pool.integer(2) * x * y + y**2, [x, y])
 ```
+
+## Complex constructors (experimental)
+
+`alkahest.experimental` exposes symbolic `conjugate`, `re`, `im`, and principal
+`arg`. These are symbolic-only: they are not registered for f64, ball, or JIT
+evaluation.
+
+Safe simplifications include involution of `conjugate`, real/integer literals
+for `re`/`im`, `arg` of a strictly positive literal or `Domain.Positive`
+symbol, and exact `arg(I)` / `arg(-I)`. Branch-sensitive cases such as
+`conjugate(log(z))`, `arg(0)`, negative reals, and generic complex inputs stay
+unevaluated. Principal Arg uses the conventional range `(−π, π]` with a cut on
+the negative real axis; do not rewrite through `atan2`, `log`, or `sqrt` yet.

--- a/python/alkahest/experimental/__init__.py
+++ b/python/alkahest/experimental/__init__.py
@@ -16,6 +16,8 @@ Other experimental surface:
 - :func:`to_stablehlo` — StableHLO / XLA bridge (V5-2)
 - :func:`to_jax` — JAX primitive integration (V5-7, requires JAX)
 - :func:`evaluate` — unified exact, f64, and interval evaluation
+- :func:`conjugate`, :func:`re`, :func:`im`, :func:`arg` — symbolic complex
+  constructors (principal Arg only; no numeric/JIT evaluation yet)
 - :class:`GroebnerBasis`, :class:`GbPoly` — parallel F4 Gröbner basis (V5-11,
   requires ``groebner`` feature)
 - :func:`solve` — polynomial system solver (V1-4, requires ``groebner`` feature)
@@ -54,6 +56,7 @@ from alkahest.alkahest import (
     EvaluationResult,
     Fps,
     OdeTrajectory,
+    arg,
     asymptotic_expand,
     conjugate,
     dirac_delta,
@@ -93,6 +96,7 @@ __all__ = [
     "GbPoly",
     "GroebnerBasis",
     "OdeTrajectory",
+    "arg",
     "asymptotic_expand",
     "compile_cuda",
     "conjugate",

--- a/tests/test_complex_symbolics.py
+++ b/tests/test_complex_symbolics.py
@@ -1,5 +1,5 @@
 import alkahest as ak
-from alkahest.experimental import conjugate, im, re
+from alkahest.experimental import arg, conjugate, im, re
 
 
 def test_symbolic_complex_constructors_and_safe_constants():
@@ -15,3 +15,23 @@ def test_branch_sensitive_conjugation_remains_symbolic():
     z = p.symbol("z", ak.Domain.Complex)
     assert str(conjugate(ak.log(z))) == "conjugate(log(z))"
     assert str(conjugate(ak.sqrt(z))) == "conjugate(sqrt(z))"
+
+
+def test_principal_arg_safe_cases():
+    p = ak.ExprPool()
+    x = p.symbol("x", ak.Domain.Positive)
+    i = p.symbol("I", ak.Domain.Complex)
+
+    assert str(ak.simplify(arg(p.integer(3))).value) == "0"
+    assert str(ak.simplify(arg(x)).value) == "0"
+    assert "pi" in str(ak.simplify(arg(i)).value)
+    assert str(ak.simplify(arg(p.integer(0))).value) == "arg(0)"
+    assert str(ak.simplify(arg(p.integer(-1))).value) == "arg(-1)"
+
+
+def test_principal_arg_leaves_branch_cut_and_generic_complex():
+    p = ak.ExprPool()
+    z = p.symbol("z", ak.Domain.Complex)
+    assert str(arg(z)) == "arg(z)"
+    assert str(arg(ak.log(z))) == "arg(log(z))"
+    assert str(arg(ak.sqrt(z))) == "arg(sqrt(z))"

--- a/tests/test_v10.py
+++ b/tests/test_v10.py
@@ -97,7 +97,7 @@ class TestExpandedPrimitives:
         # DiracDelta is a distribution; conjugate/re/im are symbolic-only
         # complex constructors with no pointwise real f64 kernel
         # (mirrors the Rust-side primitive coverage doctest).
-        assert missing == ["conjugate", "diracdelta", "im", "re"], (
+        assert missing == ["arg", "conjugate", "diracdelta", "im", "re"], (
             f"primitives missing numeric_f64 (unexpected set): {missing}"
         )
 


### PR DESCRIPTION
## Summary
- add experimental principal `arg` on top of the symbolic conjugate/re/im surface
- fold only Positive-domain symbols, strictly positive literals, and exact `±I`
- leave `arg(0)`, negative reals, and branch-cut expressions unevaluated

## Test plan
- [x] `cargo test -p alkahest-cas principal_arg`
- [x] `cargo test -p alkahest-cas --doc`
- [x] `pytest tests/test_complex_symbolics.py`
- [x] `tests/test_v10.py::TestExpandedPrimitives::test_primitive_registry_all_have_numeric_f64`

Made with [Cursor](https://cursor.com)