### PR TITLE
fix: restore log/exp inverse rules in simplify_log_exp

### DIFF
--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -653,19 +653,21 @@ impl RewriteRule for LogOfPow {
     }
 }
 
-/// Return the conservative log/exp identity rules.
+/// Return the default log/exp identity rules.
 ///
-/// Symbolic log/exp identities need real-domain or positivity facts. Use an
-/// [`crate::simplify::AssumptionContext`] to enable the condition-gated
-/// identities; this standalone ruleset intentionally keeps no such facts.
+/// Includes the inverse cancellations `log(exp(x)) → x` and `exp(log(x)) → x`.
+/// Branch-cut-sensitive expansions (`log(a*b)`, `log(a^n)`) are intentionally
+/// omitted; use an [`crate::simplify::AssumptionContext`] for condition-gated
+/// rewrites, or [`log_exp_rules_safe`] for the empty complex-safe set.
 pub fn log_exp_rules() -> Vec<Box<dyn RewriteRule>> {
-    vec![]
+    vec![Box::new(LogOfExp), Box::new(ExpOfLog)]
 }
 
 /// Log/exp rules that are safe for complex numbers (no branch-cut rewrites).
 ///
-/// No nontrivial symbolic log/exp identity is valid over all principal-complex
-/// branches, so this is intentionally empty.
+/// Empty: even the inverse cancellations assume a real/positive domain for
+/// the principal branch, so callers that need complex-safe behaviour get no
+/// rewrites here.
 pub fn log_exp_rules_safe() -> Vec<Box<dyn RewriteRule>> {
     vec![]
 }
@@ -1780,23 +1782,39 @@ mod tests {
     }
 
     #[test]
-    fn log_of_exp_stays_conservative_without_context() {
+    fn log_of_exp_folds() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.func("log", vec![pool.func("exp", vec![x])]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
-        assert_eq!(r.value, expr);
+        assert_eq!(r.value, x, "got {}", pool.display(r.value));
     }
 
     #[test]
-    fn exp_of_log_stays_conservative_without_context() {
+    fn exp_of_log_folds() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
-        assert_eq!(r.value, expr);
+        assert_eq!(r.value, x, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn log_exp_inverse_pair_folds_under_add() {
+        // Bottom-up simplify_with must rewrite both Add children.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let expr = pool.add(vec![
+            pool.func("log", vec![pool.func("exp", vec![x])]),
+            pool.func("exp", vec![pool.func("log", vec![y])]),
+        ]);
+        let rules = log_exp_rules();
+        let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        let expected = pool.add(vec![x, y]);
+        assert_eq!(r.value, expected, "got {}", pool.display(r.value));
     }
 
     #[test]

--- a/tests/test_assumptions.py
+++ b/tests/test_assumptions.py
@@ -31,7 +31,8 @@ def test_unproven_branch_cut_rewrites_remain_unchanged():
     y = p.symbol("y")
 
     assert str(alkahest.simplify(alkahest.sqrt(x**2)).value) == "sqrt(x^2)"
-    assert str(alkahest.simplify_log_exp(alkahest.exp(alkahest.log(x))).value) == "exp(log(x))"
+    # Dedicated simplify_log_exp folds inverses; default simplify stays conservative.
+    assert str(alkahest.simplify_log_exp(alkahest.exp(alkahest.log(x))).value) == "x"
     assert str(alkahest.simplify_log_exp(alkahest.log(x * y)).value) == "log((x * y))"
 
 

--- a/tests/textbook_gate/test_tg_algebra_identities.py
+++ b/tests/textbook_gate/test_tg_algebra_identities.py
@@ -6,14 +6,10 @@ Three first-course topics: log/exp inverse identities, rational-function
 checks against known references, never string-matching alkahest's normal
 form).
 
-`log(exp(x)) -> x` and `exp(log(x)) -> x` are unconditionally-valid inverse
-identities, but as of the 2026-07-20 usage eval (report7-20.md, "Output
-hygiene" section) `simplify_log_exp` doesn't fold either — even standalone,
-not just combined. That's still checked here as a plain (non-xfail) value
--preservation test: the identity holds numerically regardless of whether the
-simplifier collapses the expression's shape, and this suite promises not to
-assert on shape. The exact case documented in report7-20.md as a no-op
-(`log(exp(x)) + exp(log(y))`) is kept as the one dedicated xfail regression.
+`log(exp(x)) -> x` and `exp(log(x)) -> x` are checked numerically via
+value-preservation (this suite avoids string-matching normal form). The
+combined case `log(exp(x)) + exp(log(y))` uses structural equality against
+`simplify(x + y)` so a no-op rewrite cannot slip through as a false pass.
 """
 
 from __future__ import annotations
@@ -89,11 +85,6 @@ def test_exp_log_inverse_simplify(x):
     assert_matches_reference(r, x, lambda v: v, points=POSITIVE_POINTS)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="report7-20.md 'rough edges': simplify_log_exp(log(exp(x)) + exp(log(y))) is a no-op, "
-    "including the unconditionally-valid log(exp(x)) -> x subterm",
-)
 def test_simplify_log_exp_inverse_pair(pool, x, y):
     """log(exp(x)) + exp(log(y)) should collapse to x + y via the two
     independent inverse identities. This is checked via *structural* Expr


### PR DESCRIPTION
## Summary
- Restore `LogOfExp` / `ExpOfLog` in `log_exp_rules()` so `simplify_log_exp` folds textbook inverses (`log(exp(x))+exp(log(y)) → x+y`).
- Keep `LogOfProduct` out of the default ruleset (branch-cut conservatism).
- Clear the textbook-gate `xfail` on `test_simplify_log_exp_inverse_pair`.

## Test plan
- [x] Rust `log_of_*` / `exp_of_log_*` / inverse-pair-under-Add unit tests
- [x] `pytest tests/textbook_gate/test_tg_algebra_identities.py`
- [x] `pytest tests/test_assumptions.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logarithm and exponential inverse expressions now simplify automatically, including within larger expressions.
  * The dedicated log/exp simplification now converts `exp(log(x))` to `x`.

* **Bug Fixes**
  * Updated algebraic identity checks to accurately validate simplified results and prevent no-op rewrites from passing unnoticed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->