### PR TITLE
fix: make lean_theorem capability reflect real certifiability

### DIFF
--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -137,7 +137,25 @@ pub trait Primitive: 'static + Send + Sync {
         None
     }
 
-    /// Name of the Lean 4 / Mathlib theorem that certifies this primitive.
+    /// Name of the Lean 4 / Mathlib theorem that certifies this primitive's
+    /// derivative — but only if `alkahest_core::lean`'s certificate emitter
+    /// (`emit_lean_expr_wrt` / `diff_rule_to_tactic` / `step_is_certifiable`)
+    /// actually produces a non-`sorry` certificate for it *today*.
+    ///
+    /// This is deliberately narrower than "a Mathlib lemma with this name
+    /// exists": several primitives (`log`, `sqrt`, the hyperbolic/inverse
+    /// family, `tan`, `atan2`, `gamma`, …) have a real Mathlib derivative
+    /// lemma but the emitter withholds the certificate — either because a
+    /// side condition (e.g. `x > 0`) isn't encoded yet, or because the diff
+    /// step is recorded under the generic `diff_primitive_registry` rule
+    /// name that `diff_rule_to_tactic` never maps to a tactic. Returning
+    /// `Some` here when the emitter can't back it up would make the
+    /// `capabilities()["primitives"]` agent-contract signal a false
+    /// promise. When you make a new primitive's certificate actually
+    /// typecheck (add a `diff_rule_to_tactic` arm, wire up the rule name,
+    /// etc.), flip this back to `Some` — and verify empirically, e.g. via
+    /// `alkahest.to_lean(alkahest.diff(f(x), x))` checked with
+    /// `lake env lean`, not by inspection alone.
     fn lean_theorem(&self) -> Option<&'static str> {
         None
     }
@@ -640,9 +658,11 @@ pub mod builtins {
             args[0].log()
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.log_deriv")
-        }
+        // NOTE: no `lean_theorem` override — `diff_log` is withheld by
+        // `lean::diff_rule_to_tactic` (side-condition gap on `x > 0`), so
+        // the emitter never actually produces a non-`sorry` certificate
+        // for this primitive's derivative today. See `lean_theorem`'s
+        // trait doc for why the bit must track real certifiability.
     }
 
     // ── sqrt ─────────────────────────────────────────────────────────────────
@@ -691,9 +711,10 @@ pub mod builtins {
             args[0].sqrt()
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.sqrt_deriv")
-        }
+        // NOTE: no `lean_theorem` override — `diff_sqrt` is withheld by
+        // `lean::diff_rule_to_tactic` (side-condition gap on `x > 0`), so
+        // the emitter never actually produces a non-`sorry` certificate
+        // for this primitive's derivative today.
     }
 
     // ── tan ──────────────────────────────────────────────────────────────────
@@ -742,9 +763,10 @@ pub mod builtins {
             args[0].tan()
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.tan_deriv")
-        }
+        // NOTE: no `lean_theorem` override — this primitive's diff step is
+        // recorded under the generic `diff_primitive_registry` rule, which
+        // `lean::diff_rule_to_tactic` never certifies, so the emitter never
+        // produces a non-`sorry` certificate for its derivative today.
     }
 
     // ── sinh ─────────────────────────────────────────────────────────────────
