### PR TITLE
feat: certify exp_of_log / log_mul with positivity hypotheses

### DIFF
--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -25,7 +25,7 @@
 //! assert!(lean_src.contains("simp"));
 //! ```
 
-use crate::deriv::log::{DerivedExpr, RewriteStep};
+use crate::deriv::log::{DerivedExpr, RewriteStep, SideCondition};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 
 // ---------------------------------------------------------------------------
@@ -43,10 +43,17 @@ fn rule_to_tactic(rule_name: &str) -> &'static str {
         "sin_neg" => "by simp [Real.sin_neg]",
         "cos_neg" => "by simp [Real.cos_neg]",
         "log_of_exp" => "by simp [Real.log_exp]",
-        // Needs a positivity hypothesis on the free variable; withhold via
-        // [`step_is_certifiable`] rather than emitting a failing `positivity`.
+        // These need a positivity hypothesis on the free variable(s). When the
+        // recorded side conditions are simple (bare symbols), [`emit_step_wrt`]
+        // upgrades the goal with explicit `(x : ℝ) (hx : 0 < x)` binders and
+        // calls [`positivity_tactic`] instead of using this fallback. This
+        // entry is only reached when that upgrade isn't possible (e.g. a
+        // compound side-condition expression, or — for `log_of_product` — more
+        // factors than [`positivity_tactic`] has a chained lemma for); such
+        // steps are withheld via [`step_is_certifiable`] rather than emitting
+        // a failing `positivity`.
         "exp_of_log" => "by sorry",
-        "log_of_product" => "by sorry",
+        "log_of_product" | "log_of_product_positive" => "by sorry",
         "log_of_pow" => "by simp [Real.log_pow]",
         "sin_sq_plus_cos_sq" => "by rw [Real.sin_sq_add_cos_sq]",
         "power_rule" | "constant_rule" | "sum_rule" | "constant_multiple_rule" => "by ring",
@@ -146,6 +153,62 @@ fn diff_rule_to_tactic(rule_name: &str) -> Option<&'static str> {
     }
 }
 
+/// The name of `id` if it's a bare [`ExprData::Symbol`], else `None`.
+///
+/// Positivity certificates only bind explicit `(name : ℝ) (hname : 0 < name)`
+/// binders for symbols — a compound side-condition expression (e.g. `x + y`)
+/// has no single name to bind and is left withheld.
+fn symbol_name(id: ExprId, pool: &ExprPool) -> Option<String> {
+    pool.with(id, |d| match d {
+        ExprData::Symbol { name, .. } => Some(name.clone()),
+        _ => None,
+    })
+}
+
+/// Select the Lean tactic that discharges `rule_name` given hypothesis names
+/// `h<name>` (one per entry of `names`, in the same order as the step's
+/// recorded [`SideCondition::Positive`] facts). Returns `None` when there's no
+/// known closing lemma for this shape (e.g. `log_of_product` with more than
+/// two factors) — callers must fall back to withholding the step.
+fn positivity_tactic(rule_name: &str, names: &[String]) -> Option<String> {
+    match (rule_name, names) {
+        ("exp_of_log", [x]) => Some(format!("by rw [Real.exp_log h{x}]")),
+        ("log_of_product" | "log_of_product_positive", [x, y]) => Some(format!(
+            "by rw [Real.log_mul (ne_of_gt h{x}) (ne_of_gt h{y})]"
+        )),
+        _ => None,
+    }
+}
+
+/// Attempt to build a self-contained positivity certificate for `step`: an
+/// explicit `(x : ℝ) (hx : 0 < x) …` binder list plus a tactic that consumes
+/// those hypotheses to close the goal.
+///
+/// Returns `None` when the step has no recorded positivity side conditions,
+/// any condition is over a compound expression rather than a bare symbol, or
+/// [`positivity_tactic`] has no lemma for this rule/arity combination — in
+/// all of those cases the caller falls back to the (withheld) table tactic.
+fn positivity_certificate(step: &RewriteStep, pool: &ExprPool) -> Option<(String, String)> {
+    if step.side_conditions.is_empty() {
+        return None;
+    }
+    let names: Vec<String> = step
+        .side_conditions
+        .iter()
+        .map(|c| match c {
+            SideCondition::Positive(id) => symbol_name(*id, pool),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let tactic = positivity_tactic(step.rule_name, &names)?;
+    let mut binders = names
+        .iter()
+        .map(|n| format!("({n} : ℝ)"))
+        .collect::<Vec<_>>();
+    binders.extend(names.iter().map(|n| format!("(h{n} : 0 < {n})")));
+    Some((binders.join(" "), tactic))
+}
+
 /// Whether this step can be emitted as a Lean `example` expected to typecheck
 /// without `sorry` / `admit`.
 fn step_is_certifiable(step: &RewriteStep, wrt: Option<ExprId>, pool: &ExprPool) -> bool {
@@ -171,10 +234,10 @@ fn step_is_certifiable(step: &RewriteStep, wrt: Option<ExprId>, pool: &ExprPool)
         }
         // Algebraic cleanup steps in a diff log use plain equality goals.
         let tactic = rule_to_tactic(step.rule_name);
-        return !tactic.contains("sorry");
+        return !tactic.contains("sorry") || positivity_certificate(step, pool).is_some();
     }
     let tactic = rule_to_tactic(step.rule_name);
-    !tactic.contains("sorry")
+    !tactic.contains("sorry") || positivity_certificate(step, pool).is_some()
 }
 
 // ---------------------------------------------------------------------------
