### PR TITLE
fix: combine same-k exp coefficients for mixed exp·log integrate (B2)

### DIFF
--- a/alkahest-core/src/integrate/risch/mod.rs
+++ b/alkahest-core/src/integrate/risch/mod.rs
@@ -149,6 +149,14 @@ pub fn contains_risch_form(expr: ExprId, var: ExprId, pool: &ExprPool) -> bool {
         // is a Risch/MD form even when the transcendental appears only inside
         // the radicand — route it to the tower integrator, not the algebraic one.
         || tower_integrate::detect_radical_with_transcendental_radicand(expr, var, pool).is_some()
+        // Mixed exp+log (e.g. (log(x)+1/x)·exp(x)): the log may sit inside a
+        // coefficient Add that `needs_log_risch` does not flag as a direct
+        // `c·log` factor.  Route any such mixed tower to the exp-tower /
+        // poly-in-log RDE path rather than the rule engine.
+        || {
+            let gens = find_generators(expr, var, pool);
+            gens.iter().any(|g| g.is_exp()) && gens.iter().any(|g| g.is_log())
+        }
 }
 
 // ---------------------------------------------------------------------------
@@ -989,6 +997,29 @@ mod tests {
         assert!(
             result.is_ok(),
             "∫ (log(x)+x+1/x)·exp(x) dx must be elementary; got {result:?}"
+        );
+        verify_gapb(f, result.unwrap().value, x, &pool);
+    }
+
+    #[test]
+    fn gapb_exp_log_plus_exp_over_x_elementary() {
+        // ∫ (exp(x)·log(x) + exp(x)/x) dx = exp(x)·log(x)
+        // Classic trap (B2): each summand alone is non-elementary / Ei-related,
+        // but the sum is elementary (product rule). Same-k coefficients from
+        // `decompose_wrt_exp` must be combined before the poly-in-log RDE.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let log_x = pool.func("log", vec![x]);
+        let inv_x = pool.pow(x, pool.integer(-1_i32));
+        let f = pool.add(vec![
+            pool.mul(vec![exp_x, log_x]),
+            pool.mul(vec![exp_x, inv_x]),
+        ]);
+        let result = integrate_risch(f, x, &pool);
+        assert!(
+            result.is_ok(),
+            "∫ exp(x)log(x)+exp(x)/x dx must be elementary; got {result:?}"
         );
         verify_gapb(f, result.unwrap().value, x, &pool);
     }

