### PR TITLE
chore: release v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## 3.7.0 — 2026-07-25
+
+### Matrix / linear algebra
+
+- **SymPy-style matrix multiply:** `A * B` is the matrix product (same as
+  `A @ B`); `A * k` / `k * A` scalar-multiply; `A ** n` for non-negative
+  integer powers; named `multiply` / `scalar_mul` / `hadamard` methods.
+- **Symbolic 3×3 eigenvalues:** closed-form eigenvalues for parametric 3×3
+  matrices whose characteristic polynomial is an irreducible cubic over the
+  parameter field (Cardano / trigonometric path), not only 2×2.
+
+### Lean certificates
+
+- **Definite-integral certificates:** definite `integrate` emits a
+  type-checking Lean proof via Mathlib's FTC / interval-integral lemmas
+  (previously only indefinite integrals had certificates).
+- Broader Lean coverage for differentiation (chain rule, log/sqrt/tan,
+  quotient) and assumption-gated exp/log identities; certificates that do
+  not typecheck are withheld rather than emitting broken proofs.
+
 ### Fixes
 
 - **Laplace hyperbolic inverse:** irreducible quadratics with `ω² < 0`
@@ -49,6 +69,9 @@
   flattens nested `Add`/`Mul` so coefficients from linear canonization and
   reciprocal folds meet in one n-ary product.
 
+- **Accurate `erf`/`erfc` in f64 eval:** use libm rather than a coarse
+  approximation on the numeric evaluation path.
+
 ### Features
 
 - **Parametric `solve`:** free symbols omitted from `vars` are treated as
@@ -71,10 +94,11 @@
   *vars* is omitted.
 - Structured error messages now include the stable code prefix, e.g. ``[E-INT-004] …``.
 
-### Docs
+### Docs / release
 
 - Document `parse` in the README quickstart; clarify that `limit` / `series` are not `DerivedResult`.
 - Expand `sum_definite` / `sum_indefinite` / `diophantine` / `solve` docs (Faulhaber gap, binary Diophantine patterns, parametric solve).
+- Release wheel smoke runs the README quickstart + fresh-interpreter `parse` against the built wheel; Windows runners force UTF-8 so Lean certificates containing `∫` do not abort the smoke step.
 
 ## 3.6.0 — 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-cas"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "bitflags 2.12.1",
  "boxcar",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-mlir"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "alkahest-cas",
  "proptest",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-py"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "alkahest-cas",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "3.6.0"
+version = "3.7.0"
 edition = "2021"
 authors = ["Alkahest Contributors"]
 license = "Apache-2.0"

--- a/demo-playground/server/start.sh
+++ b/demo-playground/server/start.sh
@@ -41,7 +41,7 @@ install_alkahest_wheel() {
     aarch64|arm64) WHEEL_PLAT="manylinux_2_35_aarch64" ;;
     *) echo "Unsupported architecture for +full wheel: $(uname -m)"; return 1 ;;
   esac
-  local ALKAHEST_VERSION="${ALKAHEST_VERSION:-3.6.0}"
+  local ALKAHEST_VERSION="${ALKAHEST_VERSION:-3.7.0}"
   local FULL_WHEEL="https://github.com/alkahest-cas/alkahest/releases/download/v${ALKAHEST_VERSION}/alkahest-${ALKAHEST_VERSION}+full-${PY_TAG}-${PY_TAG}-${WHEEL_PLAT}.whl"
   echo "Installing alkahest +full wheel: $FULL_WHEEL"
   if pip install -q --force-reinstall "$FULL_WHEEL"; then

--- a/docs/mdbook/src/rl.md
+++ b/docs/mdbook/src/rl.md
@@ -132,7 +132,7 @@ prime eval run alkahest/alkahest-symbolic-integration -m <model>
 
 ### Hub checklist
 
-1. **Alkahest on PyPI** — the Hub package depends on `alkahest>=3.6.0` (includes
+1. **Alkahest on PyPI** — the Hub package depends on `alkahest>=3.7.0` (includes
    `alkahest.rl`). For local development before PyPI catches up, use `maturin develop`
    or a release wheel from GitHub.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-cas"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "bitflags",
  "boxcar",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "alkahest"
-version = "3.6.0"
+version = "3.7.0"
 description = "A high-performance computer algebra system for Python"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/alkahest/rl/envs/integration/pyproject.toml
+++ b/python/alkahest/rl/envs/integration/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 tags = ["math", "reasoning", "single-turn", "train", "eval", "symbolic"]
 dependencies = [
     "verifiers>=0.1.5",
-    "alkahest>=3.6.0",
+    "alkahest>=3.7.0",
     "datasets>=2.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "alkahest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump package version **3.6.0 → 3.7.0** in `Cargo.toml` / `pyproject.toml`, lockfiles, Hub/demo/docs pins.
- Promote `CHANGELOG` Unreleased → **3.7.0** (matrix ergonomics, symbolic 3×3 eigenvalues, Lean definite-integral certs, and post-3.6.0 fixes).

## Test plan
- [x] Main CI green on prior tip
- [x] Release workflow green (incl. Windows UTF-8 smoke fix #254)
- [ ] Merge; push `v3.7.0` tag to publish wheels to PyPI / crates


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded symbolic matrix and linear algebra support, including matrix multiplication semantics and additional 3×3 eigenvalue cases.
  * Added Lean certificate generation for definite integrals and broader differentiation and exponential/logarithm identities.

* **Bug Fixes**
  * Improved numerical evaluation accuracy for `erf` and `erfc`.

* **Documentation**
  * Updated release documentation, quickstart validation guidance, and certificate handling notes.
  * Released version 3.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->