### PR TITLE
fix(transform): round-trip Laplace/Z table (quadratic n=2, sin/cos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixes
 
+- **Transform round-trips:** Inverse Laplace now inverts repeated irreducible
+  quadratic poles of order 2 (needed for `L⁻¹{L{t sin}}` / `t cos`). Inverse Z
+  matches the forward sin/cos table forms directly so transcendental
+  coefficients (`sin(ω)`, `cos(ω)`) do not block `Z⁻¹{Z{sin(ωn)}}` via `apart`.
+  Locked in by Rust unit tests and `tests/test_transform_roundtrips.py`.
+
 - **`log(exp(z))` over ℂ:** `simplify_log_exp` only folds `log(exp(x))→x` when
   every free symbol in `x` is real-valued; `Domain.Complex` (and `I`) refuse
   the rewrite. Egglog no longer loads `Log∘Exp` (no domain check). Prevents

--- a/alkahest-core/src/transform/laplace.rs
+++ b/alkahest-core/src/transform/laplace.rs
@@ -33,7 +33,8 @@
 //! | term in `F(s)`              | `L⁻¹` term                       |
 //! |-----------------------------|----------------------------------|
 //! | `A/(s−a)^n`                 | `A·t^{n−1} e^{a t}/(n−1)!`        |
-//! | `(B s + C)/((s−p)²+ω²)^n`   | damped sin/cos (`n = 1`)         |
+//! | `(B s + C)/((s−p)²+ω²)`     | damped sin/cos (`n = 1`)         |
+//! | `(B s + C)/((s−p)²+ω²)²`    | `t`-weighted damped sin/cos      |
 //! | `e^{−a s} F(s)`             | `θ(t−a)·(L⁻¹F)(t−a)`             |
 //!
 //! A leading polynomial part of `F` (improper rational) maps back to derivatives
@@ -875,11 +876,19 @@ fn invert_linear_pole(
     Ok(pool.mul(parts))
 }
 
-/// Invert `(B s + C)/((s−p)² + ω²)` (single power `n = 1`) into damped sin/cos:
+/// Invert `(B s + C)/((s−p)² + ω²)^n` for `n ∈ {1, 2}` into damped sin/cos.
 ///
 /// ```text
-///   L⁻¹ = e^{p t} ( B cos(ω t) + ((C + B p)/ω) sin(ω t) ).
+///   n = 1:  e^{p t} ( B cos(ω t) + ((C + B p)/ω) sin(ω t) )
+///
+///   n = 2:  write B s + C = B(s−p) + (B p + C); then
+///           L⁻¹{(s−p)/den²} = (t/(2ω)) e^{p t} sin(ω t)
+///           L⁻¹{1/den²}     = e^{p t}/(2ω³) (sin(ω t) − ω t cos(ω t))
 /// ```
+///
+/// Higher powers (`n ≥ 3`) are declined.  The `n = 2` case is required for
+/// round-trips of `t·sin` / `t·cos` (frequency differentiation of the
+/// quadratic table entries).
 fn invert_quadratic(
     numer: ExprId,
     base: ExprId,
@@ -888,9 +897,9 @@ fn invert_quadratic(
     t: ExprId,
     pool: &ExprPool,
 ) -> Result<ExprId, LaplaceError> {
-    if n != 1 {
+    if n != 1 && n != 2 {
         return Err(LaplaceError::NotInvertible(
-            "repeated irreducible quadratic pole (n ≥ 2) not in table".into(),
+            "repeated irreducible quadratic pole (n ≥ 3) not in table".into(),
         ));
     }
     // Write base = s² + β s + γ. Complete the square: (s + β/2)² + (γ − β²/4).
@@ -916,14 +925,32 @@ fn invert_quadratic(
     let (bb, cc) = as_affine(numer, s, pool)
         .ok_or_else(|| LaplaceError::NotInvertible(pool.display(numer).to_string()))?;
 
-    // e^{p t} [ B cos(ω t) + ((C + B p)/ω) sin(ω t) ]
     let exp_pt = pool.func("exp", vec![pool.mul(vec![p, t])]);
     let omega_t = pool.mul(vec![omega, t]);
-    let cos_term = pool.mul(vec![bb, pool.func("cos", vec![omega_t])]);
-    let bp = pool.mul(vec![bb, p]);
-    let sin_coeff = pool.mul(vec![pool.add(vec![cc, bp]), recip(omega, pool)]);
-    let sin_term = pool.mul(vec![sin_coeff, pool.func("sin", vec![omega_t])]);
-    Ok(pool.mul(vec![exp_pt, pool.add(vec![cos_term, sin_term])]))
+    let sin_wt = pool.func("sin", vec![omega_t]);
+    let cos_wt = pool.func("cos", vec![omega_t]);
+
+    if n == 1 {
+        // e^{p t} [ B cos(ω t) + ((C + B p)/ω) sin(ω t) ]
+        let cos_term = pool.mul(vec![bb, cos_wt]);
+        let bp = pool.mul(vec![bb, p]);
+        let sin_coeff = pool.mul(vec![pool.add(vec![cc, bp]), recip(omega, pool)]);
+        let sin_term = pool.mul(vec![sin_coeff, sin_wt]);
+        return Ok(pool.mul(vec![exp_pt, pool.add(vec![cos_term, sin_term])]));
+    }
+
+    // n = 2: B·(t/(2ω)) e^{pt} sin(ωt)
+    //      + (Bp+C)·e^{pt}/(2ω³)·(sin(ωt) − ωt cos(ωt)).
+    let two = pool.integer(2_i32);
+    let two_omega = pool.mul(vec![two, omega]);
+    let bp_plus_c = pool.add(vec![pool.mul(vec![bb, p]), cc]);
+
+    let t_sin = pool.mul(vec![bb, t, recip(two_omega, pool), sin_wt]);
+    let sin_minus_wt_cos = pool.add(vec![sin_wt, neg(pool.mul(vec![omega, t, cos_wt]), pool)]);
+    let omega3 = pool.mul(vec![omega, omega, omega]);
+    let two_omega3 = pool.mul(vec![two, omega3]);
+    let second = pool.mul(vec![bp_plus_c, recip(two_omega3, pool), sin_minus_wt_cos]);
+    Ok(pool.mul(vec![exp_pt, pool.add(vec![t_sin, second])]))
 }
 
 /// Coefficients `(α, β, γ)` of a monic-or-scaled quadratic `α s² + β s + γ`.

--- a/alkahest-core/src/transform/laplace/tests.rs
+++ b/alkahest-core/src/transform/laplace/tests.rs
@@ -505,3 +505,54 @@ fn round_trip_t_squared() {
     let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
     assert_numeric_eq(back, f, t, &[0.0, 0.5, 1.0, 2.0], &pool);
 }
+
+#[test]
+fn round_trip_t_sin() {
+    // Frequency-diff of L{sin} produces a repeated quadratic pole; n = 2
+    // inverse is required for L⁻¹{L{t sin(ωt)}} = t sin(ωt).
+    let (pool, t, s) = setup();
+    let f = pool.mul(vec![
+        t,
+        pool.func("sin", vec![pool.mul(vec![pool.integer(2_i32), t])]),
+    ]);
+    let big_f = laplace_transform(f, t, s, &pool).unwrap();
+    let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    assert_numeric_eq(back, f, t, &[0.25, 0.5, 1.0, 1.5, 2.0], &pool);
+}
+
+#[test]
+fn round_trip_t_cos() {
+    let (pool, t, s) = setup();
+    let f = pool.mul(vec![
+        t,
+        pool.func("cos", vec![pool.mul(vec![pool.integer(3_i32), t])]),
+    ]);
+    let big_f = laplace_transform(f, t, s, &pool).unwrap();
+    let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+    assert_numeric_eq(back, f, t, &[0.25, 0.5, 1.0, 1.5, 2.0], &pool);
+}
+
+#[test]
+fn round_trip_table_smoke() {
+    // Cheap forward∘inverse identity checks on the core rational table.
+    let (pool, t, s) = setup();
+    let cases: Vec<ExprId> = vec![
+        pool.integer(1_i32),
+        t,
+        pool.pow(t, pool.integer(2_i32)),
+        pool.func("exp", vec![pool.mul(vec![pool.integer(-2_i32), t])]),
+        pool.func("sin", vec![pool.mul(vec![pool.integer(5_i32), t])]),
+        pool.func("cos", vec![t]),
+        pool.mul(vec![
+            pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), t])]),
+            pool.func("sin", vec![pool.mul(vec![pool.integer(3_i32), t])]),
+        ]),
+        pool.mul(vec![t, pool.func("exp", vec![t])]),
+    ];
+    let samples = [0.3_f64, 0.7, 1.1, 1.9];
+    for f in cases {
+        let big_f = laplace_transform(f, t, s, &pool).unwrap();
+        let back = inverse_laplace_transform(big_f, s, t, &pool).unwrap();
+        assert_numeric_eq(back, f, t, &samples, &pool);
+    }
+}

