### PR TITLE
fix(simplify): memoise, align rules, and bound recursion in simplify_par

### DIFF
--- a/alkahest-core/Cargo.toml
+++ b/alkahest-core/Cargo.toml
@@ -87,3 +87,20 @@ harness = false
 [[example]]
 name = "dump_ptx"
 required-features = ["cuda"]
+
+# Scaling / regression harnesses for the parallel simplifier.
+[[example]]
+name = "simplify_scaling"
+required-features = ["parallel"]
+
+[[example]]
+name = "simplify_probe"
+required-features = ["parallel"]
+
+[[example]]
+name = "simplify_clean"
+required-features = ["parallel"]
+
+[[example]]
+name = "pool_read_scaling"
+required-features = ["parallel"]

--- a/alkahest-core/examples/pool_read_scaling.rs
+++ b/alkahest-core/examples/pool_read_scaling.rs
@@ -1,0 +1,118 @@
+//! Isolates the per-node read cost in the parallel traversal.
+//!
+//! `simplify_node_par` starts every node visit with `let data = pool.get(expr)`
+//! which *clones* the `ExprData` (a `Vec<ExprId>` for Add/Mul, a `String` for
+//! Func names) — one heap allocation per node visit, on every worker.
+//! `ExprPool::with` borrows the same node with no allocation.
+//!
+//! This measures both under identical parallel traversal.
+
+use alkahest_cas::kernel::{Domain, ExprData, ExprId, ExprPool};
+use rayon::prelude::*;
+use std::time::{Duration, Instant};
+
+fn build(pool: &ExprPool, n: usize, depth: usize) -> Vec<ExprId> {
+    (0..n)
+        .map(|i| {
+            let mut e = pool.symbol(format!("x{i}"), Domain::Real);
+            for _ in 0..depth {
+                e = pool.func("sin", vec![e]);
+            }
+            e
+        })
+        .collect()
+}
+
+/// Walk the tree rooted at `id`, cloning each node (mirrors `pool.get`).
+fn walk_clone(pool: &ExprPool, id: ExprId) -> usize {
+    let data = pool.get(id);
+    let mut n = 1;
+    match data {
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for a in args {
+                n += walk_clone(pool, a);
+            }
+        }
+        ExprData::Func { args, .. } => {
+            for a in args {
+                n += walk_clone(pool, a);
+            }
+        }
+        ExprData::Pow { base, exp } => {
+            n += walk_clone(pool, base) + walk_clone(pool, exp);
+        }
+        _ => {}
+    }
+    n
+}
+
+/// Same walk via the borrowing API — no per-node allocation.
+fn walk_borrow(pool: &ExprPool, id: ExprId) -> usize {
+    pool.with(id, |data| {
+        let mut n = 1;
+        match data {
+            ExprData::Add(args) | ExprData::Mul(args) => {
+                for &a in args {
+                    n += walk_borrow(pool, a);
+                }
+            }
+            ExprData::Func { args, .. } => {
+                for &a in args {
+                    n += walk_borrow(pool, a);
+                }
+            }
+            ExprData::Pow { base, exp } => {
+                n += walk_borrow(pool, *base) + walk_borrow(pool, *exp);
+            }
+            _ => {}
+        }
+        n
+    })
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1e3
+}
+
+fn main() {
+    let n = 4096;
+    let depth = 32;
+    let pool = ExprPool::new();
+    let roots = build(&pool, n, depth);
+    println!("n={n} depth={depth}  pool_nodes={}", pool.len());
+
+    for (label, f) in [
+        ("get (clone)", walk_clone as fn(&ExprPool, ExprId) -> usize),
+        (
+            "with (borrow)",
+            walk_borrow as fn(&ExprPool, ExprId) -> usize,
+        ),
+    ] {
+        println!("\n--- {label} ---");
+        let mut base: Option<Duration> = None;
+        for nt in [1usize, 2, 4, 8, 16, 32] {
+            let tp = rayon::ThreadPoolBuilder::new()
+                .num_threads(nt)
+                .build()
+                .unwrap();
+            let mut best = Duration::from_secs(u64::MAX);
+            for _ in 0..5 {
+                let t = Instant::now();
+                let total: usize = tp.install(|| roots.par_iter().map(|&r| f(&pool, r)).sum());
+                let d = t.elapsed();
+                std::hint::black_box(total);
+                if d < best {
+                    best = d;
+                }
+            }
+            if base.is_none() {
+                base = Some(best);
+            }
+            println!(
+                "  t={nt:<3} {:>8.2} ms   scale {:>5.2}x",
+                ms(best),
+                base.unwrap().as_secs_f64() / best.as_secs_f64()
+            );
+        }
+    }
+}

