### PR TITLE
fix: typecheck the full Lean certificate pool; fix/withhold latent non-compiling certs

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -88,9 +88,12 @@ jobs:
         run: |
           python tests/lean_corpus.py --output /tmp/lean_proofs/
 
-      - name: Generate Lean proofs (randomized textbook-gate sample)
+      - name: Generate Lean proofs (full deduplicated textbook-gate pool)
         run: |
-          python tests/lean_corpus_sample.py --output /tmp/lean_sample/
+          # Every distinct certificate the library emits from the textbook gate
+          # — not a random sample. A random draw made CI green by luck; the full
+          # deduplicated pool surfaces any non-compiling certificate every run.
+          python tests/lean_corpus_sample.py --output /tmp/lean_pool/
 
       - name: Set up Mathlib (lake update + cache get)
         run: |
@@ -101,7 +104,7 @@ jobs:
       - name: Verify proofs with Lean without admissions
         run: |
           cd lean
-          for dir in /tmp/lean_proofs /tmp/lean_sample; do
+          for dir in /tmp/lean_proofs /tmp/lean_pool; do
             echo "== Verifying certificates in $dir =="
             for f in "$dir"/*.lean; do
               fname=$(basename "$f")
@@ -113,7 +116,7 @@ jobs:
               lake env lean -DwarningAsError=true "$f" || { echo "FAILED: $fname"; exit 1; }
             done
           done
-          echo "All generated Lean proofs (fixed corpus + textbook-gate sample) verified without admissions."
+          echo "All generated Lean proofs (fixed corpus + full textbook-gate pool) verified without admissions."
 
       - name: Upload generated Lean proofs on failure
         if: failure()
@@ -122,5 +125,5 @@ jobs:
           name: generated-lean-proofs
           path: |
             /tmp/lean_proofs
-            /tmp/lean_sample
+            /tmp/lean_pool
           if-no-files-found: ignore

--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -65,6 +65,12 @@ fn rule_to_tactic(rule_name: &str) -> &'static str {
         // arguments, or three-plus factors [`positivity_tactic`] has no chained
         // lemma for) must be withheld, so the table default is a withheld `sorry`.
         "sum_of_logs" => "by sorry",
+        // `log(x·y⁻¹) = log x − log y` is only sound with `x > 0`, `y > 0`.
+        // [`emit_step_wrt`] upgrades the two-symbol case to an explicit-binder
+        // certificate via [`positivity_certificate`]/[`positivity_tactic`];
+        // anything it can't upgrade must be withheld, so the table default is a
+        // withheld `sorry` rather than the (non-compiling) `ring_nf; simp`.
+        "log_of_quotient" => "by sorry",
         // `exp a · exp b · … = exp(a + b + …)` is unconditionally valid; fold the
         // product of exponentials back with `Real.exp_add` (applied right-to-left,
         // repeatedly for ≥ 3 factors).
@@ -382,26 +388,78 @@ fn chain_diff_tactic(
     ))
 }
 
+/// The single tactic that closes every "combine" differentiation step —
+/// `diff_univariate_poly`, `sum_rule`, `product_rule` — over the
+/// *everywhere-differentiable* fragment ([`diff_body_unconditional`]).
+///
+/// `simp only` rewrites strictly at `deriv`/`DifferentiableAt` positions (no
+/// algebraic normalization of the lambda body, which would desync the
+/// structural `deriv_add`/`deriv_mul` match), and the raised
+/// `maxDischargeDepth` lets simp's discharger recurse through
+/// `DifferentiableAt.add`/`.mul`/`.pow` for deeply nested products and sums
+/// (the default depth of 2 silently leaves the `deriv` unreduced — the exact
+/// "green by luck" failure this gate hardening fixes). `try ring` then
+/// reconciles Alkahest's coefficient ordering / `1 *` decorations with the
+/// Mathlib derivative; it is a no-op (not a linter error) on the rare step
+/// simp closes outright.
+const UNCONDITIONAL_DIFF_TACTIC: &str = "by\n    \
+     simp (config := { maxDischargeDepth := 8 }) only [deriv_add, deriv_mul, deriv_pow, \
+     deriv_const, deriv_id'', Real.deriv_sin, Real.deriv_cos, Real.deriv_exp, \
+     differentiableAt_pow, differentiableAt_id', differentiableAt_const, \
+     Real.differentiableAt_sin, Real.differentiableAt_cos, Real.differentiableAt_exp, \
+     DifferentiableAt.add, DifferentiableAt.mul, DifferentiableAt.pow]\n    \
+     try ring";
+
+/// True when the differentiated body `before` is built only from atoms whose
+/// derivative [`UNCONDITIONAL_DIFF_TACTIC`]'s simp set computes *without any
+/// side condition* — i.e. the function is differentiable at every real point:
+/// the differentiation variable, constant symbols (`C1`, `C2`, …) and numeric
+/// literals, sums and products of those, non-negative integer powers of the
+/// variable, and the pointwise primitives `sin`/`cos`/`exp` applied to exactly
+/// the variable.
+///
+/// Everything else must be withheld by the caller: `log`/`sqrt`/`tan` and any
+/// inverse or negative power need an `x ≠ 0` (or positivity) hypothesis the
+/// unconditional simp set cannot discharge, and a chain composite `f(g x)`
+/// with `g ≠ x` lacks the composite's `DifferentiableAt` lemma (those go
+/// through [`chain_diff_tactic`] instead, never this fragment).
+fn diff_body_unconditional(before: ExprId, wrt: ExprId, pool: &ExprPool) -> bool {
+    fn walk(f: ExprId, wrt: ExprId, pool: &ExprPool) -> bool {
+        pool.with(f, |d| match d {
+            ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => true,
+            // A bare symbol is either the differentiation variable or a free
+            // constant (`fun x => C1` is constant in `x`); both are handled by
+            // `differentiableAt_id'` / `differentiableAt_const`.
+            ExprData::Symbol { .. } => true,
+            ExprData::Pow { base, exp } => {
+                *base == wrt
+                    && pool.with(*exp, |e| match e {
+                        ExprData::Integer(n) => n.0.to_i64().is_some_and(|k| k >= 0),
+                        _ => false,
+                    })
+            }
+            ExprData::Func { name, args } => {
+                matches!(name.as_str(), "sin" | "cos" | "exp") && args.len() == 1 && args[0] == wrt
+            }
+            ExprData::Add(xs) => xs.iter().all(|&c| walk(c, wrt, pool)),
+            ExprData::Mul(xs) => xs.iter().all(|&c| walk(c, wrt, pool)),
+            _ => false,
+        })
+    }
+    walk(before, wrt, pool)
+}
+
 fn diff_rule_to_tactic(rule_name: &str) -> Option<&'static str> {
     match rule_name {
         "diff_identity" => Some("by simp [deriv_id]"),
         "diff_const" => Some("by simp [deriv_const]"),
-        // `; try ring` closes coefficient-order goals like `2 * x = x * 2`.
-        "diff_univariate_poly" => {
-            Some("by simp [deriv_pow, deriv_add, deriv_mul, deriv_const]; try ring")
-        }
-        // `deriv_add`/`deriv_mul` need DifferentiableAt side goals; include the
-        // common Real lemmas so unary trig/exp sums and products close.
-        "sum_rule" => Some(
-            "by simp [deriv_add, Real.deriv_sin, Real.deriv_cos, Real.deriv_exp, \
-             Real.differentiableAt_sin, Real.differentiableAt_cos, Real.differentiableAt_exp, \
-             deriv_pow, deriv_mul, deriv_const, one_mul, mul_one, mul_neg, neg_mul]; try ring",
-        ),
-        "product_rule" => Some(
-            "by simp [deriv_mul, Real.deriv_sin, Real.deriv_cos, Real.deriv_exp, \
-             Real.differentiableAt_sin, Real.differentiableAt_cos, Real.differentiableAt_exp, \
-             deriv_const, differentiableAt_const, one_mul, mul_one, mul_neg, neg_mul]; try ring",
-        ),
+        // Combine steps over the everywhere-differentiable fragment. Callers in
+        // [`diff_step_certificate`] gate these on [`diff_body_unconditional`]
+        // and withhold anything outside it, so the tactic never runs on a body
+        // whose `deriv`/`DifferentiableAt` it cannot discharge.
+        "diff_univariate_poly" => Some(UNCONDITIONAL_DIFF_TACTIC),
+        "sum_rule" => Some(UNCONDITIONAL_DIFF_TACTIC),
+        "product_rule" => Some(UNCONDITIONAL_DIFF_TACTIC),
         "power_rule" | "power_rule_n1" => Some("by simp [deriv_pow, deriv_mul]; try ring"),
         "power_rule_n0" => Some("by simp [deriv_const]"),
         // Pointwise Mathlib lemmas for `deriv (fun x => f x) x = …` when the
@@ -462,7 +520,13 @@ fn diff_step_certificate(
         }
         "diff_primitive_registry" => registry_diff_certificate(step.before, wrt, pool),
         "power_rule" | "power_rule_n1" | "power_rule_n0" => {
-            if is_pow_of_var(step.before, wrt, pool) {
+            // `deriv (fun x => xⁿ)` closes via `deriv_pow` only for a
+            // non-negative integer `n`; a negative/inverse power (stored as
+            // `x^(-k)`) needs `x ≠ 0` and must be withheld. `is_pow_of_var`
+            // alone accepts `x^(-2)`, so also require the unconditional gate.
+            if is_pow_of_var(step.before, wrt, pool)
+                && diff_body_unconditional(step.before, wrt, pool)
+            {
                 diff_rule_to_tactic(step.rule_name).map(|t| (None, t.to_string()))
             } else if step.rule_name == "power_rule" {
                 power_chain_certificate(step.before, wrt, pool)
@@ -470,8 +534,17 @@ fn diff_step_certificate(
                 None
             }
         }
-        "product_rule" => quotient_chain_certificate(step.before, wrt, pool)
-            .or_else(|| diff_rule_to_tactic("product_rule").map(|t| (None, t.to_string()))),
+        // Combine steps: only certifiable when the differentiated body lies in
+        // the everywhere-differentiable fragment (otherwise the unconditional
+        // simp set leaves a `deriv`/`DifferentiableAt` goal open — withhold).
+        "diff_univariate_poly" | "sum_rule" => diff_body_unconditional(step.before, wrt, pool)
+            .then(|| (None, UNCONDITIONAL_DIFF_TACTIC.to_string())),
+        // `product_rule` first tries the `f(x)/g(x)` quotient chain (which
+        // carries its own `g x ≠ 0` binder), then the unconditional fragment.
+        "product_rule" => quotient_chain_certificate(step.before, wrt, pool).or_else(|| {
+            diff_body_unconditional(step.before, wrt, pool)
+                .then(|| (None, UNCONDITIONAL_DIFF_TACTIC.to_string()))
+        }),
         name => diff_rule_to_tactic(name).map(|t| (None, t.to_string())),
     }
 }
@@ -498,6 +571,13 @@ fn positivity_tactic(rule_name: &str, names: &[String]) -> Option<String> {
         ("exp_of_log", [x]) => Some(format!("by rw [Real.exp_log h{x}]")),
         ("log_of_product" | "log_of_product_positive" | "sum_of_logs", [x, y]) => Some(format!(
             "by rw [Real.log_mul (ne_of_gt h{x}) (ne_of_gt h{y})]"
+        )),
+        // `log(x · y⁻¹) = log x + (-1)·log y`, sound under `x > 0`, `y > 0`.
+        // `Real.log_inv` (the `log y⁻¹ = -log y` half) is unconditional; only
+        // the `Real.log_mul` split needs the nonzero hypotheses.
+        ("log_of_quotient", [x, y]) => Some(format!(
+            "by rw [Real.log_mul (ne_of_gt h{x}) (inv_ne_zero (ne_of_gt h{y})), \
+             Real.log_inv]; ring"
         )),
         _ => None,
     }
@@ -662,7 +742,38 @@ fn is_double_inv_cancel(before: ExprId, after: ExprId, pool: &ExprPool) -> bool 
 /// literally contain `"sorry"`), the [`positivity_certificate`] upgrade, and
 /// finally the static per-rule-name tactic ([`rule_to_tactic`]) when it
 /// doesn't require `sorry`. Returns `None` when the step must be withheld.
+/// Certificate for a `sin_double_angle` fold `2 · sin u · cos u = sin(2u)`
+/// (Alkahest stores the LHS as `sin u · 2 · cos u` and the RHS as `sin(u·2)`).
+/// `Real.sin_two_mul u : sin (2·u) = 2 · sin u · cos u` is *unconditional*, so
+/// no side condition is needed — we only have to reconcile the `u·2` vs `2·u`
+/// argument order (a `mul_comm` rewrite confined to the sine's argument) and
+/// the factor ordering (`ring`). Returns `None` (→ withhold) if `before` is
+/// not literally a product containing a `sin` factor.
+fn sin_double_angle_certificate(before: ExprId, pool: &ExprPool) -> Option<String> {
+    let factors = pool.with(before, |d| match d {
+        ExprData::Mul(xs) => Some(xs.clone()),
+        _ => None,
+    })?;
+    let arg = factors.iter().find_map(|&fac| {
+        pool.with(fac, |d| match d {
+            ExprData::Func { name, args } if name == "sin" && args.len() == 1 => Some(args[0]),
+            _ => None,
+        })
+    })?;
+    let arg_str = expr_to_lean(arg, pool);
+    Some(format!(
+        "by rw [mul_comm ({arg_str} : ℝ) (2 : ℝ), Real.sin_two_mul]; ring"
+    ))
+}
+
 fn plain_step_certificate(step: &RewriteStep, pool: &ExprPool) -> Option<(Option<String>, String)> {
+    // `sin_double_angle` is unconditional but needs a shape-specific rewrite
+    // (`Real.sin_two_mul`); the static table's `ring_nf; simp` fallback cannot
+    // close it. Handle it here (withholding if the product shape is unexpected)
+    // so it never reaches — and wrongly trusts — that fallback.
+    if step.rule_name == "sin_double_angle" {
+        return sin_double_angle_certificate(step.before, pool).map(|t| (None, t));
+    }
     if inv_cancel_base(step.before, step.after, pool).is_some() {
         return inv_cancel_certificate(step.before, step.after, pool).map(|(b, t)| (Some(b), t));
     }
@@ -1958,6 +2069,72 @@ mod tests {
         assert!(
             !lean.contains("sorry"),
             "product certificate must not use sorry: {lean}"
+        );
+    }
+
+    #[test]
+    fn multi_term_poly_combine_certifies_via_discharge_depth() {
+        use crate::diff::diff;
+
+        // A multi-term polynomial derivative combine (`diff_univariate_poly`)
+        // whose nested `DifferentiableAt` discharge exceeds simp's default
+        // depth of 2 — the exact "green by luck" shape. It must certify (not be
+        // withheld) and use the raised `maxDischargeDepth` tactic.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![
+            pool.mul(vec![pool.integer(3_i32), pool.pow(x, pool.integer(3_i32))]),
+            pool.mul(vec![pool.integer(2_i32), pool.pow(x, pool.integer(2_i32))]),
+            pool.mul(vec![x, pool.integer(5_i32)]),
+            pool.integer(7_i32),
+        ]);
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(
+            !lean.is_empty(),
+            "multi-term polynomial derivative must be certifiable: {lean}"
+        );
+        assert!(
+            lean.contains("maxDischargeDepth"),
+            "combine steps must use the raised discharge-depth tactic: {lean}"
+        );
+        assert!(!lean.contains("sorry"), "must not admit: {lean}");
+    }
+
+    #[test]
+    fn log_in_product_combine_is_withheld() {
+        use crate::diff::diff;
+
+        // `d/dx (x · log x)` needs `x ≠ 0` (log is not differentiable at 0), a
+        // side condition the unconditional combine tactic cannot discharge — so
+        // the whole certificate must be withheld rather than emit a
+        // non-compiling `deriv (fun x => x * log x) = …` goal.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.mul(vec![x, pool.func("log", vec![x])]);
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(
+            lean.is_empty(),
+            "d/dx (x·log x) must be withheld (needs x ≠ 0), got: {lean}"
+        );
+    }
+
+    #[test]
+    fn negative_power_of_var_diff_is_withheld() {
+        use crate::diff::diff;
+
+        // `d/dx (x⁻²)` (stored as a negative power of the variable) needs
+        // `x ≠ 0`; `deriv_pow` only closes non-negative integer powers, so this
+        // must be withheld, not emitted with the unconditional power tactic.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.pow(x, pool.integer(-2_i32));
+        let derived = diff(expr, x, &pool).expect("diff");
+        let lean = emit_lean_expr_wrt(&derived, &pool, Some(x));
+        assert!(
+            lean.is_empty(),
+            "d/dx (x⁻²) must be withheld (needs x ≠ 0), got: {lean}"
         );
     }
 

--- a/tests/lean_corpus_sample.py
+++ b/tests/lean_corpus_sample.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 """
-Lean corpus sampler — V5-9.
+Lean corpus harvester — V5-10.
 
 Extends the fixed strict corpus (``tests/lean_corpus.py``, 14 curated cases)
-with a deterministic, randomized SAMPLE of Lean certificates harvested live
-from the textbook gate (``tests/textbook_gate/``) — the first-course
-calculus/algebra identity suite. The point: every certificate the library
-actually emits from a textbook identity must compile, not just the 14 fixed
-showcase cases.
+with the FULL, DEDUPLICATED set of Lean certificates harvested live from the
+textbook gate (``tests/textbook_gate/``) — the first-course calculus/algebra
+identity suite. The point: every certificate the library actually emits from a
+textbook identity must compile, not just the 14 fixed showcase cases.
+
+This deliberately replaces the earlier fixed-seed RANDOM SAMPLE (n=25,
+seed=1337). A random draw made CI green *by luck*: the candidate pool contained
+certificates that did not typecheck, and whether the seed happened to draw one
+was the difference between a passing and a failing run. Any emitter change
+reshuffled the draw and could surface a latent non-compiling certificate.
+Harvesting and checking the *entire* deduplicated pool removes that lottery —
+if the library can emit a broken certificate from a textbook identity, CI sees
+it every time.
 
 How it works: this script instruments ``alkahest.diff``, ``alkahest.simplify``,
 ``alkahest.simplify_trig``, ``alkahest.simplify_log_exp``,
@@ -26,24 +34,28 @@ written out.
 
 Indefinite ``integrate()`` results now emit certificates via the FTC
 derivative relation ``deriv (fun x => F) x = f`` (see the ``to_lean`` docstring
-in ``alkahest-py/src/lib.rs``), but they are intentionally excluded from this
-*randomized* textbook-gate sample and covered instead by the deterministic
-strict corpus in ``tests/lean_corpus.py`` (the ``int_*`` cases). Keeping them
-out of the random pool avoids reshuffling the fixed-seed sample every time the
-integrator's coverage changes, while still verifying every emitted integration
-certificate against Lean in CI.
+in ``alkahest-py/src/lib.rs``), but they are intentionally excluded here (the
+``diff`` instrumentation still captures the derivative-check steps the gate
+runs) and covered instead by the deterministic strict corpus in
+``tests/lean_corpus.py`` (the ``int_*`` cases).
+
+Deduplication: many textbook-gate cases produce byte-identical certificates
+(e.g. every ``mul_one`` cleanup step). The pool is deduplicated by certificate
+text so each *distinct* certificate is written — and hence typechecked — exactly
+once, keeping the Lean CI runtime bounded (~1.5 s of Mathlib load per file)
+while still covering every distinct shape the library can emit.
 
 Usage::
 
-    python tests/lean_corpus_sample.py --output /tmp/lean_sample/ [--n 25] [--seed 1337]
+    python tests/lean_corpus_sample.py --output /tmp/lean_sample/
 """
 
 from __future__ import annotations
 
 import argparse
 import functools
+import hashlib
 import os
-import random
 import re
 import sys
 
@@ -63,7 +75,7 @@ FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")
 # function the textbook gate exercises."
 # NOTE: `integrate` is deliberately omitted. Its certificates now emit (Part A,
 # via the FTC derivative relation) but are verified deterministically through
-# the strict corpus (`tests/lean_corpus.py`), not this randomized sample — see
+# the strict corpus (`tests/lean_corpus.py`), not this harvested pool — see
 # the module docstring.
 RECORDED_FUNCTIONS = (
     "diff",
@@ -150,11 +162,10 @@ def sanitize(text: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Sample Lean certificates harvested from the textbook gate"
+        description="Harvest the full deduplicated set of Lean certificates "
+        "emitted by the textbook gate"
     )
     parser.add_argument("--output", default=".", help="Output directory for .lean files")
-    parser.add_argument("--n", type=int, default=25, help="Max number of certificates to sample")
-    parser.add_argument("--seed", type=int, default=1337, help="Deterministic sample seed")
     args = parser.parse_args()
 
     os.makedirs(args.output, exist_ok=True)
@@ -185,34 +196,47 @@ def main() -> int:
         f"({empty} withheld as empty, {to_lean_errors} raised errors)."
     )
 
-    # Deterministic regardless of harvesting/collection order: sort first,
-    # then draw a fixed-seed sample.
+    # Deterministic and independent of harvesting order: sort by identity, then
+    # deduplicate by certificate TEXT so each distinct certificate is written —
+    # and typechecked in CI — exactly once. NO random sampling: a sample could
+    # hide a non-compiling certificate (the "green by luck" seed lottery this
+    # harvester exists to eliminate).
     candidates.sort(key=lambda c: (c[0], c[1], c[2]))
-    rng = random.Random(args.seed)
-    sample = candidates if len(candidates) <= args.n else rng.sample(candidates, args.n)
-    sample.sort(key=lambda c: (c[0], c[1], c[2]))
+    seen_hashes: set[str] = set()
+    distinct: list[tuple[str, str, int, str]] = []
+    for cand in candidates:
+        digest = hashlib.sha256(cand[3].encode("utf-8")).hexdigest()
+        if digest in seen_hashes:
+            continue
+        seen_hashes.add(digest)
+        distinct.append(cand)
+
+    print(
+        f"{len(distinct)} distinct certificates after text-deduplication "
+        f"(of {len(candidates)} non-empty)."
+    )
 
     success = 0
     admission_failures = 0
-    for i, (name, test_id, idx, lean_src) in enumerate(sample):
+    for i, (name, test_id, idx, lean_src) in enumerate(distinct):
         bad_tokens = [token for token in FORBIDDEN_TOKENS if token in lean_src]
         if bad_tokens:
             print(
-                f"ERROR: sample {i} ({name} @ {test_id}#{idx}) contains "
+                f"ERROR: certificate {i} ({name} @ {test_id}#{idx}) contains "
                 f"forbidden token(s) {bad_tokens!r}",
                 file=sys.stderr,
             )
             admission_failures += 1
             continue
-        fname = f"sample_{i:03d}_{sanitize(name)}_{sanitize(test_id)}_{idx}.lean"
+        fname = f"cert_{i:03d}_{sanitize(name)}_{sanitize(test_id)}_{idx}.lean"
         out_path = os.path.join(args.output, fname)
         with open(out_path, "w") as f:
             f.write(lean_src)
         print(f"Generated: {out_path}")
         success += 1
 
-    print(f"\n{success}/{len(sample)} sampled certificates written to {args.output}")
-    return 0 if success == len(sample) and admission_failures == 0 else 1
+    print(f"\n{success}/{len(distinct)} distinct certificates written to {args.output}")
+    return 0 if success == len(distinct) and admission_failures == 0 else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The Lean *emit ⇒ typecheck* CI gate (`tests/lean_corpus_sample.py` + `.github/workflows/lean.yml`) typechecked only a **fixed-seed random sample** (n=25, seed=1337) of the non-empty certificates harvested from the textbook gate. The full pool (~89 non-empty certs) contained **12 that did not typecheck**; whether seed 1337 drew one decided pass vs. fail. So `main` was green partly by luck, and any emitter change reshuffled the draw and could surface a broken cert — the library was capable of handing out non-compiling Lean certificates.

## Part 1 — exhaustive gate (no seed lottery)

`tests/lean_corpus_sample.py` now harvests the **full pool**, deduplicates by certificate text (SHA-256), and writes **every distinct certificate** — no random sampling. ~74 distinct files, ~2–3 min of Mathlib-loaded typechecking. The workflow verifies the whole pool (`/tmp/lean_pool`); the fixed 14→30 strict corpus check is preserved as-is.

## Part 2 — fix or withhold every non-compiling cert (12 → 0)

**Root cause of most failures:** the combine-step tactic `simp [deriv_*]; try ring` relied on simp discharging nested `DifferentiableAt` side goals, but simp's default `maxDischargeDepth` of **2** silently left `deriv` unreduced for deeply nested products/sums.

### FIXED (a correct, sound proof exists)
| Cert shape | Fix |
|---|---|
| polynomial linearity, x²·cos x, repeated-/distinct-root ODEs (eˣ·C, x·eˣ·C) | combine tactic → `simp (config := { maxDischargeDepth := 8 }) only [deriv_add, deriv_mul, deriv_pow, deriv_const, deriv_id'', Real.deriv_sin/cos/exp, differentiableAt_*, Real.differentiableAt_sin/cos/exp, DifferentiableAt.add/mul/pow]; try ring`, gated on an everywhere-differentiable fragment check |
| `sin_double_angle` (2 sin x cos x = sin 2x) | `rw [mul_comm _ 2, Real.sin_two_mul]; ring` (unconditional) |
| `log_of_quotient` (log(x·y⁻¹) = log x − log y) | positivity path: `rw [Real.log_mul (ne_of_gt hx) (inv_ne_zero (ne_of_gt hy)), Real.log_inv]` under explicit `x>0, y>0` binders |

### WITHHELD (genuine `x ≠ 0` side condition the unconditional path can't discharge — a withheld cert is honest, a non-compiling one is not)
- combine steps whose differentiated body contains `log` or an inverse/negative power: `x·log x`, `x²·log x`, `eˣ·log x` diff-checks; `sin x / x` quotient; the `y'+y=0` ODE (`C·e⁻ˣ`).
- `power_rule` on a negative power of the variable (`x⁻²`): `deriv_pow` closes only non-negative integer powers.

**Advertised surface:** the withheld certs were **non-compiling before** (broken), so no *sound* surface is lost; the compiling surface actually grows (`log_of_quotient`, `sin_double_angle` recovered). The honestly-certifiable set now excludes log/inverse-in-body derivative diff-checks and the `x⁻²` power case until their `x ≠ 0` hypotheses are threaded through the combine tactic.

No admissions (`sorry`/`admit`/`axiom`) anywhere; `-DwarningAsError=true` unchanged. Adds Rust unit tests for the certify/withhold boundary.

## Verification (local, Lean v4.9.0 + Mathlib)
- Full deduplicated pool: **74/74 typecheck**, 0 admissions (before: 12 failing).
- Fixed strict corpus: **30/30 typecheck**.
- `cargo test -p alkahest-cas`: pass (incl. 55 lean tests, 3 new).
- `pytest tests/`: 1324 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)