### PR TITLE
fix: drop unused MeasureTheory import; gate tendsto sorry

### DIFF
--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -186,9 +186,8 @@ pub fn emit_header() -> String {
     "import Mathlib.Tactic\n\
      import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic\n\
      import Mathlib.Analysis.SpecialFunctions.Log.Basic\n\
-     import Mathlib.MeasureTheory.Integral.IntervalIntegral\n\
      \n\
-     open Real MeasureTheory\n\n"
+     open Real\n\n"
         .to_string()
 }
 
@@ -231,7 +230,8 @@ pub fn emit_limit_header() -> String {
 /// * `lim`   — the computed limit value
 /// * `pool`  — expression pool
 ///
-/// Returns a complete `.lean` source snippet including the header.
+/// Returns a complete `.lean` source snippet including the header. Returns an
+/// empty string if the proof would require `sorry` or `admit` (unrecognized patterns).
 pub fn emit_tendsto_cert(expr: ExprId, var: ExprId, lim: ExprId, pool: &ExprPool) -> String {
     let var_name = pool.with(var, |d| match d {
         ExprData::Symbol { name, .. } => name.clone(),
@@ -240,6 +240,11 @@ pub fn emit_tendsto_cert(expr: ExprId, var: ExprId, lim: ExprId, pool: &ExprPool
     let body = expr_to_lean(expr, pool);
     let (codom_filter, limit_display) = lean_codom_filter(lim, pool);
     let tactic = tendsto_tactic(expr, var, lim, pool);
+
+    // Gate: do not emit certificates that would require sorry or admit.
+    if tactic.contains("sorry") || tactic.contains("admit") {
+        return String::new();
+    }
 
     let mut out = emit_limit_header();
     out.push_str(&format!(
@@ -964,16 +969,35 @@ mod tests {
     }
 
     #[test]
-    fn emit_tendsto_fallback_uses_sorry() {
+    fn emit_tendsto_unrecognized_pattern_withheld() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
-        // sin(x) → no known pattern → sorry
+        // sin(x) → no known pattern → should return empty string
         let expr = pool.func("sin", vec![x]);
         let zero = pool.integer(0_i32);
         let lean = emit_tendsto_cert(expr, x, zero, &pool);
         assert!(
-            lean.contains("sorry"),
-            "complex patterns should fall back to sorry: {lean}"
+            lean.is_empty(),
+            "unrecognized patterns must not emit sorry certificates: got {lean}"
+        );
+    }
+
+    #[test]
+    fn emit_tendsto_recognized_pattern_yields_cert() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        // exp(-x) → recognized pattern → should yield non-empty cert
+        let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
+        let expr = pool.func("exp", vec![neg_x]);
+        let zero = pool.integer(0_i32);
+        let lean = emit_tendsto_cert(expr, x, zero, &pool);
+        assert!(
+            !lean.is_empty(),
+            "recognized tendsto patterns must yield a certificate"
+        );
+        assert!(
+            !lean.contains("sorry"),
+            "recognized pattern certificate must not use sorry: {lean}"
         );
     }
 


### PR DESCRIPTION
## Summary

Two hygiene fixes in `alkahest-core/src/lean/mod.rs` per report7-20.md audit:

1. **Drop unused MeasureTheory import** (Fix 1)
   - Remove `import Mathlib.MeasureTheory.Integral.IntervalIntegral` from `emit_header()`
   - Remove `MeasureTheory` token from `open Real MeasureTheory` line
   - MeasureTheory is dead weight for simplify certificates since integration certificates are withheld

2. **Gate emit_tendsto_cert on sorry/admit** (Fix 2)
   - Add guard in `emit_tendsto_cert()` to return empty string when tactic contains `sorry` or `admit`
   - Mirrors existing guard in `emit_lean_expr_wrt()`
   - Ensures unrecognized tendsto patterns do not emit false certificates

## Test Results

- `cargo test -p alkahest-cas --lib`: **1574 passed** (includes new unit tests)
- Generated 14 Lean corpus certificates — **no MeasureTheory import present**
- New tests:
  - `emit_tendsto_unrecognized_pattern_withheld` — unrecognized patterns yield empty string
  - `emit_tendsto_recognized_pattern_yields_cert` — recognized patterns still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented generated proof certificates from containing unsupported admissions such as `sorry` or `admit`.
  * Unrecognized limit patterns now produce no certificate instead of an incomplete proof.
  * Recognized limit patterns continue to generate complete certificates without admissions.
* **Refactor**
  * Simplified the standard generated Lean header by removing an unnecessary import and namespace setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->