### PR TITLE
docs: close rough-edge gaps (parse, sums, Diophantine, DerivedResult)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Docs
+
+- Document `parse` in the README quickstart; clarify that `limit` / `series` are not `DerivedResult`.
+- Expand `sum_definite` / `sum_indefinite` / `diophantine` / `solve` docs (Faulhaber gap, binary Diophantine patterns, no parametric solve).
+
 ## 3.6.0 — 2026-07-17
 
 ### Release / packaging

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ print(ak.simplify_trig(ak.sin(x)**2 + ak.cos(x)**2).value)  # 1
 # JIT-compile to native code (interpreter fallback when caps["jit"] is False)
 f = ak.compile_expr(x**2 + 1, [x])
 print(f([3.0]))       # 10.0
+
+# String entry point for agents / notebooks (bindings optional)
+e = ak.parse("sin(x)^2 + cos(x)^2", pool, {"x": x})
+print(ak.simplify_trig(e).value)  # 1
 ```
 
 Partial fractions, definite integration, and Lean certificates:
@@ -219,11 +223,13 @@ Representation types are explicit — no silent performance cliffs. Conversion b
 
 ## Result objects
 
-Every top-level operation returns a `DerivedResult` with:
+Most transforming operations (`diff`, `simplify`, `integrate`, `sum_*`, …) return a `DerivedResult` with:
 
 - `.value` — the result expression
 - `.steps` — derivation log (list of rewrite rules applied)
 - `.certificate` — Lean 4 proof term, when available
+
+Exceptions: `limit` returns a bare `Expr`, and `series` returns a `Series` (with its own `.polynomial` / `.order` fields). Use `.value` only on `DerivedResult`.
 
 ---
 

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -7871,7 +7871,8 @@ impl PyCertifiedSolution {
     }
 }
 
-/// Integer Diophantine solver (linear parametric families, sum of two squares, Pell-type).
+/// Result of [`diophantine`](py_diophantine): a parametric linear family,
+/// a finite list of integer points, or a Pell-type description.
 #[cfg(feature = "groebner")]
 #[pyclass(name = "DiophantineSolution")]
 struct PyDiophantineSolution {
@@ -8007,6 +8008,25 @@ fn diophantine_core_to_py(
     }
 }
 
+/// `alkahest.diophantine(equation, vars)` — integer solutions of a binary
+/// Diophantine equation.
+///
+/// Solves `equation = 0` over the integers in exactly two unknowns.
+/// Supported patterns:
+///
+/// * **Linear** — returns a parametric family ``x(t), y(t)``
+///   (``kind == "parametric_linear"``).
+/// * **Sum of two squares** — ``x² + y² = n`` (finite list of points).
+/// * **Pell / generalized Pell** — ``x² − D·y² = 1`` or ``= N``.
+///
+/// Raises ``DiophantineError`` when the equation is not a polynomial in
+/// *vars*, has non-integer coefficients, is an unsupported pattern, or has
+/// no integer solution.
+///
+/// Example::
+///
+///     sol = diophantine(x + 2*y - 5, [x, y])
+///     # sol.kind == "parametric_linear"; sol.parametric = [x(t), y(t)]
 #[cfg(feature = "groebner")]
 #[pyfunction]
 #[pyo3(name = "diophantine", signature = (equation, vars))]
@@ -8087,7 +8107,9 @@ fn py_solve_numerical(
 /// equations : list[Expr]
 ///     Each expression represents `p(vars) = 0`.
 /// vars : list[Expr]
-///     Variables to solve for (symbols).
+///     Variables to solve for (symbols). Every free symbol that appears in
+///     *equations* must be listed here — parametric solve (e.g. ``x² = y``
+///     with ``y`` kept free) is not supported and raises ``SolverError``.
 /// numeric : bool, default False
 ///     Used when ``method="groebner"``: symbolic ``Expr`` values vs ``float``.
 ///     When Lex back-substitution hits a degree > 2 univariate, ``numeric=True``

--- a/docs/mdbook/src/derivations.md
+++ b/docs/mdbook/src/derivations.md
@@ -1,10 +1,10 @@
 # Derivation logs
 
-Every transformation in Alkahest returns a `DerivedResult` that records the exact sequence of rewrite steps applied. This log is the foundation for both human inspection and Lean proof export.
+Most transformations in Alkahest return a `DerivedResult` that records the exact sequence of rewrite steps applied. This log is the foundation for both human inspection and Lean proof export.
 
 ## DerivedResult
 
-`DerivedResult` is the return type of `diff`, `simplify`, `integrate`, and all top-level operations:
+`DerivedResult` is the return type of `diff`, `simplify`, `integrate`, `sum_*`, and most other transforming operations. Notable exceptions: `limit` returns a bare `Expr`, and `series` returns a `Series`.
 
 ```python
 from alkahest import diff, sin

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -973,7 +973,11 @@ _native_sum_indefinite = sum_indefinite
 
 
 def sum_indefinite(expr, k):
-    """Indefinite symbolic sum of *expr* with respect to index *k*."""
+    """Indefinite symbolic sum of *expr* with respect to index *k*.
+
+    Same algorithm family as :func:`sum_definite` (Gosper / hypergeometric).
+    Polynomial and geometric closed forms are not yet implemented.
+    """
     return _maybe_context_simplify(_native_sum_indefinite(_coerce_expr(expr), _coerce_expr(k)))
 
 
@@ -981,7 +985,14 @@ _native_sum_definite = sum_definite
 
 
 def sum_definite(expr, k, lo, hi):
-    """Definite symbolic sum of *expr* for *k* from *lo* to *hi* (inclusive)."""
+    """Definite symbolic sum of *expr* for *k* from *lo* to *hi* (inclusive).
+
+    Uses Gosper / hypergeometric summation. Polynomial Faulhaber sums
+    (e.g. ``Σ k``, ``Σ k²``) and geometric terms such as ``Σ 2^k`` are
+    **not** yet supported and raise ``SumError`` (``E-SUM-002``) even when
+    a closed form exists. Prefer an explicit formula or another CAS for
+    those textbook cases until Faulhaber / geometric handlers land.
+    """
     return _maybe_context_simplify(
         _native_sum_definite(
             _coerce_expr(expr),


### PR DESCRIPTION
## Summary
- Document `parse` in the README quickstart (string entry point for agents).
- Clarify that `limit` / `series` are not `DerivedResult` (README + mdbook).
- Expand `sum_definite` / `sum_indefinite` docs: Gosper-only; Faulhaber / geometric unsupported.
- Add a real `diophantine` docstring; note `solve` rejects free parameters (no parametric solve).

Addresses the **Small doc gaps** and doc side of **API consistency** from `temp-alkahest/planning/report7-20.md` rough edges.

## Test plan
- [ ] Spot-check README quickstart + Result objects section
- [ ] `help(alkahest.sum_definite)` / `help(alkahest.diophantine)` show new text after build
- [ ] Tier-1 CI green (docstring-only Rust change)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start with the string/agent entry point.
  * Clarified which operations return `DerivedResult`, including exceptions for `limit` and `series`.
  * Expanded documentation for indefinite and definite summation, including supported methods and limitations.
  * Documented Diophantine solution details and clarified requirements and limitations for polynomial-system solving.
  * Improved guidance on inspecting transformation steps and exporting Lean proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->