### PR TITLE
fix(ci): green main after agent merges (Basel Lean, rustdoc, ruff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixes
+
+- **Withhold Lean certificates for Basel-family infinite sums.** The
+  `basel_zeta_even` derivation step had no Mathlib proof and fell through to
+  the default `by ring_nf; simp` tactic, emitting false equalities (e.g.
+  `3/k² = π²/2`) into the textbook-gate Lean pool. Treated like Gosper:
+  withhold the whole certificate rather than emit a broken one.
+- **Rustdoc:** drop a private-item intra-doc link from `sum_definite` that
+  broke `cargo doc -D warnings`.
+- **Ruff:** quiet unused `wit` bindings and a compound assert in
+  `tests/test_cad_decide.py`.
+
 ### Performance
 
 - **`numpy_eval` / `numpy_eval_par` no longer round-trip through a Python

--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -127,6 +127,8 @@ fn is_integration_rule(rule_name: &str) -> bool {
                 | "log_rule"
                 | "gosper_indefinite"
                 | "gosper_definite_telescope"
+                // Algorithmic Basel/ζ(2m) closed form — no Mathlib step proof yet.
+                | "basel_zeta_even"
         )
 }
 
@@ -1927,6 +1929,25 @@ mod tests {
         assert!(
             lean.is_empty(),
             "∫ sin must not emit false `sin = -cos` Lean equality, got: {lean}"
+        );
+    }
+
+    #[test]
+    fn withhold_basel_zeta_even_certificate() {
+        // Σ 1/k² = π²/6 is a real closed form, but `basel_zeta_even` is not a
+        // Mathlib-backed rewrite step. Emitting `1/k² = π²/6` (or a scaled
+        // variant) as an equality example is false and must be withheld.
+        use crate::sum::sum_definite;
+
+        let pool = p();
+        let k = pool.symbol("k", Domain::Real);
+        let one = pool.integer(1_i32);
+        let term = pool.pow(k, pool.integer(-2_i32));
+        let derived = sum_definite(term, k, one, pool.pos_infinity(), &pool).expect("Basel sum");
+        let lean = emit_lean_expr(&derived, &pool);
+        assert!(
+            lean.is_empty(),
+            "Basel sum_definite must withhold Lean cert until Mathlib-backed, got: {lean}"
         );
     }
 

--- a/alkahest-core/src/sum/mod.rs
+++ b/alkahest-core/src/sum/mod.rs
@@ -137,7 +137,7 @@ pub fn sum_indefinite(
 /// warns against for the analogous FTC bound) would fabricate a meaningless
 /// value. Instead an infinite upper bound is checked against a small table of
 /// recognized closed forms — currently the Basel-family even p-series
-/// `Σ_{k=1}^{∞} c/k^{2m} = c·ζ(2m)` (see [`special::basel_family_closed_form`]),
+/// `Σ_{k=1}^{∞} c/k^{2m} = c·ζ(2m)` (Basel-family even zeta values),
 /// e.g. `sum_definite(1/k**2, k, 1, pool.pos_infinity())` → `π²/6`. Anything
 /// else with an infinite bound honestly returns
 /// [`SumError::NotGosperSummable`] rather than a wrong or unresolved-`∞`

--- a/tests/test_cad_decide.py
+++ b/tests/test_cad_decide.py
@@ -109,7 +109,7 @@ def test_decide_forall_forall_product_positive_false():
     y = pool.symbol("y")
     body = pool.gt(x * y, pool.integer(0))
     phi = alkahest.Forall(x, alkahest.Forall(y, body))
-    truth, wit = alkahest.decide(phi)
+    truth, _wit = alkahest.decide(phi)
     assert truth is False
 
 
@@ -128,7 +128,7 @@ def test_decide_forall_exists_every_x_has_bigger_y_true():
     y = pool.symbol("y")
     body = pool.gt(y, x)
     phi = alkahest.Forall(x, alkahest.Exists(y, body))
-    truth, wit = alkahest.decide(phi)
+    truth, _wit = alkahest.decide(phi)
     assert truth is True
 
 
@@ -141,7 +141,7 @@ def test_decide_exists_forall_no_x_is_upper_bound_false():
     y = pool.symbol("y")
     body = pool.ge(x, y)
     phi = alkahest.Exists(x, alkahest.Forall(y, body))
-    truth, wit = alkahest.decide(phi)
+    truth, _wit = alkahest.decide(phi)
     assert truth is False
 
 
@@ -181,7 +181,8 @@ def test_decide_univariate_regression_exists_quadratic_root():
     phi = alkahest.Exists(x, body)
     truth, wit = alkahest.decide(phi)
     assert truth is True
-    assert isinstance(wit, dict) and "x" in wit
+    assert isinstance(wit, dict)
+    assert "x" in wit
 
 
 def test_decide_univariate_regression_forall_square_nonneg():


### PR DESCRIPTION
## Summary
- Withhold Lean certificates for `basel_zeta_even` (same discipline as Gosper) so the textbook-gate Lean pool no longer typechecks false equalities.
- Fix rustdoc private intra-doc link in `sum_definite`.
- Fix Ruff issues in `tests/test_cad_decide.py`.

## Test plan
- [x] `cargo test -p alkahest-cas --lib lean::tests::withhold_basel_zeta_even_certificate`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p alkahest-cas --no-deps`
- [x] `ruff check tests/test_cad_decide.py`
- [ ] Tier 1a / docs / Lean CI green on PR


Made with [Cursor](https://cursor.com)