### PR TITLE
Expose Matrix.rref and harden symbolic linear algebra agent surface

### DIFF
--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -91,9 +91,9 @@ pub use matrix::{
     characteristic_polynomial_lambda_minus_m, cholesky, column_space_basis, diagonalize,
     eigenvalues, eigenvectors, hermite_form, hermite_form_poly, jacobian, jordan_form,
     lu_decomposition, matrix_exponential, matrix_inverse, minimal_polynomial, nullspace_basis,
-    qr_decomposition, rank, rational_canonical_form, row_space_basis, smith_form, smith_form_poly,
-    EigenError, IntegerMatrix, LinearAlgebraError, LuDecomposition, Matrix, MatrixError,
-    NormalFormError, PolyMatrixQ, QrDecomposition, RatUniPoly,
+    qr_decomposition, rank, rational_canonical_form, row_space_basis, rref, smith_form,
+    smith_form_poly, EigenError, IntegerMatrix, LinearAlgebraError, LuDecomposition, Matrix,
+    MatrixError, NormalFormError, PolyMatrixQ, QrDecomposition, RatUniPoly,
 };
 pub use numeric::{guess_integer_relation, PslqError};
 pub use ode::{
@@ -325,7 +325,7 @@ pub mod experimental {
     pub use crate::matrix::{
         cholesky, column_space_basis, jordan_form, lu_decomposition, matrix_exponential,
         matrix_inverse, minimal_polynomial, nullspace_basis, qr_decomposition, rank,
-        rational_canonical_form, row_space_basis, LinearAlgebraError, LuDecomposition,
+        rational_canonical_form, row_space_basis, rref, LinearAlgebraError, LuDecomposition,
         QrDecomposition,
     };
     pub use crate::modular::{

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -127,6 +127,11 @@ pub fn rank(m: &Matrix, pool: &ExprPool) -> Result<usize, LinearAlgebraError> {
     Ok(row_echelon_pivots(m, pool)?.pivot_cols.len())
 }
 
+/// Reduced row echelon form of `m`.
+pub fn rref(m: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
+    Ok(row_echelon_pivots(m, pool)?.echelon)
+}
+
 /// Basis of the column space of `m` (original pivot columns).
 pub fn column_space_basis(m: &Matrix, pool: &ExprPool) -> Result<Vec<Matrix>, LinearAlgebraError> {
     let rref = row_echelon_pivots(m, pool)?;
@@ -159,16 +164,19 @@ pub fn row_space_basis(m: &Matrix, pool: &ExprPool) -> Result<Vec<Matrix>, Linea
 struct RowEchelonInfo {
     pivot_cols: Vec<usize>,
     pivot_row_flags: Vec<bool>,
+    echelon: Matrix,
 }
 
 fn row_echelon_pivots(m: &Matrix, pool: &ExprPool) -> Result<RowEchelonInfo, LinearAlgebraError> {
     let rows = m.rows;
     let cols = m.cols;
     if let Some(grid) = matrix_to_rational_grid(m, pool) {
-        let (pivot_cols, pivot_row_flags) = rational_row_echelon_pivots(&grid, rows, cols);
+        let (pivot_cols, pivot_row_flags, echelon_grid) =
+            rational_row_echelon_pivots(&grid, rows, cols);
         return Ok(RowEchelonInfo {
             pivot_cols,
             pivot_row_flags,
+            echelon: rational_grid_to_matrix(&echelon_grid, pool),
         });
     }
     let mut a: Vec<Vec<ExprId>> = (0..rows)
@@ -223,6 +231,7 @@ fn row_echelon_pivots(m: &Matrix, pool: &ExprPool) -> Result<RowEchelonInfo, Lin
     Ok(RowEchelonInfo {
         pivot_cols,
         pivot_row_flags,
+        echelon: Matrix::new(a).expect("row echelon grid"),
     })
 }
 
@@ -230,7 +239,7 @@ fn rational_row_echelon_pivots(
     mat: &[Vec<Rational>],
     rows: usize,
     cols: usize,
-) -> (Vec<usize>, Vec<bool>) {
+) -> (Vec<usize>, Vec<bool>, Vec<Vec<Rational>>) {
     let mut a = mat.to_vec();
     let mut pivot_cols = Vec::new();
     let mut pivot_row_flags = vec![false; rows];
@@ -271,7 +280,7 @@ fn rational_row_echelon_pivots(
         pivot_row_flags[r] = true;
         r += 1;
     }
-    (pivot_cols, pivot_row_flags)
+    (pivot_cols, pivot_row_flags, a)
 }
 
 // ---------------------------------------------------------------------------
@@ -1337,6 +1346,28 @@ mod tests {
         let p = pool();
         let id = Matrix::identity(3, &p);
         assert_eq!(rank(&id, &p).unwrap(), 3);
+    }
+
+    #[test]
+    fn rref_2x3_rational() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(1), p.integer(2), p.integer(3)],
+            vec![p.integer(2), p.integer(4), p.integer(6)],
+        ])
+        .unwrap();
+        let r = rref(&m, &p).unwrap();
+        assert_eq!(r.rows, 2);
+        assert_eq!(r.cols, 3);
+        let one = p.integer(1_i32);
+        let two = p.integer(2_i32);
+        let three = p.integer(3_i32);
+        let z = p.integer(0_i32);
+        assert!(eigen::matrix_eq_simplified(
+            &r,
+            &Matrix::new(vec![vec![one, two, three], vec![z, z, z]]).unwrap(),
+            &p
+        ));
     }
 
     #[test]

