### PR TITLE
fix(ci): make Windows release README smoke UTF-8 safe

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -349,7 +349,11 @@ jobs:
       # See build-linux's identical step: catches the class of bug (B1, B6)
       # that only reproduces against a real wheel install in a fresh
       # interpreter, not an editable/dev environment or a warmed-up process.
+      # PYTHONIOENCODING: Windows runners default to cp1252; Lean certs print ∫.
       - name: README quickstart + fresh-interpreter parse smoke
+        env:
+          PYTHONIOENCODING: utf-8
+          PYTHONUTF8: "1"
         run: python tests/smoke_readme.py
 
       - uses: actions/upload-artifact@v7

--- a/tests/smoke_readme.py
+++ b/tests/smoke_readme.py
@@ -304,10 +304,8 @@ def _configure_stdio() -> None:
     for stream in (sys.stdout, sys.stderr):
         reconfigure = getattr(stream, "reconfigure", None)
         if callable(reconfigure):
-            try:
+            with contextlib.suppress(Exception):
                 reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
 
 
 def main() -> int:

--- a/tests/smoke_readme.py
+++ b/tests/smoke_readme.py
@@ -294,7 +294,24 @@ def run_readme_quickstart() -> None:
             _BLOCK_CHECKS[i](ns)
 
 
+def _configure_stdio() -> None:
+    """Windows CI runners default to cp1252; Lean certificates print ∫ etc.
+
+    Without this, printing README quickstart stdout (which includes
+    ``print(r.certificate)``) raises UnicodeEncodeError on Windows and
+    fails the release wheel smoke job even though the wheel itself is fine.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+
 def main() -> int:
+    _configure_stdio()
     run_parse_smoke()
     run_readme_quickstart()
 


### PR DESCRIPTION
## Summary
- Definite-integral Lean certificates now include `∫`; Windows release runners (cp1252) crashed `tests/smoke_readme.py` when printing README quickstart stdout, failing all `windows-2022` Release jobs.
- Reconfigure stdout/stderr to UTF-8 in the smoke script and set `PYTHONIOENCODING` / `PYTHONUTF8` on the Release workflow smoke step.

## Test plan
- [x] Confirm failed Release job log shows `UnicodeEncodeError` for `\u222b`
- [ ] Re-run Release workflow on merge; all Windows wheel jobs green
- [ ] Linux/macOS Release jobs still green


Made with [Cursor](https://cursor.com)