### PR TITLE
fix: output hygiene for powers, cancel, gamma(1), and /0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Output hygiene
+
+- Parenthesize nested powers in `str` / LaTeX / Unicode so `x^(1/2)^3` is unambiguous.
+- `MultiPoly.to_expr` omits unit coefficients (`cancel((x²−1)/(x−1))` → `x + 1`).
+- `simplify(gamma(1))` → `1` via a new `PrimitiveFold` rule.
+- Literal division by zero raises `ZeroDivisionError` instead of building `0^-1`.
+
 ## 3.6.0 — 2026-07-17
 
 ### Release / packaging

--- a/alkahest-core/src/kernel/display.rs
+++ b/alkahest-core/src/kernel/display.rs
@@ -381,7 +381,7 @@ fn latex_pow(base: ExprId, exp: ExprId, pool: &ExprPool) -> String {
             return latex_frac("1", &base_tex);
         }
     }
-    let base_tex = latex_wrap(base, pool, PREC_POW);
+    let base_tex = latex_wrap(base, pool, PREC_POW + 1);
     let (exp_tex, _) = latex_r(exp, pool);
     let exp_braced = if exp_tex.len() == 1 {
         exp_tex
@@ -742,7 +742,7 @@ fn unicode_pow(base: ExprId, exp: ExprId, pool: &ExprPool) -> String {
             };
         }
     }