--- a/alkahest-core/examples/simplify_clean.rs
+++ b/alkahest-core/examples/simplify_clean.rs
@@ -1,0 +1,99 @@
+//! Discriminator for the simplify_par scaling plateau.
+//!
+//! `wide_clean` has the same shape as `wide_tree` (one wide Add over N
+//! independent children) but the children are already canonical: the rule
+//! loop matches and fires nothing, so there is no interning of new nodes and
+//! no derivation-log growth — only traversal, rule matching, and scheduling.
+//!
+//! If this scales near-linearly, the plateau in `wide_tree` comes from
+//! intern/allocation contention. If it plateaus too, the limit is in the
+//! traversal/scheduling path itself.
+
+use alkahest_cas::kernel::{Domain, ExprId, ExprPool};
+use alkahest_cas::simplify::parallel::simplify_par;
+use alkahest_cas::simplify::simplify;
+use std::time::{Duration, Instant};
+
+/// Already-simplified child: sin(x_i) nested `depth` times, nothing to rewrite.
+fn clean_child(pool: &ExprPool, i: usize, depth: usize) -> ExprId {
+    let mut e = pool.symbol(format!("x{i}"), Domain::Real);
+    for _ in 0..depth {
+        e = pool.func("sin", vec![e]);
+    }
+    e
+}
+
+fn wide_clean(pool: &ExprPool, n: usize, depth: usize) -> ExprId {
+    let args: Vec<ExprId> = (0..n).map(|i| clean_child(pool, i, depth)).collect();
+    pool.add(args)
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1e3
+}
+
+fn time_min(reps: usize, mut f: impl FnMut() -> ExprId) -> Duration {
+    let mut best = Duration::from_secs(u64::MAX);
+    for _ in 0..reps {
+        let t = Instant::now();
+        let v = f();
+        std::hint::black_box(v);
+        let d = t.elapsed();
+        if d < best {
+            best = d;
+        }
+    }
+    best
+}
+
+fn main() {
+    let reps = 5;
+    let threads = [1usize, 2, 4, 8, 16, 32];
+
+    for &(n, d) in &[(1024usize, 8usize), (4096, 8)] {
+        let build = |p: &ExprPool| wide_clean(p, n, d);
+        let build_t = time_min(reps, || {
+            let pool = ExprPool::new();
+            build(&pool)
+        });
+
+        // work check: no rewrite steps should fire
+        let pool = ExprPool::new();
+        let e = build(&pool);
+        let steps = simplify(e, &pool).log.len();
+
+        let seq_t = time_min(reps, || {
+            let pool = ExprPool::new();
+            let e = build(&pool);
+            simplify(e, &pool).value
+        })
+        .saturating_sub(build_t);
+
+        println!("\n=== wide_clean n={n} depth={d}  (seq rewrite steps = {steps}) ===");
+        println!("  build          {:>9.2} ms", ms(build_t));
+        println!("  simplify (seq) {:>9.2} ms", ms(seq_t));
+
+        let mut base = None;
+        for &nt in &threads {
+            let tp = rayon::ThreadPoolBuilder::new()
+                .num_threads(nt)
+                .build()
+                .unwrap();
+            let t = time_min(reps, || {
+                let pool = ExprPool::new();
+                let e = build(&pool);
+                tp.install(|| simplify_par(e, &pool).value)
+            })
+            .saturating_sub(build_t);
+            if base.is_none() {
+                base = Some(t);
+            }
+            println!(
+                "  par t={nt:<3}      {:>9.2} ms   scale-vs-1t {:>5.2}x   vs-seq {:>5.2}x",
+                ms(t),
+                base.unwrap().as_secs_f64() / t.as_secs_f64(),
+                seq_t.as_secs_f64() / t.as_secs_f64()
+            );
+        }
+    }
+}

--- a/alkahest-core/examples/simplify_probe.rs
+++ b/alkahest-core/examples/simplify_probe.rs
@@ -1,0 +1,145 @@
+//! Follow-up probes for the simplify_par scaling study:
+//!   1. work done (derivation-log length) seq vs par — measures memo effect
+//!   2. deep-chain recursion: caller thread vs rayon worker thread
+//!   3. `expand: true` ruleset parity between seq and par
+
+use alkahest_cas::kernel::{Domain, ExprId, ExprPool};
+use alkahest_cas::simplify::parallel::simplify_par;
+use alkahest_cas::simplify::{simplify, simplify_with, SimplifyConfig};
+
+fn junk(pool: &ExprPool, x: ExprId, depth: usize) -> ExprId {
+    let one = pool.integer(1);
+    let zero = pool.integer(0);
+    let mut e = x;
+    for _ in 0..depth {
+        e = pool.mul(vec![e, one]);
+        e = pool.add(vec![e, zero]);
+        e = pool.pow(e, one);
+    }
+    e
+}
+
+fn wide_tree(pool: &ExprPool, n: usize, depth: usize) -> ExprId {
+    let args: Vec<ExprId> = (0..n)
+        .map(|i| {
+            let x = pool.symbol(format!("x{i}"), Domain::Real);
+            junk(pool, x, depth)
+        })
+        .collect();
+    pool.add(args)
+}
+
+fn wide_shared(pool: &ExprPool, n: usize, depth: usize) -> ExprId {
+    let x = pool.symbol("x", Domain::Real);
+    let shared = junk(pool, x, depth);
+    let args: Vec<ExprId> = (0..n)
+        .map(|i| {
+            let c = pool.integer(i as i64 + 1);
+            pool.mul(vec![shared, c])
+        })
+        .collect();
+    pool.add(args)
+}
+
+fn probe_work(name: &str, build: impl Fn(&ExprPool) -> ExprId) {
+    let pool = ExprPool::new();
+    let e = build(&pool);
+    let n_before = pool.len();
+    let s = simplify(e, &pool);
+    let seq_steps = s.log.len();
+    let seq_nodes = pool.len() - n_before;
+
+    let pool2 = ExprPool::new();
+    let e2 = build(&pool2);
+    let n_before2 = pool2.len();
+    let p = simplify_par(e2, &pool2);
+    let par_steps = p.log.len();
+    let par_nodes = pool2.len() - n_before2;
+
+    println!(
+        "{name:28} seq_steps={seq_steps:>8}  par_steps={par_steps:>8}  ratio={:>6.1}x   \
+         seq_new_nodes={seq_nodes:>6} par_new_nodes={par_nodes:>6}",
+        par_steps as f64 / seq_steps.max(1) as f64
+    );
+}
+
+fn probe_deep_stack() {
+    println!("\n--- deep chain: caller thread vs rayon worker ---");
+    for depth in [500usize, 1000, 2000, 4000] {
+        // (a) directly on this (main) thread, 8 MiB stack
+        let r = std::panic::catch_unwind(|| {
+            let pool = ExprPool::new();
+            let x = pool.symbol("x", Domain::Real);
+            let e = junk(&pool, x, depth);
+            simplify_par(e, &pool).value
+        });
+        println!(
+            "depth={depth:<5} main-thread simplify_par: {}",
+            if r.is_ok() { "ok" } else { "PANIC" }
+        );
+    }
+    println!("(rayon-worker variant is run separately — it aborts the process on overflow)");
+}
+
+fn probe_deep_on_worker(depth: usize) {
+    let tp = rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .build()
+        .unwrap();
+    let ok = tp.install(|| {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = junk(&pool, x, depth);
+        simplify_par(e, &pool).value
+    });
+    println!("depth={depth} on rayon worker: ok ({ok:?})");
+}
+
+fn probe_expand_parity() {
+    println!("\n--- expand: true ruleset parity ---");
+    let pool = ExprPool::new();
+    let x = pool.symbol("x", Domain::Real);
+    let y = pool.symbol("y", Domain::Real);
+    let two = pool.integer(2);
+    let sum = pool.add(vec![x, y]);
+    let sq = pool.pow(sum, two); // (x + y)^2
+    let cfg = SimplifyConfig {
+        expand: true,
+        ..Default::default()
+    };
+    let seq = simplify_with(
+        sq,
+        &pool,
+        &alkahest_cas::simplify::rules_for_config(&cfg),
+        cfg.clone(),
+    )
+    .value;
+    let par = alkahest_cas::simplify::parallel::simplify_par_with_config(sq, &pool, &cfg).value;
+    println!(
+        "(x+y)^2  expand=true\n  seq = {}\n  par = {}\n  equal: {}",
+        alkahest_cas::kernel::display::render_unicode(seq, &pool),
+        alkahest_cas::kernel::display::render_unicode(par, &pool),
+        seq == par
+    );
+}
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_default();
+    if mode == "worker" {
+        let depth: usize = std::env::args()
+            .nth(2)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2000);
+        probe_deep_on_worker(depth);
+        return;
+    }
+
+    println!("--- work done (derivation-log steps) ---");
+    probe_work("wide_tree n=256 d=8", |p| wide_tree(p, 256, 8));
+    probe_work("wide_tree n=1024 d=8", |p| wide_tree(p, 1024, 8));
+    probe_work("wide_shared n=256 d=8", |p| wide_shared(p, 256, 8));
+    probe_work("wide_shared n=1024 d=8", |p| wide_shared(p, 1024, 8));
+
+    probe_deep_stack();
+    probe_expand_parity();
+}

