### PR TITLE
feat(matrix): SymPy-style *, scalar multiplication, ** and named multiply methods

### DIFF
--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -4250,16 +4250,149 @@ impl PyMatrix {
     }
 
     fn __matmul__(&self, py: Python<'_>, other: PyRef<PyMatrix>) -> PyResult<PyMatrix> {
+        self.matmul_impl(py, &other)
+    }
+
+    /// `other @ self` (only reached when `other` is a `Matrix` that did not
+    /// itself handle `@`). Provided for symmetry with `__matmul__`.
+    fn __rmatmul__(&self, py: Python<'_>, other: PyRef<PyMatrix>) -> PyResult<PyMatrix> {
+        other.matmul_impl(py, self)
+    }
+
+    /// `self * other`.
+    ///
+    /// Follows the SymPy / CAS convention: if `other` is a :class:`Matrix`,
+    /// this is the **matrix product** (identical to ``self @ other``, with the
+    /// same inner-dimension check). If `other` is a scalar — an :class:`Expr`,
+    /// :class:`DerivedResult`, Python ``int``, or ``float`` — every entry is
+    /// scaled by it. There is no elementwise (Hadamard) product on ``*``; use
+    /// :meth:`hadamard` for that.
+    fn __mul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<PyObject> {
+        if let Ok(rhs) = other.downcast::<PyMatrix>() {
+            return Ok(self.matmul_impl(py, &rhs.borrow())?.into_py(py));
+        }
+        match self.coerce_matrix_scalar(other, py)? {
+            Some(scalar) => Ok(self.scale_impl(py, scalar).into_py(py)),
+            None => Ok(py.NotImplemented()),
+        }
+    }
+
+    /// `other * self` — scalar multiplication with the scalar on the left
+    /// (e.g. ``2 * A`` or ``expr * A``). Matrix-on-the-left products are
+    /// handled by the left operand's ``*`` / ``@``.
+    fn __rmul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<PyObject> {
+        match self.coerce_matrix_scalar(other, py)? {
+            Some(scalar) => Ok(self.scale_impl(py, scalar).into_py(py)),
+            None => Ok(py.NotImplemented()),
+        }
+    }
+
+    /// Matrix product ``self @ other`` (SymPy-style named alias).
+    ///
+    /// Same result as ``self @ other`` and ``self * other``. Raises a
+    /// `MatrixError` (E-MAT-001) if the inner dimensions do not match.
+    fn multiply(&self, py: Python<'_>, other: PyRef<PyMatrix>) -> PyResult<PyMatrix> {
+        self.matmul_impl(py, &other)
+    }
+
+    /// Scale every entry by `scalar` (an :class:`Expr`, :class:`DerivedResult`,
+    /// Python ``int``, or ``float``). Same as ``self * scalar``.
+    fn scalar_mul(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<PyMatrix> {
+        match self.coerce_matrix_scalar(other, py)? {
+            Some(scalar) => Ok(self.scale_impl(py, scalar)),
+            None => Err(PyTypeError::new_err(
+                "scalar_mul expects a scalar (Expr, DerivedResult, int, or float)",
+            )),
+        }
+    }
+
+    /// Elementwise (Hadamard) product — multiply corresponding entries.
+    ///
+    /// Requires both matrices to have the same shape. This is *not* the
+    /// matrix product; use ``@`` / ``*`` / :meth:`multiply` for that. Exposed
+    /// only as a named method (never on an operator) so ``*`` unambiguously
+    /// means the matrix product, per the CAS convention.
+    fn hadamard(&self, py: Python<'_>, other: PyRef<PyMatrix>) -> PyResult<PyMatrix> {
+        if self.inner.rows != other.inner.rows || self.inner.cols != other.inner.cols {
+            return Err(matrix_error_to_py(MatrixError::DimensionMismatch {
+                msg: format!(
+                    "cannot take Hadamard product of {}×{} and {}×{}: shapes must match",
+                    self.inner.rows, self.inner.cols, other.inner.rows, other.inner.cols
+                ),
+            }));
+        }
         let pool = self.pool.borrow(py);
-        let m = self
-            .inner
-            .mul(&other.inner, &pool.inner)
-            .map_err(matrix_error_to_py)?;
+        let rows = self.inner.rows;
+        let cols = self.inner.cols;
+        let data: Vec<Vec<ExprId>> = (0..rows)
+            .map(|r| {
+                (0..cols)
+                    .map(|c| {
+                        pool.inner
+                            .mul(vec![self.inner.get(r, c), other.inner.get(r, c)])
+                    })
+                    .collect()
+            })
+            .collect();
         drop(pool);
+        let m = Matrix::new(data).map_err(matrix_error_to_py)?;
         Ok(PyMatrix {
             inner: m,
             pool: self.pool.clone_ref(py),
         })
+    }
+
+    /// ``self ** n`` for a non-negative integer `n` (repeated matrix product).
+    ///
+    /// ``A ** 0`` is the identity matrix of the same size; ``A ** 1`` is `A`;
+    /// ``A ** n`` is ``A @ A @ ... @ A`` (`n` factors). Requires a square
+    /// matrix. Negative or non-integer exponents raise `TypeError`.
+    fn __pow__(
+        &self,
+        py: Python<'_>,
+        exp: &Bound<'_, PyAny>,
+        modulo: &Bound<'_, PyAny>,
+    ) -> PyResult<PyObject> {
+        if !modulo.is_none() {
+            return Ok(py.NotImplemented());
+        }
+        let n: i64 = match exp.extract::<i64>() {
+            Ok(n) => n,
+            Err(_) => return Ok(py.NotImplemented()),
+        };
+        if n < 0 {
+            return Err(PyTypeError::new_err(
+                "matrix power requires a non-negative integer exponent (matrix inverse for \
+                 negative powers is not supported via **; use .inverse())",
+            ));
+        }
+        if self.inner.rows != self.inner.cols {
+            return Err(matrix_error_to_py(MatrixError::DimensionMismatch {
+                msg: format!(
+                    "cannot raise a non-square {}×{} matrix to a power",
+                    self.inner.rows, self.inner.cols
+                ),
+            }));
+        }
+        let pool = self.pool.borrow(py);
+        // `A**0` is the identity; for `n >= 1` start from `A` (not `I @ A`) so
+        // that `A**1` is exactly `A` and `A**n` matches `A @ A @ ... @ A`.
+        let mut acc = if n == 0 {
+            Matrix::identity(self.inner.rows, &pool.inner)
+        } else {
+            self.inner.clone()
+        };
+        for _ in 1..n {
+            acc = acc
+                .mul(&self.inner, &pool.inner)
+                .map_err(matrix_error_to_py)?;
+        }
+        drop(pool);
+        Ok(PyMatrix {
+            inner: acc,
+            pool: self.pool.clone_ref(py),
+        }
+        .into_py(py))
     }
 
     fn det(&self, py: Python<'_>) -> PyResult<PyExpr> {
@@ -4580,6 +4713,71 @@ impl PyMatrix {
     fn __repr__(&self, py: Python<'_>) -> String {
         let pool = self.pool.borrow(py);
         self.inner.display(&pool.inner)
+    }
+}
+
+// Private (non-`#[pymethods]`) helpers shared by the multiplication surface.
+impl PyMatrix {
+    /// Matrix product `self @ other`, reused by `@`, `*`, `**`, and `multiply`.
+    fn matmul_impl(&self, py: Python<'_>, other: &PyMatrix) -> PyResult<PyMatrix> {
+        let pool = self.pool.borrow(py);
+        let m = self
+            .inner
+            .mul(&other.inner, &pool.inner)
+            .map_err(matrix_error_to_py)?;
+        drop(pool);
+        Ok(PyMatrix {
+            inner: m,
+            pool: self.pool.clone_ref(py),
+        })
+    }
+
+    /// Scale every entry by an already-coerced `ExprId` scalar.
+    fn scale_impl(&self, py: Python<'_>, scalar: ExprId) -> PyMatrix {
+        let pool = self.pool.borrow(py);
+        let m = self.inner.scale(scalar, &pool.inner);
+        drop(pool);
+        PyMatrix {
+            inner: m,
+            pool: self.pool.clone_ref(py),
+        }
+    }
+
+    /// Coerce `ob` into a scalar `ExprId` in this matrix's pool.
+    ///
+    /// Accepts `Expr`, `DerivedResult`, Python `int` (including bignum), and
+    /// `float`. Returns `Ok(None)` for anything else so operators can fall
+    /// back to `NotImplemented`. Pool mismatches raise (like the rest of the
+    /// API).
+    fn coerce_matrix_scalar(
+        &self,
+        ob: &Bound<'_, PyAny>,
+        py: Python<'_>,
+    ) -> PyResult<Option<ExprId>> {
+        if let Ok(e) = ob.extract::<PyRef<PyExpr>>() {
+            if !e.pool.is(&self.pool) {
+                return Err(pool_mismatch_err());
+            }
+            return Ok(Some(e.id));
+        }
+        if let Ok(dr) = ob.downcast::<PyDerivedResult>() {
+            let dr = dr.borrow();
+            if !dr.value.pool.is(&self.pool) {
+                return Err(pool_mismatch_err());
+            }
+            return Ok(Some(dr.value.id));
+        }
+        let pool = self.pool.borrow(py);
+        if let Ok(n) = ob.extract::<i64>() {
+            return Ok(Some(pool.inner.integer(n)));
+        }
+        if let Ok(f) = ob.extract::<f64>() {
+            return Ok(Some(pool.inner.float(f, 53)));
+        }
+        if ob.is_instance_of::<PyInt>() {
+            return Ok(Some(integer_into_pool(&pool.inner, ob)?));
+        }
+        Ok(None)
     }
 }
 

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -162,3 +162,104 @@ def test_cholesky_non_spd_declines():
     with pytest.raises(alkahest.LinearAlgebraError) as exc_info:
         m.cholesky()
     assert exc_info.value.code == "E-LINALG-003"
+
+
+def _int_matrix(pool, rows):
+    """Build a Matrix of Python ints, coercing each entry into `pool`."""
+    return alkahest.Matrix([[pool.integer(x) for x in row] for row in rows])
+
+
+def _entries(m):
+    """Simplified node ids for every entry, for structural comparison."""
+    return [[e.node() for e in row] for row in m.simplify().to_list()]
+
+
+def test_matrix_star_matrix_equals_matmul():
+    """`A * B` is the matrix product (SymPy convention), identical to `A @ B`."""
+    pool = alkahest.ExprPool()
+    a = _int_matrix(pool, [[1, 2], [3, 4]])
+    b = _int_matrix(pool, [[5, 6], [7, 8]])
+    assert _entries(a * b) == _entries(a @ b)
+    # Non-square inner-dimension product also matches.
+    c = _int_matrix(pool, [[1, 2, 3], [4, 5, 6]])
+    assert (a * c).shape() == (2, 3)
+    assert _entries(a * c) == _entries(a @ c)
+
+
+def test_matrix_scalar_multiplication_both_sides():
+    """`A * k`, `k * A`, and `A * Expr` scale every entry (int, float, Expr)."""
+    pool = alkahest.ExprPool()
+    a = _int_matrix(pool, [[1, 2], [3, 4]])
+    expected = [[2, 4], [6, 8]]
+    right = a * 2
+    left = 2 * a
+    for prod in (right, left):
+        assert _entries(prod) == [[pool.integer(v).node() for v in row] for row in expected]
+    # scalar_mul named method agrees with `*`.
+    assert _entries(a.scalar_mul(2)) == _entries(a * 2)
+    # Expr scalar on both sides.
+    x = pool.symbol("x")
+    assert _entries(a * x) == _entries(x * a)
+    # float scalar is accepted.
+    assert (a * 2.0).shape() == (2, 2)
+
+
+def test_matrix_multiply_named_method():
+    """`A.multiply(B)` is an alias for the matrix product."""
+    pool = alkahest.ExprPool()
+    a = _int_matrix(pool, [[1, 2], [3, 4]])
+    b = _int_matrix(pool, [[0, 1], [1, 0]])
+    assert _entries(a.multiply(b)) == _entries(a @ b)
+
+
+def test_matrix_star_dimension_mismatch_raises():
+    """Incompatible `*` product raises MatrixError E-MAT-001 with shapes."""
+    pool = alkahest.ExprPool()
+    c = _int_matrix(pool, [[1, 2, 3], [4, 5, 6]])
+    with pytest.raises(alkahest.MatrixError) as exc_info:
+        _ = c * c
+    assert exc_info.value.code == "E-MAT-001"
+    assert "2×3" in str(exc_info.value)
+
+
+def test_matrix_power_non_negative_integer():
+    """`A ** n` is repeated matrix product; `A ** 0` is the identity."""
+    pool = alkahest.ExprPool()
+    a = _int_matrix(pool, [[1, 1], [0, 1]])
+    assert _entries(a**0) == _entries(_int_matrix(pool, [[1, 0], [0, 1]]))
+    assert _entries(a**1) == _entries(a)
+    assert _entries(a**2) == _entries(a @ a)
+    assert _entries(a**3) == _entries(a @ a @ a)
+    # [[1,1],[0,1]] ** 3 == [[1,3],[0,1]].
+    assert _entries(a**3) == _entries(_int_matrix(pool, [[1, 3], [0, 1]]))
+
+
+def test_matrix_power_negative_declines():
+    """Negative exponents raise TypeError (no inverse via **)."""
+    pool = alkahest.ExprPool()
+    a = _int_matrix(pool, [[1, 2], [3, 4]])
+    with pytest.raises(TypeError):
+        _ = a**-1
+
+
+def test_matrix_power_non_square_declines():
+    """Powering a non-square matrix raises MatrixError E-MAT-001."""
+    pool = alkahest.ExprPool()
+    c = _int_matrix(pool, [[1, 2, 3], [4, 5, 6]])
+    with pytest.raises(alkahest.MatrixError) as exc_info:
+        _ = c**2
+    assert exc_info.value.code == "E-MAT-001"
+
+
+def test_matrix_hadamard_elementwise():
+    """`hadamard` multiplies corresponding entries; mismatched shapes decline."""
+    pool = alkahest.ExprPool()
+    a = _int_matrix(pool, [[1, 2], [3, 4]])
+    b = _int_matrix(pool, [[5, 6], [7, 8]])
+    assert _entries(a.hadamard(b)) == [
+        [pool.integer(v).node() for v in row] for row in [[5, 12], [21, 32]]
+    ]
+    c = _int_matrix(pool, [[1, 2, 3], [4, 5, 6]])
+    with pytest.raises(alkahest.MatrixError) as exc_info:
+        a.hadamard(c)
+    assert exc_info.value.code == "E-MAT-001"


### PR DESCRIPTION
## Summary

Makes matrix multiplication complete, useful, and intuitive for the Python API — especially for AI agents driving it — following the **SymPy / CAS convention** where `*` on two matrices is the *matrix product* (not elementwise). Previously only `A @ B` worked; `A * B`, `A * scalar`, `scalar * A`, and `A ** n` all raised `TypeError`.

All changes are **purely additive** (new PyO3 dunders/methods + private Rust helpers reusing the existing `Matrix::mul` / `Matrix::scale` core), so the `cargo semver-checks` gate stays green.

## New `Matrix` surface

| Expression | Meaning |
|---|---|
| `A * B` | matrix product (identical to `A @ B`, same inner-dimension check → `E-MAT-001`) |
| `A * k`, `k * A` | scalar multiplication — `int`, `float`, `Expr`, `DerivedResult` |
| `A @ B` / `__rmatmul__` | matrix product (kept; `__rmatmul__` added for symmetry) |
| `A ** n` | non-negative integer power: `A**0` = identity, `A**1` = `A`, `A**n` = `A @ … @ A` |
| `A.multiply(B)` | named alias for the matrix product (discoverable via `dir()`/`help()`) |
| `A.scalar_mul(k)` | named scalar multiplication |
| `A.hadamard(B)` | explicit elementwise product — named method only, never on `*` |

### Rationale (SymPy convention)
This is a symbolic CAS, so `*` between matrices means the matrix product, matching what agents expect from SymPy. Hadamard (elementwise) is deliberately **not** on any operator — it is exposed only as the explicit named `hadamard(...)` method so `*` is unambiguous.

### Error messages
Dimension-mismatch (`*`, `**`) and Hadamard-shape errors carry the shapes (e.g. `cannot multiply 2×3 by 2×3`) so agents get actionable feedback. Negative/non-integer `**` raises a clear `TypeError` pointing at `.inverse()`.

## Example

```python
import alkahest as al
p = al.ExprPool()
A = al.Matrix([[p.integer(1), p.integer(2)], [p.integer(3), p.integer(4)]])
B = al.Matrix([[p.integer(0), p.integer(1)], [p.integer(1), p.integer(0)]])

(A * B)               # matrix product, == A @ B
(2 * A)               # scale every entry
(A * p.symbol("k"))   # symbolic scalar
(A ** 3)              # A @ A @ A
A.hadamard(B)         # explicit elementwise
```

## Testing
- New coverage in `tests/test_linear_algebra.py`: `A*B == A@B`, scalar on both sides (int/float/Expr), `multiply`/`scalar_mul`/`hadamard`, `A**n`, and dimension-mismatch / negative-power / non-square declines.
- `cargo test -p alkahest-cas --features groebner`: pass
- Full `pytest tests/`: 1772 passed, 44 skipped
- `cargo fmt`, `ruff format`, `ruff check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added matrix multiplication using `*`, `@`, and the named `multiply` method.
  * Added scalar multiplication from either side, including supported numeric expressions.
  * Added elementwise (Hadamard) multiplication with shape validation.
  * Added matrix exponentiation for non-negative integer powers, including identity for `**0`.

* **Bug Fixes**
  * Improved errors for incompatible dimensions and unsupported power operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->