--- a/alkahest-core/src/transform/ztransform.rs
+++ b/alkahest-core/src/transform/ztransform.rs
@@ -40,7 +40,20 @@
 //! [`inverse_z_transform`] inverts a **rational** `X(z)` by writing
 //! `X(z)/z` in partial fractions (via [`crate::poly::apart`]), multiplying each
 //! term back by `z`, and mapping the resulting `z/(z−a)^k` shapes through the
-//! inverse table:
+//! inverse table.  Before the rational path, it also matches the **forward
+//! sinusoid table** forms
+//!
+//! ```text
+//!   z·sin(ω)/(z² − 2z·cos(ω) + 1)      ↦  sin(ω n)
+//!   z(z − cos(ω))/(z² − 2z·cos(ω) + 1) ↦  cos(ω n)
+//! ```
+//!
+//! (including a constant amplitude factor).  Those expressions have
+//! transcendental coefficients, so `apart` (which requires ℚ-coefficients)
+//! cannot see them as rational functions — the direct table match is what
+//! makes `Z⁻¹{Z{sin(ω n)}}` and `Z⁻¹{Z{cos(ω n)}}` round-trip.
+//!
+//! Rational inverse table:
 //!
 //! | term in `X(z)`           | `Z⁻¹` term (`n ≥ 0`)                  |
 //! |---------------------------|----------------------------------------|
