### PR TITLE
fix(eval): principal complex powers/sqrt and mpmath branch-cut oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixes
 
+- **Complex branch-cut evaluation:** `evaluate(..., mode="complex")` now
+  auto-binds the canonical imaginary unit `I → 1j`, accepts real scalar
+  bindings, and evaluates non-integer powers on the principal branch via
+  `exp(w·Log z)` (so e.g. `(-1)**(1/2) → i`). Complex `sqrt` uses the same
+  Log path to avoid cancellation near the negative-real cut. Locked in by an
+  mpmath fuzz oracle (`tests/test_complex_branchcut_oracle.py`). Exact `Arg`
+  on the cut still declines (`E-EVAL-011`). `ExprPool.imaginary_unit()` is
+  exposed in Python; `Expr ** float` builds a float-exponent node.
+
 - **Assumption-gated log/exp rewrites:** `simplify_log_exp` and egglog no longer
   apply branch-cut identities (`exp(log(x))→x`, `log(x)+log(y)→log(xy)`,
   `log(a^n)→n·log(a)`, `log(a/b)→log(a)−log(b)`) without positivity facts.

--- a/alkahest-core/src/eval/complex_f64.rs
+++ b/alkahest-core/src/eval/complex_f64.rs
@@ -26,14 +26,20 @@ impl ComplexF64 {
             self.re * o.im + self.im * o.re,
         )
     }
-    fn powi(self, n: i64) -> Self {
+    fn powi(self, n: i64) -> Result<Self, EvalError> {
         if n == 0 {
-            return Self::ONE;
+            return Ok(Self::ONE);
         }
         if n < 0 {
-            let p = self.powi(-n);
+            if self.re == 0.0 && self.im == 0.0 {
+                return Err(error(UnsupportedReason::ZeroToNegativePower));
+            }
+            let p = self.powi(-n)?;
             let d = p.re * p.re + p.im * p.im;
-            return Self::new(p.re / d, -p.im / d);
+            if d == 0.0 || !d.is_finite() {
+                return Err(error(UnsupportedReason::NonFiniteResult));
+            }
+            return Ok(Self::new(p.re / d, -p.im / d));
         }
         let mut acc = Self::ONE;
         let mut base = self;
@@ -47,16 +53,36 @@ impl ComplexF64 {
                 base = base.mul(base);
             }
         }
-        acc
+        Ok(acc)
     }
