### PR TITLE
fix: clear textbook-gate xfails (log/exp, e-limit, nullspace, cubics)

### DIFF
--- a/alkahest-core/src/calculus/limits.rs
+++ b/alkahest-core/src/calculus/limits.rs
@@ -222,12 +222,11 @@ fn limit_inner(
         return Ok(r);
     }
 
-    // Indeterminate power f^g (1^∞, 0^0, ∞^0) at ±∞: rewrite to exp(g·log f) so the
-    // exp-aware Gruntz/series machinery can handle it.  Plain `(1+1/x)^x → e` lives here.
-    if is_pos_infinity(point, pool) || is_neg_infinity(point, pool) {
-        if let Some(r) = try_indeterminate_power(expr, var, point, direction, pool, depth)? {
-            return Ok(r);
-        }
+    // Indeterminate power f^g (1^∞, 0^0, ∞^0): rewrite to exp(g·log f).
+    // Runs for finite points as well as ±∞ so textbook forms like
+    // `(1+x)^(1/x) → e` as `x → 0` are not lost to the `1^anything → 1` fold.
+    if let Some(r) = try_indeterminate_power(expr, var, point, direction, pool, depth)? {
+        return Ok(r);
     }
 
     // Gruntz algorithm — best for exp/log expressions at +∞ (runs before the 1/t substitution
@@ -381,12 +380,30 @@ fn try_indeterminate_power(
         return Ok(None);
     }
 
-    // Limits of the base and exponent (independently).  If either sub-limit is
-    // not computable, do not attempt the rewrite.
+    // Limits of the base and exponent (independently).
     let base_lim = match limit_inner(base, var, point, direction, pool, depth + 1) {
         Ok(b) => b,
         Err(_) => return Ok(None),
     };
+
+    // When `base → 1`, the classic `1^∞` rewrite `exp(g·log f)` is licensed even
+    // if `lim g` itself needs a one-sided approach (e.g. `(1+x)^(1/x)` as
+    // `x → 0`): `lim (g·log f) = lim log(1+x)/x = 1` exists bidirectionally.
+    if is_one_like(base_lim, pool) {
+        let log_base = pool.func("log", vec![base]);
+        let inner = simplify(pool.mul(vec![exp, log_base]), pool).value;
+        if let Ok(inner_lim) = limit_inner(inner, var, point, direction, pool, depth + 1) {
+            if is_pos_infinity(inner_lim, pool) {
+                return Ok(Some(pool.pos_infinity()));
+            }
+            if is_neg_infinity(inner_lim, pool) {
+                return Ok(Some(pool.integer(0_i32)));
+            }
+            let result = simplify(pool.func("exp", vec![inner_lim]), pool).value;
+            return Ok(Some(result));
+        }
+    }
+
     let exp_lim = match limit_inner(exp, var, point, direction, pool, depth + 1) {
         Ok(e) => e,
         Err(_) => return Ok(None),
@@ -741,7 +758,16 @@ fn fold_known_reals(expr: ExprId, pool: &ExprPool) -> ExprId {
         ExprData::Pow { base, exp } => {
             let b = fold_known_reals(base, pool);
             let xp = fold_known_reals(exp, pool);
+            // `1^∞` / `1^(singular)` must not collapse to 1 — that silently
+            // turns `(1+x)^(1/x)|_{x=0}` into 1 before the indeterminate-power
+            // rewrite can recover `e`.
             if is_one_like(b, pool) {
+                if substitution_is_singular(xp, pool)
+                    || is_pos_infinity(xp, pool)
+                    || is_neg_infinity(xp, pool)
+                {
+                    return simplify(pool.pow(b, xp), pool).value;
+                }
                 return pool.integer(1_i32);
             }
             simplify(pool.pow(b, xp), pool).value
@@ -1029,6 +1055,18 @@ mod tests {
                 p.display(v)
             );
         }
+    }
+
+    /// `lim_{x→0} (1 + x)^(1/x) = e` — the finite-point twin of the compound-interest form.
+    #[test]
+    fn limit_one_plus_x_to_one_over_x_is_e() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let base = p.add(vec![p.integer(1), x]);
+        let ex = simplify(p.pow(base, p.pow(x, p.integer(-1))), &p).value;
+        let r = limit(ex, x, p.integer(0_i32), LimitDirection::Bidirectional, &p).unwrap();
+        let expected = simplify(p.func("exp", vec![p.integer(1)]), &p).value;
+        assert_eq!(r, expected, "got {}", p.display(r));
     }
 
     /// Non-regression: `lim_{x→∞} (1 + 1/x) = 1` (not a power; sanity that the

--- a/alkahest-core/src/matrix/eigen.rs
+++ b/alkahest-core/src/matrix/eigen.rs
@@ -1,9 +1,11 @@
 //! V2-17 — Eigenvalues, eigenvectors, and diagonalization for dense symbolic matrices
-//! whose characteristic polynomial splits over ℚ into linear and quadratic factors.
+//! whose characteristic polynomial splits over ℚ into linear, quadratic, or cubic
+//! factors.
 //!
 //! The characteristic polynomial is `det(λI − M)` in a fresh λ symbol. Entries may
 //! be rational; the determinant is read as a ℚ-polynomial in λ and cleared to a
-//! ℤ-polynomial for factorization (same roots).
+//! ℤ-polynomial for factorization (same roots). Irreducible cubics are solved via
+//! the trigonometric (casus irreducibilis) or Cardano formula.
 
 #![allow(clippy::needless_range_loop)]
 
@@ -26,7 +28,7 @@ pub enum EigenError {
     CharPolyConversion(ConversionError),
     /// FLINT factorization failed.
     Factorization(FactorError),
-    /// The characteristic polynomial has an irreducible factor of degree greater than two.
+    /// The characteristic polynomial has an irreducible factor of degree greater than three.
     UnsupportedIrreducibleDegree { degree: usize },
     /// Algebraic and geometric multiplicity disagree (Jordan block situation).
     NonDiagonalizable,
@@ -44,7 +46,7 @@ impl fmt::Display for EigenError {
             EigenError::Factorization(e) => write!(f, "factorization failed: {e}"),
             EigenError::UnsupportedIrreducibleDegree { degree } => write!(
                 f,
-                "irreducible characteristic factor of degree {degree}; only degrees 1–2 are supported"
+                "irreducible characteristic factor of degree {degree}; only degrees 1–3 are supported"
             ),
             EigenError::NonDiagonalizable => {
                 write!(f, "matrix is not diagonalizable over the computed eigenbasis")
@@ -83,7 +85,7 @@ impl crate::errors::AlkahestError for EigenError {
             ),
             EigenError::Factorization(_) => None,
             EigenError::UnsupportedIrreducibleDegree { .. } => {
-                Some("higher-degree irreducible characteristic factors require a CAS / algebraic-numbers extension")
+                Some("degree-4+ irreducible characteristic factors require a CAS / algebraic-numbers extension")
             }
             EigenError::NonDiagonalizable => {
                 Some("use Jordan-form tooling or restrict to diagonalizable matrices")
@@ -289,6 +291,11 @@ fn eigenvalues_from_char_poly(
                 pairs.push((r1, exp as usize));
                 pairs.push((r2, exp as usize));
             }
+            3 => {
+                for r in cubic_roots(&base, pool)? {
+                    pairs.push((r, exp as usize));
+                }
+            }
             _ => return Err(EigenError::UnsupportedIrreducibleDegree { degree: d }),
         }
     }
@@ -396,6 +403,150 @@ fn order_two_roots(a: ExprId, b: ExprId, pool: &ExprPool) -> (ExprId, ExprId) {
     }
 }
 
+fn rational_to_expr(r: &Rational, pool: &ExprPool) -> ExprId {
+    if r.denom().clone() == 1 {
+        pool.integer(r.numer().clone())
+    } else {
+        pool.rational(r.numer().clone(), r.denom().clone())
+    }
+}
+
+/// Roots of an irreducible cubic `c₀ + c₁λ + c₂λ² + c₃λ³` via depression +
+/// trigonometric Cardano (three real roots) or radical Cardano (one real root).
+fn cubic_roots(p: &UniPoly, pool: &ExprPool) -> Result<[ExprId; 3], EigenError> {
+    let c = p.coefficients();
+    if c.len() != 4 {
+        return Err(EigenError::UnsupportedIrreducibleDegree {
+            degree: p.degree().max(0) as usize,
+        });
+    }
+    let c0 = c[0].clone();
+    let c1 = c[1].clone();
+    let c2 = c[2].clone();
+    let c3 = c[3].clone();
+    if c3 == 0 {
+        return Err(EigenError::UnsupportedIrreducibleDegree { degree: 2 });
+    }
+    // Monic coefficients: λ³ + a λ² + b λ + c = 0.
+    let a = Rational::from((c2, c3.clone()));
+    let b = Rational::from((c1, c3.clone()));
+    let cc = Rational::from((c0, c3));
+    // Depress: λ = t − a/3,   t³ + p t + q = 0.
+    let a2 = a.clone() * a.clone();
+    let a3 = a2.clone() * a.clone();
+    let p_coeff = b.clone() - a2 / Rational::from(3);
+    let q_coeff =
+        cc + (Rational::from(2) * a3 - Rational::from(9) * a.clone() * b) / Rational::from(27);
+    let shift = rational_to_expr(&(a / Rational::from(3)), pool);
+    let neg_shift = simplify(pool.mul(vec![pool.integer(-1_i32), shift]), pool).value;
+
+    let half_q = q_coeff.clone() / Rational::from(2);
+    let third_p = p_coeff.clone() / Rational::from(3);
+    // Δ = (q/2)² + (p/3)³.  Δ < 0 ⇒ three distinct real roots (casus irreducibilis).
+    let mut delta = half_q.clone() * half_q.clone();
+    delta += third_p.clone() * third_p.clone() * third_p.clone();
+
+    let roots_t: [ExprId; 3] = if delta < 0 {
+        // t_k = 2√(−p/3) cos((θ + 2πk)/3),  cos θ = (−q/2) / (√(−p/3))³.
+        let neg_third_p = Rational::from(0) - third_p;
+        let sqrt_neg_third_p = simplify(
+            pool.func("sqrt", vec![rational_to_expr(&neg_third_p, pool)]),
+            pool,
+        )
+        .value;
+        let two_sqrt = simplify(pool.mul(vec![pool.integer(2_i32), sqrt_neg_third_p]), pool).value;
+        let denom = simplify(pool.pow(sqrt_neg_third_p, pool.integer(3_i32)), pool).value;
+        let neg_half_q = rational_to_expr(&(Rational::from(0) - half_q), pool);
+        let cos_theta = simplify(
+            pool.mul(vec![neg_half_q, pool.pow(denom, pool.integer(-1_i32))]),
+            pool,
+        )
+        .value;
+        let theta = pool.func("acos", vec![cos_theta]);
+        let pi = pool.symbol("pi", Domain::Real);
+        let two_pi = pool.mul(vec![pool.integer(2_i32), pi]);
+        let mut out = [pool.integer(0_i32); 3];
+        for k in 0..3 {
+            let angle = simplify(
+                pool.mul(vec![
+                    pool.rational(rug::Integer::from(1), rug::Integer::from(3)),
+                    pool.add(vec![theta, pool.mul(vec![two_pi, pool.integer(k as i32)])]),
+                ]),
+                pool,
+            )
+            .value;
+            out[k] = simplify(
+                pool.mul(vec![two_sqrt, pool.func("cos", vec![angle])]),
+                pool,
+            )
+            .value;
+        }
+        out
+    } else {
+        // One real root via Cardano: A = ∛(−q/2 + √Δ), B = ∛(−q/2 − √Δ), t₀ = A+B.
+        let sqrt_delta = simplify(
+            pool.func("sqrt", vec![rational_to_expr(&delta, pool)]),
+            pool,
+        )
+        .value;
+        let neg_half_q = rational_to_expr(&(Rational::from(0) - half_q), pool);
+        let a_cbrt = simplify(
+            pool.pow(
+                pool.add(vec![neg_half_q, sqrt_delta]),
+                pool.rational(rug::Integer::from(1), rug::Integer::from(3)),
+            ),
+            pool,
+        )
+        .value;
+        let b_cbrt = simplify(
+            pool.pow(
+                pool.add(vec![
+                    neg_half_q,
+                    pool.mul(vec![pool.integer(-1_i32), sqrt_delta]),
+                ]),
+                pool.rational(rug::Integer::from(1), rug::Integer::from(3)),
+            ),
+            pool,
+        )
+        .value;
+        let t0 = simplify(pool.add(vec![a_cbrt, b_cbrt]), pool).value;
+        // Complex conjugate pair: −(A+B)/2 ± i √3 (A−B)/2.
+        let half = pool.rational(rug::Integer::from(1), rug::Integer::from(2));
+        let neg_half_sum = simplify(pool.mul(vec![pool.integer(-1_i32), half, t0]), pool).value;
+        let aminus_b = simplify(
+            pool.add(vec![a_cbrt, pool.mul(vec![pool.integer(-1_i32), b_cbrt])]),
+            pool,
+        )
+        .value;
+        let imag = simplify(
+            pool.mul(vec![
+                half,
+                pool.func("sqrt", vec![pool.integer(3_i32)]),
+                aminus_b,
+                imag_unit(pool),
+            ]),
+            pool,
+        )
+        .value;
+        let t1 = simplify(pool.add(vec![neg_half_sum, imag]), pool).value;
+        let t2 = simplify(
+            pool.add(vec![
+                neg_half_sum,
+                pool.mul(vec![pool.integer(-1_i32), imag]),
+            ]),
+            pool,
+        )
+        .value;
+        [t0, t1, t2]
+    };
+
+    let mut out = [pool.integer(0_i32); 3];
+    for (i, t) in roots_t.into_iter().enumerate() {
+        out[i] = simplify(pool.add(vec![t, neg_shift]), pool).value;
+    }
+    Ok(out)
+}
+
 // ---------------------------------------------------------------------------
 // λ I − M and M − λ I
 // ---------------------------------------------------------------------------
@@ -452,9 +603,32 @@ fn kernel_2x2_column_basis(m: &Matrix, pool: &ExprPool) -> Option<Vec<Matrix>> {
     let b01 = simplify(m.get(0, 1), pool).value;
     let c10 = simplify(m.get(1, 0), pool).value;
     let d11 = simplify(m.get(1, 1), pool).value;
+    // Full-rank gate for numeric/rational matrices: if det is a nonzero
+    // constant then the kernel is trivial.  Do *not* use an `M·v = 0` check on
+    // the candidate perpendicular — for symbolic `(A − λI)` that residual only
+    // vanishes after substituting an eigenvalue, so the check would wrongly
+    // drop legitimate eigenspace bases.
+    let det = simplify(
+        pool.add(vec![
+            pool.mul(vec![a00, d11]),
+            pool.mul(vec![pool.integer(-1_i32), b01, c10]),
+        ]),
+        pool,
+    )
+    .value;
+    let det_nonzero_const = match pool.get(det) {
+        ExprData::Integer(n) => n.0 != 0,
+        ExprData::Rational(r) => r.0 != 0,
+        _ => false,
+    };
+    if det_nonzero_const {
+        return Some(Vec::new());
+    }
     let neg_one = pool.integer(-1_i32);
     let (a, b) = if expr_is_exactly_zero(pool, a00) && expr_is_exactly_zero(pool, b01) {
         if expr_is_exactly_zero(pool, c10) && expr_is_exactly_zero(pool, d11) {
+            // Zero matrix — fall through to the general rational/Gauss path,
+            // which returns a full 2-dimensional basis.
             return None;
         }
         (c10, d11)

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -715,6 +715,10 @@ impl RewriteRule for LogOfProduct {
 }
 
 /// `log(a^n) → n * log(a)`.
+///
+/// **Branch-cut caveat**: only unconditionally valid for positive real `a` (and
+/// real `n`).  Recorded without side conditions for parity with the historical
+/// `LogOfPow` helper; prefer [`log_exp_rules_safe`] when complex-safe.
 pub struct LogOfPow;
 
 impl RewriteRule for LogOfPow {
@@ -734,14 +738,139 @@ impl RewriteRule for LogOfPow {
     }
 }
 
+/// `log(x) + log(y) + ⋯ → log(x·y·⋯)`.
+///
+/// **Branch-cut caveat**: valid when every argument is positive real.  Each
+/// factor is recorded as [`SideCondition::Positive`].  Inverse of
+/// [`LogOfProduct`] (which is *not* registered in [`log_exp_rules`], so the
+/// two cannot oscillate).
+pub struct SumOfLogs;
+
+impl RewriteRule for SumOfLogs {
+    fn name(&self) -> &'static str {
+        "sum_of_logs"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let terms = match pool.get(expr) {
+            ExprData::Add(v) if v.len() >= 2 => v,
+            _ => return None,
+        };
+        let mut args = Vec::with_capacity(terms.len());
+        for t in terms {
+            let a = func_arg("log", t, pool)?;
+            args.push(a);
+        }
+        let after = pool.func("log", vec![pool.mul(args.clone())]);
+        let conds: Vec<SideCondition> = args.iter().map(|&a| SideCondition::Positive(a)).collect();
+        let mut log = DerivationLog::new();
+        log.push(RewriteStep::with_conditions(
+            "sum_of_logs",
+            expr,
+            after,
+            conds,
+        ));
+        Some((after, log))
+    }
+}
+
+/// `log(a · b⁻¹ · ⋯) → log(a) − log(b) − ⋯`.
+///
+/// Fires only when the argument is a product containing at least one negative
+/// integer power (canonical quotient form).  Plain `log(x·y)` is intentionally
+/// left alone so it does not fight [`SumOfLogs`].
+pub struct LogOfQuotient;
+
+impl RewriteRule for LogOfQuotient {
+    fn name(&self) -> &'static str {
+        "log_of_quotient"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let arg = func_arg("log", expr, pool)?;
+        let factors = match pool.get(arg) {
+            ExprData::Mul(v) if v.len() >= 2 => v,
+            _ => return None,
+        };
+        let has_reciprocal = factors.iter().any(|&f| match pool.get(f) {
+            ExprData::Pow { exp, .. } => match pool.get(exp) {
+                ExprData::Integer(n) => n.0 < 0,
+                _ => false,
+            },
+            _ => false,
+        });
+        if !has_reciprocal {
+            return None;
+        }
+        let mut terms: Vec<ExprId> = Vec::with_capacity(factors.len());
+        let mut conds: Vec<SideCondition> = Vec::new();
+        for f in factors {
+            match pool.get(f) {
+                ExprData::Pow { base, exp } => {
+                    conds.push(SideCondition::Positive(base));
+                    let log_base = pool.func("log", vec![base]);
+                    terms.push(pool.mul(vec![exp, log_base]));
+                }
+                _ => {
+                    conds.push(SideCondition::Positive(f));
+                    terms.push(pool.func("log", vec![f]));
+                }
+            }
+        }
+        let after = pool.add(terms);
+        let mut log = DerivationLog::new();
+        log.push(RewriteStep::with_conditions(
+            "log_of_quotient",
+            expr,
+            after,
+            conds,
+        ));
+        Some((after, log))
+    }
+}
+
+/// `exp(x) · exp(y) · ⋯ → exp(x + y + ⋯)`.
+///
+/// Unconditionally valid over ℂ (unlike the log product/sum rules).
+pub struct ProductOfExps;
+
+impl RewriteRule for ProductOfExps {
+    fn name(&self) -> &'static str {
+        "product_of_exps"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let factors = match pool.get(expr) {
+            ExprData::Mul(v) if v.len() >= 2 => v,
+            _ => return None,
+        };
+        let mut args = Vec::with_capacity(factors.len());
+        for f in factors {
+            let a = func_arg("exp", f, pool)?;
+            args.push(a);
+        }
+        let after = pool.func("exp", vec![pool.add(args)]);
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
 /// Return the default log/exp identity rules.
 ///
-/// Includes the inverse cancellations `log(exp(x)) → x` and `exp(log(x)) → x`.
-/// Branch-cut-sensitive expansions (`log(a*b)`, `log(a^n)`) are intentionally
-/// omitted; use an [`crate::simplify::AssumptionContext`] for condition-gated
-/// rewrites, or [`log_exp_rules_safe`] for the empty complex-safe set.
+/// Includes inverse cancellations, the combining rules `log(x)+log(y)→log(xy)`
+/// and `exp(x)·exp(y)→exp(x+y)`, the power rule `log(a^n)→n·log(a)`, and the
+/// quotient expansion `log(a/b)→log(a)−log(b)`.  The expand-style
+/// [`LogOfProduct`] (`log(ab)→log a+log b`) is intentionally omitted so it
+/// cannot oscillate against [`SumOfLogs`].  Use [`log_exp_rules_safe`] for the
+/// empty complex-safe set.
 pub fn log_exp_rules() -> Vec<Box<dyn RewriteRule>> {
-    vec![Box::new(LogOfExp), Box::new(ExpOfLog)]
+    vec![
+        Box::new(LogOfExp),
+        Box::new(ExpOfLog),
+        Box::new(SumOfLogs),
+        Box::new(LogOfPow),
+        Box::new(LogOfQuotient),
+        Box::new(ProductOfExps),
+    ]
 }
 
 /// Log/exp rules that are safe for complex numbers (no branch-cut rewrites).
@@ -1956,6 +2085,8 @@ mod tests {
 
     #[test]
     fn log_of_product_stays_conservative_without_context() {
+        // Expand-style LogOfProduct is not registered — log(x*y) stays put
+        // (SumOfLogs runs the opposite direction).
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let y = pool.symbol("y", Domain::Real);
@@ -1993,14 +2124,55 @@ mod tests {
     }
 
     #[test]
-    fn log_of_pow_stays_conservative_without_context() {
+    fn log_of_pow_folds() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let n = pool.integer(3_i32);
         let expr = pool.func("log", vec![pool.pow(x, n)]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
-        assert_eq!(r.value, expr);
+        let expected = pool.mul(vec![n, pool.func("log", vec![x])]);
+        assert_eq!(r.value, expected, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn sum_of_logs_folds() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let expr = pool.add(vec![pool.func("log", vec![x]), pool.func("log", vec![y])]);
+        let rules = log_exp_rules();
+        let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        let expected = pool.func("log", vec![pool.mul(vec![x, y])]);
+        assert_eq!(r.value, expected, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn log_of_quotient_folds() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let quot = pool.mul(vec![x, pool.pow(y, pool.integer(-1_i32))]);
+        let expr = pool.func("log", vec![quot]);
+        let rules = log_exp_rules();
+        let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        let expected = pool.add(vec![
+            pool.func("log", vec![x]),
+            pool.mul(vec![pool.integer(-1_i32), pool.func("log", vec![y])]),
+        ]);
+        assert_eq!(r.value, expected, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn product_of_exps_folds() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let expr = pool.mul(vec![pool.func("exp", vec![x]), pool.func("exp", vec![y])]);
+        let rules = log_exp_rules();
+        let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        let expected = pool.func("exp", vec![pool.add(vec![x, y])]);
+        assert_eq!(r.value, expected, "got {}", pool.display(r.value));
     }
 
     #[test]

--- a/tests/textbook_gate/test_tg_algebra_identities.py
+++ b/tests/textbook_gate/test_tg_algebra_identities.py
@@ -107,26 +107,13 @@ def test_simplify_log_exp_inverse_pair(pool, x, y):
 
 # --- log/exp combining rules (product/power/quotient) -------------------------
 #
-# The B-series fix that landed `log(exp(x)) -> x` / `exp(log(x)) -> x` only
-# implements that direct inverse-pair rewrite. Probing empirically shows the
-# classic logarithm product/power/quotient rules — and the mirror-image
-# exponent-of-a-sum rule for `exp` — are not implemented by `simplify_log_exp`
-# (nor by plain `simplify`): the expressions below evaluate to the correct
-# value already (so a numeric value-preservation check would trivially pass
-# whether or not anything folded, exactly the blind spot
-# `test_simplify_log_exp_inverse_pair` above calls out), but structurally the
-# simplifier returns them completely unchanged — no product/power/quotient
-# rewriting occurs in either direction.
+# Inverse cancellations plus the textbook combining/expansion rules:
+# `log(x)+log(y)→log(xy)`, `log(x^n)→n·log(x)`, `log(x/y)→log(x)−log(y)`,
+# and `exp(x)·exp(y)→exp(x+y)`.  Structural equality is required here for the
+# same reason as `test_simplify_log_exp_inverse_pair`: the unsimplified forms
+# already evaluate correctly, so numeric checks cannot detect a no-op.
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "simplify_log_exp does not implement the logarithm product rule: "
-        "log(x) + log(y) is returned unchanged (still `(log(x) + log(y))`), "
-        "not folded to log(x*y)."
-    ),
-)
 def test_simplify_log_exp_product_rule_folds(pool, x, y):
     """log(x) + log(y) -> log(x*y) for positive x, y."""
     r = ak.simplify_log_exp(ak.log(x) + ak.log(y)).value
@@ -134,14 +121,6 @@ def test_simplify_log_exp_product_rule_folds(pool, x, y):
     assert r == target
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "simplify_log_exp does not implement the logarithm power rule: "
-        "log(x**2) is returned unchanged (still `log(x^2)`), not folded to "
-        "2*log(x)."
-    ),
-)
 def test_simplify_log_exp_power_rule_folds(pool, x):
     """log(x**2) -> 2*log(x) for positive x."""
     r = ak.simplify_log_exp(ak.log(x**2)).value
@@ -149,14 +128,6 @@ def test_simplify_log_exp_power_rule_folds(pool, x):
     assert r == target
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "simplify_log_exp does not implement the logarithm quotient rule: "
-        "log(x/y) is returned unchanged (still `log((x * y^-1))`), not "
-        "folded to log(x) - log(y)."
-    ),
-)
 def test_simplify_log_exp_quotient_rule_folds(pool, x, y):
     """log(x/y) -> log(x) - log(y) for positive x, y."""
     r = ak.simplify_log_exp(ak.log(x / y)).value
@@ -164,14 +135,6 @@ def test_simplify_log_exp_quotient_rule_folds(pool, x, y):
     assert r == target
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "simplify_log_exp does not implement the mirror-image exp-of-a-sum "
-        "rule: exp(x) * exp(y) is returned unchanged (still "
-        "`(exp(x) * exp(y))`), not folded to exp(x+y)."
-    ),
-)
 def test_simplify_log_exp_product_of_exps_folds(pool, x, y):
     """exp(x) * exp(y) -> exp(x+y)."""
     r = ak.simplify_log_exp(ak.exp(x) * ak.exp(y)).value

--- a/tests/textbook_gate/test_tg_limits.py
+++ b/tests/textbook_gate/test_tg_limits.py
@@ -210,12 +210,6 @@ def test_limit_of_constant(pool, x):
 # --- classic constant-defining limits -------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="new finding: limit((1+x)^(1/x), x, 0) returns 1 instead of e — this is "
-    "the textbook limit definition of e itself, arguably the single most iconic "
-    "first-course limit after sin(x)/x",
-)
 def test_limit_one_plus_x_to_one_over_x_is_e(pool, x):
     """(1+x)^(1/x) -> e as x -> 0 — the limit definition of Euler's number."""
     r = ak.limit((1 + x) ** (1 / x), x, pool.integer(0))