--- a/alkahest-core/examples/simplify_scaling.rs
+++ b/alkahest-core/examples/simplify_scaling.rs
@@ -1,0 +1,204 @@
+//! Scaling curve for `simplify_par` vs sequential `simplify`.
+//!
+//! Run with:
+//!   cargo run --release --features parallel --example simplify_scaling
+//!
+//! Three workload shapes:
+//!   * `wide_tree`   — Add of N *distinct* children (pure tree, no sharing)
+//!   * `wide_shared` — Add of N children over a shared heavy subexpression (DAG)
+//!   * `deep`        — one deep chain (no wide Add/Mul, so no par path at all)
+
+use alkahest_cas::kernel::{Domain, ExprId, ExprPool};
+use alkahest_cas::simplify::parallel::simplify_par;
+use alkahest_cas::simplify::simplify;
+use std::time::{Duration, Instant};
+
+/// Wrap `x` in `depth` layers of algebraic junk that the rule engine removes:
+/// `((e * 1) + 0)^1`.
+fn junk(pool: &ExprPool, x: ExprId, depth: usize) -> ExprId {
+    let one = pool.integer(1);
+    let zero = pool.integer(0);
+    let mut e = x;
+    for _ in 0..depth {
+        e = pool.mul(vec![e, one]);
+        e = pool.add(vec![e, zero]);
+        e = pool.pow(e, one);
+    }
+    e
+}
+
+/// Add of `n` children, each built over its own variable → no shared structure.
+fn wide_tree(pool: &ExprPool, n: usize, depth: usize) -> ExprId {
+    let args: Vec<ExprId> = (0..n)
+        .map(|i| {
+            let x = pool.symbol(format!("x{i}"), Domain::Real);
+            junk(pool, x, depth)
+        })
+        .collect();
+    pool.add(args)
+}
+
+/// Add of `n` children that all sit on top of one shared heavy subexpression.
+/// Hash-consing makes this a DAG; the sequential memo collapses it, the
+/// parallel path has no memo.
+fn wide_shared(pool: &ExprPool, n: usize, depth: usize) -> ExprId {
+    let x = pool.symbol("x", Domain::Real);
+    let shared = junk(pool, x, depth);
+    let args: Vec<ExprId> = (0..n)
+        .map(|i| {
+            let c = pool.integer(i as i64 + 1);
+            pool.mul(vec![shared, c])
+        })
+        .collect();
+    pool.add(args)
+}
+
+/// One deep chain — never hits the wide Add/Mul par path.
+fn deep(pool: &ExprPool, depth: usize) -> ExprId {
+    let x = pool.symbol("x", Domain::Real);
+    junk(pool, x, depth)
+}
+
+fn time_min<F: FnMut() -> ExprId>(reps: usize, mut f: F) -> (Duration, ExprId) {
+    let mut best = Duration::from_secs(u64::MAX);
+    let mut out = None;
+    for _ in 0..reps {
+        // Fresh pool per rep is handled by the caller's closure.
+        let t = Instant::now();
+        let v = f();
+        let d = t.elapsed();
+        if d < best {
+            best = d;
+        }
+        out = Some(v);
+    }
+    (best, out.unwrap())
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1e3
+}
+
+fn run_case(name: &str, build: &dyn Fn(&ExprPool) -> ExprId, threads: &[usize], reps: usize) {
+    // --- sequential baseline (fresh pool per rep) ---
+    let (seq_t, seq_v) = time_min(reps, || {
+        let pool = ExprPool::new();
+        let e = build(&pool);
+        let t = Instant::now();
+        let r = simplify(e, &pool).value;
+        // fold the inner timing out: we time the whole closure, so subtract
+        // nothing here — build cost is measured separately below.
+        let _ = t;
+        r
+    });
+
+    // Measure build cost alone so we can subtract it.
+    let (build_t, _) = time_min(reps, || {
+        let pool = ExprPool::new();
+        build(&pool)
+    });
+
+    let seq_net = seq_t.saturating_sub(build_t);
+    let seq_str = {
+        let pool = ExprPool::new();
+        let e = build(&pool);
+        let r = simplify(e, &pool).value;
+        alkahest_cas::kernel::display::render_unicode(r, &pool)
+    };
+
+    println!("\n=== {name} ===");
+    println!("  build          {:>10.2} ms", ms(build_t));
+    println!(
+        "  simplify (seq) {:>10.2} ms   (net of build)   result_len={}",
+        ms(seq_net),
+        seq_str.len()
+    );
+    let _ = seq_v;
+
+    let mut base_par: Option<Duration> = None;
+    for &nt in threads {
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(nt)
+            .build()
+            .unwrap();
+        let (par_t, _) = time_min(reps, || {
+            let pool = ExprPool::new();
+            let e = build(&pool);
+            tp.install(|| simplify_par(e, &pool).value)
+        });
+        let par_net = par_t.saturating_sub(build_t);
+        if base_par.is_none() {
+            base_par = Some(par_net);
+        }
+        let self_speedup = base_par.unwrap().as_secs_f64() / par_net.as_secs_f64();
+        let vs_seq = seq_net.as_secs_f64() / par_net.as_secs_f64();
+        println!(
+            "  par t={nt:<3}      {:>10.2} ms   scale-vs-1t {:>5.2}x   vs-seq {:>5.2}x",
+            ms(par_net),
+            self_speedup,
+            vs_seq
+        );
+    }
+
+    // Correctness cross-check: par and seq must agree structurally.
+    let pool = ExprPool::new();
+    let e = build(&pool);
+    let a = simplify(e, &pool).value;
+    let b = simplify_par(e, &pool).value;
+    println!(
+        "  agreement: {}",
+        if a == b {
+            "same ExprId".to_string()
+        } else {
+            format!(
+                "DIFFER seq={} par={}",
+                alkahest_cas::kernel::display::render_unicode(a, &pool),
+                alkahest_cas::kernel::display::render_unicode(b, &pool)
+            )
+        }
+    );
+}
+
+fn main() {
+    let threads: Vec<usize> = std::env::var("THREADS")
+        .ok()
+        .map(|s| s.split(',').map(|x| x.trim().parse().unwrap()).collect())
+        .unwrap_or_else(|| vec![1, 2, 4, 8, 16, 32]);
+    let reps: usize = std::env::var("REPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+
+    println!("cores={}  reps={reps}", num_cpus_hint());
+
+    for &(n, d) in &[(256usize, 8usize), (1024, 8), (4096, 4)] {
+        run_case(
+            &format!("wide_tree n={n} depth={d}"),
+            &move |p: &ExprPool| wide_tree(p, n, d),
+            &threads,
+            reps,
+        );
+    }
+
+    for &(n, d) in &[(256usize, 8usize), (1024, 8)] {
+        run_case(
+            &format!("wide_shared n={n} depth={d}"),
+            &move |p: &ExprPool| wide_shared(p, n, d),
+            &threads,
+            reps,
+        );
+    }
+
+    run_case(
+        "deep depth=2000",
+        &|p: &ExprPool| deep(p, 2000),
+        &threads,
+        reps,
+    );
+}
+
+fn num_cpus_hint() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(0)
+}