@@ -628,6 +641,11 @@ pub fn inverse_z_transform(
         return Err(ZTransformError::SameVariable);
     }
 
+    // Forward sinusoid table (transcendental coeffs — `apart` cannot see these).
+    if let Some(seq) = try_match_sinusoid_table(big_x, z, n, pool) {
+        return Ok(seq);
+    }
+
     // X(z)/z, partial-fractioned in z.
     let x_over_z = simp(pool.mul(vec![big_x, recip(z, pool)]), pool);
     let pf = crate::poly::apart(x_over_z, z, pool)
@@ -645,6 +663,147 @@ pub fn inverse_z_transform(
         out.push(invert_term(term_z, z, n, pool)?);
     }
     Ok(simp(pool.add(out), pool))
+}
+
+/// Match `X(z)` against the forward sin/cos table (unit-circle poles with
+/// transcendental coefficients that `apart` rejects as non-rational).
+///
+/// Recognises `A · z · sin(ω) / (z² − 2 z cos(ω) + 1)` and
+/// `A · z (z − cos(ω)) / (z² − 2 z cos(ω) + 1)` (any constant amplitude `A`
+/// free of `z`), returning `A·sin(ω n)` / `A·cos(ω n)`.
+fn try_match_sinusoid_table(
+    big_x: ExprId,
+    z: ExprId,
+    n: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    let (numer, denom) = split_fraction(big_x, pool)?;
+    let omega = match_unit_circle_denom(denom, z, pool)?;
+
+    let omega_n = pool.mul(vec![omega, n]);
+    if let Some(amp) = match_sin_table_numer(numer, z, omega, pool) {
+        let sin_term = pool.func("sin", vec![omega_n]);
+        return Some(match amp == pool.integer(1_i32) {
+            true => sin_term,
+            false => pool.mul(vec![amp, sin_term]),
+        });
+    }
+    if let Some(amp) = match_cos_table_numer(numer, z, omega, pool) {
+        let cos_term = pool.func("cos", vec![omega_n]);
+        return Some(match amp == pool.integer(1_i32) {
+            true => cos_term,
+            false => pool.mul(vec![amp, cos_term]),
+        });
+    }
+    None
+}
+
+/// Split `numer · denom^{−1}` (possibly flattened as a Mul of factors).
+fn split_fraction(expr: ExprId, pool: &ExprPool) -> Option<(ExprId, ExprId)> {
+    let factors: Vec<ExprId> = match pool.get(expr) {
+        ExprData::Mul(a) => a,
+        ExprData::Pow { base, exp } if is_neg_one(exp, pool) => {
+            return Some((pool.integer(1_i32), base));
+        }
+        _ => return None,
+    };
+    let mut denoms = Vec::new();
+    let mut numers = Vec::new();
+    for &fac in &factors {
+        match pool.get(fac) {
+            ExprData::Pow { base, exp } if is_neg_one(exp, pool) => denoms.push(base),
+            _ => numers.push(fac),
+        }
+    }
+    if denoms.len() != 1 {
+        return None;
+    }
+    let numer = match numers.len() {
+        0 => pool.integer(1_i32),
+        1 => numers[0],
+        _ => pool.mul(numers),
+    };
+    Some((numer, denoms[0]))
+}
+
+fn is_neg_one(exp: ExprId, pool: &ExprPool) -> bool {
+    matches!(pool.get(exp), ExprData::Integer(n) if n.0 == -1)
+}
+
+/// Recognise monic `z² − 2 z·cos(ω) + 1`, returning `ω`.
+fn match_unit_circle_denom(denom: ExprId, z: ExprId, pool: &ExprPool) -> Option<ExprId> {
+    let (b, c) = monic_quadratic_coeffs(denom, z, pool)?;
+    if c != pool.integer(1_i32) {
+        return None;
+    }
+    // cos(ω) = −b/2
+    let cos_omega = simp(
+        pool.mul(vec![neg(b, pool), pool.rational(1_i32, 2_i32)]),
+        pool,
+    );
+    match pool.get(cos_omega) {
+        ExprData::Func { name, args } if name == "cos" && args.len() == 1 => Some(args[0]),
+        _ => None,
+    }
+}
+
+/// Numer of the form `A · z · sin(ω)` with `A` free of `z`.
+fn match_sin_table_numer(
+    numer: ExprId,
+    z: ExprId,
+    omega: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    let sin_w = pool.func("sin", vec![omega]);
+    peel_factors(numer, &[z, sin_w], z, pool)
+}
+
+/// Numer of the form `A · z · (z − cos(ω))` with `A` free of `z`.
+fn match_cos_table_numer(
+    numer: ExprId,
+    z: ExprId,
+    omega: ExprId,
+    pool: &ExprPool,
+) -> Option<ExprId> {
+    let cos_w = pool.func("cos", vec![omega]);
+    let z_minus_cos = simp(pool.add(vec![z, neg(cos_w, pool)]), pool);
+    // Prefer the factored shape `z · (z − cos(ω))`.
+    if let Some(amp) = peel_factors(numer, &[z, z_minus_cos], z, pool) {
+        return Some(amp);
+    }
+    // Expanded `z² − cos(ω)·z` (= P z² + Q z with P = A, Q = −A cos(ω)).
+    let (p_coeff, q_coeff) = quadratic_numer_pq(numer, z, pool)?;
+    let want_q = simp(pool.mul(vec![neg(p_coeff, pool), cos_w]), pool);
+    if simp(q_coeff, pool) == want_q {
+        Some(p_coeff)
+    } else {
+        None
+    }
+}
+
+/// Peel each of `needles` (by `ExprId` equality after a best-effort simplify of
+/// the needle) out of a Mul, returning the product of leftover factors — which
+/// must be free of `z`.  Returns `None` if any needle is missing.
+fn peel_factors(numer: ExprId, needles: &[ExprId], z: ExprId, pool: &ExprPool) -> Option<ExprId> {
+    let mut factors: Vec<ExprId> = match pool.get(numer) {
+        ExprData::Mul(a) => a,
+        _ => vec![numer],
+    };
+    for &needle in needles {
+        let needle = simp(needle, pool);
+        let pos = factors.iter().position(|&f| simp(f, pool) == needle)?;
+        factors.remove(pos);
+    }
+    let amp = match factors.len() {
+        0 => pool.integer(1_i32),
+        1 => factors[0],
+        _ => pool.mul(factors),
+    };
+    if is_free_of(amp, z, pool) {
+        Some(amp)
+    } else {
+        None
+    }
 }
 
 /// Invert a single term `A·z^p·(z−a)^{−k}` (after re-multiplying the

