### PR TITLE
fix: hide import leaks from alkahest package namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### API
+
+- Hide import-machinery leaks (`contextlib`, `exceptions`, `alkahest`) from
+  ``dir(alkahest)`` / autocomplete; submodules remain explicitly importable.
+
 ## 3.6.0 — 2026-07-17
 
 ### Release / packaging

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1,4 +1,4 @@
-import contextlib
+from contextlib import suppress as _suppress
 from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from importlib.metadata import version as _meta_version
 
@@ -239,13 +239,13 @@ from .alkahest import (
 )
 
 # V5-7: JAX primitive integration (optional — requires JAX)
-with contextlib.suppress(ImportError):
+with _suppress(ImportError):
     from ._jax import to_jax  # noqa: F401
 
 # V1-4 / V1-16: Polynomial system solver + Gröbner basis
 # groebner is a default Cargo feature since 2.3.1 — present in all PyPI wheels.
-# contextlib.suppress is kept as a safety net for custom builds with --no-default-features.
-with contextlib.suppress(ImportError):
+# suppress is kept as a safety net for custom builds with --no-default-features.
+with _suppress(ImportError):
     from .alkahest import (
         CertifiedSolution,
         DaeIndexReduction,
@@ -1431,3 +1431,11 @@ __all__ = [
     "version",
     "voltage_source",
 ]
+
+# Drop import-machinery leaks from ``dir(alkahest)`` / autocomplete. Submodules
+# remain importable as ``alkahest.exceptions`` / ``alkahest.alkahest`` when
+# explicitly requested; they just are not pre-bound on the package object.
+for _leak in ("exceptions", "alkahest", "_suppress"):
+    globals().pop(_leak, None)
+del _leak
+

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1438,4 +1438,3 @@ __all__ = [
 for _leak in ("exceptions", "alkahest", "_suppress"):
     globals().pop(_leak, None)
 del _leak
-

--- a/tests/test_namespace_hygiene.py
+++ b/tests/test_namespace_hygiene.py
@@ -1,0 +1,27 @@
+"""Top-level ``alkahest`` must not leak import-machinery names into ``dir()``."""
+
+from __future__ import annotations
+
+import alkahest
+
+
+def test_no_stdlib_or_submodule_leaks_in_dir():
+    names = set(dir(alkahest))
+    assert "contextlib" not in names
+    assert "suppress" not in names
+    assert "exceptions" not in names
+    # Native extension submodule is loaded via ``from .alkahest import …``
+    # but must not pollute the public package namespace.
+    assert "alkahest" not in names
+
+
+def test_exceptions_submodule_still_importable():
+    from alkahest.exceptions import ParseError
+
+    assert issubclass(ParseError, Exception)
+
+
+def test_intentional_exports_still_present():
+    assert "version" in alkahest.__all__
+    assert callable(alkahest.version)
+    assert "parse" in alkahest.__all__


### PR DESCRIPTION
## Summary
- Import `suppress` privately and drop it after use so `contextlib` is not on `alkahest`.
- Drop pre-bound `exceptions` and `alkahest` submodule attributes after import (still importable as `alkahest.exceptions` / `alkahest.alkahest`).
- Add a regression test for namespace hygiene.

Addresses **Namespace** rough edges from `temp-alkahest/planning/report7-20.md`. Circuit helpers (`resistor` / `capacitor` / `voltage_source`) stay on the stable surface — they are documented acausal API, not import leaks.

## Test plan
- [ ] `python -c "import alkahest as ak; assert 'contextlib' not in dir(ak) and 'exceptions' not in dir(ak)"`
- [ ] `from alkahest.exceptions import ParseError` still works
- [ ] `pytest tests/test_namespace_hygiene.py`
- [ ] Tier-1 CI green


Made with [Cursor](https://cursor.com)