--- a/alkahest-core/src/integrate/risch/tower.rs
+++ b/alkahest-core/src/integrate/risch/tower.rs
@@ -202,16 +202,23 @@ pub fn decompose_wrt_exp(
     exp_gen: ExprId,
     pool: &ExprPool,
 ) -> (ExprId, Vec<(ExprId, i64)>) {
+    use std::collections::BTreeMap;
+
     let zero = pool.integer(0_i32);
 
     match pool.get(expr) {
         ExprData::Add(args) => {
             let mut rational_terms: Vec<ExprId> = Vec::new();
-            let mut exp_terms: Vec<(ExprId, i64)> = Vec::new();
+            // Combine coefficients of equal powers of `exp_gen`.  Without this,
+            // ∫ (c₁·θ + c₀)·exp(η) written as a sum of products
+            // (c₁·θ·exp(η) + c₀·exp(η)) is integrated term-by-term and each
+            // summand can be mis-certified NonElementary even when the combined
+            // coefficient admits a poly-in-log RDE solution (B2).
+            let mut by_k: BTreeMap<i64, Vec<ExprId>> = BTreeMap::new();
 
             for &a in &args {
                 if let Some((coeff, k)) = extract_exp_factor(a, exp_gen, pool) {
-                    exp_terms.push((coeff, k));
+                    by_k.entry(k).or_default().push(coeff);
                 } else {
                     rational_terms.push(a);
                 }
@@ -222,6 +229,16 @@ pub fn decompose_wrt_exp(
                 1 => rational_terms[0],
                 _ => pool.add(rational_terms),
             };
+            let exp_terms: Vec<(ExprId, i64)> = by_k
+                .into_iter()
+                .map(|(k, coeffs)| {
+                    let coeff = match coeffs.len() {
+                        1 => coeffs[0],
+                        _ => pool.add(coeffs),
+                    };
+                    (coeff, k)
+                })
+                .collect();
             (rational_part, exp_terms)
         }
 

--- a/tests/test_risch_integration.py
+++ b/tests/test_risch_integration.py
@@ -302,6 +302,37 @@ def test_log_x_plus_x():
     check_antiderivative(pool, x, f, result.value, "log(x)² + x", points=(0.5, 1.2, 2.7))
 
 
+def test_exp_log_plus_exp_over_x_elementary():
+    """B2: ∫ (exp(x)·log(x) + exp(x)/x) dx = exp(x)·log(x).
+
+    Each summand alone is non-elementary (Ei-related), but the sum is the
+    product-rule derivative of exp(x)·log(x). Same-k coefficients must be
+    combined before the poly-in-log RDE.
+    """
+    pool = ExprPool()
+    x = pool.symbol("x")
+    exp_x = pool.func("exp", [x])
+    log_x = pool.func("log", [x])
+    f = exp_x * log_x + exp_x / x
+    result = integrate(f, x)
+    check_antiderivative(
+        pool, x, f, result.value, "exp(x)log(x)+exp(x)/x", points=(0.5, 1.2, 2.7)
+    )
+
+
+def test_factored_log_plus_inv_x_times_exp_elementary():
+    """∫ (log(x) + 1/x)·exp(x) dx = exp(x)·log(x) — factored form of B2."""
+    pool = ExprPool()
+    x = pool.symbol("x")
+    exp_x = pool.func("exp", [x])
+    log_x = pool.func("log", [x])
+    f = (log_x + 1 / x) * exp_x
+    result = integrate(f, x)
+    check_antiderivative(
+        pool, x, f, result.value, "(log(x)+1/x)·exp(x)", points=(0.5, 1.2, 2.7)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Derivation log checks
 # ---------------------------------------------------------------------------

--- a/tests/test_risch_integration.py
+++ b/tests/test_risch_integration.py
@@ -315,9 +315,7 @@ def test_exp_log_plus_exp_over_x_elementary():
     log_x = pool.func("log", [x])
     f = exp_x * log_x + exp_x / x
     result = integrate(f, x)
-    check_antiderivative(
-        pool, x, f, result.value, "exp(x)log(x)+exp(x)/x", points=(0.5, 1.2, 2.7)
-    )
+    check_antiderivative(pool, x, f, result.value, "exp(x)log(x)+exp(x)/x", points=(0.5, 1.2, 2.7))
 
 
 def test_factored_log_plus_inv_x_times_exp_elementary():
@@ -328,9 +326,7 @@ def test_factored_log_plus_inv_x_times_exp_elementary():
     log_x = pool.func("log", [x])
     f = (log_x + 1 / x) * exp_x
     result = integrate(f, x)
-    check_antiderivative(
-        pool, x, f, result.value, "(log(x)+1/x)·exp(x)", points=(0.5, 1.2, 2.7)
-    )
+    check_antiderivative(pool, x, f, result.value, "(log(x)+1/x)·exp(x)", points=(0.5, 1.2, 2.7))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix B2: `integrate(exp(x)*log(x) + exp(x)/x, x)` now returns `exp(x)*log(x)` instead of a false `E-INT-004` NonElementary verdict.
- Root cause: `decompose_wrt_exp` kept same-power summands separate, so the poly-in-log RDE saw `log(x)·exp(x)` alone (Ei) and certified non-elementarity for the whole sum.
- Also route mixed exp+log forms (e.g. `(log(x)+1/x)·exp(x)`) into Risch when `needs_log_risch` misses a log nested inside a coefficient `Add`.

## Test plan
- [x] Rust: `gapb_exp_log_plus_exp_over_x_elementary` + existing gapb suite
- [x] Python: `test_exp_log_plus_exp_over_x_elementary`, `test_factored_log_plus_inv_x_times_exp_elementary`
- [x] Confirm `∫ exp(x)·log(x) dx` still raises `E-INT-004`


Made with [Cursor](https://cursor.com)