--- a/alkahest-core/src/simplify/parallel.rs
+++ b/alkahest-core/src/simplify/parallel.rs
@@ -14,19 +14,36 @@
 //! `Mul` nodes whose arity exceeds `PAR_THRESHOLD`.  Smaller nodes fall back
 //! to the sequential path to avoid scheduling overhead.
 //!
-//! # Sharded pool audit
+//! # Shared subexpressions
 //!
-//! `ExprPool` currently uses a single `Mutex<PoolState>`.  Under heavy
-//! parallel load the lock becomes a bottleneck.  When `--features parallel`
-//! and `--features parallel-sharded` are combined, `ExprPool` switches to a
-//! `DashMap`-based sharded intern table.  This module documents the design;
-//! the actual sharding is in `kernel/pool_sharded.rs`.
+//! The traversal is memoised through a concurrent `DashMap<ExprId, ExprId>`,
+//! one per fixed-point pass, mirroring the `HashMap` memo in
+//! [`crate::simplify::engine::simplify_with`].  Without it every occurrence of
+//! a shared subexpression is re-simplified: because the pool is hash-consed,
+//! ordinary expressions are DAGs rather than trees, and the duplicated work
+//! made `simplify_par` orders of magnitude slower than the sequential path on
+//! exactly the inputs it was supposed to accelerate.
+//!
+//! Two threads may still race to simplify the same node; both compute the same
+//! value, so only the work (and possibly a duplicated derivation-log entry) is
+//! wasted.  The memo is deliberately not held across the recursive call — doing
+//! so would hold a `DashMap` shard lock while rayon work-stealing runs nested
+//! tasks on the same thread.
+//!
+//! # Deep expressions
+//!
+//! The traversal is recursive, and rayon workers get the default 2 MiB stack
+//! rather than the main thread's 8 MiB, so a deep chain used to abort the whole
+//! process with a stack overflow.  The recursion now measures how much stack it
+//! has consumed and continues on a freshly spawned thread with a larger stack
+//! before running out; see [`with_stack_segment`].
 //!
 //! # Safety
 //!
-//! `ExprPool: Send + Sync` is asserted in `pool.rs`.  The parallel
-//! simplifier only reads from the pool (via `pool.get`) and writes via
-//! `pool.intern` (which is already `Mutex`-protected).
+//! `ExprPool: Send + Sync` is asserted in `pool.rs`.  Reads go through
+//! `ExprPool::with`, which borrows a node without cloning it; the node array is
+//! append-only and reference-stable, so interning while a borrow is live is
+//! sound.
 
 #![cfg(feature = "parallel")]
 
@@ -34,11 +51,39 @@ use crate::deriv::log::{DerivationLog, DerivedExpr};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::simplify::engine::SimplifyConfig;
 use crate::simplify::rules::RewriteRule;
+use dashmap::DashMap;
 use rayon::prelude::*;
 use std::sync::Arc;
 
 /// Arity threshold above which children are simplified in parallel.
 const PAR_THRESHOLD: usize = 4;
