### PR TITLE
feat(lean): type-checking Lean certificates for definite integrals

### DIFF
--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -1336,6 +1336,211 @@ pub fn emit_integration_cert(
     }
 }
 
+/// Lean import header for **definite** interval-integral certificates.
+///
+/// Adds Mathlib's interval-integral and second FTC lemmas
+/// (`intervalIntegral.integral_eq_sub_of_hasDerivAt`) on top of the derivative
+/// lemmas the `HasDerivAt` obligations need (`Real.hasDerivAt_sin`,
+/// `Real.hasDerivAt_exp`, `hasDerivAt_pow`, …).
+fn emit_definite_integral_header() -> String {
+    "import Mathlib.Tactic\n\
+     import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv\n\
+     import Mathlib.Analysis.SpecialFunctions.ExpDeriv\n\
+     import Mathlib.Analysis.Calculus.Deriv.Pow\n\
+     import Mathlib.MeasureTheory.Integral.IntervalIntegral\n\
+     import Mathlib.MeasureTheory.Integral.FundThmCalculus\n\
+     \n\
+     open Real\n\n"
+        .to_string()
+}
+
+/// The certifiable definite-integral fragment: an integrand class for which we
+/// can emit a `HasDerivAt` witness on `Set.uIcc a b` and an
+/// `IntervalIntegrable` side condition that Lean reliably discharges.
+///
+/// Every variant pins a concrete antiderivative `F` with `d/dx F = f` on all of
+/// `ℝ`, so the resulting certificate proves the *sound* interval-FTC statement
+/// `∫ x in a..b, f x = F b - F a` — never a false equality.
+enum DefiniteIntegrandClass {
+    /// `∫ cos x`, antiderivative `sin x`.
+    Cos,
+    /// `∫ sin x`, antiderivative `-cos x`.
+    Sin,
+    /// `∫ exp x`, antiderivative `exp x`.
+    Exp,
+    /// `∫ xⁿ` (`n ≥ 1`), antiderivative `x^(n+1) / (n+1)`.
+    Pow(i64),
+}
+
+/// Classify `integrand` into the certifiable definite-integral fragment.
+///
+/// Returns `None` (⇒ withhold) for anything outside the pointwise
+/// `sin`/`cos`/`exp` of the integration variable, a positive integer power
+/// of the variable, or the bare variable itself (treated as `x¹`). Sums,
+/// products, composites, and every other shape stay withheld — a missing
+/// certificate is always preferable to an unsound or non-compiling one.
+fn classify_definite_integrand(
+    integrand: ExprId,
+    var: ExprId,
+    pool: &ExprPool,
+) -> Option<DefiniteIntegrandClass> {
+    pool.with(integrand, |d| match d {
+        ExprData::Symbol { .. } if integrand == var => Some(DefiniteIntegrandClass::Pow(1)),
+        ExprData::Func { name, args } if args.len() == 1 && args[0] == var => match name.as_str() {
+            "sin" => Some(DefiniteIntegrandClass::Sin),
+            "cos" => Some(DefiniteIntegrandClass::Cos),
+            "exp" => Some(DefiniteIntegrandClass::Exp),
+            _ => None,
+        },
+        ExprData::Pow { base, exp } if *base == var => pool.with(*exp, |e| match e {
+            ExprData::Integer(n) => {
+                n.0.to_i64()
+                    .filter(|&k| k >= 1)
+                    .map(DefiniteIntegrandClass::Pow)
+            }
+            _ => None,
+        }),
+        _ => None,
+    })
+}
+
+/// True when `bound` is (or contains) the canonical `±∞` symbol — an improper
+/// endpoint the finite interval-FTC lemma cannot certify.
+fn bound_is_infinite(bound: ExprId, pool: &ExprPool) -> bool {
+    if bound == pool.pos_infinity() {
+        return true;
+    }
+    pool.with(bound, |d| match d {
+        ExprData::Add(xs) | ExprData::Mul(xs) => xs.iter().any(|&c| bound_is_infinite(c, pool)),
+        ExprData::Pow { base, exp } => {
+            bound_is_infinite(*base, pool) || bound_is_infinite(*exp, pool)
+        }
+        ExprData::Func { args, .. } => args.iter().any(|&a| bound_is_infinite(a, pool)),
+        _ => false,
+    })
+}
+
+/// Emit a Lean certificate for a **definite integral**
+/// `∫ x in a..b, f x = F b - F a`.
+///
+/// Unlike an indefinite integral (which can only be certified via the FTC
+/// *derivative* relation), a definite integral has a genuine equational
+/// statement Mathlib can prove directly:
+///
+/// ```text
+/// intervalIntegral.integral_eq_sub_of_hasDerivAt
+///   (hderiv : ∀ x ∈ Set.uIcc a b, HasDerivAt F (f x) x)
+///   (hint   : IntervalIntegrable f volume a b) :
+///   ∫ x in a..b, f x = F b - F a
+/// ```
+///
+/// The certificate states `∫ x in a..b, f x = F b - F a` with the endpoints
+/// substituted textually (so the right-hand side is `sin b - sin a`,
+/// `exp b - exp a`, …), and discharges it with a single `exact` of the lemma
+/// above — the substituted right-hand side is definitionally equal to
+/// `F b - F a` by β-reduction, so no fragile numeric/`ring` closer (and thus no
+/// linter noise under `-DwarningAsError=true`) is ever needed.
+///
+/// Certified integrand classes (the same family the indefinite path certifies):
+/// `cos`, `sin`, `exp` of the integration variable, and integer powers `xⁿ`
+/// (`n ≥ 1`, plus the bare variable as `x¹`). Every other integrand — and any
+/// improper (`±∞`) endpoint — is **withheld** (returns `""`). Never emits
+/// `sorry` / `admit`, and never asserts an unproven statement.
+pub fn emit_definite_integration_cert(
+    integrand: ExprId,
+    var: ExprId,
+    lower: ExprId,
+    upper: ExprId,
+    pool: &ExprPool,
+) -> String {
+    // Improper endpoints escape the finite interval-FTC lemma: withhold.
+    if bound_is_infinite(lower, pool) || bound_is_infinite(upper, pool) {
+        return String::new();
+    }
+    let Some(class) = classify_definite_integrand(integrand, var, pool) else {
+        return String::new();
+    };
+
+    let var_name = pool.with(var, |d| match d {
+        ExprData::Symbol { name, .. } => name.clone(),
+        _ => "x".to_string(),
+    });
+    let a_lean = expr_to_lean(lower, pool);
+    let b_lean = expr_to_lean(upper, pool);
+    let f_lean = expr_to_lean(integrand, pool);
+
+    // `antideriv_body(t)` renders the antiderivative `F` with the binder/endpoint
+    // spelled `t`. `F(var_name)` is the lambda body; `F(a_lean)` / `F(b_lean)`
+    // are the substituted endpoints (β-equal to `(fun x => F) a` / `… b`).
+    #[allow(clippy::type_complexity)]
+    let (antideriv_body, hderiv_close, hint_expr): (
+        Box<dyn Fn(&str) -> String>,
+        String,
+        String,
+    ) = match class {
+        DefiniteIntegrandClass::Cos => (
+            Box::new(|t: &str| format!("Real.sin ({t})")),
+            format!("exact Real.hasDerivAt_sin {var_name}"),
+            "Real.continuous_cos.intervalIntegrable _ _".to_string(),
+        ),
+        DefiniteIntegrandClass::Sin => (
+            Box::new(|t: &str| format!("-Real.cos ({t})")),
+            format!("simpa using (Real.hasDerivAt_cos {var_name}).neg"),
+            "Real.continuous_sin.intervalIntegrable _ _".to_string(),
+        ),
+        DefiniteIntegrandClass::Exp => (
+            Box::new(|t: &str| format!("Real.exp ({t})")),
+            format!("exact Real.hasDerivAt_exp {var_name}"),
+            "Real.continuous_exp.intervalIntegrable _ _".to_string(),
+        ),
+        DefiniteIntegrandClass::Pow(n) => {
+            let m = n + 1;
+            (
+                Box::new(move |t: &str| format!("({t}) ^ ({m} : ℕ) / ({m})")),
+                format!("simpa using (hasDerivAt_pow {m} {var_name}).div_const {m}"),
+                // `∫ xⁿ`: the integrand `fun x => xⁿ` is continuous. `x¹` is
+                // written by Alkahest as the bare symbol, so its integrand is
+                // `id`; higher powers use `continuous_pow`.
+                if n == 1 {
+                    "continuous_id.intervalIntegrable _ _".to_string()
+                } else {
+                    format!("(continuous_pow {n}).intervalIntegrable _ _")
+                },
+            )
+        }
+    };
+
+    let f_body = antideriv_body(&var_name);
+    let rhs = format!(
+        "({}) - ({})",
+        antideriv_body(&b_lean),
+        antideriv_body(&a_lean)
+    );
+
+    let mut out = emit_definite_integral_header();
+    out.push_str(&format!(
+        "-- ∫ {var_name} in {a_lean}..{b_lean}, {f_lean} = F {b_lean} - F {a_lean}   (F = fun {var_name} => {f_body})\n\
+         -- certified via the second FTC for interval integrals:\n\
+         --   intervalIntegral.integral_eq_sub_of_hasDerivAt (deriv F = f on uIcc) (IntervalIntegrable f)\n"
+    ));
+    out.push_str(&format!(
+        "example : ∫ {var_name} in ({a_lean})..({b_lean}), {f_lean} = {rhs} := by\n\
+         \x20 have hderiv : ∀ {var_name} ∈ Set.uIcc ({a_lean}) ({b_lean}),\n\
+         \x20     HasDerivAt (fun ({var_name} : ℝ) => {f_body}) ({f_lean}) {var_name} := by\n\
+         \x20   intro {var_name} _\n\
+         \x20   {hderiv_close}\n\
+         \x20 have hint : IntervalIntegrable (fun ({var_name} : ℝ) => {f_lean}) MeasureTheory.volume ({a_lean}) ({b_lean}) :=\n\
+         \x20   {hint_expr}\n\
+         \x20 exact intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv hint\n"
+    ));
+
+    // Defense in depth: never hand out a certificate containing admissions.
+    if out.contains("sorry") || out.contains("admit") {
+        return String::new();
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Expression → Lean syntax
 // ---------------------------------------------------------------------------
@@ -1603,6 +1808,148 @@ mod tests {
             "must state the derivative relation: {lean}"
         );
         assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn definite_integration_cert_cos() {
+        // ∫₀¹ cos x = sin 1 - sin 0, via the interval FTC.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let cos_x = pool.func("cos", vec![x]);
+        let lean = emit_definite_integration_cert(
+            cos_x,
+            x,
+            pool.integer(0_i32),
+            pool.integer(1_i32),
+            &pool,
+        );
+        assert!(
+            !lean.is_empty(),
+            "∫₀¹ cos must certify via the interval FTC"
+        );
+        assert!(
+            lean.contains("intervalIntegral.integral_eq_sub_of_hasDerivAt"),
+            "must invoke the interval FTC lemma: {lean}"
+        );
+        assert!(
+            lean.contains("HasDerivAt (fun (x : ℝ) => Real.sin (x))"),
+            "antiderivative is sin: {lean}"
+        );
+        assert!(
+            lean.contains("Real.hasDerivAt_sin"),
+            "cos derivative witness: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn definite_integration_cert_sin() {
+        // ∫₀¹ sin x = (-cos 1) - (-cos 0), via the interval FTC.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let sin_x = pool.func("sin", vec![x]);
+        let lean = emit_definite_integration_cert(
+            sin_x,
+            x,
+            pool.integer(0_i32),
+            pool.integer(1_i32),
+            &pool,
+        );
+        assert!(
+            !lean.is_empty(),
+            "∫₀¹ sin must certify via the interval FTC"
+        );
+        assert!(
+            lean.contains("intervalIntegral.integral_eq_sub_of_hasDerivAt"),
+            "must invoke the interval FTC lemma: {lean}"
+        );
+        assert!(
+            lean.contains("Real.hasDerivAt_cos"),
+            "sin derivative witness comes from cos: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn definite_integration_cert_power() {
+        // ∫₀¹ x² = 1³/3 - 0³/3, via the interval FTC + hasDerivAt_pow.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let lean =
+            emit_definite_integration_cert(x2, x, pool.integer(0_i32), pool.integer(1_i32), &pool);
+        assert!(!lean.is_empty(), "∫₀¹ x² must certify via the interval FTC");
+        assert!(
+            lean.contains("hasDerivAt_pow"),
+            "power derivative witness: {lean}"
+        );
+        assert!(
+            lean.contains("continuous_pow"),
+            "power integrability via continuous_pow: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn definite_integration_cert_exp() {
+        // ∫₀¹ exp x = exp 1 - exp 0, via the interval FTC.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_x = pool.func("exp", vec![x]);
+        let lean = emit_definite_integration_cert(
+            exp_x,
+            x,
+            pool.integer(0_i32),
+            pool.integer(1_i32),
+            &pool,
+        );
+        assert!(
+            !lean.is_empty(),
+            "∫₀¹ exp must certify via the interval FTC"
+        );
+        assert!(
+            lean.contains("Real.hasDerivAt_exp"),
+            "exp derivative witness: {lean}"
+        );
+        assert!(!lean.contains("sorry") && !lean.contains("admit"));
+    }
+
+    #[test]
+    fn definite_integration_cert_withheld_for_unsupported_integrand() {
+        // log x is outside the certifiable definite fragment: withhold.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let log_x = pool.func("log", vec![x]);
+        let lean = emit_definite_integration_cert(
+            log_x,
+            x,
+            pool.integer(1_i32),
+            pool.integer(2_i32),
+            &pool,
+        );
+        assert!(
+            lean.is_empty(),
+            "∫ log x is outside the certifiable fragment; must withhold: {lean}"
+        );
+    }
+
+    #[test]
+    fn definite_integration_cert_withheld_for_infinite_bound() {
+        // Improper integral (∞ endpoint) must never claim the finite interval FTC.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let exp_neg_x = pool.func("exp", vec![x]);
+        let lean = emit_definite_integration_cert(
+            exp_neg_x,
+            x,
+            pool.integer(0_i32),
+            pool.pos_infinity(),
+            &pool,
+        );
+        assert!(
+            lean.is_empty(),
+            "∫ with an infinite bound must withhold the interval-FTC cert: {lean}"
+        );
     }
 
     #[test]

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -180,7 +180,10 @@ pub use poly::groebner::{
 };
 
 pub use errors::AlkahestError;
-pub use lean::{emit_integration_cert, emit_lean_expr as emit_lean, emit_lean_expr_wrt};
+pub use lean::{
+    emit_definite_integration_cert, emit_integration_cert, emit_lean_expr as emit_lean,
+    emit_lean_expr_wrt,
+};
 // V2-1 — Modular / CRT framework
 #[cfg(feature = "groebner")]
 pub use diffalg::{

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1614,6 +1614,9 @@ struct PyDerivedResult {
     wrt: Option<ExprId>,
     /// Integrand and variable for lazy exact antiderivative verification.
     integration_verification_input: Option<(ExprId, ExprId)>,
+    /// `(integrand, var, lower, upper)` for a definite integral, used to emit an
+    /// interval-FTC Lean certificate (`∫ a..b f = F b − F a`) lazily.
+    definite_integration_input: Option<(ExprId, ExprId, ExprId, ExprId)>,
 }
 
 #[pymethods]
@@ -1663,6 +1666,23 @@ impl PyDerivedResult {
             }
             return Some(src);
         }
+        // Definite integrals certify the sound interval-FTC equation
+        // `∫ x in a..b, f x = F b - F a` (never emitted as a false rewrite).
+        if let Some((integrand, var, lower, upper)) = self.definite_integration_input {
+            let pool_py = self.value.pool.clone_ref(py);
+            let pool = pool_py.borrow(py);
+            let src = alkahest_core::emit_definite_integration_cert(
+                integrand,
+                var,
+                lower,
+                upper,
+                &pool.inner,
+            );
+            if src.is_empty() || src.contains("sorry") || src.contains("admit") {
+                return None;
+            }
+            return Some(src);
+        }
         if self.raw.log.is_empty() {
             return None;
         }
@@ -1692,6 +1712,22 @@ impl PyDerivedResult {
                     self.raw.value,
                     integrand,
                     var,
+                    &pool.inner,
+                );
+                if src.is_empty() || src.contains("sorry") || src.contains("admit") {
+                    None
+                } else {
+                    Some(src)
+                }
+            } else if let Some((integrand, var, lower, upper)) = self.definite_integration_input {
+                // Definite integrals certify via the interval FTC (Part A).
+                let pool_py = self.value.pool.clone_ref(py);
+                let pool = pool_py.borrow(py);
+                let src = alkahest_core::emit_definite_integration_cert(
+                    integrand,
+                    var,
+                    lower,
+                    upper,
                     &pool.inner,
                 );
                 if src.is_empty() || src.contains("sorry") || src.contains("admit") {
@@ -1838,6 +1874,7 @@ fn make_derived_result(
         raw: derived,
         wrt,
         integration_verification_input: None,
+        definite_integration_input: None,
     }
 }
 
@@ -1862,6 +1899,7 @@ fn py_derived_result_context_simplify(
             raw: dr.raw.clone(),
             wrt: dr.wrt,
             integration_verification_input: dr.integration_verification_input,
+            definite_integration_input: dr.definite_integration_input,
         });
     }
     let mut log = dr.raw.log.clone();
@@ -1876,6 +1914,7 @@ fn py_derived_result_context_simplify(
     };
     let mut result = make_derived_result(py, merged, pool_py, dr.wrt);
     result.integration_verification_input = dr.integration_verification_input;
+    result.definite_integration_input = dr.definite_integration_input;
     Ok(result)
 }
 
@@ -2893,7 +2932,9 @@ fn py_integrate_definite(
             .map_err(integrate_error_to_py)?
     };
     let pool_py = expr.pool.clone_ref(py);
-    Ok(make_derived_result(py, derived, pool_py, None))
+    let mut result = make_derived_result(py, derived, pool_py, None);
+    result.definite_integration_input = Some((expr.id, var.id, lower.id, upper.id));
+    Ok(result)
 }
 
 #[pyfunction]
@@ -3998,6 +4039,22 @@ fn py_to_lean(py: Python<'_>, arg: &Bound<'_, PyAny>) -> PyResult<String> {
             let pool = pool_py.borrow(py);
             let src =
                 alkahest_core::emit_integration_cert(d.raw.value, integrand, var, &pool.inner);
+            if src.contains("sorry") || src.contains("admit") {
+                return Ok(String::new());
+            }
+            return Ok(src);
+        }
+        // Definite integrals certify via the interval FTC equation.
+        if let Some((integrand, var, lower, upper)) = d.definite_integration_input {
+            let pool_py = d.value.pool.clone_ref(py);
+            let pool = pool_py.borrow(py);
+            let src = alkahest_core::emit_definite_integration_cert(
+                integrand,
+                var,
+                lower,
+                upper,
+                &pool.inner,
+            );
             if src.contains("sorry") || src.contains("admit") {
                 return Ok(String::new());
             }

--- a/tests/lean_corpus.py
+++ b/tests/lean_corpus.py
@@ -189,6 +189,42 @@ STRICT_CASES = [
         "int_power_rule",
         lambda pool: alkahest.integrate(pool.symbol("x") ** 2, pool.symbol("x")),
     ),
+    # Definite integrals, certified via the second fundamental theorem of
+    # calculus for interval integrals:
+    #   ∫ x in a..b, f x = F b - F a
+    # discharged by `intervalIntegral.integral_eq_sub_of_hasDerivAt` with a
+    # `HasDerivAt` witness on `Set.uIcc a b` and an `IntervalIntegrable` side
+    # condition. The recorded step is `fundamental_theorem_of_calculus`; the
+    # emitter builds the antiderivative + FTC proof for the certifiable fragment
+    # (pointwise sin/cos/exp of the variable, integer powers xⁿ).
+    (
+        "int_def_cos_0_1",
+        "fundamental_theorem_of_calculus",
+        lambda pool: alkahest.integrate(
+            alkahest.cos(pool.symbol("x")), pool.symbol("x"), pool.integer(0), pool.integer(1)
+        ),
+    ),
+    (
+        "int_def_sin_0_1",
+        "fundamental_theorem_of_calculus",
+        lambda pool: alkahest.integrate(
+            alkahest.sin(pool.symbol("x")), pool.symbol("x"), pool.integer(0), pool.integer(1)
+        ),
+    ),
+    (
+        "int_def_exp_0_1",
+        "fundamental_theorem_of_calculus",
+        lambda pool: alkahest.integrate(
+            alkahest.exp(pool.symbol("x")), pool.symbol("x"), pool.integer(0), pool.integer(1)
+        ),
+    ),
+    (
+        "int_def_x_squared_0_1",
+        "fundamental_theorem_of_calculus",
+        lambda pool: alkahest.integrate(
+            pool.symbol("x") ** 2, pool.symbol("x"), pool.integer(0), pool.integer(1)
+        ),
+    ),
     # `Real.deriv_log` holds unconditionally (no positivity hypothesis needed).
     (
         "diff_log",


### PR DESCRIPTION
## Problem

Definite integrals returned `certificate = None`, while indefinite integrals already emit a Lean proof via the FTC derivative relation (`deriv (fun x => F) x = f`).

### Repro (against `main`)
```python
import alkahest as ak
pool = ak.ExprPool()
with ak.context(pool=pool):
    x = pool.symbol("x")
    r_indef = ak.integrate(pool.func("cos", [x]), x)                       # value sin(x)
    print(bool(r_indef.certificate))                                        # True  -> full Lean cert
    r_def = ak.integrate(pool.func("sin", [x]), x, pool.integer(0), pool.integer(1))  # value 1 - cos(1)
    print(r_def.certificate)                                                # None  <-- BUG
```

## Approach

Emit a genuine, type-checking certificate for definite integrals using Mathlib's second FTC for interval integrals:

```
intervalIntegral.integral_eq_sub_of_hasDerivAt
  (hderiv : ∀ x ∈ Set.uIcc a b, HasDerivAt F (f x) x)
  (hint   : IntervalIntegrable f volume a b) :
  ∫ x in a..b, f x = F b - F a
```

The certificate states `∫ x in a..b, f x = F b - F a` with the endpoints substituted **textually** (e.g. `sin 1 - sin 0`) and discharges the whole goal with a single `exact` of the lemma. The substituted RHS is definitionally equal to `F b - F a` by β-reduction, so **no numeric / `ring` closer is needed** — which also means zero linter noise under `-DwarningAsError=true` (the exact way CI compiles certs).

Emitted Lean for `∫₀¹ cos x`:
```lean
example : ∫ x in ((0 : ℝ))..((1 : ℝ)), Real.cos ((x : ℝ)) = (Real.sin ((1 : ℝ))) - (Real.sin ((0 : ℝ))) := by
  have hderiv : ∀ x ∈ Set.uIcc ((0 : ℝ)) ((1 : ℝ)),
      HasDerivAt (fun (x : ℝ) => Real.sin (x)) (Real.cos ((x : ℝ))) x := by
    intro x _
    exact Real.hasDerivAt_sin x
  have hint : IntervalIntegrable (fun (x : ℝ) => Real.cos ((x : ℝ))) MeasureTheory.volume ((0 : ℝ)) ((1 : ℝ)) :=
    Real.continuous_cos.intervalIntegrable _ _
  exact intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv hint
```

## Certified vs withheld

**Certified** (same family the indefinite path certifies): `cos`, `sin`, `exp` of the integration variable, and integer powers `xⁿ` (`n ≥ 1`, plus the bare variable as `x¹`).

**Withheld → still `None`** (honest behavior preserved): every other integrand (sums, products, composites, `log`, `tan`, …) and any improper (`±∞`) endpoint. Never emits `sorry`/`admit`, never asserts an unproven statement.

## Changes

- **alkahest-core**: new `emit_definite_integration_cert`, re-exported from the crate root. Purely additive (no existing pub signature changed).
- **alkahest-py**: `integrate_definite(...).certificate` / `.verification` / `to_lean(...)` now surface the interval-FTC cert via a new private `definite_integration_input` field on `DerivedResult`.
- **tests**: Rust unit tests for cos/sin/exp/x² (cert present) and log / infinite-bound (withheld); four definite cases added to the Lean CI corpus (`tests/lean_corpus.py`).

## Verification

- `cargo test -p alkahest-cas`: 1623 + 53 lean tests pass.
- Every emitted definite cert (corpus + cos/sin/exp/x²/x¹/x⁵) typechecks locally with `lake env lean -DwarningAsError=true` against Mathlib `v4.9.0`, with no admissions and no linter errors.
- Python suite (`integrate`/`lean`/`definite`/`certificate`): 300 passed; README smoke test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)