-    let base_tex = unicode_wrap(base, pool, PREC_POW);
+    let base_tex = unicode_wrap(base, pool, PREC_POW + 1);
     if let ExprData::Integer(n) = pool.get(exp) {
         if let Some(v) = n.0.to_i64() {
             if v == 1 {

--- a/alkahest-core/src/kernel/pool.rs
+++ b/alkahest-core/src/kernel/pool.rs
@@ -388,6 +388,30 @@ impl fmt::Debug for ExprDisplay<'_> {
     }
 }
 
+/// Format a power base or exponent, parenthesizing compound subexpressions.
+fn fmt_pow_atom(id: ExprId, pool: &ExprPool) -> String {
+    let s = pool.display(id).to_string();
+    let needs_parens = match pool.get(id) {
+        ExprData::Symbol { .. } | ExprData::Integer(_) | ExprData::Float(_) => false,
+        ExprData::Func { .. } => false,
+        ExprData::Rational(_)
+        | ExprData::Pow { .. }
+        | ExprData::Add(_)
+        | ExprData::Mul(_)
+        | ExprData::Piecewise { .. }
+        | ExprData::Predicate { .. }
+        | ExprData::Forall { .. }
+        | ExprData::Exists { .. }
+        | ExprData::BigO(_)
+        | ExprData::RootSum { .. } => true,
+    };
+    if needs_parens {
+        format!("({s})")
+    } else {
+        s
+    }
+}
+
 fn fmt_data(data: &ExprData, pool: &ExprPool, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match data {
         ExprData::Symbol { name, .. } => write!(f, "{}", name),
@@ -415,7 +439,11 @@ fn fmt_data(data: &ExprData, pool: &ExprPool, f: &mut fmt::Formatter<'_>) -> fmt
             write!(f, ")")
         }
         ExprData::Pow { base, exp } => {
-            write!(f, "{}^{}", pool.display(*base), pool.display(*exp))
+            // Parenthesize compound bases/exponents so `x^(1/2)^3` cannot be
+            // misread as `x^1 / 2^3`. Prefer `(x^(1/2))^3`.
+            let base_s = fmt_pow_atom(*base, pool);
+            let exp_s = fmt_pow_atom(*exp, pool);
+            write!(f, "{base_s}^{exp_s}")
         }
         ExprData::Func { name, args } => {
             write!(f, "{}(", name)?;

--- a/alkahest-core/src/kernel/pool.rs
+++ b/alkahest-core/src/kernel/pool.rs
@@ -389,15 +389,18 @@ impl fmt::Debug for ExprDisplay<'_> {
 }
 
 /// Format a power base or exponent, parenthesizing compound subexpressions.
+///
+/// `Add`/`Mul` already render with outer parentheses, so wrapping again would
+/// produce `((z + -2))^-1`. Only wrap forms that do not already self-group.
 fn fmt_pow_atom(id: ExprId, pool: &ExprPool) -> String {
     let s = pool.display(id).to_string();
     let needs_parens = match pool.get(id) {
         ExprData::Symbol { .. } | ExprData::Integer(_) | ExprData::Float(_) => false,
         ExprData::Func { .. } => false,
+        // Already printed as `(…)` by fmt_data.
+        ExprData::Add(_) | ExprData::Mul(_) => false,
         ExprData::Rational(_)
         | ExprData::Pow { .. }
-        | ExprData::Add(_)
-        | ExprData::Mul(_)
         | ExprData::Piecewise { .. }
         | ExprData::Predicate { .. }
         | ExprData::Forall { .. }

--- a/alkahest-core/src/poly/multipoly.rs
+++ b/alkahest-core/src/poly/multipoly.rs
@@ -300,12 +300,17 @@ impl MultiPoly {
         if self.terms.is_empty() {
             return pool.integer(0_i32);
         }
+        let one = rug::Integer::from(1);
         let summands: Vec<ExprId> = self
             .terms
             .iter()
             .map(|(exps, coeff)| {
-                let coeff_id = pool.integer(coeff.clone());
-                let mut factors = vec![coeff_id];
+                let mut factors = Vec::new();
+                // Omit a unit coefficient when there are variable factors so
+                // cancel((x²-1)/(x-1)) prints as `x + 1`, not `1 + (x * 1)`.
+                if coeff != &one {
+                    factors.push(pool.integer(coeff.clone()));
+                }
                 for (i, &e) in exps.iter().enumerate() {
                     if e == 0 || i >= self.vars.len() {
                         continue;

--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -2303,6 +2303,19 @@ pub mod builtins {
             format!("Γ({})", pool.display(args[0]))
         }
 
+        fn simplify(&self, args: &[ExprId], pool: &ExprPool) -> Option<ExprId> {
+            // Γ(n) = (n-1)! for positive integers n.
+            let n = positive_integer_literal(args[0], pool)?;
+            if n < 1 || n > 21 {
+                return None;
+            }
+            let mut acc: i64 = 1;
+            for k in 2..n {
+                acc = acc.checked_mul(k)?;
+            }
+            Some(pool.integer(acc))
+        }
+
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
             Some(libm_gamma(args[0]))
         }

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -1,6 +1,6 @@
 use super::rules::{
     AddZero, CanonicalOrder, ConstFold, DivSelf, ExpandMul, ExpandPow, FlattenAdd, FlattenMul,
-    MulOne, MulZero, PowOne, PowZero, RewriteRule, SqrtInteger, SubSelf,
+    MulOne, MulZero, PowOne, PowZero, PrimitiveFold, RewriteRule, SqrtInteger, SubSelf,
 };
 use super::rulesets::PatternRuleSet;
 use crate::deriv::log::{DerivationLog, DerivedExpr};
@@ -68,6 +68,7 @@ pub fn rules_for_config(config: &SimplifyConfig) -> Vec<Box<dyn RewriteRule>> {
         // ConstFold's existing per-node dispatch (see rules.rs) so they don't
         // add per-node iterations to the rule loop below.
         Box::new(ConstFold),
+        Box::new(PrimitiveFold),
         Box::new(SqrtInteger),
         Box::new(SubSelf),
         Box::new(DivSelf),

--- a/alkahest-core/src/simplify/parallel.rs
+++ b/alkahest-core/src/simplify/parallel.rs
@@ -233,7 +233,7 @@ fn simplify_children_par(
 pub fn rules_for_config_par(config: &SimplifyConfig) -> Vec<Box<dyn RewriteRule + Send + Sync>> {
     use crate::simplify::rules::{
         AddZero, CanonicalOrder, ConstFold, DivSelf, ExpandMul, FlattenAdd, FlattenMul, MulOne,
-        MulZero, PowOne, PowZero, SqrtInteger, SubSelf,
+        MulZero, PowOne, PowZero, PrimitiveFold, SqrtInteger, SubSelf,
     };
     let mut rules: Vec<Box<dyn RewriteRule + Send + Sync>> = vec![
         Box::new(FlattenMul),
@@ -245,6 +245,7 @@ pub fn rules_for_config_par(config: &SimplifyConfig) -> Vec<Box<dyn RewriteRule 
         Box::new(PowOne),
         Box::new(SqrtInteger),
         Box::new(ConstFold),
+        Box::new(PrimitiveFold),
         Box::new(SubSelf),
         Box::new(DivSelf),
         Box::new(CanonicalOrder),

--- a/alkahest-core/src/simplify/rules.rs
+++ b/alkahest-core/src/simplify/rules.rs
@@ -1277,6 +1277,34 @@ impl RewriteRule for CollectExp {
 }
 
 // ---------------------------------------------------------------------------
+// PrimitiveFold: call Primitive::simplify for registered Func nodes
+// (e.g. gamma(1) → 1, digamma(n) → H_{n-1} − γ).
+// ---------------------------------------------------------------------------
+
+pub struct PrimitiveFold;
+
+impl RewriteRule for PrimitiveFold {
+    fn name(&self) -> &'static str {
+        "primitive_simplify"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let (name, args) = match pool.get(expr) {
+            ExprData::Func { name, args } => (name, args),
+            _ => return None,
+        };
+        use std::sync::OnceLock;
+        static REG: OnceLock<crate::primitive::PrimitiveRegistry> = OnceLock::new();
+        let reg = REG.get_or_init(crate::primitive::PrimitiveRegistry::default_registry);
+        let after = reg.get(&name)?.simplify(&args, pool)?;
+        if after == expr {
+            return None;
+        }
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Unit tests for rules
 // ---------------------------------------------------------------------------
 

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -203,6 +203,16 @@ fn pool_mismatch_err() -> PyErr {
     )
 }
 
+/// True when *id* is a literal integer/rational/float zero.
+fn expr_is_literal_zero(pool: &ExprPool, id: ExprId) -> bool {
+    match pool.get(id) {
+        ExprData::Integer(n) => n.0.is_zero(),
+        ExprData::Rational(r) => r.0.is_zero(),
+        ExprData::Float(f) => f.inner == 0.0,
+        _ => false,
+    }
+}
+
 /// Coerce a substitution value (``Expr``, ``DerivedResult``, ``int``, or ``float``).
 fn coerce_substituent(
     pool_py: &Py<PyExprPool>,
@@ -234,12 +244,7 @@ fn coerce_substituent(
 
 fn expr_is_zero(py: Python<'_>, expr: &PyExpr) -> bool {
     let pool = expr.pool.borrow(py);
-    match pool.inner.get(expr.id) {
-        ExprData::Integer(n) => n.0.is_zero(),
-        ExprData::Rational(r) => r.0.is_zero(),
-        ExprData::Float(f) => f.inner == 0.0,
-        _ => false,
-    }
+    expr_is_literal_zero(&pool.inner, expr.id)
 }
 
 fn expr_ids_equal(a: &PyExpr, b: &PyExpr) -> bool {
@@ -943,6 +948,11 @@ impl PyExpr {
         match self.coerce_scalar(other, py)? {
             Some(rhs) => {
                 let pool = self.pool.borrow(py);
+                if expr_is_literal_zero(&pool.inner, rhs) {
+                    return Err(pyo3::exceptions::PyZeroDivisionError::new_err(
+                        "division by zero",
+                    ));
+                }
                 let neg_one = pool.inner.integer(-1i32);
                 let inv = pool.inner.pow(rhs, neg_one);
                 let id = pool.inner.mul(vec![self.id, inv]);
@@ -962,6 +972,11 @@ impl PyExpr {
         match self.coerce_scalar(other, py)? {
             Some(lhs) => {
                 let pool = self.pool.borrow(py);
+                if expr_is_literal_zero(&pool.inner, self.id) {
+                    return Err(pyo3::exceptions::PyZeroDivisionError::new_err(
+                        "division by zero",
+                    ));
+                }
                 let neg_one = pool.inner.integer(-1i32);
                 let inv_self = pool.inner.pow(self.id, neg_one);
                 let id = pool.inner.mul(vec![lhs, inv_self]);

--- a/tests/test_output_hygiene_rough_edges.py
+++ b/tests/test_output_hygiene_rough_edges.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
-
 import alkahest as ak
+import pytest
 
 
 @pytest.fixture

--- a/tests/test_output_hygiene_rough_edges.py
+++ b/tests/test_output_hygiene_rough_edges.py
@@ -1,0 +1,48 @@
+"""Output hygiene rough edges: display, cancel, gamma(1), division by zero."""
+
+from __future__ import annotations
+
+import pytest
+
+import alkahest as ak
+
+
+@pytest.fixture
+def pool_x():
+    pool = ak.ExprPool()
+    return pool, pool.symbol("x")
+
+
+def test_cancel_omits_unit_coeff(pool_x):
+    _pool, x = pool_x
+    out = ak.cancel((x**2 - 1) / (x - 1), [x])
+    assert str(out) in {"(x + 1)", "(1 + x)", "x + 1"}
+
+
+def test_nested_pow_display_is_parenthesized(pool_x):
+    pool, x = pool_x
+    half = pool.integer(1) / pool.integer(2)
+    nested = (x**half) ** 3
+    s = str(nested)
+    assert ")^" in s or s.startswith("(")
+    assert s != "x^1/2^3"
+
+
+def test_sqrt_integral_latex_parens(pool_x):
+    _pool, x = pool_x
+    v = ak.integrate(ak.sqrt(x), x).value
+    tex = ak.latex(v)
+    # Nested power of a root must not render as ambiguous \sqrt{x}^3
+    assert r"\sqrt{x}^3" not in tex
+
+
+def test_gamma_one_simplifies(pool_x):
+    pool, _x = pool_x
+    g = ak.gamma(pool.integer(1))
+    assert str(ak.simplify(g).value) == "1"
+
+
+def test_div_by_zero_raises(pool_x):
+    pool, _x = pool_x
+    with pytest.raises(ZeroDivisionError):
+        _ = pool.integer(1) / pool.integer(0)


### PR DESCRIPTION
## Summary
- Nested powers print unambiguously (`(x^(1/2))^3`, LaTeX/Unicode parenthesize root bases).
- `cancel((x²−1)/(x−1))` returns `x + 1` (no `* 1` unit factors).
- `simplify(gamma(1))` → `1` via `PrimitiveFold` calling `Primitive::simplify`.
- Literal `1/0` raises `ZeroDivisionError` instead of building `0^-1`.

Addresses **Output hygiene** rough edges from `temp-alkahest/planning/report7-20.md`. Skips `simplify_log_exp` (another agent) and e-graph constant folding (separate pass).

## Test plan
- [ ] `pytest tests/test_output_hygiene_rough_edges.py tests/test_pretty.py`
- [ ] Spot-check: `cancel((x**2-1)/(x-1))`, `str((x**(1/2))**3)`, `ak.simplify(ak.gamma(1))`
- [ ] Tier-1 CI green


Made with [Cursor](https://cursor.com)