+
+/// Stack size handed to each refill thread (see [`with_stack_segment`]).
+const SEGMENT_STACK_BYTES: usize = 16 * 1024 * 1024;
+
+/// Stack the traversal may consume on a thread it did not create.  Rayon
+/// workers get 2 MiB by default, so this leaves a wide margin for the frames
+/// already below us and for whatever the rule engine needs.
+const FOREIGN_STACK_BUDGET: usize = 512 * 1024;
+
+/// Stack the traversal may consume on a segment thread it created itself.
+/// Kept well under [`SEGMENT_STACK_BYTES`] so a single node visit can never
+/// straddle the end of the segment.
+const OWNED_STACK_BUDGET: usize = SEGMENT_STACK_BYTES - 4 * 1024 * 1024;
+
+thread_local! {
+    /// Stack address at which this thread's segment began; 0 until first probe.
+    static SEGMENT_BASE: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    /// How much stack this thread's segment is allowed to consume.
+    static SEGMENT_BUDGET: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(FOREIGN_STACK_BUDGET) };
+}
+
+/// Per-pass memo: input `ExprId` → simplified `ExprId`.
+type Memo = DashMap<ExprId, ExprId>;
+
+/// Shared rule list handed to every worker.
+type Rules = Arc<Vec<Box<dyn RewriteRule + Send + Sync>>>;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -60,17 +105,29 @@ pub fn simplify_par_with_config(
     pool: &ExprPool,
     config: &SimplifyConfig,
 ) -> DerivedExpr<ExprId> {
-    let rules: Arc<Vec<Box<dyn RewriteRule + Send + Sync>>> =
-        Arc::new(rules_for_config_par(config));
+    let rules: Rules = Arc::new(rules_for_config_par(config));
     let mut current = expr;
     let mut full_log = DerivationLog::new();
     for _ in 0..config.max_iterations {
-        let result = simplify_node_par(current, pool, &rules);
+        // Fresh memo per pass, exactly as `simplify_with` does, so each sweep
+        // sees the expression produced by the previous one.
+        let memo = Memo::new();
+        let result = simplify_node_par(current, pool, &rules, &memo);
         full_log = full_log.merge(result.log);
         if result.value == current {
             break;
         }
         current = result.value;
+    }
+
+    // Assumption-driven (colored e-graph) pass, mirroring `simplify_with`.
+    // Without this, `simplify_par` silently ignored both explicit assumptions
+    // and static symbol domains that the sequential path honours.
+    let mut assumptions = config.assumptions.clone();
+    super::assumptions::collect_static_domain_facts(current, pool, &mut assumptions);
+    if !assumptions.is_empty() {
+        let colored = super::colored_egraph::apply_colored_if_needed(current, pool, &assumptions);
+        return DerivedExpr::with_log(colored.value, full_log.merge(colored.log));
     }
     DerivedExpr::with_log(current, full_log)
 }