--- a/alkahest-core/src/transform/ztransform/tests.rs
+++ b/alkahest-core/src/transform/ztransform/tests.rs
@@ -536,3 +536,75 @@ fn fibonacci_via_z_transform_matches_rsolve() {
         assert!((v - exp).abs() < 1e-4, "n={ni}: rsolve={v} expected={exp}");
     }
 }
+
+// ── round-trips ─────────────────────────────────────────────────────────────
+
+#[test]
+fn round_trip_sin_cos_table() {
+    // Forward sinusoid forms carry transcendental coefficients (sin(ω), cos(ω)),
+    // which `apart` rejects.  The inverse table must match them directly so
+    // Z⁻¹{Z{sin(ωn)}} and Z⁻¹{Z{cos(ωn)}} are identities.
+    let (pool, n, z) = setup();
+    let omega = pool.integer(1_i32);
+    let sin_n = pool.func("sin", vec![pool.mul(vec![omega, n])]);
+    let cos_n = pool.func("cos", vec![pool.mul(vec![omega, n])]);
+
+    for f in [sin_n, cos_n] {
+        let big_x = z_transform(f, n, z, &pool).unwrap();
+        let back = inverse_z_transform(big_x, z, n, &pool).unwrap();
+        for k in 0..=8 {
+            let va = eval_at(back, n, k as f64, &pool).expect("evaluable");
+            let vb = eval_at(f, n, k as f64, &pool).expect("evaluable");
+            assert!(
+                (va - vb).abs() < 1e-9,
+                "mismatch at n={k}: {} = {va} vs {} = {vb}",
+                pool.display(back),
+                pool.display(f),
+            );
+        }
+    }
+}
+
+#[test]
+fn round_trip_sin_scaled_amplitude() {
+    let (pool, n, z) = setup();
+    let omega = pool.rational(2_i32, 1_i32);
+    let f = pool.mul(vec![
+        pool.integer(3_i32),
+        pool.func("sin", vec![pool.mul(vec![omega, n])]),
+    ]);
+    let big_x = z_transform(f, n, z, &pool).unwrap();
+    let back = inverse_z_transform(big_x, z, n, &pool).unwrap();
+    for k in 0..=6 {
+        let va = eval_at(back, n, k as f64, &pool).expect("evaluable");
+        let vb = eval_at(f, n, k as f64, &pool).expect("evaluable");
+        assert!((va - vb).abs() < 1e-9, "n={k}: {va} vs {vb}");
+    }
+}
+
+#[test]
+fn round_trip_rational_table_smoke() {
+    let (pool, n, z) = setup();
+    let two = pool.integer(2_i32);
+    let cases: Vec<ExprId> = vec![
+        pool.integer(1_i32),
+        pool.pow(two, n),
+        n,
+        pool.mul(vec![n, pool.pow(two, n)]),
+        pool.pow(pool.integer(-1_i32), n),
+    ];
+    for f in cases {
+        let big_x = z_transform(f, n, z, &pool).unwrap();
+        let back = inverse_z_transform(big_x, z, n, &pool).unwrap();
+        for k in 0..=6 {
+            let va = eval_at(back, n, k as f64, &pool).expect("evaluable");
+            let vb = eval_at(f, n, k as f64, &pool).expect("evaluable");
+            assert!(
+                (va - vb).abs() < 1e-8 * (1.0 + va.abs() + vb.abs()),
+                "mismatch at n={k} for {}: {va} vs {vb} (back={})",
+                pool.display(f),
+                pool.display(back),
+            );
+        }
+    }
+}