@@ -420,6 +483,27 @@ pub fn emit_step(step: &RewriteStep, pool: &ExprPool) -> String {
 /// equalities (so `mul_one` is not wrongly wrapped as `deriv (1·cos) = cos`).
 pub fn emit_step_wrt(step: &RewriteStep, pool: &ExprPool, wrt: Option<ExprId>) -> String {
     let diff_step = wrt.is_some() && is_differentiation_rule(step.rule_name);
+
+    // Positivity-hypothesis certificates (`exp_of_log`, `log_of_product`, …)
+    // need explicit `(x : ℝ) (hx : 0 < x)` binders on the `example` header
+    // rather than the plain `example : before = after` goal, so they're
+    // built separately from the diff/algebraic goal below.
+    if !diff_step {
+        if let Some((binders, tactic)) = positivity_certificate(step, pool) {
+            let before_str = expr_to_lean(step.before, pool);
+            let after_str = expr_to_lean(step.after, pool);
+            let mut out = format!("example {binders} : {before_str} = {after_str} :=\n  {tactic}");
+            out.push_str("\n  -- Side conditions: ");
+            let conds: Vec<String> = step
+                .side_conditions
+                .iter()
+                .map(|c| c.display_with(pool).to_string())
+                .collect();
+            out.push_str(&conds.join(", "));
+            return out;
+        }
+    }
+
     let goal = if let (true, Some(var)) = (diff_step, wrt) {
         emit_diff_goal(step.before, step.after, var, pool)
     } else {
@@ -745,7 +829,10 @@ mod tests {
     }
 
     #[test]
-    fn withhold_exp_of_log_without_positivity_hyp() {
+    fn exp_of_log_certifies_with_positivity_hyp() {
+        // `ExpOfLog` records `SideCondition::Positive(x)`; the Lean exporter
+        // upgrades that into an explicit `(x : ℝ) (hx : 0 < x)` binder and
+        // closes the goal with `Real.exp_log hx` instead of withholding.
         use crate::simplify::{rulesets::log_exp_rules, simplify_with, SimplifyConfig};
 
         let pool = p();
@@ -754,8 +841,106 @@ mod tests {
         let derived = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
         let lean = emit_lean_expr(&derived, &pool);
         assert!(
-            lean.is_empty(),
-            "exp(log(x)) needs 0 < x; must not emit failing positivity: {lean}"
+            !lean.is_empty(),
+            "exp(log(x)) with a recorded positivity condition should certify"
+        );
+        assert!(
+            !lean.contains("sorry"),
+            "certificate must not use sorry: {lean}"
+        );
+        assert!(
+            lean.contains("(hx : 0 < x)"),
+            "expected an explicit positivity binder: {lean}"
+        );
+        assert!(
+            lean.contains("Real.exp_log hx"),
+            "expected Real.exp_log to consume the hypothesis: {lean}"
+        );
+    }
+
+    #[test]
+    fn exp_of_log_withheld_when_positivity_unproven() {
+        // A step with no recorded side condition at all (e.g. hand-built,
+        // bypassing `ExpOfLog::apply`) must still be withheld — the exporter
+        // never invents a hypothesis that wasn't in the derivation log.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
+        let step = RewriteStep::simple("exp_of_log", expr, x);
+        let lean = emit_step(&step, &pool);
+        assert!(
+            lean.contains("sorry"),
+            "step without a positivity side condition must fall back to sorry: {lean}"
+        );
+    }
+
+    #[test]
+    fn log_of_product_certifies_two_factors_under_positivity() {
+        // The colored e-graph's conditional `log_of_product_positive` rule
+        // records `Positive(x)`/`Positive(y)` once the caller's assumptions
+        // discharge them; the exporter should turn that into a real
+        // `Real.log_mul` certificate instead of withholding.
+        use crate::kernel::expr::PredicateKind;
+        use crate::simplify::AssumptionContext;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let zero = pool.integer(0_i32);
+        let mut assumptions = AssumptionContext::new();
+        assumptions
+            .refine(pool.predicate(PredicateKind::Gt, vec![x, zero]), &pool)
+            .unwrap();
+        assumptions
+            .refine(pool.predicate(PredicateKind::Gt, vec![y, zero]), &pool)
+            .unwrap();
+        let expr = pool.func("log", vec![pool.mul(vec![x, y])]);
+        let derived = assumptions.simplify(expr, &pool);
+        let lean = emit_lean_expr(&derived, &pool);
+        assert!(!lean.is_empty(), "log(x*y) should certify under x>0, y>0");
+        assert!(
+            !lean.contains("sorry"),
+            "certificate must not use sorry: {lean}"
+        );
+        assert!(
+            lean.contains("(hx : 0 < x)") && lean.contains("(hy : 0 < y)"),
+            "expected explicit positivity binders: {lean}"
+        );
+        assert!(
+            lean.contains("Real.log_mul (ne_of_gt hx) (ne_of_gt hy)"),
+            "expected Real.log_mul to consume both hypotheses: {lean}"
+        );
+    }
+
+    #[test]
+    fn log_of_product_withheld_for_three_factors() {
+        // `positivity_tactic` only has a chained lemma for two factors; a
+        // three-factor product must stay withheld rather than emit a tactic
+        // that can't close the goal.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let z = pool.symbol("z", Domain::Real);
+        let before = pool.func("log", vec![pool.mul(vec![x, y, z])]);
+        let after = pool.add(vec![
+            pool.func("log", vec![x]),
+            pool.func("log", vec![y]),
+            pool.func("log", vec![z]),
+        ]);
+        let step = RewriteStep::with_conditions(
+            "log_of_product",
+            before,
+            after,
+            vec![
+                SideCondition::Positive(x),
+                SideCondition::Positive(y),
+                SideCondition::Positive(z),
+            ],
+        );
+        let lean = emit_step(&step, &pool);
+        assert!(
+            lean.contains("sorry"),
+            "three-factor log_of_product has no known lemma yet; must withhold: {lean}"
         );
     }
 

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -662,7 +662,12 @@ impl RewriteRule for LogOfExp {
     }
 }
 
-/// `exp(log(x)) → x` (domain: x > 0 assumed).
+/// `exp(log(x)) → x`.
+///
+/// **Branch-cut caveat**: only unconditionally valid for `x > 0`. The rule
+/// still fires, but records [`SideCondition::Positive`] on `x` in the
+/// derivation log so callers (including the Lean certificate exporter) can
+/// audit — or discharge — the assumption made.
 pub struct ExpOfLog;
 
 impl RewriteRule for ExpOfLog {
@@ -673,7 +678,14 @@ impl RewriteRule for ExpOfLog {
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
         let arg = func_arg("exp", expr, pool)?;
         let inner = func_arg("log", arg, pool)?;
-        Some((inner, one_step(self.name(), expr, inner)))
+        let mut log = DerivationLog::new();
+        log.push(RewriteStep::with_conditions(
+            self.name(),
+            expr,
+            inner,
+            vec![SideCondition::Positive(inner)],
+        ));
+        Some((inner, log))
     }
 }
 

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -19,6 +19,23 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import alkahest
 
+
+def _log_of_product_case(pool):
+    """log(x*y) -> log(x) + log(y), certified under explicit x > 0, y > 0.
+
+    The default `log_exp_rules()` set omits the expand-style `log_of_product`
+    rewrite (it would oscillate against `sum_of_logs`), so this case goes
+    through the colored e-graph's conditional `log_of_product_positive` rule
+    instead, reached via `alkahest.Assumptions`.
+    """
+    x = pool.symbol("x")
+    y = pool.symbol("y")
+    assumptions = alkahest.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    assumptions.refine(pool.gt(y, pool.integer(0)))
+    return assumptions.simplify(alkahest.log(x * y))
+
+
 STRICT_CASES = [
     # (name, expected_rule, DerivedResult builder)
     (
@@ -96,6 +113,16 @@ STRICT_CASES = [
         "log_of_pow",
         "log_of_pow",
         lambda pool: alkahest.simplify_log_exp(alkahest.log(pool.symbol("x") ** 3)),
+    ),
+    (
+        "exp_of_log",
+        "exp_of_log",
+        lambda pool: alkahest.simplify_log_exp(alkahest.exp(alkahest.log(pool.symbol("x")))),
+    ),
+    (
+        "log_of_product",
+        "log_of_product_positive",
+        _log_of_product_case,
     ),
 ]
 FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -380,8 +380,8 @@ def test_lean_sum_and_product_rule_certificates():
     assert any(s["rule"] == "product_rule" for s in prod_r.steps)
 
 
-def test_lean_log_exp_parens_and_exp_log_withheld():
-    """Nested log/exp must parenthesize; exp∘log withheld (needs 0<x)."""
+def test_lean_log_exp_parens_and_exp_log_certifies_with_positivity_hyp():
+    """Nested log/exp must parenthesize; exp∘log certifies via a `0 < x` binder."""
     from alkahest import simplify_log_exp
 
     p = pool()
@@ -391,9 +391,16 @@ def test_lean_log_exp_parens_and_exp_log_withheld():
     assert "Real.log (Real.exp" in log_exp.certificate
     assert "sorry" not in log_exp.certificate
 
+    # exp(log(x)) needs `0 < x`; the derivation log records that as a
+    # positivity side condition, and the Lean exporter upgrades it into an
+    # explicit `(x : ℝ) (hx : 0 < x)` binder closed by `Real.exp_log hx`
+    # rather than withholding the certificate.
     exp_log = simplify_log_exp(exp(log(x)))
-    assert exp_log.certificate is None
-    assert to_lean(exp_log) == ""
+    assert exp_log.certificate is not None
+    assert "(hx : 0 < x)" in exp_log.certificate
+    assert "Real.exp_log hx" in exp_log.certificate
+    assert "sorry" not in exp_log.certificate
+    assert to_lean(exp_log) != ""
 
 
 def test_lean_tan_expand_certificate():


### PR DESCRIPTION
## Summary

Two rules in the Lean certificate exporter were withheld as `by sorry` because they need positivity hypotheses that weren't being threaded through:

- `exp_of_log` (`exp(log x) → x`, needs `0 < x`)
- `log_of_product` (`log(x·y) → log x + log y`, needs `0 < x`, `0 < y`)

This PR emits those as real Lean binders instead of withholding.

- `ExpOfLog::apply` (`alkahest-core/src/simplify/rulesets.rs`) now records `SideCondition::Positive(inner)` on the derivation step, matching the pattern already used by `LogOfProduct`/`SumOfLogs`/`LogOfQuotient` and the colored e-graph's conditional rules.
- `alkahest-core/src/lean/mod.rs` adds `positivity_certificate`/`positivity_tactic`: when a step's recorded positivity side conditions are bare symbols, the exporter upgrades the goal from `example : before = after` to `example (x : ℝ) (hx : 0 < x) … : before = after`, closed with `Real.exp_log hx` or `Real.log_mul (ne_of_gt hx) (ne_of_gt hy)`. `step_is_certifiable` consults the same helper so these steps are no longer filtered out.
- Falls back to withholding (never emits a broken cert) when a side condition is over a compound expression, or for `log_of_product` with more than two factors (no chained lemma wired up yet).
- `tests/lean_corpus.py` gains `exp_of_log` and `log_of_product` corpus cases. `log_of_product` goes through `alkahest.Assumptions` (colored e-graph's `log_of_product_positive` rule) since the unconditional `LogOfProduct` rewrite is intentionally not wired into the default `log_exp_rules()` ruleset (it would oscillate against `sum_of_logs`).
- Updated one existing Rust unit test and one Python smoke test that asserted the old "withheld" behavior, since it's now expected to certify.

## Test plan

- [x] `cargo test --workspace` — all pass (1576 lib tests + doctests), including new/updated `lean::tests::*`
- [x] `pytest tests/` — 1316 passed, 14 skipped (unrelated), 0 failed
- [x] `tests/lean_corpus.py --output …` generates 16/16 proofs (14 pre-existing + `exp_of_log` + `log_of_product`), none containing `sorry`/`admit`/`axiom`
- [x] `lake env lean -DwarningAsError=true` typechecks all 16 generated `.lean` files with zero failures (Mathlib v4.9.0, `lean-toolchain` pin)
- [x] `cargo fmt --check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)