@@ -82,142 +139,265 @@ pub fn simplify_par_with_config(
 fn simplify_node_par(
     expr: ExprId,
     pool: &ExprPool,
-    rules: &Arc<Vec<Box<dyn RewriteRule + Send + Sync>>>,
+    rules: &Rules,
+    memo: &Memo,
 ) -> DerivedExpr<ExprId> {
-    let data = pool.get(expr);
-    let (rebuilt, child_log) = simplify_children_par(data, pool, rules);
+    // Shared-subexpression cache: a hit returns an empty log so the same
+    // rewrite is not reported once per occurrence (as in `simplify_node`).
+    if let Some(cached) = memo.get(&expr) {
+        return DerivedExpr::new(*cached);
+    }
 
-    let mut current = rebuilt;
-    let mut rule_log = DerivationLog::new();
-    loop {
-        let mut fired = false;
-        for rule in rules.as_ref() {
-            if let Some((new_expr, step_log)) = rule.apply(current, pool) {
-                rule_log = rule_log.merge(step_log);
-                current = new_expr;
-                fired = true;
+    let result = with_stack_segment(|| {
+        // `with` borrows the node instead of cloning it: the owning `ExprData`
+        // clone was one heap allocation (and, for `Func`, one `String` clone)
+        // per node visit on every worker.
+        let (rebuilt, child_log) = pool.with(expr, |data| {
+            simplify_children_par(expr, data, pool, rules, memo)
+        });
+
+        let mut current = rebuilt;
+        let mut rule_log = DerivationLog::new();
+        loop {
+            let mut fired = false;
+            for rule in rules.as_ref() {
+                if let Some((new_expr, step_log)) = rule.apply(current, pool) {
+                    rule_log = rule_log.merge(step_log);
+                    current = new_expr;
+                    fired = true;
+                    break;
+                }
+            }
+            if !fired {
                 break;
             }
         }
-        if !fired {
-            break;
-        }
+        DerivedExpr::with_log(current, child_log.merge(rule_log))
+    });
+
+    memo.insert(expr, result.value);
+    result
+}
+
+/// Run `f`, moving it to a thread with a fresh [`SEGMENT_STACK_BYTES`] stack
+/// once the current segment has consumed its budget.
+///
+/// Rayon workers have the default 2 MiB stack, which a deep expression chain
+/// exhausts — and a stack overflow aborts the process rather than unwinding, so
+/// the caller cannot catch it.  Depth alone is a poor proxy for stack use (debug
+/// frames are several times larger than release ones), so this measures the
+/// stack actually consumed since the segment began.  Segments are spawned
+/// scoped, so the borrowed pool, rules and memo stay valid.
+///
+/// Inside a segment the ambient rayon pool is no longer installed, so nested
+/// `par_iter` calls fall back to the global pool.  That only affects subtrees
+/// deep enough to exhaust a whole segment, where returning an answer at all
+/// matters more than which pool schedules the work.
+fn with_stack_segment<R: Send>(f: impl FnOnce() -> R + Send) -> R {
+    if stack_used() < SEGMENT_BUDGET.with(|b| b.get()) {
+        return f();
     }
-    DerivedExpr::with_log(current, child_log.merge(rule_log))
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .stack_size(SEGMENT_STACK_BYTES)
+            .spawn_scoped(scope, || {
+                // Fresh thread: its own thread-locals, and a stack we sized.
+                SEGMENT_BUDGET.with(|b| b.set(OWNED_STACK_BUDGET));
+                f()
+            })
+            .expect("failed to spawn stack segment for deep recursion")
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    })
+}
+
+/// Stack bytes consumed on this thread since the current segment began.
+///
+/// Uses the address of a local as a stack-depth probe; the first probe on a
+/// thread establishes the baseline.  Stacks grow downwards on every platform
+/// this crate targets, and the subtraction is saturating, so a platform where
+/// they do not simply reports 0 and never refills.
+fn stack_used() -> usize {
+    let probe = 0u8;
+    let here = &probe as *const u8 as usize;
+    SEGMENT_BASE.with(|base| {
+        if base.get() == 0 {
+            base.set(here);
+            0
+        } else {
+            base.get().saturating_sub(here)
+        }
+    })
 }
 
 fn simplify_children_par(
-    data: ExprData,
+    expr: ExprId,
+    data: &ExprData,
     pool: &ExprPool,
-    rules: &Arc<Vec<Box<dyn RewriteRule + Send + Sync>>>,
+    rules: &Rules,
+    memo: &Memo,
 ) -> (ExprId, DerivationLog) {
     match data {
         ExprData::Add(args) if args.len() >= PAR_THRESHOLD => {
-            let results: Vec<DerivedExpr<ExprId>> = args
-                .par_iter()
-                .map(|&a| simplify_node_par(a, pool, rules))
-                .collect();
-            let new_args: Vec<ExprId> = results.iter().map(|r| r.value).collect();
-            let mut log = DerivationLog::new();
-            for r in results {
-                log = log.merge(r.log);
-            }
-            (pool.add(new_args), log)
+            let (new_args, log) = par_children(args, pool, rules, memo);
+            (rebuild_nary(expr, args, new_args, pool, NAry::Add), log)
         }
         ExprData::Mul(args) if args.len() >= PAR_THRESHOLD => {
-            let results: Vec<DerivedExpr<ExprId>> = args
-                .par_iter()
-                .map(|&a| simplify_node_par(a, pool, rules))
-                .collect();
-            let new_args: Vec<ExprId> = results.iter().map(|r| r.value).collect();
-            let mut log = DerivationLog::new();
-            for r in results {
-                log = log.merge(r.log);
-            }
-            (pool.mul(new_args), log)
+            let (new_args, log) = par_children(args, pool, rules, memo);
+            (rebuild_nary(expr, args, new_args, pool, NAry::Mul), log)
         }
         // Sequential fallback for small nodes and Pow/Func
         ExprData::Add(args) => {
-            let mut log = DerivationLog::new();
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node_par(a, pool, rules);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.add(new_args), log)
+            let (new_args, log) = seq_children(args, pool, rules, memo);
+            (rebuild_nary(expr, args, new_args, pool, NAry::Add), log)
         }
         ExprData::Mul(args) => {
-            let mut log = DerivationLog::new();
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node_par(a, pool, rules);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.mul(new_args), log)
+            let (new_args, log) = seq_children(args, pool, rules, memo);
+            (rebuild_nary(expr, args, new_args, pool, NAry::Mul), log)
         }
         ExprData::Pow { base, exp } => {
-            let rb = simplify_node_par(base, pool, rules);
-            let re = simplify_node_par(exp, pool, rules);
+            let rb = simplify_node_par(*base, pool, rules, memo);
+            let re = simplify_node_par(*exp, pool, rules, memo);
             let log = rb.log.merge(re.log);
-            (pool.pow(rb.value, re.value), log)
+            let id = if rb.value == *base && re.value == *exp {
+                expr
+            } else {
+                pool.pow(rb.value, re.value)
+            };
+            (id, log)
         }
         ExprData::Func { name, args } => {
-            let mut log = DerivationLog::new();
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node_par(a, pool, rules);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.func(&name, new_args), log)
+            let (new_args, log) = seq_children(args, pool, rules, memo);
+            let id = if new_args == *args {
+                expr
+            } else {
+                pool.func(name.as_str(), new_args)
+            };
+            (id, log)
         }
         ExprData::Piecewise { branches, default } => {
             let mut log = DerivationLog::new();
+            let mut changed = false;
             let new_branches: Vec<(ExprId, ExprId)> = branches
-                .into_iter()
-                .map(|(cond, val)| {
-                    let rv = simplify_node_par(val, pool, rules);
+                .iter()
+                .map(|&(cond, val)| {
+                    let rv = simplify_node_par(val, pool, rules, memo);
                     log = std::mem::take(&mut log).merge(rv.log);
+                    changed |= rv.value != val;
                     (cond, rv.value)
                 })
                 .collect();
-            let rd = simplify_node_par(default, pool, rules);
+            let rd = simplify_node_par(*default, pool, rules, memo);
             log = log.merge(rd.log);
-            (pool.piecewise(new_branches, rd.value), log)
+            let id = if !changed && rd.value == *default {
+                expr
+            } else {
+                pool.piecewise(new_branches, rd.value)
+            };
+            (id, log)
         }
         ExprData::Predicate { kind, args } => {
-            let mut log = DerivationLog::new();
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node_par(a, pool, rules);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.predicate(kind, new_args), log)
+            let (new_args, log) = seq_children(args, pool, rules, memo);
+            let id = if new_args == *args {
+                expr
+            } else {
+                pool.predicate(kind.clone(), new_args)
+            };
+            (id, log)
         }
         ExprData::Forall { var, body } => {
-            let rb = simplify_node_par(body, pool, rules);
-            (pool.forall(var, rb.value), rb.log)
+            let rb = simplify_node_par(*body, pool, rules, memo);
+            let id = if rb.value == *body {
+                expr
+            } else {
+                pool.forall(*var, rb.value)
+            };
+            (id, rb.log)
         }
         ExprData::Exists { var, body } => {
-            let rb = simplify_node_par(body, pool, rules);
-            (pool.exists(var, rb.value), rb.log)
+            let rb = simplify_node_par(*body, pool, rules, memo);
+            let id = if rb.value == *body {
+                expr
+            } else {
+                pool.exists(*var, rb.value)
+            };
+            (id, rb.log)
         }
         ExprData::BigO(arg) => {
-            let r = simplify_node_par(arg, pool, rules);
-            (pool.big_o(r.value), r.log)
+            let r = simplify_node_par(*arg, pool, rules, memo);
+            let id = if r.value == *arg {
+                expr
+            } else {
+                pool.big_o(r.value)
+            };
+            (id, r.log)
         }
-        leaf => (pool.intern(leaf), DerivationLog::new()),
+        // Atoms have no children; `expr` already interns this exact node.
+        _ => (expr, DerivationLog::new()),
+    }
+}
+
+/// Simplify `args` on the rayon pool, returning the new ids and merged log.
+fn par_children(
+    args: &[ExprId],
+    pool: &ExprPool,
+    rules: &Rules,
+    memo: &Memo,
+) -> (Vec<ExprId>, DerivationLog) {
+    let results: Vec<DerivedExpr<ExprId>> = args
+        .par_iter()
+        .map(|&a| simplify_node_par(a, pool, rules, memo))
+        .collect();
+    let new_args: Vec<ExprId> = results.iter().map(|r| r.value).collect();
+    let mut log = DerivationLog::new();
+    for r in results {
+        log = log.merge(r.log);
+    }
+    (new_args, log)
+}
+
+/// Simplify `args` in order on the current thread.
+fn seq_children(
+    args: &[ExprId],
+    pool: &ExprPool,
+    rules: &Rules,
+    memo: &Memo,
+) -> (Vec<ExprId>, DerivationLog) {
+    let mut log = DerivationLog::new();
+    let new_args: Vec<ExprId> = args
+        .iter()
+        .map(|&a| {
+            let r = simplify_node_par(a, pool, rules, memo);
+            log = std::mem::take(&mut log).merge(r.log);
+            r.value
+        })
+        .collect();
+    (new_args, log)
+}
+
+enum NAry {
+    Add,
+    Mul,
+}
+
+/// Re-intern an `Add`/`Mul` node, reusing `expr` when nothing changed.
+///
+/// `ExprPool::add` and `ExprPool::mul` canonically sort their arguments, so the
+/// shortcut is only sound when the original list is already sorted — otherwise
+/// reusing `expr` would skip a canonicalisation the rebuild would have applied.
+fn rebuild_nary(
+    expr: ExprId,
+    old_args: &[ExprId],
+    new_args: Vec<ExprId>,
+    pool: &ExprPool,
+    kind: NAry,
+) -> ExprId {
+    if new_args == old_args && old_args.windows(2).all(|w| w[0] <= w[1]) {
+        return expr;
+    }
+    match kind {
+        NAry::Add => pool.add(new_args),
+        NAry::Mul => pool.mul(new_args),
     }
 }
 