--- a/tests/test_transform_roundtrips.py
+++ b/tests/test_transform_roundtrips.py
@@ -34,7 +34,7 @@ def _agree(a, b, var, samples, tol=1e-5) -> None:
 
 
 @pytest.mark.parametrize(
-    "name,builder",
+    ("name", "builder"),
     [
         ("1", lambda p, t: p.integer(1)),
         ("t", lambda p, t: t),
@@ -92,10 +92,7 @@ def test_laplace_roundtrip_fuzz_trig_exp():
         elif kind == "t_sin":
             f = p.mul([t, A.sin(omega * t)])
         else:
-            if a == 0:
-                f = A.sin(omega * t)
-            else:
-                f = p.mul([A.exp(a * t), A.sin(omega * t)])
+            f = A.sin(omega * t) if a == 0 else p.mul([A.exp(a * t), A.sin(omega * t)])
         big_f = ex.laplace_transform(f, t, s)
         back = ex.inverse_laplace_transform(big_f, s, t)
         _agree(back, f, t, [0.4, 0.9, 1.3, 2.1])
@@ -107,7 +104,7 @@ def test_laplace_roundtrip_fuzz_trig_exp():
 
 
 @pytest.mark.parametrize(
-    "name,builder",
+    ("name", "builder"),
     [
         ("1", lambda p, n: p.integer(1)),
         ("2^n", lambda p, n: p.integer(2) ** n),
@@ -138,10 +135,7 @@ def test_z_roundtrip_fuzz_sin_cos():
     for _ in range(10):
         omega = rng.choice([1, 2, 3, 4])
         amp = rng.choice([1, 2, 3, -1])
-        if rng.random() < 0.5:
-            xn = amp * A.sin(omega * n)
-        else:
-            xn = amp * A.cos(omega * n)
+        xn = amp * A.sin(omega * n) if rng.random() < 0.5 else amp * A.cos(omega * n)
         big_x = ex.z_transform(xn, n, z)
         back = ex.inverse_z_transform(big_x, z, n)
         _agree(back, xn, n, list(range(0, 7)))

--- a/tests/test_transform_roundtrips.py
+++ b/tests/test_transform_roundtrips.py
@@ -1,0 +1,160 @@
+"""Forward∘inverse identity checks for Laplace and Z transforms.
+
+These are cheap correctness oracles: on the documented table,
+``L⁻¹{L{f}} ≈ f`` and ``Z⁻¹{Z{a}} ≈ a`` (numeric sampling).  Failures here
+are high-embarrassment incorrectness.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import alkahest as A
+import pytest
+from alkahest import experimental as ex
+
+
+def _numeric(expr, env: dict) -> float:
+    return float(A.eval_expr(expr, {sym: float(v) for sym, v in env.items()}))
+
+
+def _agree(a, b, var, samples, tol=1e-5) -> None:
+    for x in samples:
+        va = _numeric(a, {var: x})
+        vb = _numeric(b, {var: x})
+        assert abs(va - vb) <= tol * (1.0 + abs(va) + abs(vb)), (
+            f"mismatch at {var}={x}: {a} → {va} vs {b} → {vb}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Laplace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,builder",
+    [
+        ("1", lambda p, t: p.integer(1)),
+        ("t", lambda p, t: t),
+        ("t^2", lambda p, t: t**2),
+        ("exp(2t)", lambda p, t: A.exp(2 * t)),
+        ("sin(3t)", lambda p, t: A.sin(3 * t)),
+        ("cos(2t)", lambda p, t: A.cos(2 * t)),
+        ("t*exp(t)", lambda p, t: p.mul([t, A.exp(t)])),
+        ("t*sin(2t)", lambda p, t: p.mul([t, A.sin(2 * t)])),
+        ("t*cos(t)", lambda p, t: p.mul([t, A.cos(t)])),
+        (
+            "exp(2t)*sin(3t)",
+            lambda p, t: p.mul([A.exp(2 * t), A.sin(3 * t)]),
+        ),
+        (
+            "t*exp(t)*sin(2t)",
+            lambda p, t: p.mul([t, A.exp(t), A.sin(2 * t)]),
+        ),
+    ],
+)
+def test_laplace_forward_inverse_roundtrip(name, builder):
+    p = A.ExprPool()
+    t = p.symbol("t")
+    s = p.symbol("s")
+    f = builder(p, t)
+    big_f = ex.laplace_transform(f, t, s)
+    back = ex.inverse_laplace_transform(big_f, s, t)
+    _agree(back, f, t, [0.25, 0.5, 1.0, 1.5, 2.0])
+
+
+def test_laplace_inverse_forward_rational():
+    p = A.ExprPool()
+    t = p.symbol("t")
+    s = p.symbol("s")
+    # L⁻¹{1/(s-2)} = e^{2t}; L of that recovers 1/(s-2).
+    f = ex.inverse_laplace_transform(1 / (s - 2), s, t)
+    back = ex.laplace_transform(f, t, s)
+    _agree(back, 1 / (s - 2), s, [3.0, 4.0, 5.0, 7.0])
+
+
+def test_laplace_roundtrip_fuzz_trig_exp():
+    """Light fuzz: random ω, a over a small integer grid."""
+    rng = random.Random(0x1A0ACE)
+    p = A.ExprPool()
+    t = p.symbol("t")
+    s = p.symbol("s")
+    for _ in range(12):
+        omega = rng.choice([1, 2, 3, 4, 5])
+        a = rng.choice([-3, -2, -1, 0, 1, 2])
+        kind = rng.choice(["sin", "cos", "t_sin", "exp_sin"])
+        if kind == "sin":
+            f = A.sin(omega * t)
+        elif kind == "cos":
+            f = A.cos(omega * t)
+        elif kind == "t_sin":
+            f = p.mul([t, A.sin(omega * t)])
+        else:
+            if a == 0:
+                f = A.sin(omega * t)
+            else:
+                f = p.mul([A.exp(a * t), A.sin(omega * t)])
+        big_f = ex.laplace_transform(f, t, s)
+        back = ex.inverse_laplace_transform(big_f, s, t)
+        _agree(back, f, t, [0.4, 0.9, 1.3, 2.1])
+
+
+# ---------------------------------------------------------------------------
+# Z-transform
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,builder",
+    [
+        ("1", lambda p, n: p.integer(1)),
+        ("2^n", lambda p, n: p.integer(2) ** n),
+        ("(-1)^n", lambda p, n: p.integer(-1) ** n),
+        ("n", lambda p, n: n),
+        ("n*2^n", lambda p, n: p.mul([n, p.integer(2) ** n])),
+        ("sin(n)", lambda p, n: A.sin(n)),
+        ("cos(n)", lambda p, n: A.cos(n)),
+        ("3*sin(2n)", lambda p, n: 3 * A.sin(2 * n)),
+        ("cos(3n)", lambda p, n: A.cos(3 * n)),
+    ],
+)
+def test_z_forward_inverse_roundtrip(name, builder):
+    p = A.ExprPool()
+    n = p.symbol("n")
+    z = p.symbol("z")
+    xn = builder(p, n)
+    big_x = ex.z_transform(xn, n, z)
+    back = ex.inverse_z_transform(big_x, z, n)
+    _agree(back, xn, n, list(range(0, 8)))
+
+
+def test_z_roundtrip_fuzz_sin_cos():
+    rng = random.Random(0x27A11)
+    p = A.ExprPool()
+    n = p.symbol("n")
+    z = p.symbol("z")
+    for _ in range(10):
+        omega = rng.choice([1, 2, 3, 4])
+        amp = rng.choice([1, 2, 3, -1])
+        if rng.random() < 0.5:
+            xn = amp * A.sin(omega * n)
+        else:
+            xn = amp * A.cos(omega * n)
+        big_x = ex.z_transform(xn, n, z)
+        back = ex.inverse_z_transform(big_x, z, n)
+        _agree(back, xn, n, list(range(0, 7)))
+
+
+def test_z_sin_matches_unit_circle_samples():
+    """Sanity: Z⁻¹{z/(z²+1)} samples equal sin(π n / 2)."""
+    p = A.ExprPool()
+    n = p.symbol("n")
+    z = p.symbol("z")
+    big_x = z / (z**2 + 1)
+    xn = ex.inverse_z_transform(big_x, z, n)
+    for k in range(0, 8):
+        got = _numeric(xn, {n: k})
+        want = math.sin(math.pi * k / 2.0)
+        assert abs(got - want) < 1e-9


### PR DESCRIPTION
## Summary
- Inverse Laplace: invert `(Bs+C)/((s−p)²+ω²)²` so frequency-diff forms from `t·sin` / `t·cos` round-trip
- Inverse Z: match forward `sin(ωn)` / `cos(ωn)` table forms before `apart` (trig coeffs are not ℚ-rational)
- Add Rust + Python forward∘inverse table/fuzz tests (`tests/test_transform_roundtrips.py`)

## Test plan
- [x] `cargo test -p alkahest-cas --lib transform::`
- [x] `pytest tests/test_transform_roundtrips.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)