--- a/tests/textbook_gate/test_tg_linear_algebra.py
+++ b/tests/textbook_gate/test_tg_linear_algebra.py
@@ -200,14 +200,6 @@ def test_nullspace_vector_maps_to_zero(pool):
     assert result == pytest.approx([0.0, 0.0], abs=1e-9)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="new finding: Matrix.nullspace() returns a spurious nonzero vector for "
-    "every full-rank (invertible) 2x2 matrix tried (identity, diag(2,3), [[2,1],[1,1]], "
-    "[[1,2],[0,1]], ...) — e.g. nullspace(I2) == [[0,1]], but I2 @ [0,1] == [0,1] != 0, "
-    "so the returned vector isn't actually in the nullspace. Silently wrong, not a crash. "
-    "3x3 full-rank matrices correctly return []; the bug appears specific to the 2x2 path.",
-)
 def test_nullspace_trivial_for_full_rank(pool):
     A = ak.Matrix([[pool.integer(1), pool.integer(0)], [pool.integer(0), pool.integer(1)]])
     assert A.nullspace() == []
@@ -260,13 +252,6 @@ def test_eigenvals_triangular_matrix_are_diagonal_entries(pool):
 # --- rational-root-theorem-adjacent: char poly degree matches matrix size --
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="new finding (parallel to B5): Matrix.eigenvals() raises PyEigenError "
-    "'irreducible characteristic factor of degree 3; only degrees 1-2 are supported' "
-    "for a plain 3x3 matrix whose characteristic polynomial happens to be an "
-    "irreducible cubic — eigenvalues of 3x3+ matrices are a first-course topic",
-)
 def test_characteristic_polynomial_degree_matches_size(pool):
     rows = [[1, 2, 3], [0, 1, 4], [5, 6, 0]]
     A = ak.Matrix([[pool.integer(v) for v in row] for row in rows])


### PR DESCRIPTION
## Summary
- Register `simplify_log_exp` combining rules: `log(x)+log(y)→log(xy)`, `log(x^n)→n·log(x)`, `log(x/y)→log(x)−log(y)`, `exp(x)·exp(y)→exp(x+y)`
- Fix `limit((1+x)^(1/x), x, 0) → e` (stop folding `1^(singular)` to 1; run indeterminate-power rewrite at finite points)
- Fix `Matrix.nullspace()` on full-rank numeric 2×2 (gate on nonzero constant determinant)
- Support irreducible cubic characteristic factors via trigonometric/Cardano roots
- Remove the seven textbook-gate `xfail` markers these close

## Test plan
- [x] `pytest tests/textbook_gate/ tests/test_assumptions.py` (297 passed)
- [x] `cargo test -p alkahest-cas --lib simplify::rulesets::`
- [x] `cargo test -p alkahest-cas --lib calculus::limits::`
- [x] `cargo test -p alkahest-cas --lib eigen::`
- [ ] CI green


Made with [Cursor](https://cursor.com)