@@ -227,33 +407,16 @@ fn simplify_children_par(
 
 /// Build a rule list where each rule is `Send + Sync`.
 ///
-/// All rule structs in `alkahest_core::simplify::rules` are zero-sized, so they
-/// are trivially `Send + Sync`.  This function mirrors `rules_for_config` but
-/// produces boxed `dyn RewriteRule + Send + Sync`.
+/// `RewriteRule` already requires `Send + Sync`, so this simply delegates to
+/// [`crate::simplify::engine::rules_for_config`] rather than maintaining a
+/// second hand-written list.  The duplicate list had silently drifted: it was
+/// missing `ExpandPow`, so `simplify_par` with `expand: true` left `(x + y)^2`
+/// unexpanded while `simplify` returned `x² + y² + 2·x·y`.
 pub fn rules_for_config_par(config: &SimplifyConfig) -> Vec<Box<dyn RewriteRule + Send + Sync>> {
-    use crate::simplify::rules::{
-        AddZero, CanonicalOrder, ConstFold, DivSelf, ExpandMul, FlattenAdd, FlattenMul, MulOne,
-        MulZero, PowOne, PowZero, PrimitiveFold, SqrtInteger, SubSelf,
-    };
-    let mut rules: Vec<Box<dyn RewriteRule + Send + Sync>> = vec![
-        Box::new(FlattenMul),
-        Box::new(FlattenAdd),
-        Box::new(MulZero),
-        Box::new(AddZero),
-        Box::new(MulOne),
-        Box::new(PowZero),
-        Box::new(PowOne),
-        Box::new(SqrtInteger),
-        Box::new(ConstFold),
-        Box::new(PrimitiveFold),
-        Box::new(SubSelf),
-        Box::new(DivSelf),
-        Box::new(CanonicalOrder),
-    ];
-    if config.expand {
-        rules.push(Box::new(ExpandMul));
-    }
-    rules
+    crate::simplify::engine::rules_for_config(config)
+        .into_iter()
+        .map(|rule| rule as Box<dyn RewriteRule + Send + Sync>)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -305,6 +468,150 @@ mod tests {
         // 2 + 3 + 4 + 5 = 14
         let expected = pool.integer(14_i32);
         assert_eq!(par.value, expected);
+    }
+
+    /// The parallel rule list used to be a hand-maintained copy that had
+    /// drifted from `rules_for_config` (it was missing `ExpandPow`).  Order
+    /// matters: the rule loop fires the first match.
+    #[test]
+    fn ruleset_matches_sequential_exactly() {
+        for expand in [false, true] {
+            let config = SimplifyConfig {
+                expand,
+                ..Default::default()
+            };
+            let seq: Vec<&str> = crate::simplify::rules_for_config(&config)
+                .iter()
+                .map(|r| r.name())
+                .collect();
+            let par: Vec<&str> = rules_for_config_par(&config)
+                .iter()
+                .map(|r| r.name())
+                .collect();
+            assert_eq!(seq, par, "rule lists diverged for expand={expand}");
+        }
+    }
+
+    #[test]
+    fn par_expand_matches_sequential() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let two = pool.integer(2_i32);
+        let sum = pool.add(vec![x, y]);
+        let sq = pool.pow(sum, two);
+        let config = SimplifyConfig {
+            expand: true,
+            ..Default::default()
+        };
+        let seq = crate::simplify::simplify_with(
+            sq,
+            &pool,
+            &crate::simplify::rules_for_config(&config),
+            config.clone(),
+        );
+        let par = simplify_par_with_config(sq, &pool, &config);
+        assert_eq!(seq.value, par.value, "(x + y)^2 expanded differently");
+        // The expansion must actually have happened.
+        assert_ne!(par.value, sq);
+    }
+
+    /// Static symbol domains authorise conditional rewrites in the sequential
+    /// path; the parallel path used to skip that pass entirely.
+    #[test]
+    fn par_honours_static_domains() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Positive);
+        let two = pool.integer(2_i32);
+        let sq = pool.pow(x, two);
+        let sqrt = pool.func("sqrt", vec![sq]);
+        let seq = simplify(sqrt, &pool);
+        let par = simplify_par(sqrt, &pool);
+        assert_eq!(seq.value, par.value);
+    }
+
+    /// Shared subexpressions must be simplified once, not once per occurrence.
+    /// Pinned to a single worker so the comparison is deterministic.
+    #[test]
+    fn par_memoises_shared_subexpressions() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        let zero = pool.integer(0_i32);
+        // A chunk of removable algebraic junk, shared by every term.
+        let mut shared = x;
+        for _ in 0..8 {
+            shared = pool.mul(vec![shared, one]);
+            shared = pool.add(vec![shared, zero]);
+        }
+        let args: Vec<ExprId> = (1..=64)
+            .map(|i| {
+                let c = pool.integer(i);
+                pool.mul(vec![shared, c])
+            })
+            .collect();
+        let expr = pool.add(args);
+
+        let seq = simplify(expr, &pool);
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let par = tp.install(|| simplify_par(expr, &pool));
+
+        assert_eq!(seq.value, par.value);
+        assert_eq!(
+            seq.log.len(),
+            par.log.len(),
+            "parallel path re-simplified shared subexpressions"
+        );
+    }
+
+    /// Build `((x * 1) + 0)^1` nested `depth` times — all of it removable.
+    fn deep_chain(pool: &ExprPool, depth: usize) -> ExprId {
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        let zero = pool.integer(0_i32);
+        let mut e = x;
+        for _ in 0..depth {
+            e = pool.mul(vec![e, one]);
+            e = pool.add(vec![e, zero]);
+            e = pool.pow(e, one);
+        }
+        e
+    }
+
+    /// A deep chain on a rayon worker (2 MiB stack) used to overflow the stack
+    /// and abort the whole process instead of returning.  3000 recursion levels
+    /// is roughly five times what an unguarded debug traversal survives there.
+    ///
+    /// Only the parallel path is exercised: the sequential traversal recurses
+    /// just as deep and still overflows a small stack well before this size.
+    #[test]
+    fn par_survives_deep_chain_on_worker_thread() {
+        let pool = p();
+        let deep = deep_chain(&pool, 1000);
+        let x = pool.symbol("x", Domain::Real);
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .unwrap();
+        let par = tp.install(|| simplify_par(deep, &pool));
+        assert_eq!(par.value, x);
+    }
+
+    /// At a depth both paths can handle, the results must still agree.
+    #[test]
+    fn par_matches_sequential_on_moderate_chain() {
+        let pool = p();
+        let deep = deep_chain(&pool, 100);
+        let seq = simplify(deep, &pool);
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .unwrap();
+        let par = tp.install(|| simplify_par(deep, &pool));
+        assert_eq!(seq.value, par.value);
     }
 
     #[test]


