### PR TITLE
fix: sum Faulhaber/geometric, solve numeric fallback, README (B4–B6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ expr = x**2 + 1
 
 # Differentiation with derivation log
 result = ak.diff(ak.sin(expr), x)
-print(result.value)   # 2*x*cos(x^2)
+print(result.value)   # 2*x*cos(x^2 + 1)
 print(result.steps)   # list of rewrite steps
 
 # Integration

--- a/alkahest-core/src/solver/mod.rs
+++ b/alkahest-core/src/solver/mod.rs
@@ -109,8 +109,8 @@ impl AlkahestError for SolverError {
                  transcendental functions are not supported",
             ),
             SolverError::HighDegree(_) => Some(
-                "degree > 2 univariate solving is not yet implemented; \
-                 the Gröbner basis is still returned for manual inspection",
+                "degree > 2 univariate solving is not yet implemented symbolically; \
+                 retry with numeric=True or method=\"homotopy\"",
             ),
             SolverError::ShapeMismatch => {
                 Some("provide one equation per variable for zero-dimensional system solving")

--- a/alkahest-core/src/sum/expr_ratio.rs
+++ b/alkahest-core/src/sum/expr_ratio.rs
@@ -89,6 +89,10 @@ fn ratio_factor(f: ExprId, k: ExprId, pool: &ExprPool) -> Result<RatFunc, SumErr
             }
         }
         ExprData::Pow { base, exp } => {
+            // Geometric / exponential-in-k: c^k or c^{a·k+b} with c free of k.
+            if is_free_of_k(base, k, pool) && !is_free_of_k(exp, k, pool) {
+                return geometric_base_ratio(base, exp, k, pool);
+            }
             let e = match pool.get(exp) {
                 ExprData::Integer(n) => {
                     n.0.to_i32()
@@ -100,11 +104,22 @@ fn ratio_factor(f: ExprId, k: ExprId, pool: &ExprPool) -> Result<RatFunc, SumErr
                 return Ok(RatFunc::one());
             }
             let rb = ratio_factor(base, k, pool)?;
-            let mut acc = rb.clone();
-            for _ in 1..e {
-                acc = acc.mul_ratfunc(&rb);
+            if e > 0 {
+                let mut acc = rb.clone();
+                for _ in 1..e {
+                    acc = acc.mul_ratfunc(&rb);
+                }
+                Ok(acc)
+            } else {
+                let inv = rb.inv().ok_or_else(|| {
+                    SumError::NotHypergeometric("zero base raised to a negative power".into())
+                })?;
+                let mut acc = inv.clone();
+                for _ in 1..(-e) {
+                    acc = acc.mul_ratfunc(&inv);
+                }
+                Ok(acc)
             }
-            Ok(acc)
         }
         ExprData::Mul(_) => ratio_product(f, k, pool),
         ExprData::Add(_) => {
@@ -151,6 +166,145 @@ fn ratio_factor(f: ExprId, k: ExprId, pool: &ExprPool) -> Result<RatFunc, SumErr
     }
 }
 
+fn is_free_of_k(expr: ExprId, k: ExprId, pool: &ExprPool) -> bool {
+    if expr == k {
+        return false;
+    }
+    match pool.get(expr) {
+        ExprData::Add(args) | ExprData::Mul(args) => args.iter().all(|&a| is_free_of_k(a, k, pool)),
+        ExprData::Pow { base, exp } => is_free_of_k(base, k, pool) && is_free_of_k(exp, k, pool),
+        ExprData::Func { args, .. } => args.iter().all(|&a| is_free_of_k(a, k, pool)),
+        _ => true,
+    }
+}
+
+fn const_to_rational(expr: ExprId, pool: &ExprPool) -> Result<Rational, SumError> {
+    match pool.get(expr) {
+        ExprData::Integer(n) => Ok(Rational::from(n.0.clone())),
+        ExprData::Rational(r) => Ok(r.0.clone()),
+        ExprData::Mul(args) => {
+            let mut acc = Rational::from(1);
+            for &a in &args {
+                acc *= const_to_rational(a, pool)?;
+            }
+            Ok(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            let b = const_to_rational(base, pool)?;
+            let e = match pool.get(exp) {
+                ExprData::Integer(n) => n.0.to_i32().ok_or_else(|| {
+                    SumError::NotHypergeometric("constant exponent too large".into())
+                })?,
+                _ => {
+                    return Err(SumError::NotHypergeometric(
+                        "geometric base must be a rational constant".into(),
+                    ))
+                }
+            };
+            if e >= 0 {
+                let mut p = Rational::from(1);
+                for _ in 0..e {
+                    p *= b.clone();
+                }
+                Ok(p)
+            } else {
+                if b.is_zero() {
+                    return Err(SumError::NotHypergeometric("zero geometric base".into()));
+                }
+                let mut p = Rational::from(1);
+                for _ in 0..(-e) {
+                    p *= b.clone();
+                }
+                Ok(Rational::from(1) / p)
+            }
+        }
+        _ => Err(SumError::NotHypergeometric(
+            "geometric base must be a rational constant".into(),
+        )),
+    }
+}
+
+/// `F(k) = c^{a·k+b}` with `c` free of `k` ⇒ `F(k+1)/F(k) = c^a`.
+fn geometric_base_ratio(
+    base: ExprId,
+    exp: ExprId,
+    k: ExprId,
+    pool: &ExprPool,
+) -> Result<RatFunc, SumError> {
+    let c = const_to_rational(base, pool)?;
+    if c.is_zero() {
+        return Err(SumError::NotHypergeometric(
+            "geometric term with zero base".into(),
+        ));
+    }
+    let a = affine_slope_in_k(exp, k, pool)?;
+    if a == 0 {
+        return Ok(RatFunc::one());
+    }
+    let mut pow = Rational::from(1);
+    let steps = a.unsigned_abs();
+    for _ in 0..steps {
+        pow *= c.clone();
+    }
+    if a > 0 {
+        Ok(RatFunc::scalar(pow))
+    } else {
+        Ok(RatFunc::scalar(Rational::from(1) / pow))
+    }
+}
+
+/// Extract integer slope `a` from an affine exponent `a·k + b` (`b` free of `k`).
+fn affine_slope_in_k(exp: ExprId, k: ExprId, pool: &ExprPool) -> Result<i64, SumError> {
+    if exp == k {
+        return Ok(1);
+    }
+    match pool.get(exp) {
+        ExprData::Add(args) => {
+            let mut slope = 0_i64;
+            for &a in &args {
+                slope += affine_slope_in_k(a, k, pool)?;
+            }
+            Ok(slope)
+        }
+        ExprData::Mul(args) => {
+            let mut slope_part = None;
+            let mut coeff = Rational::from(1);
+            for &a in &args {
+                if !is_free_of_k(a, k, pool) {
+                    if slope_part.is_some() {
+                        return Err(SumError::NotHypergeometric(
+                            "geometric exponent must be affine in k".into(),
+                        ));
+                    }
+                    slope_part = Some(affine_slope_in_k(a, k, pool)?);
+                } else {
+                    coeff *= const_to_rational(a, pool)?;
+                }
+            }
+            match slope_part {
+                Some(s) => {
+                    let scaled = coeff * Rational::from(s);
+                    if *scaled.denom() != 1 {
+                        return Err(SumError::NotHypergeometric(
+                            "geometric exponent slope must be an integer".into(),
+                        ));
+                    }
+                    scaled.numer().to_i64().ok_or_else(|| {
+                        SumError::NotHypergeometric(
+                            "geometric exponent slope must be an integer".into(),
+                        )
+                    })
+                }
+                None => Ok(0),
+            }
+        }
+        _ if is_free_of_k(exp, k, pool) => Ok(0),
+        _ => Err(SumError::NotHypergeometric(
+            "geometric exponent must be affine in k".into(),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,5 +320,26 @@ mod tests {
         let r = hypergeom_ratio(term, k, &pool).unwrap();
         let cert = gosper_certificate(&r).expect("gosper");
         assert!(!cert.num.is_zero());
+    }
+
+    #[test]
+    fn ratio_geometric_two_pow_k() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let term = pool.pow(pool.integer(2_i32), k);
+        let r = hypergeom_ratio(term, k, &pool).expect("2^k is hypergeometric");
+        assert_eq!(r.den.degree(), 0);
+        assert_eq!(r.num.coeffs[0], Rational::from(2));
+        assert!(gosper_certificate(&r).is_some());
+    }
+
+    #[test]
+    fn ratio_inv_k_times_k_plus_1() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let den = pool.mul(vec![k, pool.add(vec![k, pool.integer(1_i32)])]);
+        let term = pool.pow(den, pool.integer(-1_i32));
+        let r = hypergeom_ratio(term, k, &pool).expect("1/(k(k+1)) ratio");
+        assert!(gosper_certificate(&r).is_some());
     }
 }

--- a/alkahest-core/src/sum/gosper.rs
+++ b/alkahest-core/src/sum/gosper.rs
@@ -133,7 +133,11 @@ fn rational_gaussian_solve(
                 break;
             }
         }
-        let pr = piv?;
+        // A zero column is a free variable (set to 0), not a failure — e.g. the
+        // constant basis poly for `x(k+1)-x(k)=k` is identically zero.
+        let Some(pr) = piv else {
+            continue;
+        };
         mat.swap(row, pr);
         rhs.swap(row, pr);
         let factor = mat[row][col].clone();
@@ -303,5 +307,28 @@ mod tests {
         let r = RatFunc { num, den }.normalize();
         let cert = gosper_certificate(&r).expect("Gosper certificate exists");
         assert!(!cert.num.is_zero());
+    }
+
+    #[test]
+    fn gosper_sums_polynomial_k() {
+        // F(k)=k ⇒ r=(k+1)/k ⇒ R=(k-1)/2
+        let num = compose_affine(&RatUniPoly::x(), &Rational::from(1), &Rational::from(1));
+        let den = RatUniPoly::x();
+        let r = RatFunc { num, den }.normalize();
+        let cert = gosper_certificate(&r).expect("Gosper must sum F(k)=k");
+        // R = (k - 1)/2
+        assert_eq!(cert.den.degree(), 0);
+        assert_eq!(cert.num.degree(), 1);
+        assert_eq!(cert.num.coeffs[1], Rational::from(1) / Rational::from(2));
+        assert_eq!(cert.num.coeffs[0], Rational::from(-1) / Rational::from(2));
+    }
+
+    #[test]
+    fn gosper_sums_polynomial_k_squared() {
+        let lin = compose_affine(&RatUniPoly::x(), &Rational::from(1), &Rational::from(1));
+        let num = &lin * &lin;
+        let den = &RatUniPoly::x() * &RatUniPoly::x();
+        let r = RatFunc { num, den }.normalize();
+        assert!(gosper_certificate(&r).is_some(), "Gosper must sum F(k)=k^2");
     }
 }

--- a/alkahest-core/src/sum/mod.rs
+++ b/alkahest-core/src/sum/mod.rs
@@ -270,6 +270,44 @@ mod tests {
     }
 
     #[test]
+    fn indefinite_sum_of_k() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let r = sum_indefinite(k, k, &pool).expect("Σk indefinite");
+        // G(k) = k(k-1)/2
+        for ki in 1..=10 {
+            let mut env = HashMap::new();
+            env.insert(k, ki as f64);
+            let gv = eval_interp(r.value, &env, &pool).expect("G eval");
+            let expected = (ki * (ki - 1)) as f64 / 2.0;
+            assert!((gv - expected).abs() < 1e-9, "G({ki})={gv} want {expected}");
+        }
+    }
+
+    #[test]
+    fn definite_sum_of_k_one_to_ten() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let lo = pool.integer(1_i32);
+        let hi = pool.integer(10_i32);
+        let s = sum_definite(k, k, lo, hi, &pool).expect("Σ_{1}^{10} k");
+        let v = eval_interp(s.value, &HashMap::new(), &pool).expect("eval");
+        assert!((v - 55.0).abs() < 1e-9, "got {v}");
+    }
+
+    #[test]
+    fn definite_geometric_two_pow_k() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let term = pool.pow(pool.integer(2_i32), k);
+        let lo = pool.integer(0_i32);
+        let hi = pool.integer(5_i32);
+        let s = sum_definite(term, k, lo, hi, &pool).expect("Σ 2^k");
+        let v = eval_interp(s.value, &HashMap::new(), &pool).expect("eval");
+        assert!((v - 63.0).abs() < 1e-9, "got {v}"); // 1+2+4+8+16+32
+    }
+
+    #[test]
     fn wz_pair_zero_is_certificate() {
         let pool = ExprPool::new();
         let n = pool.symbol("n", Domain::Real);

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -8063,6 +8063,8 @@ fn py_solve_numerical(
 ///     Variables to solve for (symbols).
 /// numeric : bool, default False
 ///     Used when ``method="groebner"``: symbolic ``Expr`` values vs ``float``.
+///     When Lex back-substitution hits a degree > 2 univariate, ``numeric=True``
+///     falls back to homotopy continuation (same as ``method="homotopy"``).
 /// method : str, default ``"groebner"``
 ///     ``"groebner"`` — Lex basis + triangular back-substitution.
 ///     ``"homotopy"`` — total-degree homotopy continuation in ``ℂⁿ`` followed
@@ -8146,8 +8148,39 @@ fn py_solve(
 
     let result = {
         let pool = pool_py.borrow(py);
-        solve_polynomial_system(eq_ids, var_ids.clone(), &pool.inner)
+        solve_polynomial_system(eq_ids.clone(), var_ids.clone(), &pool.inner)
     };
+
+    // B5: `numeric=True` means the caller accepts floats — when Lex back-substitution
+    // hits a degree > 2 univariate, fall through to homotopy instead of raising.
+    if numeric {
+        if let Err(alkahest_core::SolverError::HighDegree(_)) = &result {
+            let opts = HomotopyOpts::default();
+            let pts = {
+                let pool = pool_py.borrow(py);
+                solve_numerical(&eq_ids, &var_ids, &pool.inner, &opts)
+            };
+            return match pts {
+                Err(e) => Err(homotopy_err_to_py(e)),
+                Ok(points) => {
+                    let list = pyo3::types::PyList::empty_bound(py);
+                    for p in points {
+                        let d = pyo3::types::PyDict::new_bound(py);
+                        for (i, &val) in p.coordinates.iter().enumerate() {
+                            let var_expr = PyExpr {
+                                id: var_ids[i],
+                                pool: pool_py.clone_ref(py),
+                            };
+                            d.set_item(var_expr.into_py(py), val)?;
+                        }
+                        list.append(d)?;
+                    }
+                    Ok(list.into())
+                }
+            };
+        }
+    }
+
     finite_solutions_to_py(py, result, &pool_py, &var_ids, numeric)
 }
 

--- a/tests/test_homotopy_v214.py
+++ b/tests/test_homotopy_v214.py
@@ -56,10 +56,19 @@ def test_solve_numeric_true_falls_back_past_degree_two():
     # Symbolic Groebner still raises HighDegree.
     with pytest.raises(Exception) as exc_info:
         alkahest.solve(eqs, [x, y, z])
-    assert "degree" in str(exc_info.value).lower() or getattr(exc_info.value, "code", "") == "E-SOLVE-002"
+    msg = str(exc_info.value).lower()
+    code = getattr(exc_info.value, "code", "")
+    assert "degree" in msg or code == "E-SOLVE-002"
 
     sols = alkahest.solve(eqs, [x, y, z], numeric=True)
     assert len(sols) == 6
-    perms = {(1.0, 2.0, 3.0), (1.0, 3.0, 2.0), (2.0, 1.0, 3.0), (2.0, 3.0, 1.0), (3.0, 1.0, 2.0), (3.0, 2.0, 1.0)}
+    perms = {
+        (1.0, 2.0, 3.0),
+        (1.0, 3.0, 2.0),
+        (2.0, 1.0, 3.0),
+        (2.0, 3.0, 1.0),
+        (3.0, 1.0, 2.0),
+        (3.0, 2.0, 1.0),
+    }
     found = {(round(s[x], 6), round(s[y], 6), round(s[z], 6)) for s in sols}
     assert found == {(round(a, 6), round(b, 6), round(c, 6)) for a, b, c in perms}

--- a/tests/test_homotopy_v214.py
+++ b/tests/test_homotopy_v214.py
@@ -46,3 +46,20 @@ def test_solve_numerical_certified_solution_api():
     d = pts[0].to_dict()
     assert len(d) == 1
     assert abs(next(iter(d.values())) ** 2 - 1.0) < 1e-10
+
+
+def test_solve_numeric_true_falls_back_past_degree_two():
+    """B5: numeric=True must not die on degree-3 Lex back-substitution."""
+    p = alkahest.ExprPool()
+    x, y, z = p.symbol("x"), p.symbol("y"), p.symbol("z")
+    eqs = [x + y + z - 6, x * y + y * z + z * x - 11, x * y * z - 6]
+    # Symbolic Groebner still raises HighDegree.
+    with pytest.raises(Exception) as exc_info:
+        alkahest.solve(eqs, [x, y, z])
+    assert "degree" in str(exc_info.value).lower() or getattr(exc_info.value, "code", "") == "E-SOLVE-002"
+
+    sols = alkahest.solve(eqs, [x, y, z], numeric=True)
+    assert len(sols) == 6
+    perms = {(1.0, 2.0, 3.0), (1.0, 3.0, 2.0), (2.0, 1.0, 3.0), (2.0, 3.0, 1.0), (3.0, 1.0, 2.0), (3.0, 2.0, 1.0)}
+    found = {(round(s[x], 6), round(s[y], 6), round(s[z], 6)) for s in sols}
+    assert found == {(round(a, 6), round(b, 6), round(c, 6)) for a, b, c in perms}

--- a/tests/test_sum_v210.py
+++ b/tests/test_sum_v210.py
@@ -56,3 +56,34 @@ def test_verify_wz_pair_trivial():
     k = pool.symbol("k")
     z = pool.integer(0)
     assert alkahest.verify_wz_pair(z, z, n, k)
+
+
+def test_sum_definite_polynomial_k_faulhaber():
+    """B4: Σ_{k=1}^{10} k = 55 (polynomial / Faulhaber base case)."""
+    pool = alkahest.ExprPool()
+    k = pool.symbol("k")
+    s = alkahest.sum_definite(k, k, pool.integer(1), pool.integer(10)).value
+    assert abs(alkahest.eval_expr(s, {}) - 55.0) < 1e-9
+
+
+def test_sum_definite_k_squared():
+    pool = alkahest.ExprPool()
+    k = pool.symbol("k")
+    s = alkahest.sum_definite(k**2, k, pool.integer(1), pool.integer(10)).value
+    assert abs(alkahest.eval_expr(s, {}) - 385.0) < 1e-9
+
+
+def test_sum_definite_telescoping_partial_fractions():
+    pool = alkahest.ExprPool()
+    k = pool.symbol("k")
+    term = 1 / (k * (k + 1))
+    s = alkahest.sum_definite(term, k, pool.integer(1), pool.integer(10)).value
+    # Σ_{1}^{10} (1/k - 1/(k+1)) = 1 - 1/11 = 10/11
+    assert abs(alkahest.eval_expr(s, {}) - 10.0 / 11.0) < 1e-9
+
+
+def test_sum_definite_geometric_two_pow_k():
+    pool = alkahest.ExprPool()
+    k = pool.symbol("k")
+    s = alkahest.sum_definite(pool.integer(2) ** k, k, pool.integer(0), pool.integer(5)).value
+    assert abs(alkahest.eval_expr(s, {}) - 63.0) < 1e-9


### PR DESCRIPTION
## Summary
- **B4:** Fix Gosper so polynomial sums work (`Σk`, `Σk²`, telescoping `1/(k(k+1))`) and support geometric `c^k` (e.g. `Σ 2^k`). Root cause was Gaussian elimination treating a free/zero column as failure.
- **B5:** `solve(..., numeric=True)` falls back to homotopy when Lex back-substitution hits degree > 2 (e.g. `{x+y+z=6, xy+yz+zx=11, xyz=6}`).
- **B6:** README quickstart comment now matches `diff(sin(x²+1))` → `2·x·cos(x²+1)`.

## Test plan
- [x] Rust `sum::` suite (incl. `Σ_{1}^{10} k = 55`, `Σ 2^k = 63`)
- [x] `pytest tests/test_sum_v210.py tests/test_homotopy_v214.py`
- [x] Manual: `solve(eqs, vars, numeric=True)` returns 6 permutations of (1,2,3)


Made with [Cursor](https://cursor.com)