### PR TITLE
fix(ci): repair nightly fuzz build and LSAN symbolization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 2 * * *"   # 02:00 UTC daily — triggers the nightly job
+  workflow_dispatch:        # allow re-running nightly shards after CI fixes
 
 env:
   CARGO_TERM_COLOR: always
@@ -132,7 +133,7 @@ jobs:
   tier1-python-slow:
     name: Tier 1b — Python slow tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -181,7 +182,7 @@ jobs:
   nightly:
     name: Nightly (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,9 +267,22 @@ jobs:
       - name: LeakSanitizer
         if: matrix.shard == 'lsan'
         env:
-          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan.supp
-          LLVM_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-15
+          # Prefer the real binary from llvm-15-tools; the /usr/bin/llvm-symbolizer-15
+          # alternative is missing on some Ubuntu noble images, leaving stacks
+          # unsymbolized so lsan.supp (mpfr_*/__gmp*) never matches.
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan.supp:symbolize=1
         run: |
+          for candidate in /usr/lib/llvm-15/bin/llvm-symbolizer /usr/bin/llvm-symbolizer-15 /usr/bin/llvm-symbolizer; do
+            if [ -x "$candidate" ]; then
+              export LLVM_SYMBOLIZER_PATH="$candidate"
+              break
+            fi
+          done
+          if [ -z "${LLVM_SYMBOLIZER_PATH:-}" ]; then
+            echo "error: no llvm-symbolizer found; LSAN suppressions will not match" >&2
+            exit 1
+          fi
+          echo "Using LLVM_SYMBOLIZER_PATH=$LLVM_SYMBOLIZER_PATH"
           RUSTFLAGS="-Zsanitizer=leak" \
           cargo +nightly test --workspace --lib --tests \
             --target x86_64-unknown-linux-gnu \

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -15,14 +15,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "alkahest-core"
-version = "2.0.0"
+name = "alkahest-cas"
+version = "3.6.0"
 dependencies = [
  "bitflags",
  "boxcar",
  "gmp-mpfr-sys",
  "num-integer",
  "rug",
+ "wide",
 ]
 
 [[package]]
@@ -30,7 +31,7 @@ name = "alkahest-fuzz"
 version = "0.1.0"
 dependencies = [
  "afl",
- "alkahest-core",
+ "alkahest-cas",
 ]
 
 [[package]]
@@ -56,6 +57,12 @@ name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "gmp-mpfr-sys"
@@ -128,10 +135,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "windows-link"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,7 +6,8 @@ publish = false
 
 [dependencies]
 afl = "0.15"
-alkahest-core = { path = "../alkahest-core" }
+# Package renamed to alkahest-cas; keep the dep key so `use alkahest_core::…` still works.
+alkahest-core = { path = "../alkahest-core", package = "alkahest-cas" }
 
 [[bin]]
 name = "fuzz_expr_builder"


### PR DESCRIPTION
## Summary
- Fix `fuzz/Cargo.toml` to depend on `package = \"alkahest-cas\"` (same pattern as `alkahest-py` / `alkahest-mlir`) so nightly `fuzz-expr` / `fuzz-simplifier` can build after the rename.
- Resolve `llvm-symbolizer` from llvm-15 install paths so LeakSanitizer stacks are symbolized and `lsan.supp` entries for mpfr/gmp can match.

## Context
Scheduled main CI ([run 29802632734](https://github.com/alkahest-cas/alkahest/actions/runs/29802632734)) failed:
- fuzz shards: `no matching package named alkahest-core found`
- lsan: leaks reported with unsymbolized `alkahest_cas-…+offset` frames after all tests passed

Push CI on main was already green; this targets the nightly shards.

## Test plan
- [x] `cargo check --manifest-path fuzz/Cargo.toml --bin fuzz_simplifier`
- [ ] CI nightly shards `fuzz-expr`, `fuzz-simplifier`, `lsan` green (or re-run schedule)
- [ ] Note: CodSpeed on main still needs the intentional `test_log_exp_simplify_depth4` ack (separate from this PR)


Made with [Cursor](https://cursor.com)