### PR TITLE
fix: reward RL refusal only on provably-non-elementary integrands (audit #3)

### DIFF
--- a/python/alkahest/rl/envs/integration/env.py
+++ b/python/alkahest/rl/envs/integration/env.py
@@ -25,6 +25,37 @@ constant of integration. If no elementary antiderivative exists, write exactly: 
 N_TIERS = len(TIERS)
 
 
+def _known_nonelementary_forms(pool: ak.ExprPool, x: ak.Expr) -> list:
+    """Curated corpus of integrands with *no* elementary antiderivative.
+
+    SOUNDNESS INVARIANT (directional issue #3): hard-negative ("nonelementary")
+    training rows are labelled ONLY from this hand-verified list — never from the
+    engine's own ``integrate()`` verdict. The engine's ``NonElementary`` verdict
+    (``E-INT-004``) is a *sound-but-incomplete* oracle: it can emit a FALSE
+    ``NonElementary`` on an actually-elementary integrand (see bug B2, fixed in
+    #219) and, conversely, it gives up with ``E-INT-001`` ("not implemented") on
+    genuinely non-elementary integrands it cannot classify. Trusting either code
+    to *generate* labels would poison the "honest refusal" reward. Each entry
+    below is a classical, textbook-known non-elementary integrand:
+
+      * exp(x^2)        — Gaussian; antiderivative is erf (non-elementary).
+      * sin(x)/x        — sine integral Si(x).
+      * exp(x)/x        — exponential integral Ei(x).
+      * log(log(x+2))   — logarithmic-integral family; genuinely non-elementary
+                          even though the engine only reports E-INT-001 for it.
+
+    The reward (see ``verifier.IntegrationVerifier``) credits an honest refusal
+    solely on rows carrying this curated ``is_elementary=False`` label, so a
+    refusal is rewarded ONLY when the integrand is provably non-elementary.
+    """
+    return [
+        ak.exp(x * x),
+        ak.sin(x) / x,
+        ak.exp(x) / x,
+        ak.log(ak.log(x + pool.integer(2))),
+    ]
+
+
 def load_environment(
     difficulty_tier: int = 0,
     hard_negative_fraction: float = 0.25,
@@ -91,13 +122,8 @@ def _make_row(tier: int, nonelementary: bool, rng: random.Random) -> dict:
     pool = ak.ExprPool()
     x = pool.symbol("x")
     if nonelementary:
-        ne_forms = [
-            ak.exp(x * x),
-            ak.sin(x) / x,
-            ak.exp(x) / x,
-            ak.log(ak.log(x + pool.integer(2))),
-        ]
-        f = rng.choice(ne_forms)
+        # Labels come from the curated corpus, NOT from the engine's verdict.
+        f = rng.choice(_known_nonelementary_forms(pool, x))
         return {
             "prompt": [{"role": "user", "content": f"Find ∫ {ak.unicode_str(f)} dx"}],
             "f_str": str(f),

--- a/python/alkahest/rl/envs/integration/verifier.py
+++ b/python/alkahest/rl/envs/integration/verifier.py
@@ -13,6 +13,19 @@ _SPOT_PRIMES = [3, 5, 7, 11, 13, 17, 19, 23]
 
 
 class IntegrationVerifier(BaseVerifier):
+    """Reward model integration attempts.
+
+    Soundness note (directional issue #3): the "honest refusal" reward is gated
+    exclusively on the ``is_elementary`` label carried by the row — which comes
+    from the curated known-non-elementary corpus in ``env._known_nonelementary_forms``
+    — and NEVER on the engine's own ``integrate()`` classification. We therefore
+    reward a refusal only when the integrand is *provably* non-elementary, and
+    never when the engine merely gave up (``E-INT-001``) or emitted a false
+    ``NonElementary`` verdict (``E-INT-004``; cf. bug B2, fixed in #219). A model
+    answer is otherwise scored by differentiating it and comparing to the
+    integrand, independent of any engine verdict.
+    """
+
     def verify(self, completion: str, metadata: dict) -> float:
         is_elementary: bool = metadata["is_elementary"]
         f_expr: Expr = metadata["f_expr"]

--- a/tests/test_rl_nonelementary_soundness.py
+++ b/tests/test_rl_nonelementary_soundness.py
@@ -1,0 +1,128 @@
+"""Soundness guards for the RL "honest refusal" reward (directional issue #3).
+
+The RL integration environment rewards a model for refusing to integrate a
+*non-elementary* integrand. That reward is only trustworthy if the label
+"non-elementary" is itself sound. Two independent properties must hold:
+
+1. The engine must NEVER classify an actually-ELEMENTARY integrand as
+   ``NonElementary`` (error code ``E-INT-004``). A false ``NonElementary``
+   verdict (bug B2, fixed in #219) would let a training pipeline mint a
+   hard-negative from an elementary integrand and reward a *wrong* refusal.
+
+2. The RL hard-negative labels must come from a curated known-non-elementary
+   corpus, not from trusting the engine's own verdict — because that verdict is
+   sound-but-incomplete (it gives up with ``E-INT-001`` on genuinely
+   non-elementary integrands, and historically could emit a false ``E-INT-004``).
+
+These tests need only ``alkahest`` (no ``verifiers`` / ``datasets`` extra).
+"""
+
+from __future__ import annotations
+
+import alkahest as ak
+
+# Known-ELEMENTARY integrands. Each has a genuine elementary antiderivative, so
+# integrate() must NOT return the E-INT-004 (NonElementary) verdict. It is
+# acceptable for the engine to *succeed* or to decline with a non-E-INT-004
+# code (e.g. E-INT-001 "not implemented"); the only forbidden outcome is a
+# false NonElementary claim.
+KNOWN_ELEMENTARY = [
+    # B2 regression: ∫ (exp(x)·log(x) + exp(x)/x) dx = exp(x)·log(x).
+    # Before #219 the engine falsely reported this as NonElementary.
+    "exp(x)*log(x) + exp(x)/x",
+    # Rational / polynomial.
+    "2*x",
+    "x^3 - 2*x + 1",
+    "1/(1+x^2)",  # atan(x)
+    "1/x",  # log(x)
+    # Trigonometric.
+    "cos(x)",
+    "sin(x)*cos(x)",
+    # By parts.
+    "x*exp(x)",
+    # Algebraic.
+    "1/sqrt(1-x^2)",  # asin(x)
+    "exp(x)",
+]
+
+
+def _integrate_code(f_str: str) -> str:
+    """Return "OK" if integrate() succeeds, else the E-INT-* error code."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    f = ak.parse(f_str, pool, {"x": x})
+    try:
+        ak.integrate(f, x)
+        return "OK"
+    except ak.IntegrationError as exc:
+        return getattr(exc, "code", "E-INT-?")
+
+
+def test_elementary_integrands_never_classified_nonelementary():
+    """No known-elementary integrand may receive the E-INT-004 verdict."""
+    offenders = {s: code for s in KNOWN_ELEMENTARY if (code := _integrate_code(s)) == "E-INT-004"}
+    assert not offenders, (
+        f"engine falsely classified elementary integrands as NonElementary (E-INT-004): {offenders}"
+    )
+
+
+def test_b2_case_integrates_to_exp_times_log():
+    """B2: ∫ (exp(x)·log(x) + exp(x)/x) dx must succeed and equal exp(x)·log(x)."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    f = ak.parse("exp(x)*log(x) + exp(x)/x", pool, {"x": x})
+
+    # Must NOT raise (and in particular must not be E-INT-004).
+    result = ak.integrate(f, x)
+
+    # Verify by differentiating the returned antiderivative back to f.
+    d = ak.diff(result.value, x)
+    residual = ak.simplify(ak.simplify(d.value).value - f).value
+    if str(residual).strip() not in ("0", "0/1"):
+        reduced = ak.simplify_egraph(residual)
+        residual = getattr(reduced, "value", reduced)
+    assert str(residual).strip() in ("0", "0/1"), (
+        f"d/dx of returned antiderivative != integrand; residual={residual}"
+    )
+
+
+def test_curated_nonelementary_labels_are_genuinely_nonelementary():
+    """The RL curated hard-negatives must not be integrable to an elementary form.
+
+    Guards against a future edit that slips an elementary integrand into the
+    curated corpus (which would reward a *wrong* refusal). We assert the engine
+    never *succeeds* on them; whether it reports E-INT-004 or E-INT-001 is
+    irrelevant to the label's correctness, which is established by the curation.
+    """
+    from alkahest.rl.envs.integration.env import _known_nonelementary_forms
+
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    integrable = []
+    for f in _known_nonelementary_forms(pool, x):
+        try:
+            ak.integrate(f, x)
+            integrable.append(str(f))
+        except ak.IntegrationError:
+            pass
+    assert not integrable, (
+        f"curated 'non-elementary' forms were integrated to a closed form: {integrable}"
+    )
+
+
+def test_reward_never_reads_engine_verdict_for_labels():
+    """The RL row label must be the curated flag, independent of the engine.
+
+    A hard-negative row is stamped ``is_elementary=False`` purely from the
+    curated corpus; an elementary row is stamped ``is_elementary=True``. This
+    documents/locks the invariant that labels are curated, not engine-derived.
+    """
+    import random
+
+    from alkahest.rl.envs.integration.env import _make_row
+
+    neg = _make_row(tier=0, nonelementary=True, rng=random.Random(0))
+    assert neg["is_elementary"] is False
+
+    pos = _make_row(tier=0, nonelementary=False, rng=random.Random(0))
+    assert pos["is_elementary"] is True


### PR DESCRIPTION
## Audit: RL "honest refusal" reward (directional issue #3)

The RL `IntegrationVerifier` rewards a model for refusing to integrate a
non-elementary integrand. That reward is only trustworthy if the "non-elementary"
label is sound. B2 (#219) showed the engine can emit a **false** `NonElementary`
verdict on an elementary integrand, so the reward must credit refusal only when the
integrand is *provably* non-elementary — never when the engine merely gave up.

### Findings (evidence in code)

1. **How are non-elementary rows labelled?** From a **curated** hardcoded list, not the
   engine's verdict. `env._make_row(nonelementary=True)` draws from a fixed set
   (`exp(x^2)`, `sin(x)/x`, `exp(x)/x`, `log(log(x+2))`) — all textbook-known
   non-elementary — and stamps `is_elementary=False`. It never calls `integrate()`.

2. **Does the reward gate on E-INT-004 vs E-INT-001?** Neither — the reward never
   consults the engine's E-INT code. `IntegrationVerifier.verify` scores purely on the
   curated `is_elementary` label plus the model's own textual refusal
   (`_model_declined`); a correct antiderivative is checked by differentiation. So a
   refusal is credited **only** on curated provably-non-elementary rows. An
   E-INT-001 "not implemented" (or a false E-INT-004) integrand can never enter the
   hard-negative pool, because elementary rows are generated from `diff(F)` of a known
   antiderivative and labelled `is_elementary=True`.

3. **Soundness guard against elementary→NonElementary?** None existed at the RL layer
   (not needed there, since it doesn't trust the engine). The engine-level property —
   elementary integrands must never be classified `E-INT-004` — was untested at this
   boundary. This PR adds that guard.

**Conclusion:** the reward design is already sound; the invariant was implicit and
unguarded. This PR makes it explicit and adds a regression guard.

### Changes

- `env.py`: extract the curated corpus into `_known_nonelementary_forms` with a
  docstring stating the soundness invariant (labels are curated, never from
  E-INT-004/E-INT-001).
- `verifier.py`: document that the refusal reward is gated on the curated label,
  independent of any engine verdict.
- `tests/test_rl_nonelementary_soundness.py`: soundness regression test —
  - runs a known-elementary corpus (incl. **B2** `∫(exp(x)·log(x)+exp(x)/x)dx =
    exp(x)·log(x)`, plus rational, trig, by-parts, `1/sqrt(1-x^2)`) through
    `integrate()` and asserts **none** are classified `E-INT-004`;
  - verifies the B2 antiderivative differentiates back to the integrand;
  - guards that curated hard-negatives are genuinely non-integrable and that row
    labels are curated, not engine-derived.

Needs only `alkahest` (no `verifiers`/`datasets` extra).

### Test result
`4 passed` (incl. B2). Full RL/integration subset: `20 passed, 6 skipped`;
integration suite: `148 passed, 4 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved classification of integration examples marked as non-elementary.
  - Prevented valid elementary integrals from being incorrectly treated as unsolvable.
  - Ensured refusal scoring uses the intended dataset labels rather than conflicting engine classifications.
  - Corrected handling of cases involving exponential and logarithmic expressions.

- **Tests**
  - Added regression coverage confirming valid integrals produce correct antiderivatives.
  - Added checks that non-elementary examples are genuinely non-elementary and labels remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->