### PR TITLE
fix: API consistency for constructors, optional vars, error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### API
+
+- `UniPoly.from_coefficients` accepts Python ``int`` coefficients (not only ``Expr``).
+- `cancel` / `together` / `MultiPoly.from_symbolic` / `radical` infer free symbols when
+  *vars* is omitted.
+- Structured error messages now include the stable code prefix, e.g. ``[E-INT-004] …``.
+
 ## 3.6.0 — 2026-07-17
 
 ### Release / packaging

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -106,12 +106,12 @@ pub use ode::{
 pub use parse::{parse, ParseError};
 pub use pattern::{match_pattern, Pattern, Substitution};
 pub use poly::{
-    apart, cancel, factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z,
-    gcd_sparse_modular, poly_normal, real_roots, real_roots_symbolic, refine_root, residue,
-    resultant, sparse_interpolate, sparse_interpolate_univariate, subresultant_prs, together,
-    together_parts, ApartError, ConversionError, FactorError, GaussRat, MultiPoly,
-    MultiPolyFactorization, RationalFunction, RealRootError, ResidueError, ResultantError,
-    RootInterval, SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP,
+    apart, cancel, collect_free_vars, factor_multivariate_z, factor_univariate_mod_p,
+    factor_univariate_z, gcd_sparse_modular, poly_normal, real_roots, real_roots_symbolic,
+    refine_root, residue, resultant, sparse_interpolate, sparse_interpolate_univariate,
+    subresultant_prs, together, together_parts, ApartError, ConversionError, FactorError, GaussRat,
+    MultiPoly, MultiPolyFactorization, RationalFunction, RealRootError, ResidueError,
+    ResultantError, RootInterval, SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP,
     UniPolyFactorization,
 };
 
@@ -275,13 +275,13 @@ pub mod stable {
     pub use crate::parse::{parse, ParseError};
     pub use crate::pattern::{match_pattern, Pattern, Substitution};
     pub use crate::poly::{
-        apart, cancel, factor_multivariate_z, factor_univariate_mod_p, factor_univariate_z,
-        gcd_sparse_modular, poly_normal, real_roots, real_roots_symbolic, refine_root, residue,
-        resultant, sparse_interpolate, sparse_interpolate_univariate, subresultant_prs, together,
-        together_parts, ApartError, ConversionError, FactorError, GaussRat, MultiPoly,
-        MultiPolyFactorization, RationalFunction, RealRootError, ResidueError, ResultantError,
-        RootInterval, SparseGcdError, SparseInterpError, UniPoly, UniPolyFactorModP,
-        UniPolyFactorization,
+        apart, cancel, collect_free_vars, factor_multivariate_z, factor_univariate_mod_p,
+        factor_univariate_z, gcd_sparse_modular, poly_normal, real_roots, real_roots_symbolic,
+        refine_root, residue, resultant, sparse_interpolate, sparse_interpolate_univariate,
+        subresultant_prs, together, together_parts, ApartError, ConversionError, FactorError,
+        GaussRat, MultiPoly, MultiPolyFactorization, RationalFunction, RealRootError, ResidueError,
+        ResultantError, RootInterval, SparseGcdError, SparseInterpError, UniPoly,
+        UniPolyFactorModP, UniPolyFactorization,
     };
     pub use crate::primitive::{Primitive, PrimitiveRegistry};
     pub use crate::real::{

--- a/alkahest-core/src/poly/mod.rs
+++ b/alkahest-core/src/poly/mod.rs
@@ -42,7 +42,7 @@ pub use partial_fractions::{apart, ApartError};
 pub use rational::RationalFunction;
 pub use residue::{residue, ResidueError};
 // V2-2 — Resultants and subresultant PRS
-pub use resultant::{resultant, subresultant_prs, ResultantError};
+pub use resultant::{collect_free_vars, resultant, subresultant_prs, ResultantError};
 // V2-4 — Real root isolation (VAS)
 pub use real_roots::{real_roots, real_roots_symbolic, refine_root, RealRootError, RootInterval};
 pub use unipoly::UniPoly;

--- a/alkahest-core/src/poly/resultant.rs
+++ b/alkahest-core/src/poly/resultant.rs
@@ -85,7 +85,7 @@ impl crate::errors::AlkahestError for ResultantError {
 /// Walk the expression DAG and collect every distinct [`ExprId`] that
 /// corresponds to a `Symbol` node.  Result is sorted by `ExprId` for a
 /// deterministic variable ordering.
-pub(crate) fn collect_free_vars(expr: ExprId, pool: &ExprPool) -> Vec<ExprId> {
+pub fn collect_free_vars(expr: ExprId, pool: &ExprPool) -> Vec<ExprId> {
     let mut set = BTreeSet::new();
     collect_vars_rec(expr, pool, &mut set);
     set.into_iter().collect()

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -288,14 +288,16 @@ fn make_structured_err<E: AlkahestErrorTrait>(
     e: &E,
 ) -> PyErr {
     let msg = e.to_string();
+    let code = e.code();
     let remediation = e.remediation().unwrap_or("");
+    // Prefix the stable code so `str(exc)` / logs are greppable without reading `.code`.
     let full_msg = if remediation.is_empty() {
-        msg
+        format!("[{code}] {msg}")
     } else {
-        format!("{msg}\nRemediation: {remediation}")
+        format!("[{code}] {msg}\nRemediation: {remediation}")
     };
     let exc = exc_type.call1((full_msg,)).unwrap();
-    exc.setattr("code", e.code()).ok();
+    exc.setattr("code", code).ok();
     exc.setattr("remediation", e.remediation()).ok();
     exc.setattr("span", e.span()).ok();
     PyErr::from_value_bound(exc)
@@ -2397,41 +2399,56 @@ impl PyUniPoly {
             .map_err(conv_error_to_py)
     }
 
-    /// Construct a `UniPoly` from a list of symbolic integer expressions (constant term first).
+    /// Construct a `UniPoly` from coefficients (constant term first).
+    ///
+    /// Each coefficient may be a Python ``int`` or an integer ``Expr`` from the
+    /// same pool as *var*.
     ///
     /// ```python
     /// p = ExprPool()
     /// x = p.symbol("x")
     /// # -1 + x^2  (coefficients in ascending degree order)
+    /// poly = UniPoly.from_coefficients([-1, 0, 1], x)
+    /// # also accepted:
     /// poly = UniPoly.from_coefficients([p.integer(-1), p.integer(0), p.integer(1)], x)
     /// ```
     ///
-    /// Raises `TypeError` if any coefficient is not an integer expression.
+    /// Raises `TypeError` if any coefficient is not an int / integer expression.
     /// Raises `OverflowError` if any coefficient overflows `i64`.
     #[staticmethod]
     fn from_coefficients(
         py: Python<'_>,
-        coefficients: Vec<PyRef<'_, PyExpr>>,
+        coefficients: Vec<Bound<'_, PyAny>>,
         var: PyRef<'_, PyExpr>,
     ) -> PyResult<Self> {
         let pool = var.pool.borrow(py);
         let mut i64_coeffs: Vec<i64> = Vec::with_capacity(coefficients.len());
         for (idx, coeff) in coefficients.iter().enumerate() {
-            match pool.inner.get(coeff.id) {
-                alkahest_core::ExprData::Integer(bi) => {
-                    let n = bi.0.to_i64().ok_or_else(|| {
-                        PyOverflowError::new_err(format!(
-                            "UniPoly.from_coefficients: coefficient at index {idx} overflows i64"
-                        ))
-                    })?;
-                    i64_coeffs.push(n);
-                }
-                _ => {
-                    return Err(PyTypeError::new_err(format!(
-                        "UniPoly.from_coefficients: coefficient at index {idx} is not an integer expression"
-                    )));
+            if let Ok(n) = coeff.extract::<i64>() {
+                i64_coeffs.push(n);
+                continue;
+            }
+            if let Ok(expr) = coeff.extract::<PyRef<PyExpr>>() {
+                match pool.inner.get(expr.id) {
+                    alkahest_core::ExprData::Integer(bi) => {
+                        let n = bi.0.to_i64().ok_or_else(|| {
+                            PyOverflowError::new_err(format!(
+                                "UniPoly.from_coefficients: coefficient at index {idx} overflows i64"
+                            ))
+                        })?;
+                        i64_coeffs.push(n);
+                        continue;
+                    }
+                    _ => {
+                        return Err(PyTypeError::new_err(format!(
+                            "UniPoly.from_coefficients: coefficient at index {idx} is not an integer expression"
+                        )));
+                    }
                 }
             }
+            return Err(PyTypeError::new_err(format!(
+                "UniPoly.from_coefficients: coefficient at index {idx} must be int or integer Expr"
+            )));
         }
         let coeffs = alkahest_core::FlintPoly::from_coefficients(&i64_coeffs);
         Ok(PyUniPoly {
@@ -2525,14 +2542,22 @@ impl PyUniPoly {
 
 #[pymethods]
 impl PyMultiPoly {
+    /// Build a multivariate polynomial from a symbolic expression.
+    ///
+    /// If *vars* is omitted, free symbols of *expr* are used (sorted by
+    /// internal id for a deterministic order).
     #[staticmethod]
+    #[pyo3(signature = (expr, vars=None))]
     fn from_symbolic(
         py: Python<'_>,
         expr: PyRef<PyExpr>,
-        vars: Vec<PyRef<PyExpr>>,
+        vars: Option<Vec<PyRef<PyExpr>>>,
     ) -> PyResult<Self> {
-        let var_ids: Vec<_> = vars.iter().map(|v| v.id).collect();
         let pool = expr.pool.borrow(py);
+        let var_ids: Vec<_> = match vars {
+            Some(v) => v.iter().map(|v| v.id).collect(),
+            None => alkahest_core::collect_free_vars(expr.id, &pool.inner),
+        };
         MultiPoly::from_symbolic(expr.id, var_ids, &pool.inner)
             .map(|p| PyMultiPoly {
                 inner: p,
@@ -6318,9 +6343,12 @@ fn py_poly_normal(
 /// listed in *vars*, or a base with a symbolic exponent) is treated as an
 /// opaque generator.
 ///
+/// If *vars* is omitted, free symbols of *expr* are used.
+///
 /// Examples::
 ///
 ///     cancel((x**2 - 1) / (x - 1), [x])   # -> x + 1
+///     cancel((x**2 - 1) / (x - 1))        # vars inferred
 ///     cancel(1/x + 1/(x + 1), [x])         # -> (2*x + 1) / (x**2 + x)
 ///     cancel(x / x, [x])                   # -> 1
 ///
@@ -6328,12 +6356,19 @@ fn py_poly_normal(
 /// ``sin(2*x/2)`` are distinct), and bases raised to symbolic exponents are
 /// opaque as a whole.
 #[pyfunction]
-#[pyo3(name = "cancel")]
-fn py_cancel(py: Python<'_>, expr: PyRef<PyExpr>, vars: Vec<PyRef<PyExpr>>) -> PyResult<PyExpr> {
+#[pyo3(name = "cancel", signature = (expr, vars=None))]
+fn py_cancel(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    vars: Option<Vec<PyRef<PyExpr>>>,
+) -> PyResult<PyExpr> {
     let pool_py = expr.pool.clone_ref(py);
-    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
     let result = {
         let pool = pool_py.borrow(py);
+        let var_ids: Vec<ExprId> = match vars {
+            Some(v) => v.iter().map(|v| v.id).collect(),
+            None => alkahest_core::collect_free_vars(expr.id, &pool.inner),
+        };
         core_cancel(expr.id, var_ids, &pool.inner).map_err(conv_error_to_py)?
     };
     Ok(PyExpr {
@@ -6348,16 +6383,25 @@ fn py_cancel(py: Python<'_>, expr: PyRef<PyExpr>, vars: Vec<PyRef<PyExpr>>) -> P
 /// the underlying rational-function constructor); provided as a companion name
 /// for callers that want the explicit "put over a common denominator" intent.
 ///
+/// If *vars* is omitted, free symbols of *expr* are used.
+///
 /// Example::
 ///
 ///     together(1/x + 1/(x + 1), [x])   # -> (2*x + 1) / (x**2 + x)
 #[pyfunction]
-#[pyo3(name = "together")]
-fn py_together(py: Python<'_>, expr: PyRef<PyExpr>, vars: Vec<PyRef<PyExpr>>) -> PyResult<PyExpr> {
+#[pyo3(name = "together", signature = (expr, vars=None))]
+fn py_together(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    vars: Option<Vec<PyRef<PyExpr>>>,
+) -> PyResult<PyExpr> {
     let pool_py = expr.pool.clone_ref(py);
-    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
     let result = {
         let pool = pool_py.borrow(py);
+        let var_ids: Vec<ExprId> = match vars {
+            Some(v) => v.iter().map(|v| v.id).collect(),
+            None => alkahest_core::collect_free_vars(expr.id, &pool.inner),
+        };
         core_together(expr.id, var_ids, &pool.inner).map_err(conv_error_to_py)?
     };
     Ok(PyExpr {
@@ -7748,23 +7792,50 @@ fn py_primary_decomposition(
     Ok(out)
 }
 
-/// Radical √I of the ideal generated by `polys` (same variable order as `vars`).
+/// Radical √I of the ideal generated by `polys`.
+///
+/// If *vars* is omitted, free symbols across all *polys* are used (sorted by
+/// internal id). At least one free symbol must be present.
 #[cfg(feature = "groebner")]
 #[pyfunction]
-#[pyo3(name = "radical", signature = (polys, vars))]
+#[pyo3(name = "radical", signature = (polys, vars=None))]
 fn py_ideal_radical(
     py: Python<'_>,
     polys: Vec<PyRef<PyExpr>>,
-    vars: Vec<PyRef<PyExpr>>,
+    vars: Option<Vec<PyRef<PyExpr>>>,
 ) -> PyResult<Py<PyGroebnerBasis>> {
-    if polys.is_empty() || vars.is_empty() {
+    if polys.is_empty() {
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "radical requires at least one polynomial and one variable",
+            "radical requires at least one polynomial",
         ));
     }
     let pool_py = polys[0].pool.clone_ref(py);
     let pool = pool_py.borrow(py);
-    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
+    let var_ids: Vec<ExprId> = match vars {
+        Some(v) => {
+            if v.is_empty() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "radical requires at least one variable",
+                ));
+            }
+            v.iter().map(|v| v.id).collect()
+        }
+        None => {
+            let mut set = std::collections::BTreeSet::new();
+            for p in &polys {
+                for v in alkahest_core::collect_free_vars(p.id, &pool.inner) {
+                    set.insert(v);
+                }
+            }
+            let ids: Vec<ExprId> = set.into_iter().collect();
+            if ids.is_empty() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "radical: no free symbols found to use as variables",
+                ));
+            }
+            ids
+        }
+    };
     let mut gb_polys = Vec::with_capacity(polys.len());
     for p in &polys {
         let gbp = expr_to_gbpoly(p.id, &var_ids, &pool.inner)

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1035,18 +1035,29 @@ _native_cancel = cancel
 _native_together = together
 
 
-def cancel(expr, vars):
+def cancel(expr, vars=None):
     """Combine *expr* over a common denominator and cancel common polynomial factors.
 
     Non-polynomial sub-expressions (e.g. ``sin(x)`` or symbols not in *vars*) are
     treated as opaque generators. Accepts :class:`DerivedResult` as *expr*.
+
+    If *vars* is omitted, free symbols of *expr* are inferred.
     """
-    return _native_cancel(_coerce_expr(expr), [_coerce_expr(v) for v in vars])
+    coerced = _coerce_expr(expr)
+    if vars is None:
+        return _native_cancel(coerced)
+    return _native_cancel(coerced, [_coerce_expr(v) for v in vars])
 
 
-def together(expr, vars):
-    """Combine *expr* over a single common denominator (alias of :func:`cancel`)."""
-    return _native_together(_coerce_expr(expr), [_coerce_expr(v) for v in vars])
+def together(expr, vars=None):
+    """Combine *expr* over a single common denominator (alias of :func:`cancel`).
+
+    If *vars* is omitted, free symbols of *expr* are inferred.
+    """
+    coerced = _coerce_expr(expr)
+    if vars is None:
+        return _native_together(coerced)
+    return _native_together(coerced, [_coerce_expr(v) for v in vars])
 
 
 _native_eval_expr = eval_expr

--- a/tests/test_api_consistency_rough_edges.py
+++ b/tests/test_api_consistency_rough_edges.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
-
 import alkahest as ak
+import pytest
 
 
 @pytest.fixture
@@ -14,7 +13,7 @@ def pool_x():
 
 
 def test_unipoly_from_coefficients_accepts_python_ints(pool_x):
-    pool, x = pool_x
+    _pool, x = pool_x
     poly = ak.UniPoly.from_coefficients([-1, 0, 1], x)
     assert poly.degree() == 2
     assert poly.coefficients() == [-1, 0, 1]

--- a/tests/test_api_consistency_rough_edges.py
+++ b/tests/test_api_consistency_rough_edges.py
@@ -1,0 +1,48 @@
+"""API consistency rough edges: ints in constructors, optional vars, error codes."""
+
+from __future__ import annotations
+
+import pytest
+
+import alkahest as ak
+
+
+@pytest.fixture
+def pool_x():
+    pool = ak.ExprPool()
+    return pool, pool.symbol("x")
+
+
+def test_unipoly_from_coefficients_accepts_python_ints(pool_x):
+    pool, x = pool_x
+    poly = ak.UniPoly.from_coefficients([-1, 0, 1], x)
+    assert poly.degree() == 2
+    assert poly.coefficients() == [-1, 0, 1]
+
+
+def test_cancel_infers_vars(pool_x):
+    _pool, x = pool_x
+    out = ak.cancel((x**2 - 1) / (x - 1))
+    simplified = ak.simplify(out).value
+    assert simplified == x + 1 or simplified == 1 + x
+
+
+def test_together_infers_vars(pool_x):
+    _pool, x = pool_x
+    out = ak.together(1 / x + 1 / (x + 1))
+    assert out is not None
+
+
+def test_multipoly_from_symbolic_infers_vars(pool_x):
+    pool, x = pool_x
+    y = pool.symbol("y")
+    mp = ak.MultiPoly.from_symbolic(x**2 * y + x)
+    assert not mp.is_zero()
+
+
+def test_error_message_includes_stable_code(pool_x):
+    _pool, x = pool_x
+    with pytest.raises(ak.IntegrationError) as ei:
+        ak.integrate(ak.exp(-(x**2)), x)
+    assert ei.value.code == "E-INT-004"
+    assert "[E-INT-004]" in str(ei.value)

--- a/tests/textbook_gate/test_tg_algebra_identities.py
+++ b/tests/textbook_gate/test_tg_algebra_identities.py
@@ -207,15 +207,14 @@ def test_together_reciprocal_difference(x, y):
     assert_two_var_matches_reference(r, x, y, lambda a, b: 1 / a - 1 / b)
 
 
-def test_cancel_requires_vars_argument(x):
-    """cancel/together require an explicit vars list — omitting it raises
-    TypeError (documented API quirk from report7-20.md's 'API consistency'
-    section, kept here as a green canary so the signature isn't silently
-    loosened or tightened further without this suite noticing).
+def test_cancel_infers_vars_when_omitted(x):
+    """cancel/together infer free symbols when *vars* is omitted (API consistency
+    fix from report7-20.md rough edges). Explicit vars remain supported.
     """
     e = (x**2 - 4) / (x - 2)
-    with pytest.raises(TypeError):
-        ak.cancel(e)
+    out = ak.cancel(e)
+    assert ak.simplify(out).value == x + 2 or ak.simplify(out).value == 2 + x
+    assert ak.cancel(e, [x]) is not None
 
 
 # --- exponent rules ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `UniPoly.from_coefficients([-1, 0, 1], x)` works (Python ints, not only `Expr`).
- `cancel` / `together` / `MultiPoly.from_symbolic` / `radical` infer free symbols when `vars` is omitted.
- Structured exceptions print `[E-INT-004] …` so codes are greppable without reading `.code`.

Addresses **API consistency** rough edges from `temp-alkahest/planning/report7-20.md` (except parametric `solve`, which remains documented as unsupported in the docs PR).

## Test plan
- [ ] `pytest tests/test_api_consistency_rough_edges.py`
- [ ] Spot-check: `cancel((x**2-1)/(x-1))`, `UniPoly.from_coefficients([-1,0,1], x)`
- [ ] Confirm `str(IntegrationError)` contains `[E-INT-004]`
- [ ] Tier-1 CI green


Made with [Cursor](https://cursor.com)