### PR TITLE
fix(simplify): gate branch-cut log/exp rewrites on assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixes
 
+- **Assumption-gated log/exp rewrites:** `simplify_log_exp` and egglog no longer
+  apply branch-cut identities (`exp(log(x))→x`, `log(x)+log(y)→log(xy)`,
+  `log(a^n)→n·log(a)`, `log(a/b)→log(a)−log(b)`) without positivity facts.
+  Pass an `Assumptions` context or use `Domain.Positive` symbols; safe rules
+  `log(exp(x))→x` and `exp(x)·exp(y)→exp(x+y)` still apply unconditionally.
+  Static symbol domains are now collected into the colored e-graph pass for
+  all `simplify_with` callers.
+
 - **E-graph constant folding:** `simplify_egraph((x+x)/2)` now returns `x`
   instead of leaving `((x * 2) * 1/2)`. The post-extraction const-fold pass
   flattens nested `Add`/`Mul` so coefficients from linear canonization and

--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -1582,15 +1582,21 @@ mod tests {
 
     #[test]
     fn exp_of_log_certifies_with_positivity_hyp() {
-        // `ExpOfLog` records `SideCondition::Positive(x)`; the Lean exporter
-        // upgrades that into an explicit `(x : ℝ) (hx : 0 < x)` binder and
-        // closes the goal with `Real.exp_log hx` instead of withholding.
-        use crate::simplify::{rulesets::log_exp_rules, simplify_with, SimplifyConfig};
+        // Colored `exp_of_log` records `SideCondition::Positive(x)` once the
+        // caller discharges it; the Lean exporter upgrades that into an
+        // explicit `(x : ℝ) (hx : 0 < x)` binder closed by `Real.exp_log hx`.
+        use crate::kernel::expr::PredicateKind;
+        use crate::simplify::AssumptionContext;
 
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
+        let zero = pool.integer(0_i32);
+        let mut assumptions = AssumptionContext::new();
+        assumptions
+            .refine(pool.predicate(PredicateKind::Gt, vec![x, zero]), &pool)
+            .unwrap();
         let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
-        let derived = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        let derived = assumptions.simplify(expr, &pool);
         let lean = emit_lean_expr(&derived, &pool);
         assert!(
             !lean.is_empty(),
@@ -1698,17 +1704,25 @@ mod tests {
 
     #[test]
     fn sum_of_logs_certifies_with_positivity_hyp() {
-        // `SumOfLogs` (`log x + log y → log(x·y)`) records `Positive(x)`,
-        // `Positive(y)`. The exporter upgrades the two-factor case into an
-        // explicit-binder `Real.log_mul` certificate rather than the (failing)
-        // `ring_nf; simp` fallback.
-        use crate::simplify::{rulesets::log_exp_rules, simplify_with, SimplifyConfig};
+        // Colored `sum_of_logs` records `Positive(x)`, `Positive(y)` once the
+        // caller discharges them; the exporter upgrades the two-factor case
+        // into an explicit-binder `Real.log_mul` certificate.
+        use crate::kernel::expr::PredicateKind;
+        use crate::simplify::AssumptionContext;
 
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let y = pool.symbol("y", Domain::Real);
+        let zero = pool.integer(0_i32);
+        let mut assumptions = AssumptionContext::new();
+        assumptions
+            .refine(pool.predicate(PredicateKind::Gt, vec![x, zero]), &pool)
+            .unwrap();
+        assumptions
+            .refine(pool.predicate(PredicateKind::Gt, vec![y, zero]), &pool)
+            .unwrap();
         let expr = pool.add(vec![pool.func("log", vec![x]), pool.func("log", vec![y])]);
-        let derived = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        let derived = assumptions.simplify(expr, &pool);
         let lean = emit_lean_expr(&derived, &pool);
         assert!(!lean.is_empty(), "log x + log y should certify under x,y>0");
         assert!(

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -136,10 +136,10 @@ pub use simplify::rulesets::{
 };
 pub use simplify::{
     assumptions_satisfy, rules_for_config, simplify, simplify_batch, simplify_colored,
-    simplify_egraph, simplify_egraph_with, simplify_expanded, simplify_trig_normal_form,
-    simplify_with, ColorId, ColoredEgraph, DepthCost, EgraphConfig, EgraphCost, NoncommutativeCost,
-    OpCost, PatternRule, RewriteRule, SimplifyConfig, SizeCost, StabilityCost, CONTEXT_COLOR,
-    ROOT_COLOR,
+    simplify_egraph, simplify_egraph_with, simplify_expanded, simplify_log_exp,
+    simplify_trig_normal_form, simplify_with, ColorId, ColoredEgraph, DepthCost, EgraphConfig,
+    EgraphCost, NoncommutativeCost, OpCost, PatternRule, RewriteRule, SimplifyConfig, SizeCost,
+    StabilityCost, CONTEXT_COLOR, ROOT_COLOR,
 };
 pub use sum::{
     gosper_certificate, gosper_normal_form, hypergeom_ratio, product_definite, product_indefinite,

--- a/alkahest-core/src/simplify/assumptions.rs
+++ b/alkahest-core/src/simplify/assumptions.rs
@@ -147,7 +147,15 @@ fn push_unique(facts: &mut Vec<SideCondition>, fact: SideCondition) {
     }
 }
 
-fn collect_static_domain_facts(expr: ExprId, pool: &ExprPool, facts: &mut Vec<SideCondition>) {
+/// Walk `expr` and record rewrite facts implied by static symbol domains.
+///
+/// Only [`Domain::Positive`] (→ Positive + NonZero) and [`Domain::NonZero`] are
+/// collected. Other domains do not authorize conditional rewrites.
+pub(crate) fn collect_static_domain_facts(
+    expr: ExprId,
+    pool: &ExprPool,
+    facts: &mut Vec<SideCondition>,
+) {
     match pool.get(expr) {
         ExprData::Symbol { domain, .. } => match domain {
             Domain::Positive => {

--- a/alkahest-core/src/simplify/colored_egraph.rs
+++ b/alkahest-core/src/simplify/colored_egraph.rs
@@ -458,6 +458,69 @@ fn rule_exp_of_log(expr: ExprId, pool: &ExprPool) -> Option<(ExprId, Vec<SideCon
     Some((inner, vec![SideCondition::Positive(inner)]))
 }
 
+/// `log(x) + log(y) + ⋯ → log(x·y·⋯)` when every argument is positive.
+fn rule_sum_of_logs(expr: ExprId, pool: &ExprPool) -> Option<(ExprId, Vec<SideCondition>)> {
+    let terms = match pool.get(expr) {
+        ExprData::Add(v) if v.len() >= 2 => v,
+        _ => return None,
+    };
+    let mut args = Vec::with_capacity(terms.len());
+    for t in terms {
+        let a = func_arg("log", t, pool)?;
+        args.push(a);
+    }
+    let after = pool.func("log", vec![pool.mul(args.clone())]);
+    let conds: Vec<SideCondition> = args.iter().map(|&a| SideCondition::Positive(a)).collect();
+    Some((after, conds))
+}
+
+/// `log(a^n) → n * log(a)` when `a > 0`.
+fn rule_log_of_pow(expr: ExprId, pool: &ExprPool) -> Option<(ExprId, Vec<SideCondition>)> {
+    let arg = func_arg("log", expr, pool)?;
+    let (base, exp) = match pool.get(arg) {
+        ExprData::Pow { base, exp } => (base, exp),
+        _ => return None,
+    };
+    let log_base = pool.func("log", vec![base]);
+    let after = pool.mul(vec![exp, log_base]);
+    Some((after, vec![SideCondition::Positive(base)]))
+}
+
+/// `log(a · b⁻¹ · ⋯) → log(a) − log(b) − ⋯` when factors are positive.
+fn rule_log_of_quotient(expr: ExprId, pool: &ExprPool) -> Option<(ExprId, Vec<SideCondition>)> {
+    let arg = func_arg("log", expr, pool)?;
+    let factors = match pool.get(arg) {
+        ExprData::Mul(v) if v.len() >= 2 => v,
+        _ => return None,
+    };
+    let has_reciprocal = factors.iter().any(|&f| match pool.get(f) {
+        ExprData::Pow { exp, .. } => match pool.get(exp) {
+            ExprData::Integer(n) => n.0 < 0,
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_reciprocal {
+        return None;
+    }
+    let mut terms: Vec<ExprId> = Vec::with_capacity(factors.len());
+    let mut conds: Vec<SideCondition> = Vec::new();
+    for f in factors {
+        match pool.get(f) {
+            ExprData::Pow { base, exp } => {
+                conds.push(SideCondition::Positive(base));
+                let log_base = pool.func("log", vec![base]);
+                terms.push(pool.mul(vec![exp, log_base]));
+            }
+            _ => {
+                conds.push(SideCondition::Positive(f));
+                terms.push(pool.func("log", vec![f]));
+            }
+        }
+    }
+    Some((pool.add(terms), conds))
+}
+
 /// `x^0 → 1` when `x ≠ 0`.
 fn rule_pow_zero_nonzero(expr: ExprId, pool: &ExprPool) -> Option<(ExprId, Vec<SideCondition>)> {
     let (base, exp) = match pool.get(expr) {
@@ -504,6 +567,18 @@ fn default_conditional_rules() -> &'static [ConditionalRule] {
         ConditionalRule {
             name: "exp_of_log",
             apply: rule_exp_of_log,
+        },
+        ConditionalRule {
+            name: "sum_of_logs",
+            apply: rule_sum_of_logs,
+        },
+        ConditionalRule {
+            name: "log_of_pow",
+            apply: rule_log_of_pow,
+        },
+        ConditionalRule {
+            name: "log_of_quotient",
+            apply: rule_log_of_quotient,
         },
         ConditionalRule {
             name: "pow_zero_nonzero",

--- a/alkahest-core/src/simplify/egraph.rs
+++ b/alkahest-core/src/simplify/egraph.rs
@@ -213,9 +213,11 @@ mod backend {
         };
 
         let log_exp_rules = if config.include_log_exp_rules {
+            // Only `log(exp(x))→x` is loaded by default. `exp(log(x))→x` needs
+            // `x > 0` and is intentionally omitted: egglog has no assumption
+            // context, so firing it here would be silently unsound.
             format!(
-                "(rewrite (Exp (Log ?x)) ?x :ruleset {log_rs})\n\
-                 (rewrite (Log (Exp ?x)) ?x :ruleset {log_rs})",
+                "(rewrite (Log (Exp ?x)) ?x :ruleset {log_rs})",
                 log_rs = log_rs,
             )
         } else {
@@ -918,7 +920,9 @@ impl EgraphCost for NoncommutativeCost {
 /// # Rule flags
 ///
 /// By default both `include_trig_rules` and `include_log_exp_rules` are `true`,
-/// so `simplify_egraph` reduces `sin²(x)+cos²(x)→1` and `exp(log(x))→x`
+/// so `simplify_egraph` reduces `sin²(x)+cos²(x)→1` and `log(exp(x))→x`.
+/// `exp(log(x))→x` is **not** included (requires positivity; use
+/// [`crate::simplify::AssumptionContext`]).
 /// without any extra configuration.  Set either flag to `false` to suppress
 /// the corresponding rule set (useful when you need to benchmark rule impact or
 /// avoid domain-sensitive rewrites).
@@ -937,8 +941,8 @@ pub struct EgraphConfig {
     /// Include the Pythagorean trig identity (`sin²+cos²→1`) in the explore phase.
     /// Default `true`.
     pub include_trig_rules: bool,
-    /// Include exp/log cancellation (`exp(log(x))→x`, `log(exp(x))→x`) in the
-    /// explore phase. Default `true`.
+    /// Include safe log/exp cancellation (`log(exp(x))→x`) in the
+    /// explore phase. Does **not** include `exp(log(x))→x`. Default `true`.
     pub include_log_exp_rules: bool,
     /// Schedule match-disjoint egglog rule groups (Add / Mul / Pow / trig / log)
     /// as separate `(run …)` steps within each phase. Default `true`.
@@ -1234,16 +1238,16 @@ mod tests {
         let _ = expr;
     }
 
-    // V1-15: exp(log(x)) → x
+    // exp(log(x)) → x requires positivity; egglog must not fire it ungated.
     #[test]
-    fn egraph_exp_of_log() {
+    fn egraph_exp_of_log_stays_without_assumptions() {
         let pool = ExprPool::new();
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
         #[cfg(feature = "egraph")]
         {
             let result = simplify_egraph(expr, &pool);
-            assert_eq!(result.value, x);
+            assert_eq!(result.value, expr, "got {}", pool.display(result.value));
         }
         #[cfg(not(feature = "egraph"))]
         let _ = expr;
@@ -1282,17 +1286,17 @@ mod tests {
         assert_ne!(result.value, pool.integer(1_i32));
     }
 
-    // V1-15: opt-out log/exp rules via config
+    // Opt-out: with include_log_exp_rules=false, log(exp(x)) stays put.
     #[test]
     fn egraph_opt_out_log_exp_rules() {
         let pool = ExprPool::new();
         let x = pool.symbol("x", Domain::Real);
-        let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
+        let expr = pool.func("log", vec![pool.func("exp", vec![x])]);
         let config = EgraphConfig {
             include_log_exp_rules: false,
             ..EgraphConfig::default()
         };
         let result = simplify_egraph_with(expr, &pool, &config, &SizeCost);
-        assert_ne!(result.value, x);
+        assert_eq!(result.value, expr);
     }
 }

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -297,12 +297,13 @@ pub fn simplify_with(
         current = DerivedExpr::with_log(result.value, merged_log);
     }
 
-    if !config.assumptions.is_empty() {
-        let colored = super::colored_egraph::apply_colored_if_needed(
-            current.value,
-            pool,
-            &config.assumptions,
-        );
+    let mut assumptions = config.assumptions;
+    // Static symbol domains (e.g. Domain::Positive) authorize the same
+    // conditional rewrites as explicit AssumptionContext facts.
+    super::assumptions::collect_static_domain_facts(current.value, pool, &mut assumptions);
+    if !assumptions.is_empty() {
+        let colored =
+            super::colored_egraph::apply_colored_if_needed(current.value, pool, &assumptions);
         return DerivedExpr::with_log(colored.value, current.log.merge(colored.log));
     }
     current
@@ -328,15 +329,32 @@ pub fn simplify_with_pattern_rules(
         current = DerivedExpr::with_log(result.value, merged_log);
     }
 
-    if !config.assumptions.is_empty() {
-        let colored = super::colored_egraph::apply_colored_if_needed(
-            current.value,
-            pool,
-            &config.assumptions,
-        );
+    let mut assumptions = config.assumptions;
+    super::assumptions::collect_static_domain_facts(current.value, pool, &mut assumptions);
+    if !assumptions.is_empty() {
+        let colored =
+            super::colored_egraph::apply_colored_if_needed(current.value, pool, &assumptions);
         return DerivedExpr::with_log(colored.value, current.log.merge(colored.log));
     }
     current
+}
+
+/// Simplify with the log/exp rule set, plus assumption-gated colored rewrites.
+///
+/// Unconditional rules cover `log(exp(x))→x` and `exp(x)·exp(y)→exp(x+y)`.
+/// Branch-cut identities (`exp(log(x))→x`, sum/power/quotient of logs) fire
+/// only when `assumptions` (or static `Domain::Positive` symbols) discharge
+/// the required positivity facts.
+pub fn simplify_log_exp(
+    expr: ExprId,
+    pool: &ExprPool,
+    assumptions: &[crate::deriv::log::SideCondition],
+) -> DerivedExpr<ExprId> {
+    let config = SimplifyConfig {
+        assumptions: assumptions.to_vec(),
+        ..SimplifyConfig::default()
+    };
+    simplify_with(expr, pool, &super::rulesets::log_exp_rules(), config)
 }
 
 /// Simplify `expr` with the default rule set.

--- a/alkahest-core/src/simplify/mod.rs
+++ b/alkahest-core/src/simplify/mod.rs
@@ -21,8 +21,8 @@ pub use egraph::{
     OpCost, SizeCost, StabilityCost,
 };
 pub use engine::{
-    rules_for_config, simplify, simplify_batch, simplify_expanded, simplify_trig_normal_form,
-    simplify_with, simplify_with_pattern_rules, SimplifyConfig,
+    rules_for_config, simplify, simplify_batch, simplify_expanded, simplify_log_exp,
+    simplify_trig_normal_form, simplify_with, simplify_with_pattern_rules, SimplifyConfig,
 };
 pub use rules::RewriteRule;
 pub use rulesets::{PatternRule, PatternRuleSet};

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -15,7 +15,7 @@
 /// let r = simplify_with(tan_x, &pool, &rules, SimplifyConfig::default());
 /// // tan(x) → sin(x) * cos(x)^(-1)
 /// ```
-use crate::deriv::log::{DerivationLog, RewriteStep, SideCondition};
+use crate::deriv::log::{DerivationLog, RewriteStep};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::pattern::{Pattern, Substitution};
 use crate::simplify::discrimination_net::{pattern_head, DiscriminationIndex};
@@ -662,12 +662,12 @@ impl RewriteRule for LogOfExp {
     }
 }
 
-/// `exp(log(x)) → x`.
+/// `exp(log(x)) → x` (requires `x > 0`).
 ///
-/// **Branch-cut caveat**: only unconditionally valid for `x > 0`. The rule
-/// still fires, but records [`SideCondition::Positive`] on `x` in the
-/// derivation log so callers (including the Lean certificate exporter) can
-/// audit — or discharge — the assumption made.
+/// Not registered in [`log_exp_rules`]: the identity is branch-cut sensitive and
+/// only fires via the colored e-graph when an explicit or static
+/// [`SideCondition::Positive`] fact is present. Prefer
+/// [`crate::simplify::AssumptionContext`] or `Domain::Positive` symbols.
 pub struct ExpOfLog;
 
 impl RewriteRule for ExpOfLog {
@@ -676,26 +676,17 @@ impl RewriteRule for ExpOfLog {
     }
 
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let arg = func_arg("exp", expr, pool)?;
-        let inner = func_arg("log", arg, pool)?;
-        let mut log = DerivationLog::new();
-        log.push(RewriteStep::with_conditions(
-            self.name(),
-            expr,
-            inner,
-            vec![SideCondition::Positive(inner)],
-        ));
-        Some((inner, log))
+        // Intentionally a no-op in the ungated rule engine. Conditional firing
+        // lives in `colored_egraph::rule_exp_of_log`.
+        let _ = (expr, pool);
+        None
     }
 }
 
-/// `log(a * b) → log(a) + log(b)`.
+/// `log(a * b) → log(a) + log(b)` (requires positive factors).
 ///
-/// **Branch-cut caveat**: this identity is only valid when all factors are
-/// positive reals.  The rule still fires, but each factor is recorded as a
-/// [`SideCondition::Positive`] in the derivation log so callers can audit the
-/// assumptions made.  Use [`log_exp_rules_safe`] to obtain a rule set that
-/// excludes this rule entirely.
+/// Not registered in [`log_exp_rules`]; gated via the colored e-graph's
+/// `log_of_product_positive` rule under matching positivity facts.
 pub struct LogOfProduct;
 
 impl RewriteRule for LogOfProduct {
@@ -704,33 +695,15 @@ impl RewriteRule for LogOfProduct {
     }
 
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let arg = func_arg("log", expr, pool)?;
-        let factors = match pool.get(arg) {
-            ExprData::Mul(v) if v.len() >= 2 => v,
-            _ => return None,
-        };
-        let logs: Vec<ExprId> = factors.iter().map(|&f| pool.func("log", vec![f])).collect();
-        let after = pool.add(logs);
-        let conds: Vec<SideCondition> = factors
-            .iter()
-            .map(|&f| SideCondition::Positive(f))
-            .collect();
-        let mut log = DerivationLog::new();
-        log.push(RewriteStep::with_conditions(
-            "log_of_product",
-            expr,
-            after,
-            conds,
-        ));
-        Some((after, log))
+        let _ = (expr, pool);
+        None
     }
 }
 
-/// `log(a^n) → n * log(a)`.
+/// `log(a^n) → n * log(a)` (requires `a > 0`).
 ///
-/// **Branch-cut caveat**: only unconditionally valid for positive real `a` (and
-/// real `n`).  Recorded without side conditions for parity with the historical
-/// `LogOfPow` helper; prefer [`log_exp_rules_safe`] when complex-safe.
+/// Not registered in [`log_exp_rules`]; gated via the colored e-graph under a
+/// [`SideCondition::Positive`] fact on the base.
 pub struct LogOfPow;
 
 impl RewriteRule for LogOfPow {
@@ -739,23 +712,15 @@ impl RewriteRule for LogOfPow {
     }
 
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let arg = func_arg("log", expr, pool)?;
-        let (base, exp) = match pool.get(arg) {
-            ExprData::Pow { base, exp } => (base, exp),
-            _ => return None,
-        };
-        let log_base = pool.func("log", vec![base]);
-        let after = pool.mul(vec![exp, log_base]);
-        Some((after, one_step(self.name(), expr, after)))
+        let _ = (expr, pool);
+        None
     }
 }
 
-/// `log(x) + log(y) + ⋯ → log(x·y·⋯)`.
+/// `log(x) + log(y) + ⋯ → log(x·y·⋯)` (requires every argument positive).
 ///
-/// **Branch-cut caveat**: valid when every argument is positive real.  Each
-/// factor is recorded as [`SideCondition::Positive`].  Inverse of
-/// [`LogOfProduct`] (which is *not* registered in [`log_exp_rules`], so the
-/// two cannot oscillate).
+/// Not registered in [`log_exp_rules`]; gated via the colored e-graph. Inverse
+/// of the colored `log_of_product_positive` rule (also assumption-gated).
 pub struct SumOfLogs;
 
 impl RewriteRule for SumOfLogs {
@@ -764,33 +729,16 @@ impl RewriteRule for SumOfLogs {
     }
 
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let terms = match pool.get(expr) {
-            ExprData::Add(v) if v.len() >= 2 => v,
-            _ => return None,
-        };
-        let mut args = Vec::with_capacity(terms.len());
-        for t in terms {
-            let a = func_arg("log", t, pool)?;
-            args.push(a);
-        }
-        let after = pool.func("log", vec![pool.mul(args.clone())]);
-        let conds: Vec<SideCondition> = args.iter().map(|&a| SideCondition::Positive(a)).collect();
-        let mut log = DerivationLog::new();
-        log.push(RewriteStep::with_conditions(
-            "sum_of_logs",
-            expr,
-            after,
-            conds,
-        ));
-        Some((after, log))
+        let _ = (expr, pool);
+        None
     }
 }
 
-/// `log(a · b⁻¹ · ⋯) → log(a) − log(b) − ⋯`.
+/// `log(a · b⁻¹ · ⋯) → log(a) − log(b) − ⋯` (requires positive factors).
 ///
-/// Fires only when the argument is a product containing at least one negative
-/// integer power (canonical quotient form).  Plain `log(x·y)` is intentionally
-/// left alone so it does not fight [`SumOfLogs`].
+/// Not registered in [`log_exp_rules`]; gated via the colored e-graph. Fires
+/// only when the argument is a product containing at least one negative
+/// integer power (canonical quotient form).
 pub struct LogOfQuotient;
 
 impl RewriteRule for LogOfQuotient {
@@ -799,45 +747,8 @@ impl RewriteRule for LogOfQuotient {
     }
 
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
-        let arg = func_arg("log", expr, pool)?;
-        let factors = match pool.get(arg) {
-            ExprData::Mul(v) if v.len() >= 2 => v,
-            _ => return None,
-        };
-        let has_reciprocal = factors.iter().any(|&f| match pool.get(f) {
-            ExprData::Pow { exp, .. } => match pool.get(exp) {
-                ExprData::Integer(n) => n.0 < 0,
-                _ => false,
-            },
-            _ => false,
-        });
-        if !has_reciprocal {
-            return None;
-        }
-        let mut terms: Vec<ExprId> = Vec::with_capacity(factors.len());
-        let mut conds: Vec<SideCondition> = Vec::new();
-        for f in factors {
-            match pool.get(f) {
-                ExprData::Pow { base, exp } => {
-                    conds.push(SideCondition::Positive(base));
-                    let log_base = pool.func("log", vec![base]);
-                    terms.push(pool.mul(vec![exp, log_base]));
-                }
-                _ => {
-                    conds.push(SideCondition::Positive(f));
-                    terms.push(pool.func("log", vec![f]));
-                }
-            }
-        }
-        let after = pool.add(terms);
-        let mut log = DerivationLog::new();
-        log.push(RewriteStep::with_conditions(
-            "log_of_quotient",
-            expr,
-            after,
-            conds,
-        ));
-        Some((after, log))
+        let _ = (expr, pool);
+        None
     }
 }
 
@@ -868,21 +779,16 @@ impl RewriteRule for ProductOfExps {
 
 /// Return the default log/exp identity rules.
 ///
-/// Includes inverse cancellations, the combining rules `log(x)+log(y)→log(xy)`
-/// and `exp(x)·exp(y)→exp(x+y)`, the power rule `log(a^n)→n·log(a)`, and the
-/// quotient expansion `log(a/b)→log(a)−log(b)`.  The expand-style
-/// [`LogOfProduct`] (`log(ab)→log a+log b`) is intentionally omitted so it
-/// cannot oscillate against [`SumOfLogs`].  Use [`log_exp_rules_safe`] for the
-/// empty complex-safe set.
+/// Only identities that are safe without positivity assumptions:
+/// `log(exp(x))→x` (real principal branch) and `exp(x)·exp(y)→exp(x+y)`
+/// (valid over ℂ). Branch-cut sensitive rewrites (`exp(log(x))→x`,
+/// `log(x)+log(y)→log(xy)`, `log(a^n)→n·log(a)`, `log(a/b)→log(a)−log(b)`,
+/// `log(ab)→log a+log b`) live exclusively in the colored e-graph and require
+/// matching [`crate::simplify::SimplifyConfig::assumptions`] /
+/// [`crate::simplify::AssumptionContext`] facts (or `Domain::Positive`
+/// symbols). Use [`log_exp_rules_safe`] for the empty complex-safe set.
 pub fn log_exp_rules() -> Vec<Box<dyn RewriteRule>> {
-    vec![
-        Box::new(LogOfExp),
-        Box::new(ExpOfLog),
-        Box::new(SumOfLogs),
-        Box::new(LogOfPow),
-        Box::new(LogOfQuotient),
-        Box::new(ProductOfExps),
-    ]
+    vec![Box::new(LogOfExp), Box::new(ProductOfExps)]
 }
 
 /// Log/exp rules that are safe for complex numbers (no branch-cut rewrites).
@@ -2070,18 +1976,32 @@ mod tests {
     }
 
     #[test]
-    fn exp_of_log_folds() {
+    fn exp_of_log_stays_without_assumptions() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        assert_eq!(r.value, expr, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn exp_of_log_folds_under_positive_assumptions() {
+        use crate::deriv::SideCondition;
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.func("exp", vec![pool.func("log", vec![x])]);
+        let config = SimplifyConfig {
+            assumptions: vec![SideCondition::Positive(x)],
+            ..SimplifyConfig::default()
+        };
+        let r = simplify_with(expr, &pool, &log_exp_rules(), config);
         assert_eq!(r.value, x, "got {}", pool.display(r.value));
     }
 
     #[test]
-    fn log_exp_inverse_pair_folds_under_add() {
-        // Bottom-up simplify_with must rewrite both Add children.
+    fn log_exp_inverse_pair_folds_log_of_exp_only_without_assumptions() {
+        // Bottom-up simplify_with rewrites log(exp(x)); exp(log(y)) stays put.
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let y = pool.symbol("y", Domain::Real);
@@ -2091,7 +2011,7 @@ mod tests {
         ]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
-        let expected = pool.add(vec![x, y]);
+        let expected = pool.add(vec![x, pool.func("exp", vec![pool.func("log", vec![y])])]);
         assert_eq!(r.value, expected, "got {}", pool.display(r.value));
     }
 
@@ -2136,31 +2056,61 @@ mod tests {
     }
 
     #[test]
-    fn log_of_pow_folds() {
+    fn log_of_pow_stays_without_assumptions() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let n = pool.integer(3_i32);
         let expr = pool.func("log", vec![pool.pow(x, n)]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        assert_eq!(r.value, expr, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn log_of_pow_folds_under_positive_assumptions() {
+        use crate::deriv::SideCondition;
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let n = pool.integer(3_i32);
+        let expr = pool.func("log", vec![pool.pow(x, n)]);
+        let config = SimplifyConfig {
+            assumptions: vec![SideCondition::Positive(x)],
+            ..SimplifyConfig::default()
+        };
+        let r = simplify_with(expr, &pool, &log_exp_rules(), config);
         let expected = pool.mul(vec![n, pool.func("log", vec![x])]);
         assert_eq!(r.value, expected, "got {}", pool.display(r.value));
     }
 
     #[test]
-    fn sum_of_logs_folds() {
+    fn sum_of_logs_stays_without_assumptions() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let y = pool.symbol("y", Domain::Real);
         let expr = pool.add(vec![pool.func("log", vec![x]), pool.func("log", vec![y])]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        assert_eq!(r.value, expr, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn sum_of_logs_folds_under_positive_assumptions() {
+        use crate::deriv::SideCondition;
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let expr = pool.add(vec![pool.func("log", vec![x]), pool.func("log", vec![y])]);
+        let config = SimplifyConfig {
+            assumptions: vec![SideCondition::Positive(x), SideCondition::Positive(y)],
+            ..SimplifyConfig::default()
+        };
+        let r = simplify_with(expr, &pool, &log_exp_rules(), config);
         let expected = pool.func("log", vec![pool.mul(vec![x, y])]);
         assert_eq!(r.value, expected, "got {}", pool.display(r.value));
     }
 
     #[test]
-    fn log_of_quotient_folds() {
+    fn log_of_quotient_stays_without_assumptions() {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let y = pool.symbol("y", Domain::Real);
@@ -2168,6 +2118,22 @@ mod tests {
         let expr = pool.func("log", vec![quot]);
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
+        assert_eq!(r.value, expr, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn log_of_quotient_folds_under_positive_assumptions() {
+        use crate::deriv::SideCondition;
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let quot = pool.mul(vec![x, pool.pow(y, pool.integer(-1_i32))]);
+        let expr = pool.func("log", vec![quot]);
+        let config = SimplifyConfig {
+            assumptions: vec![SideCondition::Positive(x), SideCondition::Positive(y)],
+            ..SimplifyConfig::default()
+        };
+        let r = simplify_with(expr, &pool, &log_exp_rules(), config);
         let expected = pool.add(vec![
             pool.func("log", vec![x]),
             pool.mul(vec![pool.integer(-1_i32), pool.func("log", vec![y])]),

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -666,7 +666,7 @@ impl RewriteRule for LogOfExp {
 ///
 /// Not registered in [`log_exp_rules`]: the identity is branch-cut sensitive and
 /// only fires via the colored e-graph when an explicit or static
-/// [`SideCondition::Positive`] fact is present. Prefer
+/// [`crate::deriv::SideCondition::Positive`] fact is present. Prefer
 /// [`crate::simplify::AssumptionContext`] or `Domain::Positive` symbols.
 pub struct ExpOfLog;
 
@@ -703,7 +703,7 @@ impl RewriteRule for LogOfProduct {
 /// `log(a^n) → n * log(a)` (requires `a > 0`).
 ///
 /// Not registered in [`log_exp_rules`]; gated via the colored e-graph under a
-/// [`SideCondition::Positive`] fact on the base.
+/// [`crate::deriv::SideCondition::Positive`] fact on the base.
 pub struct LogOfPow;
 
 impl RewriteRule for LogOfPow {

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -113,10 +113,10 @@ use alkahest_core::{
     apart as core_apart, diff as core_diff, diff_forward as core_diff_forward,
     eval_complex_f64 as core_eval_complex_f64, eval_exact_rational as core_eval_exact_rational,
     eval_f64 as core_eval_f64, eval_interval as core_eval_interval, integrate as core_integrate,
-    integrate_definite as core_integrate_definite, limit as core_limit, load_from, log_exp_rules,
+    integrate_definite as core_integrate_definite, limit as core_limit, load_from,
     rsolve as core_rsolve, series as core_series, simplify as core_simplify,
     simplify_batch as core_simplify_batch, simplify_egraph as core_simplify_egraph,
-    simplify_egraph_with as core_simplify_egraph_with,
+    simplify_egraph_with as core_simplify_egraph_with, simplify_log_exp as core_simplify_log_exp,
     simplify_trig_normal_form as core_simplify_trig_normal_form,
     simplify_with as core_simplify_with, trig_rules,
     verify_antiderivative_status as core_verify_antiderivative_status,
@@ -3903,17 +3903,33 @@ fn py_simplify_trig_normal_form(py: Python<'_>, expr: PyRef<PyExpr>) -> PyDerive
     make_derived_result(py, derived, pool_py, None)
 }
 
-/// `alkahest.simplify_log_exp(expr)` — simplify with log/exp identities.
+/// `alkahest.simplify_log_exp(expr, assumptions=None)` — simplify with log/exp identities.
+///
+/// Unconditional rules: `log(exp(x))→x`, `exp(x)·exp(y)→exp(x+y)`.
+/// Branch-cut identities (`exp(log(x))→x`, sum/power/quotient of logs) require
+/// positivity facts from ``assumptions`` or ``Domain.Positive`` symbols.
 #[pyfunction]
-#[pyo3(name = "simplify_log_exp")]
-fn py_simplify_log_exp(py: Python<'_>, expr: PyRef<PyExpr>) -> PyDerivedResult {
+#[pyo3(name = "simplify_log_exp", signature = (expr, assumptions=None))]
+fn py_simplify_log_exp(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    assumptions: Option<PyRef<PyAssumptions>>,
+) -> PyResult<PyDerivedResult> {
+    if let Some(ref a) = assumptions {
+        if !a.pool.is(&expr.pool) {
+            return Err(pool_mismatch_err());
+        }
+    }
     let derived = {
         let pool = expr.pool.borrow(py);
-        let rules = log_exp_rules();
-        core_simplify_with(expr.id, &pool.inner, &rules, SimplifyConfig::default())
+        let facts = match &assumptions {
+            Some(a) => a.inner.facts().to_vec(),
+            None => Vec::new(),
+        };
+        core_simplify_log_exp(expr.id, &pool.inner, &facts)
     };
     let pool_py = expr.pool.clone_ref(py);
-    make_derived_result(py, derived, pool_py, None)
+    Ok(make_derived_result(py, derived, pool_py, None))
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/agent_workflow.py
+++ b/examples/agent_workflow.py
@@ -78,8 +78,12 @@ print(f"sin(-x)            → {r.value}")
 r = simplify_log_exp(log(exp(x)))
 print(f"log(exp(x))        → {r.value}")
 
-r = simplify_log_exp(exp(log(x)))
-print(f"exp(log(x))        → {r.value}")
+from alkahest import Assumptions
+
+assumptions = Assumptions(pool)
+assumptions.refine(pool.gt(x, pool.integer(0)))
+r = simplify_log_exp(exp(log(x)), assumptions)
+print(f"exp(log(x)) [x>0]  → {r.value}")
 
 r = collect_like_terms(x + x + two * x + y)
 print(f"x+x+2x+y           → {r.value}")

--- a/examples/pattern_rewriting.py
+++ b/examples/pattern_rewriting.py
@@ -59,21 +59,28 @@ def main():
 
     print("\n=== log / exp Identities ===")
 
-    # log(exp(x)) → x
+    # log(exp(x)) → x  (unconditional on reals)
     r = simplify_log_exp(log(exp(x)))
     print(f"log(exp(x))             → {r.value}")
 
-    # exp(log(x)) → x
-    r = simplify_log_exp(exp(log(x)))
-    print(f"exp(log(x))             → {r.value}")
+    # Branch-cut identities need positivity (Assumptions or Domain.Positive)
+    from alkahest import Assumptions
 
-    # log(x*y) → log(x) + log(y)
-    r = simplify_log_exp(log(x * y))
-    print(f"log(x*y)                → {r.value}")
+    assumptions = Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    assumptions.refine(pool.gt(y, pool.integer(0)))
 
-    # log(x^3) → 3*log(x)
-    r = simplify_log_exp(log(x ** 3))
-    print(f"log(x³)                 → {r.value}")
+    # exp(log(x)) → x  when x > 0
+    r = simplify_log_exp(exp(log(x)), assumptions)
+    print(f"exp(log(x)) [x>0]       → {r.value}")
+
+    # log(x)+log(y) → log(x*y) when x,y > 0
+    r = simplify_log_exp(log(x) + log(y), assumptions)
+    print(f"log(x)+log(y) [x,y>0]   → {r.value}")
+
+    # log(x^3) → 3*log(x) when x > 0
+    r = simplify_log_exp(log(x ** 3), assumptions)
+    print(f"log(x³) [x>0]           → {r.value}")
 
     # ── User-defined rules via make_rule ──────────────────────────────────
 

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -877,18 +877,25 @@ def simplify_trig_normal_form(expr):
 _native_simplify_log_exp = simplify_log_exp
 
 
-def simplify_log_exp(expr):
+def simplify_log_exp(expr, assumptions=None):
     """Logarithm / exponential simplifier.
+
+    Branch-cut identities such as ``exp(log(x)) → x`` and
+    ``log(x) + log(y) → log(x*y)`` require positivity facts from
+    ``assumptions`` (an :class:`Assumptions` context) or symbols declared
+    with ``Domain.Positive``. Safe identities ``log(exp(x)) → x`` and
+    ``exp(x)*exp(y) → exp(x+y)`` always apply.
 
     Parameters
     ----------
     expr : Expr or DerivedResult
+    assumptions : Assumptions, optional
 
     Returns
     -------
     DerivedResult
     """
-    return _native_simplify_log_exp(_coerce_expr(expr))
+    return _native_simplify_log_exp(_coerce_expr(expr), assumptions)
 
 
 _native_simplify_expanded = simplify_expanded

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -20,6 +20,16 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import alkahest
 
 
+def _positive_log_case(pool, builder):
+    """Run ``builder(x[, y])`` under explicit positivity assumptions."""
+    x = pool.symbol("x")
+    y = pool.symbol("y")
+    assumptions = alkahest.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    assumptions.refine(pool.gt(y, pool.integer(0)))
+    return assumptions.simplify(builder(x, y))
+
+
 def _log_of_product_case(pool):
     """log(x*y) -> log(x) + log(y), certified under explicit x > 0, y > 0.
 
@@ -28,12 +38,23 @@ def _log_of_product_case(pool):
     through the colored e-graph's conditional `log_of_product_positive` rule
     instead, reached via `alkahest.Assumptions`.
     """
+    return _positive_log_case(pool, lambda x, y: alkahest.log(x * y))
+
+
+def _exp_of_log_case(pool):
+    """exp(log(x)) -> x under x > 0."""
     x = pool.symbol("x")
-    y = pool.symbol("y")
     assumptions = alkahest.Assumptions(pool)
     assumptions.refine(pool.gt(x, pool.integer(0)))
-    assumptions.refine(pool.gt(y, pool.integer(0)))
-    return assumptions.simplify(alkahest.log(x * y))
+    return assumptions.simplify(alkahest.exp(alkahest.log(x)))
+
+
+def _log_of_pow_case(pool):
+    """log(x^3) -> 3*log(x) under x > 0."""
+    x = pool.symbol("x")
+    assumptions = alkahest.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    return assumptions.simplify(alkahest.log(x**3))
 
 
 STRICT_CASES = [
@@ -112,12 +133,12 @@ STRICT_CASES = [
     (
         "log_of_pow",
         "log_of_pow",
-        lambda pool: alkahest.simplify_log_exp(alkahest.log(pool.symbol("x") ** 3)),
+        _log_of_pow_case,
     ),
     (
         "exp_of_log",
         "exp_of_log",
-        lambda pool: alkahest.simplify_log_exp(alkahest.exp(alkahest.log(pool.symbol("x")))),
+        _exp_of_log_case,
     ),
     (
         "log_of_product",

--- a/tests/test_assumptions.py
+++ b/tests/test_assumptions.py
@@ -31,9 +31,33 @@ def test_unproven_branch_cut_rewrites_remain_unchanged():
     y = p.symbol("y")
 
     assert str(alkahest.simplify(alkahest.sqrt(x**2)).value) == "sqrt(x^2)"
-    # Dedicated simplify_log_exp folds inverses; default simplify stays conservative.
-    assert str(alkahest.simplify_log_exp(alkahest.exp(alkahest.log(x))).value) == "x"
+    # Branch-cut log/exp identities stay put without positivity facts.
+    assert str(alkahest.simplify_log_exp(alkahest.exp(alkahest.log(x))).value) == "exp(log(x))"
     assert str(alkahest.simplify_log_exp(alkahest.log(x * y)).value) == "log((x * y))"
+    assert str(alkahest.simplify_log_exp(alkahest.log(x) + alkahest.log(y)).value) == (
+        "(log(x) + log(y))"
+    )
+
+
+def test_simplify_log_exp_folds_under_assumptions():
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    y = p.symbol("y")
+    assumptions = Assumptions(p)
+    assumptions.refine(p.gt(x, p.integer(0)))
+    assumptions.refine(p.gt(y, p.integer(0)))
+
+    assert str(alkahest.simplify_log_exp(alkahest.exp(alkahest.log(x)), assumptions).value) == "x"
+    assert str(alkahest.simplify_log_exp(alkahest.log(x) + alkahest.log(y), assumptions).value) == (
+        "log((x * y))"
+    )
+
+
+def test_static_positive_domain_enables_exp_of_log():
+    p = alkahest.ExprPool()
+    x = p.symbol("x", domain=alkahest.Domain.Positive)
+    assert str(alkahest.simplify_log_exp(alkahest.exp(alkahest.log(x))).value) == "x"
+    assert str(alkahest.simplify(alkahest.sqrt(x**2)).value) == "x"
 
 
 def test_contradiction_is_structured_and_context_is_unchanged():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -434,8 +434,8 @@ def test_lean_sum_and_product_rule_certificates():
 
 
 def test_lean_log_exp_parens_and_exp_log_certifies_with_positivity_hyp():
-    """Nested log/exp must parenthesize; exp∘log certifies via a `0 < x` binder."""
-    from alkahest import simplify_log_exp
+    """Nested log/exp must parenthesize; exp∘log certifies under x > 0."""
+    from alkahest import Assumptions, simplify_log_exp
 
     p = pool()
     x = p.symbol("x")
@@ -444,11 +444,11 @@ def test_lean_log_exp_parens_and_exp_log_certifies_with_positivity_hyp():
     assert "Real.log (Real.exp" in log_exp.certificate
     assert "sorry" not in log_exp.certificate
 
-    # exp(log(x)) needs `0 < x`; the derivation log records that as a
-    # positivity side condition, and the Lean exporter upgrades it into an
-    # explicit `(x : ℝ) (hx : 0 < x)` binder closed by `Real.exp_log hx`
-    # rather than withholding the certificate.
-    exp_log = simplify_log_exp(exp(log(x)))
+    # exp(log(x)) needs `0 < x`; gate via Assumptions so the colored rewrite
+    # records positivity and the Lean exporter emits `(hx : 0 < x)`.
+    assumptions = Assumptions(p)
+    assumptions.refine(p.gt(x, p.integer(0)))
+    exp_log = simplify_log_exp(exp(log(x)), assumptions)
     assert exp_log.certificate is not None
     assert "(hx : 0 < x)" in exp_log.certificate
     assert "Real.exp_log hx" in exp_log.certificate

--- a/tests/test_v15.py
+++ b/tests/test_v15.py
@@ -2,7 +2,7 @@
 
 Verifies that:
 1. simplify_egraph reduces sin(x)**2 + cos(x)**2 → 1 by default.
-2. simplify_egraph reduces exp(log(x)) → x by default.
+2. simplify_egraph does **not** reduce exp(log(x)) → x (needs positivity).
 3. simplify_egraph reduces log(exp(x)) → x by default.
 4. Existing egraph proptests are not broken (basic identities still hold).
 5. Opt-out: EgraphConfig(include_trig_rules=False) does NOT apply trig rules.
@@ -59,10 +59,10 @@ class TestEgraphTrigIdentity:
 
 class TestEgraphLogExpCancellation:
     @needs_egraph
-    def test_exp_of_log(self, pool, x):
+    def test_exp_of_log_stays_without_assumptions(self, pool, x):
         expr = exp(log(x))
         result = simplify_egraph(expr)
-        assert str(result.value) == "x"
+        assert str(result.value) == "exp(log(x))"
 
     @needs_egraph
     def test_log_of_exp(self, pool, x):
@@ -112,9 +112,9 @@ class TestEgraphConfig:
     @needs_egraph
     def test_opt_out_log_exp_rules_does_not_simplify(self, pool, x):
         cfg = EgraphConfig(include_log_exp_rules=False)
-        expr = exp(log(x))
+        expr = log(exp(x))
         result = simplify_egraph_with(expr, cfg)
-        assert str(result.value) != "x"
+        assert str(result.value) == "log(exp(x))"
 
     def test_custom_node_limit_attr(self):
         cfg = EgraphConfig(node_limit=50_000)

--- a/tests/textbook_gate/test_tg_algebra_identities.py
+++ b/tests/textbook_gate/test_tg_algebra_identities.py
@@ -145,6 +145,7 @@ def test_simplify_log_exp_product_of_exps_folds(pool, x, y):
 
 # --- cancel / together --------------------------------------------------------
 
+
 def test_cancel_difference_of_squares(x):
     """cancel((x^2-4)/(x-2), [x]) -> x+2, checked away from the removed x=2
     singularity.

--- a/tests/textbook_gate/test_tg_algebra_identities.py
+++ b/tests/textbook_gate/test_tg_algebra_identities.py
@@ -73,9 +73,11 @@ def test_log_exp_inverse_simplify(x):
     assert_matches_reference(r, x, lambda v: v)
 
 
-def test_exp_log_inverse_simplify_log_exp(x):
-    """exp(log(x)) -> x for positive x, checked via simplify_log_exp."""
-    r = ak.simplify_log_exp(ak.exp(ak.log(x))).value
+def test_exp_log_inverse_simplify_log_exp(x, pool):
+    """exp(log(x)) -> x for positive x, via Assumptions + simplify_log_exp."""
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    r = ak.simplify_log_exp(ak.exp(ak.log(x)), assumptions).value
     assert_matches_reference(r, x, lambda v: v, points=POSITIVE_POINTS)
 
 
@@ -86,21 +88,11 @@ def test_exp_log_inverse_simplify(x):
 
 
 def test_simplify_log_exp_inverse_pair(pool, x, y):
-    """log(exp(x)) + exp(log(y)) should collapse to x + y via the two
-    independent inverse identities. This is checked via *structural* Expr
-    equality against `simplify(x + y)` (the same technique the exemplar
-    `test_tg_derivatives.py::test_derivative_of_constant_wrt_unrelated_var`
-    uses via `r.value == pool.integer(0)`) rather than numeric evaluation:
-    since `log(exp(x)) + exp(log(y))` already evaluates correctly to `x + y`
-    even when left completely unsimplified, a numeric value-preservation
-    check cannot detect this no-op at all (it trivially passes either way).
-    Structural equality is not the same as string-matching the normal form —
-    it's the pool's own canonical-node equality, and it's precisely what's
-    needed to notice "nothing was folded" as opposed to "something wrong was
-    computed".
-    """
+    """log(exp(x)) + exp(log(y)) collapses to x + y under y > 0."""
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(y, pool.integer(0)))
     combined = ak.log(ak.exp(x)) + ak.exp(ak.log(y))
-    r = ak.simplify_log_exp(combined).value
+    r = ak.simplify_log_exp(combined, assumptions).value
     target = ak.simplify(x + y).value
     assert r == target
 
@@ -112,25 +104,34 @@ def test_simplify_log_exp_inverse_pair(pool, x, y):
 # and `exp(x)·exp(y)→exp(x+y)`.  Structural equality is required here for the
 # same reason as `test_simplify_log_exp_inverse_pair`: the unsimplified forms
 # already evaluate correctly, so numeric checks cannot detect a no-op.
+# Positivity-sensitive rules require explicit Assumptions.
 
 
 def test_simplify_log_exp_product_rule_folds(pool, x, y):
     """log(x) + log(y) -> log(x*y) for positive x, y."""
-    r = ak.simplify_log_exp(ak.log(x) + ak.log(y)).value
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    assumptions.refine(pool.gt(y, pool.integer(0)))
+    r = ak.simplify_log_exp(ak.log(x) + ak.log(y), assumptions).value
     target = ak.simplify(ak.log(x * y)).value
     assert r == target
 
 
 def test_simplify_log_exp_power_rule_folds(pool, x):
     """log(x**2) -> 2*log(x) for positive x."""
-    r = ak.simplify_log_exp(ak.log(x**2)).value
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    r = ak.simplify_log_exp(ak.log(x**2), assumptions).value
     target = ak.simplify(2 * ak.log(x)).value
     assert r == target
 
 
 def test_simplify_log_exp_quotient_rule_folds(pool, x, y):
     """log(x/y) -> log(x) - log(y) for positive x, y."""
-    r = ak.simplify_log_exp(ak.log(x / y)).value
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    assumptions.refine(pool.gt(y, pool.integer(0)))
+    r = ak.simplify_log_exp(ak.log(x / y), assumptions).value
     target = ak.simplify(ak.log(x) - ak.log(y)).value
     assert r == target
 
@@ -143,7 +144,6 @@ def test_simplify_log_exp_product_of_exps_folds(pool, x, y):
 
 
 # --- cancel / together --------------------------------------------------------
-
 
 def test_cancel_difference_of_squares(x):
     """cancel((x^2-4)/(x-2), [x]) -> x+2, checked away from the removed x=2


### PR DESCRIPTION
## Summary
- Stop silent incorrectness: `exp(log(x))`, sum/power/quotient of logs, and egglog `Exp∘Log` no longer fire without positivity facts
- Move those identities exclusively to the colored e-graph; `simplify_log_exp` accepts optional `Assumptions`; static `Domain.Positive` facts are collected for all `simplify_with` callers
- Safe unconditional rules remain: `log(exp(x))→x`, `exp(x)·exp(y)→exp(x+y)`

## Test plan
- [x] `cargo test -p alkahest-cas --lib` filters for `exp_of_log` / `sum_of_logs` / `log_of_pow` / `log_of_quotient` / lean positivity certs
- [x] `pytest tests/test_assumptions.py tests/test_v15.py tests/test_smoke.py tests/textbook_gate/test_tg_algebra_identities.py`
- [x] `python tests/lean_corpus.py` generates 30/30 including `exp_of_log` under Assumptions
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)