### PR TITLE
docs: record the level-scheduled simplifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+- **`simplify_redex`: level-scheduled parallel simplification** (Rust,
+  `--features parallel`, exported through `experimental`). Buckets the
+  expression DAG by height and simplifies each level with one `par_iter`, using
+  a flat `Vec<AtomicU32>` indexed by `ExprId` as the memo instead of a hashed
+  side table. Borrowed from HVM2's redex-bag scheduling; the interaction-net
+  runtime itself does not transfer, since alkahest's hot paths are FLINT/Arb
+  arithmetic. Does **not** replace `simplify_par` — best time over 1–32 threads
+  on 32 cores: deep chain 23.1 ms → 5.5 ms, but a wide sum of independent terms
+  5.1 ms → 10.3 ms. Fork-join keeps a chain on one worker and wins on width;
+  level scheduling wins on depth, and on every shape at one thread. The
+  traversal is iterative (no stack-overflow risk on deep inputs) and each node
+  is visited once, so the derivation log is deterministic across thread counts.
+  A barrier-free variant using per-node counters of unreduced children — HVM2's
+  actual discipline — was measured and was never reliably faster, so it is not
+  included.
+
 ### Fixes
 
 - **Withhold Lean certificates for Basel-family infinite sums.** The

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,7 +25,9 @@ Current stable feature surface.
 - Phased saturation with `node_limit` / `iter_limit` config
 - `collect_like_terms`, `poly_normal`
 - Branch-cut-aware log/exp rewrites with `SideCondition` tracking
-- Parallel simplification (`simplify_par`, `--features parallel`)
+- Parallel simplification, two schedulers (`--features parallel`): fork-join
+  (`simplify_par`) and level-scheduled (`simplify_redex`, Rust-only, deterministic
+  derivation logs) — see [Simplification](mdbook/src/simplification.md) for which wins where
 - Pauli and Clifford algebra rewrite tables (`simplify_pauli`, `simplify_clifford_orthogonal`)
 
 ## Polynomial algebra (FLINT-backed)

--- a/docs/mdbook/src/simplification.md
+++ b/docs/mdbook/src/simplification.md
@@ -81,6 +81,36 @@ exprs = [x**i for i in range(100)]
 results = simplify_par(exprs)
 ```
 
+Builds without `--features parallel` (including the default PyPI wheel) fall
+back to the sequential path, so `simplify_par` is always callable.
+
+On the Rust side there are two parallel schedulers, and neither dominates:
+
+| | `simplify_par` | `simplify_redex` |
+|---|---|---|
+| Strategy | fork-join mirroring the sequential traversal | expression bucketed by height, one `par_iter` per level |
+| Forks on | `Add`/`Mul` with ≥ 4 children | every node, regardless of type |
+| Memo | sharded `DashMap` | flat `Vec<AtomicU32>` indexed by `ExprId` |
+| Traversal | recursive (stack-refill trampoline for deep inputs) | iterative |
+| Derivation log | order varies with thread count | deterministic |
+
+Measured on 32 cores, best time over 1–32 threads:
+
+| shape | sequential | `simplify_par` | `simplify_redex` |
+|---|---|---|---|
+| deep chain (2000 levels, width 1) | 38.7 ms | 23.1 ms | **5.5 ms** |
+| wide sum, independent terms | 28.4 ms | **5.1 ms** | 10.3 ms |
+| many medium chains | 115.6 ms | **19.2 ms** | 36.6 ms |
+| wide sum over a shared DAG | 2.48 ms | 0.89 ms | **0.83 ms** |
+
+Fork-join keeps each chain on one worker and wins on wide expressions through
+cache locality. Level scheduling wins on deep ones, where fork-join finds no
+wide node to fork on and runs essentially sequentially. At one thread the level
+scheduler is faster on every shape measured. Reproduce with
+`cargo run --release --features parallel --example simplify_three_way`.
+
+Both are `experimental`: `alkahest_core::experimental::{simplify_par, simplify_redex}`.
+
 ## E-graph simplification
 
 `simplify_egraph` uses equality saturation via [egglog](https://github.com/egraphs-good/egglog) to explore many equivalent forms simultaneously before committing to the best one via a cost function.


### PR DESCRIPTION
Documentation follow-up to #259, which added `simplify_redex`.

- `docs/features.md` — the parallel-simplification bullet now names both schedulers.
- `docs/mdbook/src/simplification.md` — comparison table (strategy, what each forks on, memo, traversal, log determinism), the measured numbers, and the command to reproduce them. Also notes that `simplify_par` falls back to sequential without `--features parallel`, which was previously unstated.
- `CHANGELOG.md` — Unreleased entry, including the negative result on the barrier-free variant.

The Sphinx Python API page is deliberately untouched: `simplify_redex` has no Python binding.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)