### PR TITLE
fix(simplify): refuse log(exp(z))→z for complex-valued z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixes
 
+- **`log(exp(z))` over ℂ:** `simplify_log_exp` only folds `log(exp(x))→x` when
+  every free symbol in `x` is real-valued; `Domain.Complex` (and `I`) refuse
+  the rewrite. Egglog no longer loads `Log∘Exp` (no domain check). Prevents
+  silent wrong answers when `Im(z) ∉ (−π, π]`.
+
 - **Complex branch-cut evaluation:** `evaluate(..., mode="complex")` now
   auto-binds the canonical imaginary unit `I → 1j`, accepts real scalar
   bindings, and evaluates non-integer powers on the principal branch via

--- a/alkahest-core/src/simplify/egraph.rs
+++ b/alkahest-core/src/simplify/egraph.rs
@@ -193,7 +193,7 @@ mod backend {
         } else {
             "explore"
         };
-        let log_rs = if config.disjoint_schedule {
+        let _log_rs = if config.disjoint_schedule {
             "explore-log"
         } else {
             "explore"
@@ -213,13 +213,10 @@ mod backend {
         };
 
         let log_exp_rules = if config.include_log_exp_rules {
-            // Only `log(exp(x))→x` is loaded by default. `exp(log(x))→x` needs
-            // `x > 0` and is intentionally omitted: egglog has no assumption
-            // context, so firing it here would be silently unsound.
-            format!(
-                "(rewrite (Log (Exp ?x)) ?x :ruleset {log_rs})",
-                log_rs = log_rs,
-            )
+            // Intentionally empty: egglog cannot check symbol domains, and
+            // `log(exp(z))→z` / `exp(log(z))→z` are unsound over ℂ without
+            // that check. Use `simplify_log_exp` (real-gated) or Assumptions.
+            String::new()
         } else {
             String::new()
         };
@@ -919,10 +916,9 @@ impl EgraphCost for NoncommutativeCost {
 ///
 /// # Rule flags
 ///
-/// By default both `include_trig_rules` and `include_log_exp_rules` are `true`,
-/// so `simplify_egraph` reduces `sin²(x)+cos²(x)→1` and `log(exp(x))→x`.
-/// `exp(log(x))→x` is **not** included (requires positivity; use
-/// [`crate::simplify::AssumptionContext`]).
+/// By default `include_trig_rules` is `true` so `simplify_egraph` reduces
+/// `sin²(x)+cos²(x)→1`. Log/exp cancellation is **not** loaded in egglog
+/// (no domain check); use [`crate::simplify::engine::simplify_log_exp`].
 /// without any extra configuration.  Set either flag to `false` to suppress
 /// the corresponding rule set (useful when you need to benchmark rule impact or
 /// avoid domain-sensitive rewrites).
@@ -941,8 +937,9 @@ pub struct EgraphConfig {
     /// Include the Pythagorean trig identity (`sin²+cos²→1`) in the explore phase.
     /// Default `true`.
     pub include_trig_rules: bool,
-    /// Include safe log/exp cancellation (`log(exp(x))→x`) in the
-    /// explore phase. Does **not** include `exp(log(x))→x`. Default `true`.
+    /// Reserved for log/exp egglog rules. Currently a no-op: principal-branch
+    /// log/exp cancellation needs a domain check egglog cannot express.
+    /// Prefer [`crate::simplify::engine::simplify_log_exp`]. Default `true`.
     pub include_log_exp_rules: bool,
     /// Schedule match-disjoint egglog rule groups (Add / Mul / Pow / trig / log)
     /// as separate `(run …)` steps within each phase. Default `true`.
@@ -1253,16 +1250,16 @@ mod tests {
         let _ = expr;
     }
 
-    // V1-15: log(exp(x)) → x
+    // log(exp(x)) must not fire in egglog (no domain check).
     #[test]
-    fn egraph_log_of_exp() {
+    fn egraph_log_of_exp_stays() {
         let pool = ExprPool::new();
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.func("log", vec![pool.func("exp", vec![x])]);
         #[cfg(feature = "egraph")]
         {
             let result = simplify_egraph(expr, &pool);
-            assert_eq!(result.value, x);
+            assert_eq!(result.value, expr, "got {}", pool.display(result.value));
         }
         #[cfg(not(feature = "egraph"))]
         let _ = expr;
@@ -1286,7 +1283,7 @@ mod tests {
         assert_ne!(result.value, pool.integer(1_i32));
     }
 
-    // Opt-out: with include_log_exp_rules=false, log(exp(x)) stays put.
+    // Opt-out flag remains API-stable; log/exp egglog rules are already empty.
     #[test]
     fn egraph_opt_out_log_exp_rules() {
         let pool = ExprPool::new();

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -16,7 +16,7 @@
 /// // tan(x) → sin(x) * cos(x)^(-1)
 /// ```
 use crate::deriv::log::{DerivationLog, RewriteStep};
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
 use crate::pattern::{Pattern, Substitution};
 use crate::simplify::discrimination_net::{pattern_head, DiscriminationIndex};
 use crate::simplify::rules::{FlattenAdd, FlattenMul, RewriteRule};
@@ -25,6 +25,43 @@ fn one_step(name: &'static str, before: ExprId, after: ExprId) -> DerivationLog 
     let mut log = DerivationLog::new();
     log.push(RewriteStep::simple(name, before, after));
     log
+}
+
+/// True when every free symbol in `expr` lives in a real subdomain.
+///
+/// Used to gate `log(exp(x)) → x`, which fails for complex `x` whenever
+/// `Im(x) ∉ (−π, π]` (principal branch). `Domain::Complex` symbols (including
+/// the imaginary unit) refuse the rewrite.
+fn is_real_valued(expr: ExprId, pool: &ExprPool) -> bool {
+    match pool.get(expr) {
+        ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => true,
+        ExprData::Symbol { domain, .. } => matches!(
+            domain,
+            Domain::Real
+                | Domain::Integer
+                | Domain::Positive
+                | Domain::NonNegative
+                | Domain::NonZero
+        ),
+        ExprData::Add(args) | ExprData::Mul(args) | ExprData::Func { args, .. } => {
+            args.iter().all(|&a| is_real_valued(a, pool))
+        }
+        ExprData::Pow { base, exp } => is_real_valued(base, pool) && is_real_valued(exp, pool),
+        ExprData::Piecewise { branches, default } => {
+            branches
+                .iter()
+                .all(|&(c, v)| is_real_valued(c, pool) && is_real_valued(v, pool))
+                && is_real_valued(default, pool)
+        }
+        ExprData::Predicate { args, .. } => args.iter().all(|&a| is_real_valued(a, pool)),
+        ExprData::BigO(arg) => is_real_valued(arg, pool),
+        ExprData::Forall { var, body } | ExprData::Exists { var, body } => {
+            is_real_valued(var, pool) && is_real_valued(body, pool)
+        }
+        ExprData::RootSum { poly, var, body } => {
+            is_real_valued(poly, pool) && is_real_valued(var, pool) && is_real_valued(body, pool)
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -647,7 +684,12 @@ pub fn trig_normal_form_rules() -> Vec<Box<dyn RewriteRule>> {
 // log / exp identity rules
 // ---------------------------------------------------------------------------
 
-/// `log(exp(x)) → x`.
+/// `log(exp(x)) → x` when `x` is real-valued.
+///
+/// Over ℂ the identity fails whenever `Im(x) ∉ (−π, π]` on the principal
+/// branch. The rule therefore requires every free symbol in `x` to live in a
+/// real subdomain (`Real` / `Integer` / `Positive` / …); `Domain::Complex`
+/// (including `I`) refuses the rewrite.
 pub struct LogOfExp;
 
 impl RewriteRule for LogOfExp {
@@ -658,6 +700,9 @@ impl RewriteRule for LogOfExp {
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
         let arg = func_arg("log", expr, pool)?;
         let inner = func_arg("exp", arg, pool)?;
+        if !is_real_valued(inner, pool) {
+            return None;
+        }
         Some((inner, one_step(self.name(), expr, inner)))
     }
 }
@@ -779,12 +824,12 @@ impl RewriteRule for ProductOfExps {
 
 /// Return the default log/exp identity rules.
 ///
-/// Only identities that are safe without positivity assumptions:
-/// `log(exp(x))→x` (real principal branch) and `exp(x)·exp(y)→exp(x+y)`
-/// (valid over ℂ). Branch-cut sensitive rewrites (`exp(log(x))→x`,
-/// `log(x)+log(y)→log(xy)`, `log(a^n)→n·log(a)`, `log(a/b)→log(a)−log(b)`,
-/// `log(ab)→log a+log b`) live exclusively in the colored e-graph and require
-/// matching [`crate::simplify::SimplifyConfig::assumptions`] /
+/// Includes `log(exp(x))→x` only when `x` is real-valued (see [`LogOfExp`]) and
+/// `exp(x)·exp(y)→exp(x+y)` (valid over ℂ). Branch-cut sensitive rewrites
+/// (`exp(log(x))→x`, `log(x)+log(y)→log(xy)`, `log(a^n)→n·log(a)`,
+/// `log(a/b)→log(a)−log(b)`, `log(ab)→log a+log b`) live exclusively in the
+/// colored e-graph and require matching
+/// [`crate::simplify::SimplifyConfig::assumptions`] /
 /// [`crate::simplify::AssumptionContext`] facts (or `Domain::Positive`
 /// symbols). Use [`log_exp_rules_safe`] for the empty complex-safe set.
 pub fn log_exp_rules() -> Vec<Box<dyn RewriteRule>> {
@@ -1973,6 +2018,27 @@ mod tests {
         let rules = log_exp_rules();
         let r = simplify_with(expr, &pool, &rules, SimplifyConfig::default());
         assert_eq!(r.value, x, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn log_of_exp_stays_for_complex_symbol() {
+        // Principal log(exp(z)) ≠ z when Im(z) ∉ (−π, π].
+        let pool = p();
+        let z = pool.symbol("z", Domain::Complex);
+        let expr = pool.func("log", vec![pool.func("exp", vec![z])]);
+        let r = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        assert_eq!(r.value, expr, "got {}", pool.display(r.value));
+    }
+
+    #[test]
+    fn log_of_exp_stays_when_imaginary_unit_present() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let i = pool.imaginary_unit();
+        let inner = pool.add(vec![x, i]);
+        let expr = pool.func("log", vec![pool.func("exp", vec![inner])]);
+        let r = simplify_with(expr, &pool, &log_exp_rules(), SimplifyConfig::default());
+        assert_eq!(r.value, expr, "got {}", pool.display(r.value));
     }
 
     #[test]

--- a/tests/test_complex_branchcut_oracle.py
+++ b/tests/test_complex_branchcut_oracle.py
@@ -212,3 +212,16 @@ def test_symbolic_arg_folds_remain_branch_safe(pool, i):
     assert "pi" in str(ak.simplify(arg(i)).value)
     assert str(ak.simplify(arg(pool.integer(-1))).value) == "arg(-1)"
     assert str(ak.simplify(arg(pool.integer(0))).value) == "arg(0)"
+
+
+def test_log_of_exp_not_folded_for_complex_symbol(pool):
+    """log(exp(z))→z is unsound over ℂ when Im(z) wraps the principal strip."""
+    from alkahest import simplify_log_exp
+
+    z = pool.symbol("z", ak.Domain.Complex)
+    expr = log(exp(z))
+    assert str(simplify_log_exp(expr).value) == "log(exp(z))"
+    # Numeric: at Im = 3π the principal value is πi, not 3πi.
+    w = complex(0, 3 * math.pi)
+    orig = evaluate(expr, {z: w}, mode="complex").value
+    assert _close(orig, complex(0, math.pi), rel=1e-9, abs_tol=1e-9)

--- a/tests/test_v15.py
+++ b/tests/test_v15.py
@@ -3,7 +3,7 @@
 Verifies that:
 1. simplify_egraph reduces sin(x)**2 + cos(x)**2 → 1 by default.
 2. simplify_egraph does **not** reduce exp(log(x)) → x (needs positivity).
-3. simplify_egraph reduces log(exp(x)) → x by default.
+3. simplify_egraph does **not** reduce log(exp(x)) → x (needs real domain check).
 4. Existing egraph proptests are not broken (basic identities still hold).
 5. Opt-out: EgraphConfig(include_trig_rules=False) does NOT apply trig rules.
 
@@ -65,10 +65,10 @@ class TestEgraphLogExpCancellation:
         assert str(result.value) == "exp(log(x))"
 
     @needs_egraph
-    def test_log_of_exp(self, pool, x):
+    def test_log_of_exp_stays_in_egraph(self, pool, x):
         expr = log(exp(x))
         result = simplify_egraph(expr)
-        assert str(result.value) == "x"
+        assert str(result.value) == "log(exp(x))"
 
 
 class TestEgraphExistingRulesUnaffected:


### PR DESCRIPTION
## Summary
- `simplify_log_exp` only folds `log(exp(x))→x` when every free symbol in `x` is real-valued; `Domain.Complex` / `I` refuse the rewrite
- Egglog no longer loads `Log∘Exp` (cannot check domains)
- Locks in the silent incorrectness found when simplifying at `z = 3πi` (principal value is `πi`, not `3πi`)

## Test plan
- [x] `cargo test -p alkahest-cas --lib log_of_exp`
- [x] `pytest tests/test_complex_branchcut_oracle.py tests/test_v15.py` (+ textbook/smoke log∘exp cases)
- [ ] CI green


Made with [Cursor](https://cursor.com)