@@ -786,9 +808,8 @@ pub mod builtins {
             Some(args[0].sinh())
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.sinh_deriv")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── cosh ─────────────────────────────────────────────────────────────────
@@ -830,9 +851,8 @@ pub mod builtins {
             Some(args[0].cosh())
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.cosh_deriv")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── tanh ─────────────────────────────────────────────────────────────────
@@ -883,9 +903,8 @@ pub mod builtins {
             Some(args[0].tanh())
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.tanh_deriv")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── asin ─────────────────────────────────────────────────────────────────
@@ -1038,9 +1057,8 @@ pub mod builtins {
             Some(args[0].atan())
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.arctan_deriv")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── asinh ────────────────────────────────────────────────────────────────
@@ -1091,9 +1109,8 @@ pub mod builtins {
             Some(args[0].asinh())
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.arsinh")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── acosh ────────────────────────────────────────────────────────────────
@@ -1144,9 +1161,8 @@ pub mod builtins {
             args[0].acosh()
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.arcosh")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── atanh ────────────────────────────────────────────────────────────────
@@ -1195,9 +1211,8 @@ pub mod builtins {
             args[0].atanh()
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.artanh")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── erf ──────────────────────────────────────────────────────────────────
@@ -2053,9 +2068,8 @@ pub mod builtins {
             Some(pool.mul(vec![numerator, pool.pow(denominator, neg_one)]))
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.arctan2")
-        }
+        // NOTE: no `lean_theorem` override — see the `tan` primitive above
+        // for why (generic `diff_primitive_registry` rule, never certified).
     }
 
     // ── lambert_w ────────────────────────────────────────────────────────────
@@ -2320,9 +2334,9 @@ pub mod builtins {
             Some(libm_gamma(args[0]))
         }
 
-        fn lean_theorem(&self) -> Option<&'static str> {
-            Some("Real.Gamma")
-        }
+        // NOTE: no `lean_theorem` override — `gamma` isn't even wired into
+        // `diff::diff` yet (see E-DIFF-001), let alone certified by
+        // `lean::diff_rule_to_tactic`, so no certificate is ever emitted.
     }
 
     // ── min ──────────────────────────────────────────────────────────────────

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -56,6 +56,42 @@ def test_cranelift_jit_enables_session_jit_flag():
     } == primitives[0].keys()
 
 
+def test_lean_theorem_bit_reflects_actual_certificate_availability():
+    """`primitives[i]["lean_theorem"]` must be a *truthful* signal: true only
+    for primitives whose derivative certificate actually emits (non-empty,
+    no `sorry`) from `alkahest.to_lean(alkahest.diff(...))` today.
+
+    This is deliberately narrower than "a Mathlib lemma with this name
+    exists" — see the `Primitive::lean_theorem` doc comment in
+    `alkahest-core/src/primitive/mod.rs`. `log`, `sqrt`, `tan`, the
+    hyperbolic/inverse family, `atan2`, and `gamma` all have real Mathlib
+    derivative lemmas, but Alkahest's Lean emitter withholds their
+    certificates (side conditions or chain-rule encoding not implemented
+    yet), so their bit must stay `False` until the emitter catches up.
+
+    If you make a new primitive's certificate typecheck, flip its
+    `lean_theorem()` override to `Some(...)`, add it to
+    `CERTIFIABLE_PRIMITIVES` below, and verify with
+    `lake env lean -DwarningAsError=true <file>` in `lean/` — not by
+    inspection alone.
+    """
+    CERTIFIABLE_PRIMITIVES = {"sin", "cos", "exp"}
+
+    primitives = alkahest.capabilities()["primitives"]
+    claiming = {row["name"] for row in primitives if row["lean_theorem"]}
+    assert claiming == CERTIFIABLE_PRIMITIVES
+
+    pool = alkahest.ExprPool()
+    x = pool.symbol("x")
+    for name in CERTIFIABLE_PRIMITIVES:
+        fn = getattr(alkahest, name)
+        derived = alkahest.diff(fn(x), x)
+        cert = alkahest.to_lean(derived)
+        assert cert.strip(), f"{name}: lean_theorem=True but to_lean() is empty"
+        assert "sorry" not in cert, f"{name}: certificate contains sorry"
+        assert "admit" not in cert, f"{name}: certificate contains admit"
+
+
 def test_capabilities_describes_verification_boundary():
     verification = alkahest.capabilities()["verification"]
 


### PR DESCRIPTION
## Summary

`capabilities()["primitives"]` advertised `lean_theorem: true` for a
primitive whenever `Primitive::lean_theorem()` returned a Mathlib lemma
*name* — regardless of whether Alkahest's own Lean 4 certificate emitter
(`alkahest_core::lean`) actually produces a certificate for that
primitive's derivative. It didn't: `log`, `sqrt`, `tan`, the
hyperbolic/inverse family (`sinh`, `cosh`, `tanh`, `asinh`, `acosh`,
`atanh`, `atan`), `atan2`, and `gamma` all claimed `lean_theorem: true`
while `to_lean(diff(f(x), x))` returned an **empty string** for every one
of them — `log`/`sqrt` because the side condition (`x > 0`) isn't encoded
in `diff_rule_to_tactic`, everything else because their diff step is
logged under the generic `diff_primitive_registry` rule name, which
`diff_rule_to_tactic` never maps to a tactic (chain-rule encoding gap).

This overclaims to any agent consuming the capability bit as a promise
that a certificate is obtainable.

## What changed

- `alkahest-core/src/primitive/mod.rs`: removed the `lean_theorem()`
  override for every primitive whose certificate the emitter withholds
  today (12 primitives — see below), leaving only `sin`, `cos`, `exp`.
  Rewrote the trait's doc comment to state the bit's real, narrower
  contract and point at `lean::diff_rule_to_tactic` /
  `step_is_certifiable` as the source of truth.
- `tests/test_agent_contract.py`: added
  `test_lean_theorem_bit_reflects_actual_certificate_availability`,
  which pins the truthful set (`{sin, cos, exp}`) and, for each, actually
  calls `alkahest.diff` + `alkahest.to_lean` and asserts the certificate
  is non-empty and free of `sorry`/`admit` — a regression guard so the
  bit can't silently drift back to overclaiming.
- No change needed in `alkahest-py/src/lib.rs` — it just surfaces the
  bitflag, which is now correct automatically.

## Empirically determined certifiable set

Built the extension (`maturin develop --features groebner`), then for
every registered primitive: `diff(f(x), x)` → `to_lean(...)`, and for
every non-empty, non-`sorry` certificate, typechecked it with
`lake env lean -DwarningAsError=true` against Mathlib v4.9.0 (`lean/`).

| Result | Primitives |
|---|---|
| **Typechecks** | `sin`, `cos`, `exp` |
| Empty certificate (withheld) | `log`, `sqrt`, `tan`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `atan`, `atan2`, `gamma` |
| `diff` itself not implemented (separate, pre-existing gap) | `gamma`, `abs`, `arg`, `ceil`, `conjugate`, `digamma`, `floor`, `im`, `re`, `round`, `sign` |
| No Python binding to probe | Elliptic functions, `diracdelta`, `heaviside` |

Only the first row (`sin`, `cos`, `exp`) now reports `lean_theorem: true`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo test -p alkahest-cas` — 1573 passed, 4 ignored (pre-existing), 25 doctests passed
- [x] `ruff format tests/test_agent_contract.py` — no changes needed
- [x] `pytest tests/test_agent_contract.py -q` — 5 passed (including the new regression test)
- [x] `pytest tests/ -q` — 1317 passed, 14 skipped (pre-existing), 1 deselected
- [x] Empirical Lean typecheck of `sin`/`cos`/`exp` certificates via `lake env lean -DwarningAsError=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)