### PR TITLE
feat(release): Cranelift JIT in default PyPI wheels + install matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,11 @@ jobs:
       - name: ruff format --check
         run: ruff format --check python/ tests/
 
-      - name: maturin develop
-        run: maturin develop --manifest-path alkahest-py/Cargo.toml --features "groebner egraph"
+      - name: maturin develop (PyPI-parity features)
+        run: maturin develop --manifest-path alkahest-py/Cargo.toml --features "groebner egraph cranelift"
 
       - name: Cranelift capability smoke test
-        run: |
-          maturin develop --manifest-path alkahest-py/Cargo.toml --features "groebner egraph cranelift"
-          python -c "import alkahest as ak; f = ak.capabilities()['features']; assert f['cranelift_jit'] and not f['llvm_jit'] and not f['parallel']"
+        run: python -c "import alkahest as ak; f = ak.capabilities()['features']; assert f['cranelift_jit'] and not f['llvm_jit'] and not f['parallel']; assert ak.jit_is_available()"
 
       - name: ty check
         run: ty check python/alkahest/

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -51,7 +51,7 @@ jobs:
           command: build
           # Explicit CPython list — --find-interpreter also picks up PyPy and
           # Python 3.14, which PyO3 0.21 cannot target.
-          args: --release --strip --out dist --features egraph,groebner --interpreter python3.9 python3.10 python3.11 python3.12 python3.13
+          args: --release --strip --out dist --features egraph,groebner,cranelift --interpreter python3.9 python3.10 python3.11 python3.12 python3.13
           manylinux: "2_28"
           before-script-linux: |
             dnf install -y epel-release || true
@@ -75,13 +75,15 @@ jobs:
           print(ak.simplify(x + 0).value)
           print(ak.simplify_egraph(x + 0).value)
           assert hasattr(ak, 'solve'), 'expected groebner APIs in default wheel'
