### PR TITLE
fix: make Lean certificates typecheck beyond the B3 corpus

### DIFF
--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -43,9 +43,11 @@ fn rule_to_tactic(rule_name: &str) -> &'static str {
         "sin_neg" => "by simp [Real.sin_neg]",
         "cos_neg" => "by simp [Real.cos_neg]",
         "log_of_exp" => "by simp [Real.log_exp]",
-        "exp_of_log" => "by simp [Real.exp_log (by positivity)]",
-        "log_of_product" => "by rw [Real.log_mul (by positivity) (by positivity)]",
-        "log_of_pow" => "by rw [Real.log_pow]",
+        // Needs a positivity hypothesis on the free variable; withhold via
+        // [`step_is_certifiable`] rather than emitting a failing `positivity`.
+        "exp_of_log" => "by sorry",
+        "log_of_product" => "by sorry",
+        "log_of_pow" => "by simp [Real.log_pow]",
         "sin_sq_plus_cos_sq" => "by rw [Real.sin_sq_add_cos_sq]",
         "power_rule" | "constant_rule" | "sum_rule" | "constant_multiple_rule" => "by ring",
         // Integration rules must not be emitted as bare `integrand = F` equalities
@@ -54,7 +56,8 @@ fn rule_to_tactic(rule_name: &str) -> &'static str {
         "collect_add_terms" | "collect_mul_factors" => "by ring",
         "flatten_mul" | "flatten_add" | "canonical_order" => "by ring",
         "expand_mul" => "by ring",
-        "tan_expand" => "by rw [Real.tan_eq_sin_div_cos]",
+        // `tan_eq_sin_div_cos` yields `/`; Alkahest stores the reciprocal product.
+        "tan_expand" => "by rw [Real.tan_eq_sin_div_cos, div_eq_mul_inv]",
         _ => "by ring_nf; simp",
     }
 }
@@ -101,15 +104,35 @@ fn is_unary_of_var(before: ExprId, wrt: ExprId, pool: &ExprPool) -> bool {
     )
 }
 
+/// `before` is structurally `wrt ^ e` for some exponent.
+fn is_pow_of_var(before: ExprId, wrt: ExprId, pool: &ExprPool) -> bool {
+    pool.with(
+        before,
+        |d| matches!(d, ExprData::Pow { base, .. } if *base == wrt),
+    )
+}
+
 fn diff_rule_to_tactic(rule_name: &str) -> Option<&'static str> {
     match rule_name {
         "diff_identity" => Some("by simp [deriv_id]"),
         "diff_const" => Some("by simp [deriv_const]"),
-        "diff_univariate_poly" => Some("by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]"),
-        "sum_rule" => Some("by simp [deriv_add]; ring"),
-        // product_rule currently leaves unsolved goals on realistic logs — withhold.
-        "product_rule" => None,
-        "power_rule" | "power_rule_n1" => Some("by simp [deriv_pow, deriv_mul]; ring"),
+        // `; try ring` closes coefficient-order goals like `2 * x = x * 2`.
+        "diff_univariate_poly" => {
+            Some("by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]; try ring")
+        }
+        // `deriv_add`/`deriv_mul` need DifferentiableAt side goals; include the
+        // common Real lemmas so unary trig/exp sums and products close.
+        "sum_rule" => Some(
+            "by simp [deriv_add, Real.deriv_sin, Real.deriv_cos, Real.deriv_exp, \
+             Real.differentiableAt_sin, Real.differentiableAt_cos, Real.differentiableAt_exp, \
+             deriv_pow, deriv_mul, deriv_const, one_mul, mul_one, mul_neg, neg_mul]; try ring",
+        ),
+        "product_rule" => Some(
+            "by simp [deriv_mul, Real.deriv_sin, Real.deriv_cos, Real.deriv_exp, \
+             Real.differentiableAt_sin, Real.differentiableAt_cos, Real.differentiableAt_exp, \
+             deriv_const, differentiableAt_const, one_mul, mul_one, mul_neg, neg_mul]; try ring",
+        ),
+        "power_rule" | "power_rule_n1" => Some("by simp [deriv_pow, deriv_mul]; try ring"),
         "power_rule_n0" => Some("by simp [deriv_const]"),
         // Pointwise Mathlib lemmas for `deriv (fun x => f x) x = …` when the
         // argument is exactly the free variable. Chain-rule cases are withheld.
@@ -135,6 +158,12 @@ fn step_is_certifiable(step: &RewriteStep, wrt: Option<ExprId>, pool: &ExprPool)
                 "diff_sin" | "diff_cos" | "diff_exp" | "diff_log" | "diff_sqrt" => {
                     // Chain rule / composite arguments are not yet encoded.
                     return is_unary_of_var(step.before, var, pool)
+                        && diff_rule_to_tactic(step.rule_name).is_some();
+                }
+                // Generalized power rule `d/dx[f^n]` embeds a chain rule when
+                // `f ≠ x`; only `d/dx[x^n]` is Lean-encoded today.
+                "power_rule" | "power_rule_n1" | "power_rule_n0" => {
+                    return is_pow_of_var(step.before, var, pool)
                         && diff_rule_to_tactic(step.rule_name).is_some();
                 }
                 name => return diff_rule_to_tactic(name).is_some(),
@@ -538,12 +567,16 @@ fn expr_to_lean(expr: ExprId, pool: &ExprPool) -> String {
         }
         ExprData::Func { name, args } => {
             let arg_strs: Vec<String> = args.iter().map(|&a| expr_to_lean(a, pool)).collect();
+            // Always parenthesize the argument: `Real.log Real.exp x` parses as
+            // `(Real.log Real.exp) x`, and `Real.log x ^ 3` parses as
+            // `(Real.log x) ^ 3` — both are type/math errors.
             match name.as_str() {
-                "sin" => format!("Real.sin {}", arg_strs[0]),
-                "cos" => format!("Real.cos {}", arg_strs[0]),
-                "exp" => format!("Real.exp {}", arg_strs[0]),
-                "log" => format!("Real.log {}", arg_strs[0]),
-                "sqrt" => format!("Real.sqrt {}", arg_strs[0]),
+                "sin" => format!("Real.sin ({})", arg_strs[0]),
+                "cos" => format!("Real.cos ({})", arg_strs[0]),
+                "tan" => format!("Real.tan ({})", arg_strs[0]),
+                "exp" => format!("Real.exp ({})", arg_strs[0]),
+                "log" => format!("Real.log ({})", arg_strs[0]),
+                "sqrt" => format!("Real.sqrt ({})", arg_strs[0]),
                 other => format!("{other} ({})", arg_strs.join(", ")),
             }
         }
@@ -689,6 +722,160 @@ mod tests {
                 "mul_one cleanup must be a plain equality, got: {mul_one_block}"
             );
         }
