### PR TITLE
feat: Lean certificates for integration via the FTC derivative relation

### DIFF
--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -741,6 +741,120 @@ pub fn emit_lean_expr_wrt(
     out
 }
 
+/// Structural gate for antiderivatives whose FTC derivative certificate is
+/// known to typecheck under the reused differentiation machinery.
+///
+/// The diff exporter's `deriv (fun x => F) x = …` tactics reliably close for a
+/// restricted fragment: constants, powers of the differentiation variable,
+/// *pointwise* `sin`/`cos`/`exp` (argument exactly the variable), sums of
+/// those, and *flat* products of those (a product whose factors are atoms /
+/// pointwise primitives, e.g. `x · cos x`). Two shapes that the diff exporter
+/// currently emits but does **not** discharge — leaving `deriv` or a
+/// `DifferentiableAt` side goal open — must be withheld here:
+///
+/// * a **chain composite** `f(g x)` with `g ≠ x` (e.g. `exp (x²)`), because the
+///   product-rule simp set lacks the composite's `DifferentiableAt` lemma;
+/// * a **sum nested inside a product** (e.g. `-1 · (a + b)`), because the
+///   post-`simp` `ring` cannot reduce the still-symbolic nested `deriv`.
+///
+/// Rejecting these keeps the integration certificate sound: a withheld integral
+/// is always preferable to a `.lean` file that fails to typecheck. Composites
+/// and by-parts results outside this fragment simply stay withheld.
+fn antiderivative_in_certifiable_fragment(f: ExprId, var: ExprId, pool: &ExprPool) -> bool {
+    // `in_product`: we are inside a Mul, where a nested Add would defeat `ring`.
+    fn walk(f: ExprId, var: ExprId, pool: &ExprPool, in_product: bool) -> bool {
+        pool.with(f, |d| match d {
+            ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => true,
+            ExprData::Symbol { .. } => true,
+            ExprData::Pow { base, exp } => {
+                // Only powers of the differentiation variable with an integer
+                // exponent — the polynomial / reciprocal fast path.
+                *base == var && pool.with(*exp, |e| matches!(e, ExprData::Integer(_)))
+            }
+            ExprData::Func { name, args } => {
+                // Pointwise primitive only: sin/cos/exp applied to exactly `var`.
+                matches!(name.as_str(), "sin" | "cos" | "exp") && args.len() == 1 && args[0] == var
+            }
+            ExprData::Add(xs) => {
+                // A sum inside a product is the shape `ring` cannot finish.
+                !in_product && xs.iter().all(|&c| walk(c, var, pool, false))
+            }
+            ExprData::Mul(xs) => xs.iter().all(|&c| walk(c, var, pool, true)),
+            _ => false,
+        })
+    }
+    walk(f, var, pool, false)
+}
+
+/// Emit a Lean certificate for an **indefinite integral** `∫ f dx = F`.
+///
+/// A bare `f = F` equality is false (`sin x ≠ -cos x`), so an integration
+/// result cannot be certified as a rewrite. The sound statement that pins the
+/// antiderivative is the FTC derivative relation
+///
+/// ```text
+/// deriv (fun x => F) x = f
+/// ```
+///
+/// which we discharge by *reusing the differentiation-certificate machinery*:
+/// we differentiate `F` in the kernel and hand the resulting derivation log to
+/// [`emit_lean_expr_wrt`]. That already proves `deriv (fun x => F) x = d/dx F`
+/// via `deriv_pow` / `Real.deriv_sin` / `HasDerivAt.comp` / … and withholds
+/// (returns `""`) whenever the goal escapes the certifiable diff fragment.
+///
+/// The one extra obligation for an *integral* is that the differentiated
+/// antiderivative is syntactically the integrand, so that the certificate's
+/// final right-hand side is exactly `f` (i.e. the cert really proves
+/// `deriv F = f`, not `deriv F = <something else>`). We require the kernel's
+/// simplified `d/dx F` to intern to the same [`ExprId`] as `integrand`;
+/// otherwise we WITHHOLD. This is precisely the exact-residual antiderivative
+/// check, so numeric-only antiderivatives stay withheld.
+///
+/// Returns `""` (no certificate) when `F` cannot be differentiated, when its
+/// derivative is not structurally the integrand, or when the diff certificate
+/// itself is withheld. Never emits `sorry` / `admit`.
+pub fn emit_integration_cert(
+    antiderivative: ExprId,
+    integrand: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> String {
+    // Withhold antiderivatives whose derivative certificate escapes the
+    // reliably-typechecking diff fragment (chain composites, sums nested in
+    // products): the reused exporter would emit a non-closing proof for them.
+    if !antiderivative_in_certifiable_fragment(antiderivative, var, pool) {
+        return String::new();
+    }
+    let Ok(derived_diff) = crate::diff::diff(antiderivative, var, pool) else {
+        return String::new();
+    };
+    // The certificate proves `deriv F = d/dx F`; only present it as certifying
+    // `∫ f = F` when `d/dx F` is exactly the integrand.
+    if derived_diff.value != integrand {
+        return String::new();
+    }
+    let cert = emit_lean_expr_wrt(&derived_diff, pool, Some(var));
+    if cert.is_empty() {
+        return String::new();
+    }
+    // Prefix a note tying the diff certificate back to the integral it proves.
+    let f = expr_to_lean(integrand, pool);
+    let big_f = expr_to_lean(antiderivative, pool);
+    let var_name = pool.with(var, |d| match d {
+        ExprData::Symbol { name, .. } => name.clone(),
+        _ => "x".to_string(),
+    });
+    let note = format!(
+        "-- ∫ {f} d{var_name} = {big_f}\n\
+         -- certified via the FTC derivative relation: deriv (fun {var_name} => {big_f}) {var_name} = {f}\n"
+    );
+    // Splice the note directly before the first proof step, after the imports.
+    match cert.find("-- Step 1") {
+        Some(idx) => format!("{}{note}{}", &cert[..idx], &cert[idx..]),
+        None => format!("{cert}{note}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Expression → Lean syntax
 // ---------------------------------------------------------------------------
@@ -923,6 +1037,128 @@ mod tests {
         assert!(
             lean.is_empty(),
             "∫ sin must not emit false `sin = -cos` Lean equality, got: {lean}"
+        );
+    }
+
+    #[test]
+    fn integration_cert_cos_via_ftc_derivative() {
+        // ∫ cos x dx = sin x, certified as `deriv (fun x => sin x) x = cos x`.
+        use crate::integrate::integrate;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let cos_x = pool.func("cos", vec![x]);
+        let derived = integrate(cos_x, x, &pool).expect("integrate");
+        let lean = emit_integration_cert(derived.value, cos_x, x, &pool);
+        assert!(
+            !lean.is_empty(),
+            "∫ cos x should certify via the FTC relation"
+        );
+        assert!(
+            lean.contains("deriv (fun (x : ℝ)"),
+            "must state the derivative relation, got: {lean}"
+        );
+        assert!(
+            lean.contains("Real.deriv_sin"),
+            "antiderivative sin is discharged by Real.deriv_sin: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn integration_cert_sin_via_ftc_derivative() {
+        // ∫ sin x dx = -cos x, certified as `deriv (fun x => -cos x) x = sin x`.
+        use crate::integrate::integrate;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let sin_x = pool.func("sin", vec![x]);
+        let derived = integrate(sin_x, x, &pool).expect("integrate");
+        let lean = emit_integration_cert(derived.value, sin_x, x, &pool);
+        assert!(
+            !lean.is_empty(),
+            "∫ sin x should certify via the FTC relation, got empty"
+        );
+        assert!(
+            lean.contains("deriv (fun (x : ℝ)"),
+            "must state the derivative relation: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn integration_cert_exp_via_ftc_derivative() {
+        use crate::integrate::integrate;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let derived = integrate(exp_x, x, &pool).expect("integrate");
+        let lean = emit_integration_cert(derived.value, exp_x, x, &pool);
+        assert!(
+            !lean.is_empty(),
+            "∫ exp x should certify via the FTC relation"
+        );
+        assert!(
+            lean.contains("Real.deriv_exp"),
+            "expected deriv_exp: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn integration_cert_power_via_ftc_derivative() {
+        // ∫ x² dx = x³/3, certified via the polynomial derivative fragment.
+        use crate::integrate::integrate;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let derived = integrate(x2, x, &pool).expect("integrate");
+        let lean = emit_integration_cert(derived.value, x2, x, &pool);
+        assert!(!lean.is_empty(), "∫ x² should certify via the FTC relation");
+        assert!(
+            lean.contains("deriv (fun (x : ℝ)"),
+            "must state the derivative relation: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn integration_cert_withheld_for_chain_composite_antiderivative() {
+        // ∫ x·exp(x²) dx = ½·exp(x²). Its derivative certificate would emit a
+        // product rule whose factor is the composite exp(x²); the reused diff
+        // tactic leaves a `DifferentiableAt` side goal open, so the integral
+        // certificate must be withheld by the fragment gate.
+        use crate::integrate::integrate;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let integrand = pool.mul(vec![x, pool.func("exp", vec![x2])]);
+        let derived = integrate(integrand, x, &pool).expect("integrate");
+        let lean = emit_integration_cert(derived.value, integrand, x, &pool);
+        assert!(
+            lean.is_empty(),
+            "∫ x·exp(x²) has a composite antiderivative; must withhold: {lean}"
+        );
+    }
+
+    #[test]
+    fn integration_cert_withheld_for_non_certifiable_diff() {
+        // ∫ log x dx = x·log x − x. Its derivative routes through `diff_log`,
+        // which is outside the certifiable diff fragment, so the integral cert
+        // must be withheld rather than emit an admission.
+        use crate::integrate::integrate;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let log_x = pool.func("log", vec![x]);
+        let derived = integrate(log_x, x, &pool).expect("integrate");
+        let lean = emit_integration_cert(derived.value, log_x, x, &pool);
+        assert!(
+            lean.is_empty(),
+            "∫ log x's antiderivative differentiates via diff_log; must withhold: {lean}"
         );
     }
 

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -180,7 +180,7 @@ pub use poly::groebner::{
 };
 
 pub use errors::AlkahestError;
-pub use lean::{emit_lean_expr as emit_lean, emit_lean_expr_wrt};
+pub use lean::{emit_integration_cert, emit_lean_expr as emit_lean, emit_lean_expr_wrt};
 // V2-1 — Modular / CRT framework
 #[cfg(feature = "groebner")]
 pub use diffalg::{

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1637,12 +1637,21 @@ impl PyDerivedResult {
     /// ``integrand = F`` would be false), or would require an admission (B3).
     #[getter]
     fn certificate(&self, py: Python<'_>) -> Option<String> {
-        if self.raw.log.is_empty() {
-            return None;
-        }
         // Integration derivation logs construct antiderivatives; emitting them
-        // as rewrite equalities is unsound (e.g. `sin x = -cos x`).
-        if self.integration_verification_input.is_some() {
+        // as rewrite equalities is unsound (e.g. `sin x = -cos x`). They are
+        // instead certified via the FTC derivative relation
+        // `deriv (fun x => F) x = f` (Part A).
+        if let Some((integrand, var)) = self.integration_verification_input {
+            let pool_py = self.value.pool.clone_ref(py);
+            let pool = pool_py.borrow(py);
+            let src =
+                alkahest_core::emit_integration_cert(self.raw.value, integrand, var, &pool.inner);
+            if src.is_empty() || src.contains("sorry") || src.contains("admit") {
+                return None;
+            }
+            return Some(src);
+        }
+        if self.raw.log.is_empty() {
             return None;
         }
         let pool_py = self.value.pool.clone_ref(py);
@@ -1663,7 +1672,22 @@ impl PyDerivedResult {
     fn verification<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
         let metadata = PyDict::new_bound(py);
         let lean_certificate = {
-            if self.raw.log.is_empty() || self.integration_verification_input.is_some() {
+            if let Some((integrand, var)) = self.integration_verification_input {
+                // Integrals certify via the FTC derivative relation (Part A).
+                let pool_py = self.value.pool.clone_ref(py);
+                let pool = pool_py.borrow(py);
+                let src = alkahest_core::emit_integration_cert(
+                    self.raw.value,
+                    integrand,
+                    var,
+                    &pool.inner,
+                );
+                if src.is_empty() || src.contains("sorry") || src.contains("admit") {
+                    None
+                } else {
+                    Some(src)
+                }
+            } else if self.raw.log.is_empty() {
                 None
             } else {
                 let pool_py = self.value.pool.clone_ref(py);
@@ -3922,9 +3946,17 @@ fn py_simplify_log_exp(py: Python<'_>, expr: PyRef<PyExpr>) -> PyDerivedResult {
 fn py_to_lean(py: Python<'_>, arg: &Bound<'_, PyAny>) -> PyResult<String> {
     if let Ok(derived_bound) = arg.downcast::<PyDerivedResult>() {
         let d = derived_bound.borrow();
-        // Match `.certificate`: withhold unsound / unfinished Lean sources.
-        if d.integration_verification_input.is_some() {
-            return Ok(String::new());
+        // Integration results certify via the FTC derivative relation
+        // `deriv (fun x => F) x = f` rather than a false `f = F` equality.
+        if let Some((integrand, var)) = d.integration_verification_input {
+            let pool_py = d.value.pool.clone_ref(py);
+            let pool = pool_py.borrow(py);
+            let src =
+                alkahest_core::emit_integration_cert(d.raw.value, integrand, var, &pool.inner);
+            if src.contains("sorry") || src.contains("admit") {
+                return Ok(String::new());
+            }
+            return Ok(src);
         }
         let pool_py = d.value.pool.clone_ref(py);
         let pool = pool_py.borrow(py);
@@ -3941,6 +3973,15 @@ fn py_to_lean(py: Python<'_>, arg: &Bound<'_, PyAny>) -> PyResult<String> {
             let pool = pool_py.borrow(py);
             core_simplify(expr.id, &pool.inner)
         };
+        // Part C: the default simplifier may leave the expression untouched
+        // (e.g. `exp(log(x))`, whose rewrite lives in `simplify_log_exp`, not
+        // the default set). Emitting `example : e = e := rfl` in that case reads
+        // as a proven theorem about `e` when nothing was actually derived. When
+        // no non-trivial rewrite occurred, withhold instead of presenting a
+        // vacuous reflexive identity as a certificate.
+        if derived.log.is_empty() {
+            return Ok(String::new());
+        }
         let pool = pool_py.borrow(py);
         return Ok(alkahest_core::emit_lean(&derived, &pool.inner));
     }

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -145,6 +145,29 @@ STRICT_CASES = [
         "diff_sin",
         lambda pool: alkahest.diff(alkahest.sin(pool.symbol("x") ** 3), pool.symbol("x")),
     ),
+    # Indefinite integrals, certified via the FTC derivative relation
+    # `deriv (fun x => F) x = f` (Part A). The recorded step is the integration
+    # rule; `to_lean` differentiates the antiderivative and certifies that.
+    (
+        "int_cos",
+        "int_cos",
+        lambda pool: alkahest.integrate(alkahest.cos(pool.symbol("x")), pool.symbol("x")),
+    ),
+    (
+        "int_sin",
+        "int_sin",
+        lambda pool: alkahest.integrate(alkahest.sin(pool.symbol("x")), pool.symbol("x")),
+    ),
+    (
+        "int_exp",
+        "int_exp",
+        lambda pool: alkahest.integrate(alkahest.exp(pool.symbol("x")), pool.symbol("x")),
+    ),
+    (
+        "int_power_x_squared",
+        "int_power_rule",
+        lambda pool: alkahest.integrate(pool.symbol("x") ** 2, pool.symbol("x")),
+    ),
 ]
 FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")
 

--- a/tests/lean_corpus_sample.py
+++ b/tests/lean_corpus_sample.py
@@ -19,12 +19,19 @@ lists to drift out of sync — see ``tests/_tg_helpers.py`` and
 ``tests/textbook_gate/*.py``, which this reuses as-is).
 
 ``alkahest.to_lean()`` deliberately WITHHOLDS a certificate (returns ``""``)
-for results it cannot certify soundly yet — most notably every
-``integrate()`` result, since integration certificates are not currently
-symbolically re-derivable (see the ``to_lean`` docstring in
-``alkahest-py/src/lib.rs``). Those withheld/empty certificates are
-correct-by-design and are skipped here, not treated as generation failures.
-Only genuinely emitted (non-empty) certificates are sampled and written out.
+for results it cannot certify soundly yet. Those withheld/empty certificates
+are correct-by-design and are skipped here, not treated as generation
+failures. Only genuinely emitted (non-empty) certificates are sampled and
+written out.
+
+Indefinite ``integrate()`` results now emit certificates via the FTC
+derivative relation ``deriv (fun x => F) x = f`` (see the ``to_lean`` docstring
+in ``alkahest-py/src/lib.rs``), but they are intentionally excluded from this
+*randomized* textbook-gate sample and covered instead by the deterministic
+strict corpus in ``tests/lean_corpus.py`` (the ``int_*`` cases). Keeping them
+out of the random pool avoids reshuffling the fixed-seed sample every time the
+integrator's coverage changes, while still verifying every emitted integration
+certificate against Lean in CI.
 
 Usage::
 
@@ -54,6 +61,10 @@ FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")
 # naturally filtered out below like any other empty cert, so including it
 # costs nothing and keeps this list matching "every derivation-producing
 # function the textbook gate exercises."
+# NOTE: `integrate` is deliberately omitted. Its certificates now emit (Part A,
+# via the FTC derivative relation) but are verified deterministically through
+# the strict corpus (`tests/lean_corpus.py`), not this randomized sample — see
+# the module docstring.
 RECORDED_FUNCTIONS = (
     "diff",
     "simplify",
@@ -61,7 +72,6 @@ RECORDED_FUNCTIONS = (
     "simplify_log_exp",
     "sum_indefinite",
     "sum_definite",
-    "integrate",
 )
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -301,10 +301,28 @@ def test_solver_linear_system():
 def test_lean_export():
     p = pool()
     x = p.symbol("x")
-    # to_lean takes an Expr, not a DerivedResult
-    lean = to_lean(x**2)
+    # to_lean takes an Expr, not a DerivedResult. A bare Expr whose default
+    # simplification does real work (here `x + 0 → x` via add_zero) emits a
+    # certificate of that derivation.
+    lean = to_lean(x + p.integer(0))
     assert isinstance(lean, str)
     assert len(lean) > 0
+    assert "add_zero" in lean or "simp" in lean
+
+
+def test_lean_export_withholds_vacuous_identity():
+    """Part C: a bare Expr the default simplifier leaves untouched has no
+    derivation, so `to_lean` must not present `example : e = e := rfl` (which
+    reads as a proven theorem). It withholds (returns "") instead."""
+    p = pool()
+    x = p.symbol("x")
+    # `x**2` is already canonical (empty derivation log). The rewrite that would
+    # touch `exp(log(x))` lives in `simplify_log_exp`, not the default set, so
+    # the default simplifier also leaves it untouched.
+    for expr in (x**2, exp(log(x))):
+        src = to_lean(expr)
+        assert src == "", f"vacuous identity must withhold, got: {src!r}"
+        assert "rfl" not in src
 
 
 def test_lean_diff_export():
@@ -320,15 +338,34 @@ def test_lean_diff_export():
     assert any(step["rule"] == "diff_univariate_poly" for step in result.steps)
 
 
-def test_lean_withholds_false_integrate_certificate():
-    """B3: ∫ sin must not emit the false equality `sin x = -cos x`."""
+def test_lean_integrate_certifies_via_ftc_derivative():
+    """Part A: ∫ f dx = F certifies via the FTC derivative relation
+    `deriv (fun x => F) x = f`, never the false unwrapped equality `f = F`
+    (e.g. `sin x = -cos x`)."""
     p = pool()
     x = p.symbol("x")
     r = integrate(sin(x), x)
-    assert r.certificate is None
-    assert to_lean(r) == ""
+    cert = r.certificate
+    assert isinstance(cert, str) and cert
+    assert to_lean(r) == cert
+    # The sound statement is the derivative relation, not `sin x = -cos x`.
+    assert "deriv (fun" in cert
+    assert "sorry" not in cert and "admit" not in cert
+    # Must never assert the false unwrapped integration equality.
+    assert "Real.sin ((x : ℝ)) = " not in cert
     # Residual check still labels the antiderivative as exact.
     assert r.verification["status"] == "exactly_verified"
+
+
+def test_lean_withholds_non_elementary_integrate_certificate():
+    """An antiderivative whose derivative escapes the certifiable diff fragment
+    (here `∫ log x dx`, differentiating via `diff_log`) stays withheld rather
+    than emitting an admission."""
+    p = pool()
+    x = p.symbol("x")
+    r = integrate(log(x), x)
+    assert r.certificate is None
+    assert to_lean(r) == ""
 
 
 def test_lean_diff_sin_certificate_has_no_sorry():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -346,11 +346,13 @@ def test_lean_integrate_certifies_via_ftc_derivative():
     x = p.symbol("x")
     r = integrate(sin(x), x)
     cert = r.certificate
-    assert isinstance(cert, str) and cert
+    assert isinstance(cert, str)
+    assert cert
     assert to_lean(r) == cert
     # The sound statement is the derivative relation, not `sin x = -cos x`.
     assert "deriv (fun" in cert
-    assert "sorry" not in cert and "admit" not in cert
+    assert "sorry" not in cert
+    assert "admit" not in cert
     # Must never assert the false unwrapped integration equality.
     assert "Real.sin ((x : ℝ)) = " not in cert
     # Residual check still labels the antiderivative as exact.


### PR DESCRIPTION
## Summary

Indefinite integrals previously withheld **all** Lean certificates. This certifies them soundly via the **FTC derivative relation**: `∫ f dx = F` is certified by proving `deriv (fun x => F) x = f`, reusing the existing differentiation-certificate machinery. In effect: certify ∫ by proving `d/dx F = f`.

## Part A — indefinite integral certificates (primary)

- `emit_integration_cert(F, integrand, var)` differentiates the antiderivative `F` and emits the diff certificate for `deriv (fun x => F) x = f`, reusing `emit_diff_header` / `diff_rule_to_tactic` / `step_is_certifiable` via `emit_lean_expr_wrt`.
- Gated so the certificate's final RHS is exactly the integrand (`d/dx F == f`, structurally) — this is precisely the exact-residual antiderivative check, so numeric-only antiderivatives stay withheld.
- A **structural fragment gate** withholds antiderivatives whose derivative certificate would escape the reliably-typechecking diff fragment:
  - chain composites `f(g x)` with `g ≠ x` (e.g. `exp(x²)`) — the product-rule simp set lacks the composite's `DifferentiableAt` lemma;
  - a sum nested inside a product (e.g. `-1·(a+b)`) — post-`simp` `ring` cannot reduce the nested `deriv`.
- Wired into the `certificate`, `verification`, and `to_lean` Python bindings.

**Certifies:** `∫cos=sin`, `∫sin=-cos`, `∫exp=exp`, `∫xⁿ`, `∫x⁻²`, `∫x·sin x`.
**Withholds:** `∫log x`, `∫1/x`, `∫x·exp(x²)`, `∫x²cos x`, and all non-elementary integrands.

Never emits `sorry`/`admit`.

## Part B — definite integrals (FTC-2)

**Withheld.** The continuity/interval hypotheses for `intervalIntegral.integral_deriv_eq_sub` were not discharged cleanly, so definite integrals continue to return no certificate (as before).

## Part C — `to_lean(Expr)` vacuous-rfl fix

The bare-`Expr` `to_lean` path ran the default simplifier and emitted `example : e = e := rfl` when nothing was derived (e.g. `exp(log(x))`, whose rewrite lives in `simplify_log_exp`, not the default set). It now returns `""` when the derivation log is empty, rather than presenting a vacuous reflexive identity as a proven theorem. `to_lean(exp(log(x)))` no longer emits a misleading rfl proof.

## Verification

- `cargo test -p alkahest-cas` — all pass (new lean unit tests for each integral shape).
- Strict Lean corpus (`tests/lean_corpus.py`, incl. new `int_cos`/`int_sin`/`int_exp`/`int_power`) — all 24 typecheck under `lake env lean -DwarningAsError=true`, no admissions.
- Randomized textbook-gate sampler — green. Indefinite `integrate` is kept out of the *randomized* pool (covered deterministically by the strict corpus) so the fixed-seed sample is not reshuffled by integrator-coverage changes.
- `tests/test_smoke.py`, `tests/test_agent_contract.py` — pass.

## Note

Differentiation-region edits were kept minimal to avoid conflicts with a parallel change to that region.