-          assert ak.capabilities()["features"] == {
+          f = ak.capabilities()["features"]
+          assert f == {
               "egraph": True, "groebner": True, "jit": False,
-              "cranelift": False, "llvm_jit": False, "cranelift_jit": False,
+              "cranelift": True, "llvm_jit": False, "cranelift_jit": True,
               "parallel": False, "numpy": False, "cuda": False,
               "groebner_cuda": False,
           }
-          print('groebner ok')
+          assert ak.jit_is_available(), "expected Cranelift JIT in default wheel"
+          print('default wheel ok (groebner + cranelift)')
           "
 
       - uses: actions/upload-artifact@v7
@@ -295,7 +297,7 @@ jobs:
 
       - name: Build wheel (macOS)
         if: runner.os == 'macOS'
-        run: maturin build --release --strip --features "egraph groebner" --out dist
+        run: maturin build --release --strip --features "egraph groebner cranelift" --out dist
 
       - name: Build wheel (Windows)
         if: runner.os == 'Windows'
@@ -305,7 +307,7 @@ jobs:
         # build script's `sh -c "configure ..."` couldn't find the compiler.
         shell: msys2 {0}
         run: |
-          maturin build --release --strip --features "egraph groebner" --target x86_64-pc-windows-gnu --out dist
+          maturin build --release --strip --features "egraph groebner cranelift" --target x86_64-pc-windows-gnu --out dist
 
       - name: Repair wheel with delvewheel (Windows)
         if: runner.os == 'Windows'
@@ -328,7 +330,7 @@ jobs:
       - name: Smoke test
         run: |
           pip install --no-index --find-links dist alkahest
-          python -c "import alkahest; p = alkahest.ExprPool(); x = p.symbol('x'); print(alkahest.simplify(x + 0)); caps = alkahest.capabilities(); assert caps['features']['egraph'] and caps['features']['groebner']; assert not caps['features']['jit'] and not caps['features']['parallel']"
+          python -c "import alkahest; p = alkahest.ExprPool(); x = p.symbol('x'); print(alkahest.simplify(x + 0)); caps = alkahest.capabilities(); f = caps['features']; assert f['egraph'] and f['groebner'] and f['cranelift_jit']; assert not f['llvm_jit'] and not f['parallel']; assert caps['jit'] and alkahest.jit_is_available()"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 A high-performance computer algebra system for Python built for both humans and agents. Symbolic operations run orders of magnitude faster than SymPy and can run on modern accelerated hardware. Every computation produces a derivation log; a meaningful subset can export Lean 4 proofs for independent verification.
 
-**Install:** the package is published on [PyPI](https://pypi.org/project/alkahest/); use `pip install alkahest` (**Python 3.9–3.13**). See [Install](#install) below for optional **`+jit`** / **`+full`** Linux wheels (GitHub Releases or a future extras index) and building from source.
+**Install:** the package is published on [PyPI](https://pypi.org/project/alkahest/); use `pip install alkahest` (**Python 3.9–3.13**). Default wheels ship **Cranelift** CPU JIT (pure Rust, no LLVM). See [Install](#install) for the capability matrix and optional **`+jit`** / **`+full`** Linux wheels (GitHub Releases).
 
 **Demo:** try the hosted **[playground](https://alkahest-cas.github.io/playground/)** (WASM in-browser, or bring your own server/Jupyter URL + token), or run [`demo-playground/`](demo-playground/) locally for the full agent and recording stack. See [`demo-playground/README.md`](demo-playground/README.md).
 
@@ -45,7 +45,21 @@ python -m pip install -U pip
 pip install alkahest
 ```
 
-Default PyPI wheels include the **vendored egglog** e-graph backend (`egraph` feature) and the **Gröbner solver** (`groebner` feature — so `alkahest.solve`, Diophantine, homotopy, and related APIs are available out of the box) but **not** LLVM JIT, Cranelift, or `parallel`. Numeric APIs use the tree-walking interpreter fallback. For native LLVM CPU JIT—or JIT plus parallel F4—use a **PyTorch-style** opt-in wheel (separate artifact / index), not the default PyPI resolver path. From source, add `--features cranelift` for a pure-Rust fast-compile JIT tier without system LLVM.
+Default PyPI wheels include the **vendored egglog** e-graph backend (`egraph`), the **Gröbner solver** (`groebner` — so `alkahest.solve`, Diophantine, homotopy, and related APIs work out of the box), and **Cranelift** Tier-1 CPU JIT (`cranelift`, pure Rust, ~2 MB larger than the interpreter-only baseline). They do **not** include LLVM JIT or `parallel`. For LLVM CPU JIT—or JIT plus parallel F4—use a **PyTorch-style** opt-in **`+jit`** / **`+full`** Linux wheel from [GitHub Releases](#opt-in-linux-wheels-jit-and-full-pytorch-style), not the default PyPI resolver path.
+
+### Install matrix (default vs opt-in wheels)
+
+Probe your environment after install: `alkahest.capabilities()["features"]` and `alkahest.jit_is_available()`.
+
+| Artifact | Where | OS / arch (CI) | Python | `egraph` | `groebner` | Cranelift JIT | LLVM JIT | `parallel` |
+|----------|-------|----------------|--------|----------|------------|---------------|----------|------------|
+| **Default** (`pip install alkahest`) | [PyPI](https://pypi.org/project/alkahest/) | Linux manylinux x86_64; macOS arm64; Windows x86_64 | 3.9–3.13 | yes | yes | yes | no | no |
+| **`+jit`** (`X.Y.Z+jit`) | GitHub Releases only | Linux x86_64 | 3.9–3.13 | yes | yes | no | yes | no |
+| **`+full`** (`X.Y.Z+full`) | GitHub Releases only | Linux x86_64 | 3.9–3.13 | yes | yes | no | yes | yes |
+
+**macOS / Windows:** default PyPI wheels include Cranelift JIT. **`+jit`** and **`+full`** are **not** built in CI (LLVM / MSYS2 constraints); use [building from source](#from-source) with `--features jit` (and `parallel` for F4 parallelism) on those platforms.
+
+**Linux LLVM wheels** vendor LLVM and related `.so` files under `site-packages/alkahest.libs/`. If `import alkahest` fails with a missing `libffi-*.so` or `libLLVM-*.so`, prepend that directory to `LD_LIBRARY_PATH`.
 
 ### Opt-in Linux wheels: `+jit` and `+full` (PyTorch-style)
 
@@ -57,8 +71,9 @@ There is **no** `pip install alkahest[jit]` / `alkahest[full]` that swaps the na
 
 | Local version | Cargo features | When to use |
 |---------------|----------------|-------------|
-| `+jit` | `egraph groebner jit` | LLVM CPU JIT (smaller than `+full`; groebner/egraph are already in default wheels). |
-| `+full` | `egraph groebner jit parallel` | JIT plus parallel F4 S-polynomial reduction (largest wheel; groebner already in default). |
+| *(default PyPI)* | `egraph groebner cranelift` | Cranelift CPU JIT on all published platforms; no system LLVM. |
+| `+jit` | `egraph groebner jit` | LLVM CPU JIT (Linux only in CI; larger than default; no Cranelift). |
+| `+full` | `egraph groebner jit parallel` | LLVM JIT plus parallel F4 S-polynomial reduction (largest wheel; Linux only in CI). |
 
 Direct-install examples (adjust tag and filename after checking the release assets):
 
@@ -71,9 +86,9 @@ These wheels vendor LLVM (for JIT) and related `.so` files under `site-packages/
 
 If your client chokes on `+` in the URL, use percent-encoding (`2.3.1%2Bfull` in the filename segment).
 
-After installing `+jit` or `+full`, `alkahest.jit_is_available()` should be `True`. Gröbner-backed APIs such as `alkahest.solve` are available in **all** wheels (including the default PyPI wheel) since `groebner` became a default feature.
+After installing the **default** wheel, `alkahest.jit_is_available()` is `True` (Cranelift). After **`+jit`** or **`+full`**, it is also `True` (LLVM). Gröbner-backed APIs such as `alkahest.solve` are available in **all** wheels since `groebner` became a default feature.
 
-*macOS and Windows `+jit` / `+full` wheels are not produced in CI yet (LLVM / MSYS2 constraints); use [building from source](#from-source) there.*
+*See the [install matrix](#install-matrix-default-vs-opt-in-wheels) for per-platform coverage.*
 
 **Target layout (roadmap):** a small **extra index** URL (PEP 503) hosting only `+jit` / `+full` wheels, mirroring PyTorch’s `--extra-index-url` workflow:
 

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -40,7 +40,6 @@ def test_cranelift_jit_enables_session_jit_flag():
         assert features["cranelift"] is True
         assert not features["llvm_jit"]
 
-
     primitives = alkahest.capabilities()["primitives"]
 
     assert primitives

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -31,7 +31,16 @@ def test_capabilities_reports_installed_build_features():
     assert caps["jit"] is alkahest.jit_is_available()
 
 
-def test_capabilities_primitive_rows_are_deterministic():
+def test_cranelift_jit_enables_session_jit_flag():
+    caps = alkahest.capabilities()
+    features = caps["features"]
+    if features["cranelift_jit"]:
+        assert caps["jit"] is True
+        assert alkahest.jit_is_available()
+        assert features["cranelift"] is True
+        assert not features["llvm_jit"]
+
+
     primitives = alkahest.capabilities()["primitives"]
 
     assert primitives


### PR DESCRIPTION
## Summary
- Enable the pure-Rust `cranelift` Cargo feature in default release wheels (Linux manylinux, macOS arm64, Windows x86_64) so `pip install alkahest` ships Cranelift CPU JIT without LLVM (~2 MB wheel size increase in local smoke builds).
- Update release CI smoke tests to assert `cranelift_jit` and `jit_is_available()` on default wheels; align main CI `maturin develop` with PyPI-parity features.
- Add an unambiguous README install matrix (default vs `+jit` vs `+full`) with OS/Python coverage and macOS/Windows notes.

## Test plan
- [x] Local `maturin build` with `egraph,groebner,cranelift` — wheel ~9.8 MB → ~12 MB; smoke `capabilities()` + `jit_is_available()` pass
- [x] `pytest tests/test_agent_contract.py` with cranelift develop build
- [ ] Release CI `build-linux` / `build-wheels` smoke tests on merge
- [ ] Verify `+jit` / `+full` wheels remain excluded from PyPI upload


Made with [Cursor](https://cursor.com)