--- a/alkahest-core/src/matrix/mod.rs
+++ b/alkahest-core/src/matrix/mod.rs
@@ -23,7 +23,8 @@ pub use eigen::{
 pub use linear_algebra::{
     cholesky, column_space_basis, jordan_form, lu_decomposition, matrix_exponential,
     matrix_inverse, minimal_polynomial, nullspace_basis, qr_decomposition, rank,
-    rational_canonical_form, row_space_basis, LinearAlgebraError, LuDecomposition, QrDecomposition,
+    rational_canonical_form, row_space_basis, rref, LinearAlgebraError, LuDecomposition,
+    QrDecomposition,
 };
 pub use normal_form::{
     hermite_form, hermite_form_poly, smith_form, smith_form_poly, IntegerMatrix, NormalFormError,
@@ -381,6 +382,10 @@ impl Matrix {
 
     pub fn rank(&self, pool: &ExprPool) -> Result<usize, LinearAlgebraError> {
         linear_algebra::rank(self, pool)
+    }
+
+    pub fn rref(&self, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
+        linear_algebra::rref(self, pool)
     }
 
     pub fn column_space(&self, pool: &ExprPool) -> Result<Vec<Matrix>, LinearAlgebraError> {

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -4133,6 +4133,19 @@ impl PyMatrix {
             .map_err(linear_algebra_error_to_py)
     }
 
+    fn rref(&self, py: Python<'_>) -> PyResult<PyMatrix> {
+        let pool = self.pool.borrow(py);
+        let r = self
+            .inner
+            .rref(&pool.inner)
+            .map_err(linear_algebra_error_to_py)?;
+        drop(pool);
+        Ok(PyMatrix {
+            inner: r,
+            pool: self.pool.clone_ref(py),
+        })
+    }
+
     fn column_space(&self, py: Python<'_>) -> PyResult<Vec<PyMatrix>> {
         let pool = self.pool.borrow(py);
         let bas = self

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -271,6 +271,7 @@ from .exceptions import (
     JitError,
     LatticeError,
     LimitError,
+    LinearAlgebraError,
     LinearRecurrenceError,
     MatrixError,
     NumberTheoryError,
@@ -305,6 +306,7 @@ _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "JitError",
     "LatticeError",
     "LimitError",
+    "LinearAlgebraError",
     "LinearRecurrenceError",
     "MatrixError",
     "NumberTheoryError",
@@ -1108,6 +1110,10 @@ def capabilities() -> dict:
         ``llvm_jit`` / ``cranelift_jit`` backend flags; ``primitives`` is
         deterministic per-primitive implementation coverage, and
         ``verification`` describes available evidence artifacts and checkers.
+        Symbolic linear algebra (``Matrix.rref``, ``rank``, ``nullspace``,
+        ``jordan_form``, ``minimal_polynomial``, LU/QR/Cholesky, etc.) is available
+        on :class:`Matrix`; unsupported inputs raise :class:`LinearAlgebraError`
+        with stable ``E-LINALG-*`` codes.
 
     Example
     -------
@@ -1196,6 +1202,7 @@ __all__ = [
     "JitError",
     "LatticeError",
     "LimitError",
+    "LinearAlgebraError",
     "LinearRecurrenceError",
     # Phase 15
     "Matrix",

--- a/python/alkahest/experimental/__init__.py
+++ b/python/alkahest/experimental/__init__.py
@@ -6,10 +6,14 @@ removed between minor versions without a deprecation cycle.  Graduate to
 ``alkahest.*`` once the API has been exercised in production.
 
 Current experimental surface (linear algebra on ``Matrix``):
-- ``Matrix.nullspace``, ``rank``, ``column_space``, ``row_space``
+- ``Matrix.rref``, ``nullspace``, ``rank``, ``column_space``, ``row_space``
 - ``Matrix.lu``, ``qr``, ``cholesky``
 - ``Matrix.jordan_form``, ``rational_canonical_form``, ``minimal_polynomial``,
   ``matrix_exp``, ``inverse``
+
+Agents should probe ``alkahest.capabilities()`` at session start; symbolic LA
+methods live on :class:`~alkahest.Matrix` and raise :class:`~alkahest.LinearAlgebraError`
+(``E-LINALG-*``) when an operation is unsupported for the input field or shape.
 
 Other experimental surface:
 - :class:`Assumptions` — explicit positive/nonzero refinement for conservative

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import alkahest
+import pytest
 
 
 def test_matrix_from_rows_mixed_int_expr():
@@ -23,6 +24,22 @@ def test_matrix_from_rows_all_int_with_active_pool():
     assert m.shape() == (2, 2)
     assert m2.shape() == (2, 2)
     assert m.get(1, 0).node() == pool.integer(-1).node()
+
+
+def test_rref_rank_consistency():
+    pool = alkahest.ExprPool()
+    m = alkahest.Matrix(
+        [
+            [pool.integer(1), pool.integer(2), pool.integer(3)],
+            [pool.integer(2), pool.integer(4), pool.integer(6)],
+        ]
+    )
+    r = m.rref().simplify()
+    assert r.shape() == (2, 3)
+    assert m.rank() == 1
+    assert r.get(1, 0).node() == pool.integer(0).node()
+    assert r.get(1, 1).node() == pool.integer(0).node()
+    assert r.get(1, 2).node() == pool.integer(0).node()
 
 
 def test_nullspace_rank_column_row_space():
@@ -52,6 +69,26 @@ def test_jordan_block_2x2():
     assert (p @ j @ inv).simplify().to_list() == m.simplify().to_list()
 
 
+def test_jordan_defective_3x3():
+    """Defective matrix with a 3×3 Jordan block (algebraic mult 3, geometric mult 1)."""
+    pool = alkahest.ExprPool()
+    z = pool.integer(0)
+    one = pool.integer(1)
+    two = pool.integer(2)
+    m = alkahest.Matrix(
+        [
+            [two, one, z],
+            [z, two, one],
+            [z, z, two],
+        ]
+    )
+    p, j = m.jordan_form()
+    assert p.rows == 3
+    assert j.rows == 3
+    inv = p.inverse()
+    assert (p @ j @ inv).simplify().to_list() == m.simplify().to_list()
+
+
 def test_rational_canonical_diagonal():
     pool = alkahest.ExprPool()
     m = alkahest.Matrix(
@@ -67,14 +104,15 @@ def test_rational_canonical_diagonal():
 
 def test_minimal_polynomial_diagonal():
     pool = alkahest.ExprPool()
-    m = alkahest.Matrix(
-        [
-            [pool.integer(1), pool.integer(0)],
-            [pool.integer(0), pool.integer(2)],
-        ]
-    )
-    minpoly = m.minimal_polynomial()
-    assert minpoly is not None
+    one = pool.integer(1)
+    two = pool.integer(2)
+    z = pool.integer(0)
+    m = alkahest.Matrix([[one, z], [z, two]])
+    minpoly = alkahest.simplify(m.minimal_polynomial()).value
+    # Distinct eigenvalues {1, 2} ⇒ degree-2 minimal polynomial (λ² - 3λ + 2).
+    node = minpoly.node()
+    assert node[0] == "add"
+    assert len(node[1]) == 3
 
 
 def test_matrix_exp_diagonal():
@@ -87,3 +125,40 @@ def test_matrix_exp_diagonal():
     )
     expm = m.matrix_exp()
     assert expm.rows == 2
+
+
+def test_non_square_jordan_form_declines():
+    pool = alkahest.ExprPool()
+    m = alkahest.Matrix([[pool.integer(1), pool.integer(0), pool.integer(0)]])
+    with pytest.raises(alkahest.LinearAlgebraError) as exc_info:
+        m.jordan_form()
+    assert exc_info.value.code == "E-LINALG-001"
+
+
+def test_non_square_minimal_polynomial_declines():
+    pool = alkahest.ExprPool()
+    m = alkahest.Matrix([[pool.integer(1), pool.integer(2)]])
+    with pytest.raises(alkahest.LinearAlgebraError) as exc_info:
+        m.minimal_polynomial()
+    assert exc_info.value.code == "E-LINALG-001"
+
+
+def test_non_square_matrix_exp_declines():
+    pool = alkahest.ExprPool()
+    m = alkahest.Matrix([[pool.integer(1), pool.integer(0)]])
+    with pytest.raises(alkahest.LinearAlgebraError) as exc_info:
+        m.matrix_exp()
+    assert exc_info.value.code == "E-LINALG-001"
+
+
+def test_cholesky_non_spd_declines():
+    pool = alkahest.ExprPool()
+    m = alkahest.Matrix(
+        [
+            [pool.integer(1), pool.integer(2)],
+            [pool.integer(2), pool.integer(1)],
+        ]
+    )
+    with pytest.raises(alkahest.LinearAlgebraError) as exc_info:
+        m.cholesky()
+    assert exc_info.value.code == "E-LINALG-003"


### PR DESCRIPTION
## Summary
- Add public `Matrix.rref()` (reduced row echelon form) by returning the echelon matrix already computed internally for rank/nullspace; wire through Rust, PyO3, and crate re-exports.
- Export `LinearAlgebraError` at the top-level Python package so agents can catch stable `E-LINALG-*` codes; document Matrix symbolic LA in `capabilities()` and `alkahest.experimental`.
- Expand `tests/test_linear_algebra.py`: rref/rank consistency, 3×3 defective Jordan block, minimal-polynomial shape check, and sound declines for non-square / non-SPD inputs.

## Gap analysis (pre-PR audit vs origin/main)
Already present in Rust + PyO3: `nullspace`, `rank`, `column_space`, `row_space`, `lu`, `qr`, `cholesky`, `jordan_form`, `rational_canonical_form`, `minimal_polynomial`, `matrix_exp`, `inverse`; `LinearAlgebraError` with `E-LINALG-001`…`009` in Rust and `errors/codes.rs`.
Missing / thin before this PR: public **`rref`** (elimination existed internally only), **`LinearAlgebraError` not exported** in `python/alkahest/__init__.py`, no agent-facing doc pointers in `capabilities()`, and incomplete Python tests (no rref, no defective Jordan, no structured decline assertions).

## Test plan
- [x] `cargo fmt`
- [x] `cargo test -p alkahest-cas rref_2x3`
- [x] `pytest tests/test_linear_algebra.py -v` (14 tests)

Made with [Cursor](https://cursor.com)