+    }
+
+    #[test]
+    fn emit_lean_parens_nested_log_exp() {
+        use crate::simplify::{rulesets::log_exp_rules, simplify_with, SimplifyConfig};
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("log", vec![pool.func("exp", vec![x])]);
+        let derived = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        let lean = emit_lean_expr(&derived, &pool);
+        assert!(!lean.is_empty(), "log(exp(x)) should be Lean-certifiable");
+        assert!(
+            lean.contains("Real.log (Real.exp"),
+            "nested funcs must be parenthesized, got: {lean}"
+        );
+        assert!(
+            !lean.contains("Real.log Real.exp "),
+            "unparenthesized application is a type error: {lean}"
+        );
+    }
+
+    #[test]
+    fn withhold_exp_of_log_without_positivity_hyp() {
+        use crate::simplify::{rulesets::log_exp_rules, simplify_with, SimplifyConfig};
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
+        let derived = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        let lean = emit_lean_expr(&derived, &pool);
+        assert!(
+            lean.is_empty(),
+            "exp(log(x)) needs 0 < x; must not emit failing positivity: {lean}"
+        );
+    }
+
+    #[test]
+    fn emit_lean_diff_x_squared_closes_with_ring() {
+        use crate::diff::diff;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.pow(x, pool.integer(2_i32));
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(!lean.is_empty(), "d/dx x² should be Lean-certifiable");
+        assert!(
+            lean.contains("try ring") || lean.contains("; ring"),
+            "x² coeff order needs ring: {lean}"
+        );
+    }
+
+    #[test]
+    fn emit_lean_sum_rule_sin_cos() {
+        use crate::diff::diff;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![pool.func("sin", vec![x]), pool.func("cos", vec![x])]);
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(
+            !lean.is_empty(),
+            "d/dx (sin+cos) should be Lean-certifiable"
+        );
+        assert!(
+            lean.contains("differentiableAt_sin") || lean.contains("deriv_add"),
+            "sum_rule needs DifferentiableAt lemmas: {lean}"
+        );
+        assert!(
+            !lean.contains("sorry"),
+            "sum certificate must not use sorry: {lean}"
+        );
+    }
+
+    #[test]
+    fn emit_lean_product_rule_sin_exp() {
+        use crate::diff::diff;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.mul(vec![pool.func("sin", vec![x]), pool.func("exp", vec![x])]);
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(
+            !lean.is_empty(),
+            "d/dx (sin·exp) should be Lean-certifiable after product_rule fix"
+        );
+        assert!(
+            lean.contains("deriv_mul"),
+            "expected product_rule deriv_mul tactic: {lean}"
+        );
+        assert!(
+            !lean.contains("sorry"),
+            "product certificate must not use sorry: {lean}"
+        );
+    }
+
+    #[test]
+    fn emit_lean_tan_expand_uses_div_eq_mul_inv() {
+        use crate::simplify::{rulesets::trig_rules, simplify_with, SimplifyConfig};
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("tan", vec![x]);
+        let derived = simplify_with(expr, &pool, &trig_rules(), SimplifyConfig::default());
+        let lean = emit_lean_expr(&derived, &pool);
+        assert!(!lean.is_empty(), "tan(x) expand should be Lean-certifiable");
+        assert!(
+            lean.contains("div_eq_mul_inv"),
+            "tan→sin/cos needs div_eq_mul_inv for reciprocal form: {lean}"
+        );
+        assert!(
+            lean.contains("Real.tan"),
+            "tan must emit Real.tan, got: {lean}"
+        );
+    }
+
+    #[test]
+    fn emit_lean_log_pow_parenthesized() {
+        use crate::simplify::{rulesets::log_exp_rules, simplify_with, SimplifyConfig};
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("log", vec![pool.pow(x, pool.integer(3_i32))]);
+        let derived = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        let lean = emit_lean_expr(&derived, &pool);
+        assert!(!lean.is_empty(), "log(x^3) should be Lean-certifiable");
+        assert!(
+            lean.contains("Real.log (") && lean.contains("^"),
+            "log of a power must keep the power inside the log arg: {lean}"
+        );
+        // Guard against `(Real.log x) ^ 3` parse.
+        assert!(
+            !lean.contains("Real.log (x : ℝ)) ^") && !lean.contains("Real.log x ^"),
+            "power must not bind tighter than log: {lean}"
+        );
+    }
+
+    #[test]
+    fn withhold_generalized_power_rule_on_sin_squared() {
+        use crate::diff::diff;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let sin_x = pool.func("sin", vec![x]);
+        let expr = pool.pow(sin_x, pool.integer(2_i32));
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(
+            lean.is_empty(),
+            "d/dx sin(x)² embeds chain rule via power_rule; must withhold: {lean}"
+        );
     }
 
     #[test]

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -57,9 +57,49 @@ STRICT_CASES = [
         lambda pool: alkahest.diff(pool.symbol("x") ** 3, pool.symbol("x")),
     ),
     (
+        "diff_x_squared",
+        "diff_univariate_poly",
+        lambda pool: alkahest.diff(pool.symbol("x") ** 2, pool.symbol("x")),
+    ),
+    (
         "diff_sin",
         "diff_sin",
         lambda pool: alkahest.diff(alkahest.sin(pool.symbol("x")), pool.symbol("x")),
+    ),
+    (
+        "diff_sum_sin_cos",
+        "sum_rule",
+        lambda pool: alkahest.diff(
+            alkahest.sin(pool.symbol("x")) + alkahest.cos(pool.symbol("x")),
+            pool.symbol("x"),
+        ),
+    ),
+    (
+        "diff_product_sin_exp",
+        "product_rule",
+        lambda pool: alkahest.diff(
+            alkahest.sin(pool.symbol("x")) * alkahest.exp(pool.symbol("x")),
+            pool.symbol("x"),
+        ),
+    ),
+    (
+        "log_of_exp",
+        "log_of_exp",
+        lambda pool: alkahest.simplify_log_exp(
+            alkahest.log(alkahest.exp(pool.symbol("x")))
+        ),
+    ),
+    (
+        "tan_expand",
+        "tan_expand",
+        lambda pool: alkahest.simplify_trig(alkahest.tan(pool.symbol("x"))),
+    ),
+    (
+        "log_of_pow",
+        "log_of_pow",
+        lambda pool: alkahest.simplify_log_exp(
+            alkahest.log(pool.symbol("x") ** 3)
+        ),
     ),
 ]
 FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -85,9 +85,7 @@ STRICT_CASES = [
     (
         "log_of_exp",
         "log_of_exp",
-        lambda pool: alkahest.simplify_log_exp(
-            alkahest.log(alkahest.exp(pool.symbol("x")))
-        ),
+        lambda pool: alkahest.simplify_log_exp(alkahest.log(alkahest.exp(pool.symbol("x")))),
     ),
     (
         "tan_expand",
@@ -97,9 +95,7 @@ STRICT_CASES = [
     (
         "log_of_pow",
         "log_of_pow",
-        lambda pool: alkahest.simplify_log_exp(
-            alkahest.log(pool.symbol("x") ** 3)
-        ),
+        lambda pool: alkahest.simplify_log_exp(alkahest.log(pool.symbol("x") ** 3)),
     ),
 ]
 FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -20,6 +20,7 @@ from alkahest import (
     interval_eval,
     jit_is_available,
     latex,
+    log,
     parse,
     simplify,
     sin,
@@ -350,6 +351,60 @@ def test_lean_withholds_chain_rule_diff_certificate():
     r = diff(sin(x**2), x)
     assert r.certificate is None
     assert r.verification["status"] == "unverified"
+
+
+def test_lean_diff_x_squared_certificate():
+    """d/dx x² must close coeff order (`2*x` vs `x*2`) without sorry."""
+    p = pool()
+    x = p.symbol("x")
+    r = diff(x**2, x)
+    cert = r.certificate
+    assert isinstance(cert, str) and cert
+    assert "sorry" not in cert
+    assert "deriv (fun" in cert
+
+
+def test_lean_sum_and_product_rule_certificates():
+    """Sum/product of unary trig/exp diffs should emit, not withhold."""
+    p = pool()
+    x = p.symbol("x")
+    sum_r = diff(sin(x) + cos(x), x)
+    assert sum_r.certificate
+    assert "sorry" not in sum_r.certificate
+    assert any(s["rule"] == "sum_rule" for s in sum_r.steps)
+
+    prod_r = diff(sin(x) * exp(x), x)
+    assert prod_r.certificate
+    assert "sorry" not in prod_r.certificate
+    assert any(s["rule"] == "product_rule" for s in prod_r.steps)
+
+
+def test_lean_log_exp_parens_and_exp_log_withheld():
+    """Nested log/exp must parenthesize; exp∘log withheld (needs 0<x)."""
+    from alkahest import simplify_log_exp
+
+    p = pool()
+    x = p.symbol("x")
+    log_exp = simplify_log_exp(log(exp(x)))
+    assert log_exp.certificate
+    assert "Real.log (Real.exp" in log_exp.certificate
+    assert "sorry" not in log_exp.certificate
+
+    exp_log = simplify_log_exp(exp(log(x)))
+    assert exp_log.certificate is None
+    assert to_lean(exp_log) == ""
+
+
+def test_lean_tan_expand_certificate():
+    from alkahest import simplify_trig, tan
+
+    p = pool()
+    x = p.symbol("x")
+    r = simplify_trig(tan(x))
+    assert r.certificate
+    assert "div_eq_mul_inv" in r.certificate
+    assert "Real.tan" in r.certificate
+    assert "sorry" not in r.certificate
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -359,7 +359,8 @@ def test_lean_diff_x_squared_certificate():
     x = p.symbol("x")
     r = diff(x**2, x)
     cert = r.certificate
-    assert isinstance(cert, str) and cert
+    assert isinstance(cert, str)
+    assert cert
     assert "sorry" not in cert
     assert "deriv (fun" in cert
 


### PR DESCRIPTION
## Summary
- Fix Lean emitter bugs that produced non-compiling certificates after B3: nested `Real.f` parentheses, `d/dx x²` coeff order, sum/product DifferentiableAt tactics, `tan_expand` / `log_of_pow`.
- Withhold certificates that still cannot typecheck (`exp_of_log` positivity, generalized `power_rule` on non-variable bases / chain-rule composites).
- Expand the strict Lean CI corpus from 8 → 14 proofs (sums, products, log/exp, tan, `x²`).

## Test plan
- [x] `cargo test -p alkahest-cas lean:: --lib`
- [x] `pytest tests/test_smoke.py -k lean`
- [x] `python tests/lean_corpus.py` + `lake env lean -DwarningAsError=true` on all generated proofs
- [ ] CI Lean 4 Proofs workflow green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Lean certificate support for polynomial, sum, product, and selected trigonometric differentiation cases.
  * Improved Lean expression rendering for nested function calls and powers.
  * Added broader deterministic Lean derivation coverage for differentiation and logarithmic/trigonometric simplification.

* **Bug Fixes**
  * Corrected tangent expansion certificates to use the expected reciprocal form.
  * Withheld certificates when required positivity or generalized power-chain conditions cannot be certified.

* **Tests**
  * Added smoke tests covering certificate generation, withholding behavior, nested expressions, and differentiation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->