-    fn sqrt(self) -> Self {
-        let r = (self.re * self.re + self.im * self.im).sqrt();
-        let re = ((r + self.re) / 2.0).max(0.0).sqrt();
-        let mut im = ((r - self.re) / 2.0).max(0.0).sqrt();
-        if self.im < 0.0 {
-            im = -im;
+
+    /// Principal-branch power `z^w = exp(w · Log z)` for `z ≠ 0`.
+    fn powc(self, exp: Self) -> Result<Self, EvalError> {
+        if self.re == 0.0 && self.im == 0.0 {
+            // 0^w: only non-negative real exponents are defined in the
+            // principal sense we support here.
+            if exp.im == 0.0 && exp.re > 0.0 {
+                return Ok(Self::ZERO);
+            }
+            if exp.re == 0.0 && exp.im == 0.0 {
+                return Err(error(UnsupportedReason::UnsupportedExpression {
+                    kind: "branch_cut",
+                }));
+            }
+            return Err(error(UnsupportedReason::ZeroToNegativePower));
         }
-        Self::new(re, im)
+        let ln = self.ln()?;
+        Ok(exp.mul(ln).exp())
+    }
+
+    fn sqrt(self) -> Result<Self, EvalError> {
+        // Use the principal logarithm rather than the textbook geometric
+        // formula: `((r±re)/2)^½` suffers catastrophic cancellation for
+        // arguments near the negative-real cut (e.g. -100 + 1e-6·i).
+        if self.re == 0.0 && self.im == 0.0 {
+            return Ok(Self::ZERO);
+        }
+        self.powc(Self::new(0.5, 0.0))
     }
     fn exp(self) -> Self {
         let s = self.re.exp();
@@ -116,10 +142,17 @@ fn eval_node(
         ExprData::Integer(n) => Ok(ComplexF64::new(n.0.to_f64(), 0.0)),
         ExprData::Rational(r) => Ok(ComplexF64::new(r.0.to_f64(), 0.0)),
         ExprData::Float(f) => Ok(ComplexF64::new(f.inner.to_f64(), 0.0)),
-        ExprData::Symbol { .. } => bindings
-            .get(&expr)
-            .copied()
-            .ok_or(error(UnsupportedReason::UnboundSymbol { symbol: expr })),
+        ExprData::Symbol { .. } => {
+            if let Some(&v) = bindings.get(&expr) {
+                Ok(v)
+            } else if pool.is_imaginary_unit(expr) {
+                // Canonical I evaluates to 0+1j in complex mode without an
+                // explicit binding (matches symbolic `i² → −1` folding).
+                Ok(ComplexF64::new(0.0, 1.0))
+            } else {
+                Err(error(UnsupportedReason::UnboundSymbol { symbol: expr }))
+            }
+        }
         ExprData::Add(args) => args.iter().try_fold(ComplexF64::ZERO, |a, &x| {
             Ok(a.add(eval_node(x, pool, bindings)?))
         }),
@@ -129,11 +162,21 @@ fn eval_node(
         ExprData::Pow { base, exp } => {
             let b = eval_node(base, pool, bindings)?;
             match pool.get(exp) {
-                ExprData::Integer(n) => Ok(b.powi(n.0.to_i64().unwrap_or(0))),
+                ExprData::Integer(n) => b.powi(n.0.to_i64().unwrap_or(0)),
                 ExprData::Rational(r) if *r.0.denom() == 1 => {
-                    Ok(b.powi(r.0.numer().to_i64().unwrap_or(0)))
+                    b.powi(r.0.numer().to_i64().unwrap_or(0))
                 }
-                _ => Err(error(UnsupportedReason::NonIntegerExponent)),
+                // Principal branch: z^w = exp(w · Log z). Covers float and
+                // non-integer rational exponents (e.g. (-1)^(1/2) → i).
+                _ => {
+                    let e = eval_node(exp, pool, bindings)?;
+                    // Fast path: pure integer-valued real exponent.
+                    if e.im == 0.0 && e.re.fract() == 0.0 && e.re.abs() < (i64::MAX as f64) {
+                        b.powi(e.re as i64)
+                    } else {
+                        b.powc(e)
+                    }
+                }
             }
         }
         ExprData::Func { name, args } if args.len() == 1 => {
@@ -143,7 +186,7 @@ fn eval_node(
                 "cos" => Ok(x.cos()),
                 "exp" => Ok(x.exp()),
                 "log" => x.ln(),
-                "sqrt" => Ok(x.sqrt()),
+                "sqrt" => x.sqrt(),
                 "re" => Ok(ComplexF64::new(x.re, 0.0)),
                 "im" => Ok(ComplexF64::new(x.im, 0.0)),
                 "conjugate" => Ok(ComplexF64::new(x.re, -x.im)),
@@ -176,5 +219,40 @@ mod tests {
                 .reason,
             UnsupportedReason::UnsupportedExpression { kind: "branch_cut" }
         );
+    }
+
+    #[test]
+    fn imaginary_unit_auto_binds() {
+        let pool = crate::kernel::ExprPool::new();
+        let i = pool.imaginary_unit();
+        let v = eval_complex_f64(i, &pool, &HashMap::new()).unwrap();
+        assert_eq!(v, ComplexF64::new(0.0, 1.0));
+        let i2 = pool.mul(vec![i, i]);
+        let v2 = eval_complex_f64(i2, &pool, &HashMap::new()).unwrap();
+        assert!((v2.re + 1.0).abs() < 1e-12 && v2.im.abs() < 1e-12);
+    }
+
+    #[test]
+    fn principal_sqrt_of_negative_one() {
+        let pool = crate::kernel::ExprPool::new();
+        let expr = pool.func("sqrt", vec![pool.integer(-1_i32)]);
+        let v = eval_complex_f64(expr, &pool, &HashMap::new()).unwrap();
+        assert!((v.re).abs() < 1e-12 && (v.im - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn principal_half_power_of_negative_one() {
+        let pool = crate::kernel::ExprPool::new();
+        let expr = pool.pow(pool.integer(-1_i32), pool.rational(1, 2));
+        let v = eval_complex_f64(expr, &pool, &HashMap::new()).unwrap();
+        assert!((v.re).abs() < 1e-12 && (v.im - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn log_of_negative_one_is_i_pi() {
+        let pool = crate::kernel::ExprPool::new();
+        let expr = pool.func("log", vec![pool.integer(-1_i32)]);
+        let v = eval_complex_f64(expr, &pool, &HashMap::new()).unwrap();
+        assert!(v.re.abs() < 1e-12 && (v.im - std::f64::consts::PI).abs() < 1e-12);
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -654,6 +654,16 @@ impl PyExprPool {
         Ok(PyExpr { id, pool })
     }
 
+    /// Canonical imaginary unit `I` (`Domain.Complex` symbol named ``"I"``).
+    ///
+    /// In ``evaluate(..., mode="complex")`` this auto-binds to ``1j`` when
+    /// unbound. Symbolic simplification folds ``I**2 → -1``, etc.
+    fn imaginary_unit(slf: PyRef<'_, Self>) -> PyExpr {
+        let id = slf.inner.imaginary_unit();
+        let pool: Py<PyExprPool> = slf.into();
+        PyExpr { id, pool }
+    }
+
     fn integer(slf: PyRef<'_, Self>, n: &Bound<'_, PyAny>) -> PyResult<PyExpr> {
         let id = integer_into_pool(&slf.inner, n)?;
         let pool: Py<PyExprPool> = slf.into();
@@ -1010,11 +1020,13 @@ impl PyExpr {
         _modulo: Option<PyObject>,
         py: Python<'_>,
     ) -> PyObject {
-        // Accept both Python int literals (x**2) and pool.integer(n) Expr objects
-        // (x**pool.integer(2)) so either style works without raising TypeError.
+        // Accept Python int/float literals and Expr exponents.
         let pool = self.pool.borrow(py);
         let exp_id = if let Ok(n) = exp.extract::<i64>() {
             pool.inner.integer(n)
+        } else if let Ok(x) = exp.extract::<f64>() {
+            // IEEE float literal → pool float node (complex eval uses principal Log).
+            pool.inner.float(x, 53)
         } else if let Ok(expr_ref) = exp.extract::<PyRef<PyExpr>>() {
             expr_ref.id
         } else {
@@ -2937,6 +2949,13 @@ fn try_complex_binding(ob: &Bound<'_, PyAny>) -> Option<ComplexF64> {
             let im: f64 = t.get_item(1).ok()?.extract().ok()?;
             return Some(ComplexF64::new(re, im));
         }
+    }
+    // Real scalars are valid complex bindings (im = 0) in complex mode.
+    if let Ok(x) = ob.extract::<f64>() {
+        return Some(ComplexF64::new(x, 0.0));
+    }
+    if let Ok(x) = ob.extract::<i64>() {
+        return Some(ComplexF64::new(x as f64, 0.0));
     }
     None
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -2940,6 +2940,23 @@ fn parse_gauss_point(ob: &Bound<'_, PyAny>) -> PyResult<GaussRat> {
     ))
 }
 fn try_complex_binding(ob: &Bound<'_, PyAny>) -> Option<ComplexF64> {
+    if let Some(v) = try_strict_complex_binding(ob) {
+        return Some(v);
+    }
+    // Real scalars are valid only when the caller already selected complex mode.
+    if let Ok(x) = ob.extract::<f64>() {
+        return Some(ComplexF64::new(x, 0.0));
+    }
+    if let Ok(x) = ob.extract::<i64>() {
+        return Some(ComplexF64::new(x as f64, 0.0));
+    }
+    None
+}
+
+/// True complex values that should trigger auto-mode complex evaluation.
+/// Deliberately excludes reals/`Fraction` (those extract as `f64`) so auto
+/// mode still prefers exact rational / f64 backends.
+fn try_strict_complex_binding(ob: &Bound<'_, PyAny>) -> Option<ComplexF64> {
     if let Ok(c) = ob.downcast::<PyComplex>() {
         return Some(ComplexF64::new(c.real(), c.imag()));
     }
@@ -2949,13 +2966,6 @@ fn try_complex_binding(ob: &Bound<'_, PyAny>) -> Option<ComplexF64> {
             let im: f64 = t.get_item(1).ok()?.extract().ok()?;
             return Some(ComplexF64::new(re, im));
         }
-    }
-    // Real scalars are valid complex bindings (im = 0) in complex mode.
-    if let Ok(x) = ob.extract::<f64>() {
-        return Some(ComplexF64::new(x, 0.0));
-    }
-    if let Ok(x) = ob.extract::<i64>() {
-        return Some(ComplexF64::new(x as f64, 0.0));
     }
     None
 }
@@ -5906,7 +5916,7 @@ fn py_evaluate(
         || (mode == "auto"
             && bindings
                 .iter()
-                .any(|(_, v)| try_complex_binding(&v).is_some()));
+                .any(|(_, v)| try_strict_complex_binding(&v).is_some()));
     if wants_complex {
         let mut env = std::collections::HashMap::new();
         for (key, value) in bindings.iter() {
@@ -5914,7 +5924,9 @@ fn py_evaluate(
             env.insert(
                 var.id,
                 try_complex_binding(&value).ok_or_else(|| {
-                    PyTypeError::new_err("complex bindings must be complex numbers")
+                    PyTypeError::new_err(
+                        "complex bindings must be complex numbers (or real scalars in mode='complex')",
+                    )
                 })?,
             );
         }

--- a/tests/test_complex_branchcut_oracle.py
+++ b/tests/test_complex_branchcut_oracle.py
@@ -1,0 +1,214 @@
+"""mpmath oracle: complex / branch-cut numeric evaluation.
+
+Fuzzes ``evaluate(..., mode="complex")`` for sqrt, log, Arg, powers, and the
+imaginary unit against mpmath's principal branch.
+
+Run:
+    pytest tests/test_complex_branchcut_oracle.py -v
+
+Requires:
+    pip install mpmath
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pytest
+
+mpmath = pytest.importorskip("mpmath")
+
+import alkahest as ak  # noqa: E402
+from alkahest import (  # noqa: E402
+    arg,
+    conjugate,
+    cos,
+    evaluate,
+    exp,
+    im,
+    log,
+    re,
+    sin,
+    sqrt,
+)
+
+mp = mpmath
+mp.mp.dps = 40
+
+
+def _mpc(z: complex):
+    return mp.mpc(z.real, z.imag)
+
+
+def _close(got: complex, expect: complex, *, rel: float = 1e-9, abs_tol: float = 1e-9) -> bool:
+    err = abs(got - expect)
+    scale = max(abs(got), abs(expect), 1.0)
+    return err <= max(abs_tol, rel * scale)
+
+
+def _points(seed: int = 0) -> list[complex]:
+    rng = random.Random(seed)
+    pts: list[complex] = []
+    # On / near the negative-real branch cut
+    for x in (-3.0, -2.0, -1.0, -0.5, -1e-8, -100.0):
+        pts.extend(
+            [
+                complex(x, 0.0),
+                complex(x, 1e-12),
+                complex(x, -1e-12),
+                complex(x, 1e-6),
+                complex(x, -1e-6),
+            ]
+        )
+    # Axes and quadrants
+    pts.extend(
+        [
+            1 + 0j,
+            0 + 1j,
+            0 - 1j,
+            1 + 1j,
+            -1 + 1j,
+            -1 - 1j,
+            1 - 1j,
+            0.5 + 0j,
+            -0.5 + 0.1j,
+        ]
+    )
+    for _ in range(80):
+        pts.append(complex(rng.uniform(-5, 5), rng.uniform(-5, 5)))
+    return pts
+
+
+@pytest.fixture
+def pool() -> ak.ExprPool:
+    return ak.ExprPool()
+
+
+@pytest.fixture
+def z(pool: ak.ExprPool):
+    return pool.symbol("z", ak.Domain.Complex)
+
+
+@pytest.fixture
+def i(pool: ak.ExprPool):
+    return pool.imaginary_unit()
+
+
+# ---------------------------------------------------------------------------
+# Fixed principal-branch cases
+# ---------------------------------------------------------------------------
+
+
+def test_sqrt_log_neg_one_principal(pool):
+    got_sqrt = evaluate(sqrt(pool.integer(-1)), {}, mode="complex").value
+    assert _close(got_sqrt, 1j)
+    got = evaluate(log(pool.integer(-1)), {}, mode="complex").value
+    assert _close(got, complex(0, math.pi))
+
+
+def test_half_power_neg_one_is_principal_i(pool):
+    expr = pool.integer(-1) ** pool.rational(1, 2)
+    assert _close(evaluate(expr, {}, mode="complex").value, 1j)
+
+
+def test_imaginary_unit_auto_binds(i):
+    r = evaluate(i, {}, mode="complex")
+    assert r.status == "ok"
+    assert r.value == 1j
+    assert evaluate(i * i, {}, mode="complex").value == -1 + 0j
+    assert _close(evaluate(arg(i), {}, mode="complex").value, complex(math.pi / 2, 0))
+
+
+def test_arg_declines_on_negative_real_cut(pool, z):
+    """Exact negative reals are discontinuous for Arg — decline, don't guess."""
+    r = evaluate(arg(pool.integer(-1)), {}, mode="complex")
+    assert r.status == "unsupported"
+    assert r.reason == "E-EVAL-011"
+    r2 = evaluate(arg(z), {z: -2 + 0j}, mode="complex")
+    assert r2.status == "unsupported"
+    assert r2.reason == "E-EVAL-011"
+
+
+def test_arg_matches_mpmath_off_cut(z):
+    for w in (1 + 0j, 0 + 1j, 0 - 1j, -1 + 1e-9j, -1 - 1e-9j, 2 - 3j):
+        r = evaluate(arg(z), {z: w}, mode="complex")
+        assert r.status == "ok", (w, r.reason)
+        expect = complex(float(mp.arg(_mpc(w))), 0.0)
+        assert _close(r.value, expect), (w, r.value, expect)
+
+
+def test_real_bindings_accepted_in_complex_mode(pool, z):
+    r = evaluate(sqrt(z), {z: -4.0}, mode="complex")
+    assert r.status == "ok"
+    assert _close(r.value, 2j)
+
+
+# ---------------------------------------------------------------------------
+# Fuzz vs mpmath
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_unary_ops_match_mpmath(z, seed):
+    ops = [
+        ("sqrt", sqrt, lambda w: complex(mp.sqrt(_mpc(w)))),
+        ("log", log, lambda w: complex(mp.log(_mpc(w)))),
+        ("exp", exp, lambda w: complex(mp.exp(_mpc(w)))),
+        ("sin", sin, lambda w: complex(mp.sin(_mpc(w)))),
+        ("cos", cos, lambda w: complex(mp.cos(_mpc(w)))),
+        ("conjugate", conjugate, lambda w: complex(w.real, -w.imag)),
+        ("re", re, lambda w: complex(w.real, 0.0)),
+        ("im", im, lambda w: complex(w.imag, 0.0)),
+    ]
+    for w in _points(seed):
+        if abs(w) < 1e-18:
+            continue
+        for name, build, ref in ops:
+            r = evaluate(build(z), {z: w}, mode="complex")
+            assert r.status == "ok", f"{name}@{w}: {r.reason}"
+            expect = ref(w)
+            assert _close(r.value, expect), f"{name}@{w}: got {r.value}, want {expect}"
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_integer_powers_match_mpmath(z, seed):
+    for w in _points(seed):
+        if abs(w) < 1e-8:
+            continue
+        for n in range(-4, 5):
+            r = evaluate(z**n, {z: w}, mode="complex")
+            expect = complex(mp.power(_mpc(w), n))
+            assert r.status == "ok", (w, n, r.reason)
+            assert _close(r.value, expect, rel=1e-8, abs_tol=1e-8), (w, n, r.value, expect)
+
+
+@pytest.mark.parametrize("seed", range(2))
+def test_principal_noninteger_powers_match_mpmath(z, seed):
+    exponents = [0.5, -0.5, 1.5, 2.5, 1 / 3, -1 / 3, math.pi]
+    for w in _points(seed):
+        if abs(w) < 1e-6:
+            continue
+        for e in exponents:
+            r = evaluate(z**e, {z: w}, mode="complex")
+            expect = complex(mp.power(_mpc(w), e))
+            assert r.status == "ok", (w, e, r.reason)
+            assert _close(r.value, expect, rel=1e-7, abs_tol=1e-7), (w, e, r.value, expect)
+
+
+def test_rational_half_power_matches_sqrt_on_cut(pool, z):
+    """(-x)^(1/2) must agree with principal sqrt for negative reals."""
+    for x in (-0.25, -1.0, -4.0, -9.0):
+        half = evaluate(z ** pool.rational(1, 2), {z: complex(x, 0)}, mode="complex")
+        root = evaluate(sqrt(z), {z: complex(x, 0)}, mode="complex")
+        assert half.status == root.status == "ok"
+        assert _close(half.value, root.value)
+        assert _close(half.value, complex(mp.sqrt(x)))
+
+
+def test_symbolic_arg_folds_remain_branch_safe(pool, i):
+    """Symbolic Arg only folds domain-safe cases; negatives stay symbolic."""
+    assert str(ak.simplify(arg(pool.integer(3))).value) == "0"
+    assert "pi" in str(ak.simplify(arg(i)).value)
+    assert str(ak.simplify(arg(pool.integer(-1))).value) == "arg(-1)"
+    assert str(ak.simplify(arg(pool.integer(0))).value) == "arg(0)"

--- a/tests/test_complex_numeric_eval.py
+++ b/tests/test_complex_numeric_eval.py
@@ -28,3 +28,17 @@ def test_arg_branch_cut_declines():
 
     assert result.status == "unsupported"
     assert result.reason == "E-EVAL-011"
+
+
+def test_imaginary_unit_auto_binds_in_complex_mode():
+    pool = ak.ExprPool()
+    i = pool.imaginary_unit()
+    assert evaluate(i, {}, mode="complex").value == 1j
+    assert evaluate(i * i, {}, mode="complex").value == -1 + 0j
+
+
+def test_principal_half_power_of_negative():
+    pool = ak.ExprPool()
+    result = evaluate(pool.integer(-1) ** pool.rational(1, 2), {}, mode="complex")
+    assert result.status == "ok"
+    assert abs(result.value - 1j) < 1e-9

--- a/tests/test_complex_symbolics.py
+++ b/tests/test_complex_symbolics.py
@@ -20,7 +20,7 @@ def test_branch_sensitive_conjugation_remains_symbolic():
 def test_principal_arg_safe_cases():
     p = ak.ExprPool()
     x = p.symbol("x", ak.Domain.Positive)
-    i = p.symbol("I", ak.Domain.Complex)
+    i = p.imaginary_unit()
 
     assert str(ak.simplify(arg(p.integer(3))).value) == "0"
     assert str(ak.simplify(arg(x)).value) == "0"


### PR DESCRIPTION
## Summary
- Fix silent numeric inaccuracy near the negative-real cut: complex `sqrt` now uses principal `exp(½ Log z)` instead of the cancellation-prone geometric formula
- Complex mode auto-binds canonical `I → 1j`, accepts real scalar bindings, and evaluates non-integer powers on the principal branch (`(-1)**(1/2) → i`)
- Add `tests/test_complex_branchcut_oracle.py` fuzzing sqrt/log/Arg/powers against mpmath across the cut; exact `Arg` on the cut still declines (`E-EVAL-011`)

## Test plan
- [x] `cargo test -p alkahest-cas --lib complex_f64`
- [x] `pytest tests/test_complex_branchcut_oracle.py tests/test_complex_numeric_eval.py tests/test_complex_symbolics.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic support for the canonical imaginary unit `I` in complex evaluations.
  * Complex mode now accepts real-number bindings.
  * Added principal-branch results for non-integer powers and complex square roots.

* **Bug Fixes**
  * Improved accuracy near the negative-real branch cut.
  * Added structured handling for unsupported complex power cases.

* **Tests**
  * Expanded coverage against principal-branch mathematical results, including fuzz testing and branch-cut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->