### PR DESCRIPTION
Started as a scaling study of `simplify_par` and turned into three correctness fixes plus one avoidable cost. Measured on a 32-core box, release, `--features parallel`.

## Bugs fixed

**No memoisation on the parallel path.** `simplify_node` carries a per-pass `HashMap<ExprId, ExprId>` so a shared subexpression is simplified once. `simplify_node_par` had no equivalent and re-simplified every occurrence. The pool is hash-consed, so ordinary expressions are DAGs — this hit the common case, not a corner:

| shared-subexpression sum | rewrite steps before | after |
|---|---|---|
| 256 terms | 6,146 (236× sequential) | 162 (6.2×) |
| 1024 terms | 24,578 (945× sequential) | 32 (1.2×) |

Wall clock on the 1024-term case: was 38.7 ms at 1 thread and 6.0 ms at 32 — i.e. **2.3× slower than sequential even on 32 cores**. Now 2.9 ms at 1 thread, 1.3 ms at 32, **2.0× faster than sequential**.

**Rule list had silently drifted.** `rules_for_config_par` was a hand-maintained copy of `rules_for_config` missing `ExpandPow`, so with `expand: true`:

```
(x+y)^2   simplify     → x² + y² + 2·x·y
          simplify_par → (x + y)²
```

`RewriteRule` already requires `Send + Sync`, so the copy is now a delegation and cannot drift. A test pins the two lists in order.

**Assumptions pass was skipped.** `simplify_with` runs a colored e-graph pass over explicit assumptions plus static symbol domains; `simplify_par` skipped it entirely and silently ignored domain facts the sequential path honours.

**Deep expressions aborted the process.** The traversal is recursive and rayon workers get a 2 MiB stack, so a deep chain overflowed — and a stack overflow aborts rather than unwinding, so callers cannot catch it. The recursion now measures the stack it has consumed and continues on a freshly spawned larger-stacked thread before running out. Depth counting was tried first and rejected: debug frames are several times larger than release ones, so no fixed depth is right for both.

| chain depth on a rayon worker | before | after |
|---|---|---|
| 2000 | `fatal runtime error: stack overflow, aborting` | ok |
| 8000 | — | ok |

## Cost removed

Node reads go through `ExprPool::with` (borrow) instead of `get` (clone), and unchanged nodes are reused rather than re-interned. That removes one heap allocation — and for `Func`, a `String` clone — per node visit. Single-threaded `simplify_par` on a 1024-term sum: 43.1 ms → 31.4 ms. A microbenchmark of the two read paths under rayon is included (`pool_read_scaling`): borrow is 2.4× faster single-threaded and scales to 20.7× vs 15.8× on 32 cores.

## Scope note

`ExprPool` has not used `Mutex<PoolState>` for some time — it is `boxcar::Vec` plus a sharded `DashMap`. The stale module comment claiming the pool lock is the parallel bottleneck is corrected; measurements show the limit is per-node work in the rule loop, not synchronisation.

The shipped PyPI wheel does not enable `parallel`, and `py_simplify_par` falls back to sequential there, so none of these were user-visible on the default wheel — they affected builds with `--features parallel`.

## What is still true after this change

Peak scaling on wide independent-child workloads is ~3.5–4× on 32 cores, limited by allocation in the rule loop (every `rule.apply` still clones the node it inspects). Fixing that means touching all of `rules.rs` and is left out deliberately.

## Also added

Four benchmark examples, gated on `required-features = ["parallel"]` so `--all-targets` builds stay clean: `simplify_scaling`, `simplify_probe`, `simplify_clean`, `pool_read_scaling`.

## Testing

- `cargo test --workspace --features parallel` — 1694 passed, 0 failed
- `cargo test --all` (default features) — 1668 passed, 0 failed
- `cargo test --features "parallel egraph"` — 10/10 parallel-module tests pass (exercises the new assumptions pass through the real colored e-graph)
- `cargo clippy --all-targets`, `--features parallel`, `--features "parallel egraph"` — clean
- `cargo fmt --all -- --check` — clean

Six new tests cover each fix, including a deep chain on a rayon worker that aborted the whole test binary before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved parallel simplification performance for wide, shared, and deeply nested expressions.
  * Added more efficient processing for repeated subexpressions and large expression trees.
  * Preserved consistent results between sequential and parallel simplification, including expansion and domain-aware transformations.
  * Improved handling of deeply nested expressions across caller and worker threads.

* **Tests**
  * Added coverage for rule consistency, expansion behavior, shared-subexpression reuse, static domains, and deep-chain simplification.

* **Tools**
  * Added benchmark examples for evaluating simplification and expression-pool traversal scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->