### PR TITLE
fix(ci): release Linux smoke test quoting

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -68,7 +68,8 @@ jobs:
       - name: Smoke test
         run: |
           pip install --no-index --find-links dist alkahest
-          python -c "
+          # Heredoc (not python -c) so bash does not strip Python "..." quotes.
+          python - <<'PY'
           import alkahest as ak
           p = ak.ExprPool()
           x = p.symbol('x')
@@ -84,7 +85,7 @@ jobs:
           }
           assert ak.jit_is_available(), "expected Cranelift JIT in default wheel"
           print('default wheel ok (groebner + cranelift)')
-          "
+          PY
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- Release CI failed on `wheels / ubuntu-22.04` smoke test with `NameError: name 'features' is not defined`.
- Cause: nested `python -c "..."` inside the workflow `run:` block — bash ate the `"features"` / dict-key double quotes.
- Fix: run the smoke script via a quoted heredoc (`python - <<'PY'`), matching other steps in the same workflow.

Failed run: https://github.com/alkahest-cas/alkahest/actions/runs/29553918192

## Test plan
- [ ] Merge this PR
- [ ] Re-run Release (`workflow_dispatch`) on main and confirm Linux smoke test passes
- [ ] Confirm publish-to-TestPyPI proceeds if that was the intent of the dispatch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Linux release smoke test so embedded Python strings and quotes are handled reliably during build verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->