### PR TITLE
perf(core): three hot-path optimizations in the pool and rule engine

### DIFF
--- a/alkahest-core/Cargo.toml
+++ b/alkahest-core/Cargo.toml
@@ -108,3 +108,6 @@ required-features = ["parallel"]
 [[example]]
 name = "simplify_three_way"
 required-features = ["parallel"]
+
+[[example]]
+name = "pool_build_scaling"

--- a/alkahest-core/examples/pool_build_scaling.rs
+++ b/alkahest-core/examples/pool_build_scaling.rs
@@ -1,0 +1,57 @@
+//! Does `ExprPool::mul` scale linearly in the size of the expression?
+//!
+//! `pool.mul` calls `mult_tree_is_commutative`, which walks the *entire*
+//! subtree on every call.  `pool.add` does no such walk.  If that walk is the
+//! cost, building a nested product should grow quadratically while a nested
+//! sum grows linearly.
+
+use alkahest_cas::kernel::{Domain, ExprId, ExprPool};
+use std::time::Instant;
+
+fn chain_mul(pool: &ExprPool, depth: usize) -> ExprId {
+    let one = pool.integer(1);
+    let mut e = pool.symbol("x", Domain::Real);
+    for _ in 0..depth {
+        e = pool.mul(vec![e, one]);
+    }
+    e
+}
+
+fn chain_add(pool: &ExprPool, depth: usize) -> ExprId {
+    let zero = pool.integer(0);
+    let mut e = pool.symbol("x", Domain::Real);
+    for _ in 0..depth {
+        e = pool.add(vec![e, zero]);
+    }
+    e
+}
+
+fn main() {
+    println!(
+        "{:>8} {:>12} {:>12}   {:>10}",
+        "depth", "mul (ms)", "add (ms)", "mul/add"
+    );
+    let mut prev_mul = 0.0_f64;
+    for depth in [500usize, 1000, 2000, 4000, 8000] {
+        let pool = ExprPool::new();
+        let t = Instant::now();
+        std::hint::black_box(chain_mul(&pool, depth));
+        let mul = t.elapsed().as_secs_f64() * 1e3;
+
+        let pool2 = ExprPool::new();
+        let t = Instant::now();
+        std::hint::black_box(chain_add(&pool2, depth));
+        let add = t.elapsed().as_secs_f64() * 1e3;
+
+        let growth = if prev_mul > 0.0 {
+            format!("{:.1}x vs prev depth", mul / prev_mul)
+        } else {
+            String::new()
+        };
+        prev_mul = mul;
+        println!(
+            "{depth:>8} {mul:>12.2} {add:>12.2}   {:>10.1}x  {growth}",
+            mul / add
+        );
+    }
+}

--- a/alkahest-core/src/kernel/expr_props.rs
+++ b/alkahest-core/src/kernel/expr_props.rs
@@ -9,30 +9,12 @@ use crate::kernel::ExprId;
 /// Used to decide whether multiplication may be canonically sorted or whether
 /// rules like [`crate::simplify::rules::DivSelf`] may merge powers by base.
 pub fn mult_tree_is_commutative(pool: &ExprPool, expr: ExprId) -> bool {
-    pool.with(expr, |data| match data {
-        ExprData::Symbol { commutative, .. } => *commutative,
-        ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => true,
-        ExprData::Add(args) | ExprData::Mul(args) => {
-            args.iter().all(|&c| mult_tree_is_commutative(pool, c))
-        }
-        ExprData::Pow { base, exp } => {
-            mult_tree_is_commutative(pool, *base) && mult_tree_is_commutative(pool, *exp)
-        }
-        ExprData::Func { args, .. } => args.iter().all(|&c| mult_tree_is_commutative(pool, c)),
-        ExprData::Piecewise { branches, default } => {
-            branches.iter().all(|(c, v)| {
-                mult_tree_is_commutative(pool, *c) && mult_tree_is_commutative(pool, *v)
-            }) && mult_tree_is_commutative(pool, *default)
-        }
-        ExprData::Predicate { args, .. } => args.iter().all(|&c| mult_tree_is_commutative(pool, c)),
-        ExprData::Forall { var, body } | ExprData::Exists { var, body } => {
-            mult_tree_is_commutative(pool, *var) && mult_tree_is_commutative(pool, *body)
-        }
-        ExprData::BigO(inner) => mult_tree_is_commutative(pool, *inner),
-        ExprData::RootSum { poly, body, .. } => {
-            mult_tree_is_commutative(pool, *poly) && mult_tree_is_commutative(pool, *body)
-        }
-    })
+    // The flag is computed once, when `expr` is interned, from its children's
+    // already-cached flags.  This used to walk the whole subtree on every call,
+    // which made `ExprPool::mul` quadratic in the size of its argument: building
+    // a nested product of depth 8000 took 373 ms against 2.5 ms for the
+    // equivalent sum, and grew 4x for every doubling of depth.
+    pool.is_mult_commutative(expr)
 }
 
 /// `true` iff some subtree is a symbol with `commutative == false`.
@@ -72,4 +54,91 @@ pub fn expr_contains_noncommutative_symbol(pool: &ExprPool, expr: ExprId) -> boo
                 || expr_contains_noncommutative_symbol(pool, *body)
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    /// The pre-cache implementation, kept here as an oracle: walk the whole
+    /// subtree every time.
+    fn reference(pool: &ExprPool, expr: ExprId) -> bool {
+        pool.with(expr, |data| match data {
+            ExprData::Symbol { commutative, .. } => *commutative,
+            ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => true,
+            ExprData::Add(args) | ExprData::Mul(args) => args.iter().all(|&c| reference(pool, c)),
+            ExprData::Pow { base, exp } => reference(pool, *base) && reference(pool, *exp),
+            ExprData::Func { args, .. } => args.iter().all(|&c| reference(pool, c)),
+            ExprData::Piecewise { branches, default } => {
+                branches
+                    .iter()
+                    .all(|(c, v)| reference(pool, *c) && reference(pool, *v))
+                    && reference(pool, *default)
+            }
+            ExprData::Predicate { args, .. } => args.iter().all(|&c| reference(pool, c)),
+            ExprData::Forall { var, body } | ExprData::Exists { var, body } => {
+                reference(pool, *var) && reference(pool, *body)
+            }
+            ExprData::BigO(inner) => reference(pool, *inner),
+            ExprData::RootSum { poly, body, .. } => {
+                reference(pool, *poly) && reference(pool, *body)
+            }
+        })
+    }
+
+    /// The cached flag must agree with a full subtree walk everywhere,
+    /// including when a non-commutative generator is buried deep.
+    #[test]
+    fn cached_flag_matches_full_walk() {
+        let pool = ExprPool::new();
+        let c = pool.symbol("c", Domain::Real);
+        let nc = pool.symbol_commutative("nc", Domain::Real, false);
+        let two = pool.integer(2_i32);
+
+        let mut nodes = vec![c, nc, two];
+        // Commutative-only subtree.
+        let pure = pool.add(vec![c, two]);
+        nodes.push(pure);
+        nodes.push(pool.pow(pure, two));
+        nodes.push(pool.func("sin", vec![pure]));
+        // Same shapes with a non-commutative generator buried inside.
+        let tainted = pool.add(vec![nc, two]);
+        nodes.push(tainted);
+        nodes.push(pool.pow(tainted, two));
+        nodes.push(pool.func("sin", vec![tainted]));
+        nodes.push(pool.mul(vec![pure, tainted]));
+        nodes.push(pool.big_o(tainted));
+        nodes.push(pool.pred_lt(tainted, pure));
+        // Deeply nested, so a stale flag would show up.
+        let mut deep = c;
+        for _ in 0..50 {
+            deep = pool.mul(vec![deep, two]);
+            nodes.push(deep);
+        }
+        let mut deep_nc = nc;
+        for _ in 0..50 {
+            deep_nc = pool.mul(vec![deep_nc, two]);
+            nodes.push(deep_nc);
+        }
+
+        for id in nodes {
+            assert_eq!(
+                mult_tree_is_commutative(&pool, id),
+                reference(&pool, id),
+                "cached flag disagrees with full walk for {}",
+                crate::kernel::display::render_unicode(id, &pool)
+            );
+        }
+    }
+
+    #[test]
+    fn noncommutative_blocks_canonical_sorting() {
+        let pool = ExprPool::new();
+        let a = pool.symbol_commutative("a", Domain::Real, false);
+        let b = pool.symbol_commutative("b", Domain::Real, false);
+        // `mul` may not sort these, so the two orders stay distinct.
+        assert_ne!(pool.mul(vec![a, b]), pool.mul(vec![b, a]));
+        assert!(!mult_tree_is_commutative(&pool, pool.mul(vec![a, b])));
+    }
 }

--- a/alkahest-core/src/kernel/pool.rs
+++ b/alkahest-core/src/kernel/pool.rs
@@ -82,9 +82,21 @@ impl PoolIndex {
 /// into a `boxcar::Vec` via a single atomic load with no lock acquisition.
 /// Write operations (`intern`) use a per-shard lock (parallel mode) or a
 /// `Mutex` (non-parallel mode) only during new-node insertion.
+/// A node plus the properties that are cheaper to record once than to recompute.
+struct Node {
+    data: ExprData,
+    /// Whether every generator in this subtree commutes under multiplication.
+    ///
+    /// This is a bottom-up property, and hash-consing guarantees a node's
+    /// children are interned before the node itself, so it is computed once
+    /// here from the children's cached flags — O(arity) — instead of by
+    /// walking the whole subtree on every query.
+    mult_commutative: bool,
+}
+
 pub struct ExprPool {
     /// Lock-free, append-only, reference-stable node array.
-    nodes: boxcar::Vec<ExprData>,
+    nodes: boxcar::Vec<Node>,
     /// Deduplication index: ExprData → ExprId.
     #[cfg(feature = "parallel")]
     index: PoolIndex,
@@ -118,8 +130,10 @@ impl ExprPool {
             // Slow path: DashMap shard write-lock ensures at most one push
             // per unique key.  `boxcar::push` is lock-free so it can be
             // called safely while the shard lock is held.
-            self.index
-                .or_insert_with(data.clone(), || ExprId(self.nodes.push(data) as u32))
+            self.index.or_insert_with(data.clone(), || {
+                let node = self.make_node(data);
+                ExprId(self.nodes.push(node) as u32)
+            })
         }
 
         #[cfg(not(feature = "parallel"))]
@@ -128,18 +142,60 @@ impl ExprPool {
             if let Some(id) = idx.get(&data) {
                 return id;
             }
-            let id = ExprId(self.nodes.push(data.clone()) as u32);
+            let node = self.make_node(data.clone());
+            let id = ExprId(self.nodes.push(node) as u32);
             idx.insert(data, id);
             id
         }
     }
 
+    /// Wrap `data` with its cached properties.  Children are already interned,
+    /// so their flags are just array reads.
+    fn make_node(&self, data: ExprData) -> Node {
+        let mult_commutative = self.compute_mult_commutative(&data);
+        Node {
+            data,
+            mult_commutative,
+        }
+    }
+
+    /// One level of the `mult_tree_is_commutative` recurrence, reading each
+    /// child's cached flag rather than descending into it.
+    fn compute_mult_commutative(&self, data: &ExprData) -> bool {
+        let child = |c: ExprId| self.is_mult_commutative(c);
+        match data {
+            ExprData::Symbol { commutative, .. } => *commutative,
+            ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => true,
+            ExprData::Add(args) | ExprData::Mul(args) => args.iter().copied().all(child),
+            ExprData::Pow { base, exp } => child(*base) && child(*exp),
+            ExprData::Func { args, .. } => args.iter().copied().all(child),
+            ExprData::Piecewise { branches, default } => {
+                branches.iter().all(|&(c, v)| child(c) && child(v)) && child(*default)
+            }
+            ExprData::Predicate { args, .. } => args.iter().copied().all(child),
+            ExprData::Forall { var, body } | ExprData::Exists { var, body } => {
+                child(*var) && child(*body)
+            }
+            ExprData::BigO(inner) => child(*inner),
+            ExprData::RootSum { poly, body, .. } => child(*poly) && child(*body),
+        }
+    }
+
+    /// Whether every generator in the subtree rooted at `id` commutes under
+    /// multiplication.  O(1): the flag was computed when `id` was interned.
+    pub fn is_mult_commutative(&self, id: ExprId) -> bool {
+        self.node(id).mult_commutative
+    }
+
+    fn node(&self, id: ExprId) -> &Node {
+        self.nodes
+            .get(id.0 as usize)
+            .expect("ExprPool: ExprId out of range")
+    }
+
     /// Borrow a node by id and apply `f` without cloning.  Lock-free.
     pub fn with<R, F: FnOnce(&ExprData) -> R>(&self, id: ExprId, f: F) -> R {
-        f(self
-            .nodes
-            .get(id.0 as usize)
-            .expect("ExprPool: ExprId out of range"))
+        f(&self.node(id).data)
     }
 
     /// Clone and return the `ExprData` for `id`.

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -111,9 +111,11 @@ fn simplify_node(
         return DerivedExpr::new(cached);
     }
 
-    // 1. Rebuild with simplified children
-    let data = pool.get(expr);
-    let (rebuilt, child_log) = simplify_children(data, pool, rules, memo);
+    // 1. Rebuild with simplified children.  `with` borrows the node; cloning
+    //    it here allocated a fresh `Vec` (and a `String` for `Func`) per visit.
+    let (rebuilt, child_log) = pool.with(expr, |data| {
+        simplify_children(expr, data, pool, rules, memo)
+    });
 
     // 2. Apply rules to rebuilt node until no rule fires
     let mut current = rebuilt;
@@ -149,8 +151,9 @@ fn simplify_node_indexed(
         return DerivedExpr::new(cached);
     }
 
-    let data = pool.get(expr);
-    let (rebuilt, child_log) = simplify_children(data, pool, child_rules, memo);
+    let (rebuilt, child_log) = pool.with(expr, |data| {
+        simplify_children(expr, data, pool, child_rules, memo)
+    });
 
     let mut current = rebuilt;
     let mut rule_log = DerivationLog::new();
@@ -175,8 +178,18 @@ fn simplify_node_indexed(
 }
 
 /// Simplify children of a node and return (rebuilt_expr, child_log).
+///
+/// When every child simplifies to itself, `expr` is reused instead of being
+/// re-interned.  Interning re-hashes the whole node, and `ExprPool::mul`
+/// additionally consults the commutativity of its arguments, so rebuilding an
+/// unchanged node is pure overhead — and most nodes in a pass are unchanged.
+///
+/// `add` and `mul` canonically sort their arguments, so for those the shortcut
+/// is only taken when the original list is already sorted; otherwise reusing
+/// `expr` would skip a canonicalisation the rebuild would have applied.
 fn simplify_children(
-    data: ExprData,
+    expr: ExprId,
+    data: &ExprData,
     pool: &ExprPool,
     rules: &[Box<dyn RewriteRule>],
     memo: &mut HashMap<ExprId, ExprId>,
@@ -184,91 +197,135 @@ fn simplify_children(
     let mut log = DerivationLog::new();
     match data {
         ExprData::Add(args) => {
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node(a, pool, rules, memo);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.add(new_args), log)
+            let (new_args, changed) = simplify_args(args, pool, rules, memo, &mut log);
+            let id = if !changed && is_sorted(args) {
+                expr
+            } else {
+                pool.add(new_args)
+            };
+            (id, log)
         }
         ExprData::Mul(args) => {
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node(a, pool, rules, memo);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.mul(new_args), log)
+            let (new_args, changed) = simplify_args(args, pool, rules, memo, &mut log);
+            let id = if !changed && is_sorted(args) {
+                expr
+            } else {
+                pool.mul(new_args)
+            };
+            (id, log)
         }
         ExprData::Pow { base, exp } => {
-            let rb = simplify_node(base, pool, rules, memo);
+            let rb = simplify_node(*base, pool, rules, memo);
             log = log.merge(rb.log);
-            let re = simplify_node(exp, pool, rules, memo);
+            let re = simplify_node(*exp, pool, rules, memo);
             log = log.merge(re.log);
-            (pool.pow(rb.value, re.value), log)
+            let id = if rb.value == *base && re.value == *exp {
+                expr
+            } else {
+                pool.pow(rb.value, re.value)
+            };
+            (id, log)
         }
         ExprData::Func { name, args } => {
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node(a, pool, rules, memo);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.func(name, new_args), log)
+            let (new_args, changed) = simplify_args(args, pool, rules, memo, &mut log);
+            let id = if changed {
+                pool.func(name.as_str(), new_args)
+            } else {
+                expr
+            };
+            (id, log)
         }
         // PA-9: Simplify values in each branch and the default.
         // The condition expressions (predicates) are passed through unchanged
         // since there are no simplification rules for predicates yet.
         ExprData::Piecewise { branches, default } => {
+            let mut changed = false;
             let new_branches: Vec<(ExprId, ExprId)> = branches
-                .into_iter()
-                .map(|(cond, val)| {
+                .iter()
+                .map(|&(cond, val)| {
                     let rv = simplify_node(val, pool, rules, memo);
                     log = std::mem::take(&mut log).merge(rv.log);
+                    changed |= rv.value != val;
                     (cond, rv.value)
                 })
                 .collect();
-            let rd = simplify_node(default, pool, rules, memo);
+            let rd = simplify_node(*default, pool, rules, memo);
             log = log.merge(rd.log);
-            (pool.piecewise(new_branches, rd.value), log)
+            let id = if !changed && rd.value == *default {
+                expr
+            } else {
+                pool.piecewise(new_branches, rd.value)
+            };
+            (id, log)
         }
         // Predicate args may be simplified as expressions.
         ExprData::Predicate { kind, args } => {
-            let new_args: Vec<ExprId> = args
-                .into_iter()
-                .map(|a| {
-                    let r = simplify_node(a, pool, rules, memo);
-                    log = std::mem::take(&mut log).merge(r.log);
-                    r.value
-                })
-                .collect();
-            (pool.predicate(kind, new_args), log)
+            let (new_args, changed) = simplify_args(args, pool, rules, memo, &mut log);
+            let id = if changed {
+                pool.predicate(kind.clone(), new_args)
+            } else {
+                expr
+            };
+            (id, log)
         }
         ExprData::Forall { var, body } => {
-            let rb = simplify_node(body, pool, rules, memo);
+            let rb = simplify_node(*body, pool, rules, memo);
             log = log.merge(rb.log);
-            (pool.forall(var, rb.value), log)
+            let id = if rb.value == *body {
+                expr
+            } else {
+                pool.forall(*var, rb.value)
+            };
+            (id, log)
         }
         ExprData::Exists { var, body } => {
-            let rb = simplify_node(body, pool, rules, memo);
+            let rb = simplify_node(*body, pool, rules, memo);
             log = log.merge(rb.log);
-            (pool.exists(var, rb.value), log)
+            let id = if rb.value == *body {
+                expr
+            } else {
+                pool.exists(*var, rb.value)
+            };
+            (id, log)
         }
         ExprData::BigO(arg) => {
-            let r = simplify_node(arg, pool, rules, memo);
+            let r = simplify_node(*arg, pool, rules, memo);
             log = log.merge(r.log);
-            (pool.big_o(r.value), log)
+            let id = if r.value == *arg {
+                expr
+            } else {
+                pool.big_o(r.value)
+            };
+            (id, log)
         }
-        // Atoms have no children
-        atom => (pool.intern(atom), log),
+        // Atoms have no children; `expr` already interns this exact node.
+        _ => (expr, log),
     }
+}
+
+/// Simplify each argument in order, reporting whether any of them changed.
+fn simplify_args(
+    args: &[ExprId],
+    pool: &ExprPool,
+    rules: &[Box<dyn RewriteRule>],
+    memo: &mut HashMap<ExprId, ExprId>,
+    log: &mut DerivationLog,
+) -> (Vec<ExprId>, bool) {
+    let mut changed = false;
+    let new_args: Vec<ExprId> = args
+        .iter()
+        .map(|&a| {
+            let r = simplify_node(a, pool, rules, memo);
+            *log = std::mem::take(log).merge(r.log);
+            changed |= r.value != a;
+            r.value
+        })
+        .collect();
+    (new_args, changed)
+}
+
+fn is_sorted(args: &[ExprId]) -> bool {
+    args.windows(2).all(|w| w[0] <= w[1])
 }
 
 // ---------------------------------------------------------------------------

--- a/alkahest-core/src/simplify/rules.rs
+++ b/alkahest-core/src/simplify/rules.rs
@@ -30,47 +30,63 @@ pub trait RewriteRule: Send + Sync {
 // ---------------------------------------------------------------------------
 
 fn as_integer(expr: ExprId, pool: &ExprPool) -> Option<rug::Integer> {
-    match pool.get(expr) {
+    // `pool.get` would clone the whole node — for an `Integer` that is a
+    // bignum allocation — only for `n.0` to be cloned again below.
+    pool.with(expr, |data| match data {
         ExprData::Integer(n) => Some(n.0.clone()),
         _ => None,
-    }
+    })
+}
+
+/// Test an integer literal without materialising it.
+///
+/// `is_zero`/`is_one` run on nearly every node visited by `MulZero`, `AddZero`
+/// and `MulOne`, so going through `as_integer` cost two bignum clones per test.
+fn integer_is(expr: ExprId, pool: &ExprPool, value: i32) -> bool {
+    pool.with(expr, |data| match data {
+        ExprData::Integer(n) => n.0 == value,
+        _ => false,
+    })
 }
 
 fn is_neg_imaginary_unit(expr: ExprId, pool: &ExprPool) -> bool {
-    match pool.get(expr) {
-        ExprData::Mul(args) if args.len() == 2 => {
-            (as_integer(args[0], pool).is_some_and(|n| n == -1) && pool.is_imaginary_unit(args[1]))
-                || (as_integer(args[1], pool).is_some_and(|n| n == -1)
-                    && pool.is_imaginary_unit(args[0]))
-        }
-        _ => false,
-    }
+    let args = pool.with(expr, |data| match data {
+        ExprData::Mul(args) if args.len() == 2 => Some([args[0], args[1]]),
+        _ => None,
+    });
+    let Some([a0, a1]) = args else {
+        return false;
+    };
+    (as_integer(a0, pool).is_some_and(|n| n == -1) && pool.is_imaginary_unit(a1))
+        || (as_integer(a1, pool).is_some_and(|n| n == -1) && pool.is_imaginary_unit(a0))
 }
 
 fn is_strictly_positive_literal(expr: ExprId, pool: &ExprPool) -> bool {
-    match pool.get(expr) {
+    pool.with(expr, |data| match data {
         ExprData::Integer(n) => n.0 > 0,
         ExprData::Rational(r) => r.0 > 0,
         _ => false,
-    }
+    })
 }
 
 fn is_positive_domain_symbol(expr: ExprId, pool: &ExprPool) -> bool {
-    matches!(
-        pool.get(expr),
-        ExprData::Symbol {
-            domain: Domain::Positive,
-            ..
-        }
-    )
+    pool.with(expr, |data| {
+        matches!(
+            data,
+            ExprData::Symbol {
+                domain: Domain::Positive,
+                ..
+            }
+        )
+    })
 }
 
 fn is_zero(expr: ExprId, pool: &ExprPool) -> bool {
-    as_integer(expr, pool).is_some_and(|n| n == 0)
+    integer_is(expr, pool, 0)
 }
 
 fn is_one(expr: ExprId, pool: &ExprPool) -> bool {
-    as_integer(expr, pool).is_some_and(|n| n == 1)
+    integer_is(expr, pool, 1)
 }
 
 pub(crate) fn one_step(name: &'static str, before: ExprId, after: ExprId) -> DerivationLog {
@@ -99,9 +115,12 @@ pub(super) fn extract_int_coeff(expr: ExprId, pool: &ExprPool) -> (rug::Integer,
             let mut int_product = rug::Integer::from(1);
             let mut non_ints: Vec<ExprId> = vec![];
             for &a in &args {
-                match pool.get(a) {
-                    ExprData::Integer(n) => int_product *= n.0.clone(),
-                    _ => non_ints.push(a),
+                match pool.with(a, |d| match d {
+                    ExprData::Integer(n) => Some(n.0.clone()),
+                    _ => None,
+                }) {
+                    Some(n) => int_product *= n,
+                    None => non_ints.push(a),
                 }
             }
             if non_ints.len() == args.len() {
@@ -284,11 +303,16 @@ impl RewriteRule for MulZero {
         // literal `0^(negative)` factor is itself undefined (division by
         // zero), so the product is indeterminate, not `0`. This is the
         // n=0 boundary of `0 * x^(-1)` being indeterminate at x=0.
-        let has_zero_to_neg_pow = args.iter().any(|&a| match pool.get(a) {
-            ExprData::Pow { base, exp } => {
-                is_zero(base, pool) && as_integer(exp, pool).is_some_and(|e| e < 0)
+        let has_zero_to_neg_pow = args.iter().any(|&a| {
+            match pool.with(a, |d| match d {
+                ExprData::Pow { base, exp } => Some((*base, *exp)),
+                _ => None,
+            }) {
+                Some((base, exp)) => {
+                    is_zero(base, pool) && as_integer(exp, pool).is_some_and(|e| e < 0)
+                }
+                None => false,
             }
-            _ => false,
         });
         if has_zero_to_neg_pow {
             return None;
@@ -597,7 +621,7 @@ impl RewriteRule for ConstFold {
                 // lets `π · (4π)^(-1)` reduce to `π · 4^(-1) · π^(-1)`, which
                 // `DivSelf` and the b^e fold below then collapse to `1/4`.
                 if let Some(n) = as_integer(exp, pool) {
-                    if let ExprData::Mul(_) = pool.get(base) {
+                    if pool.with(base, |d| matches!(d, ExprData::Mul(_))) {
                         let (coeff, rest) = extract_int_coeff(base, pool);
                         if coeff != 1 && coeff != -1 && coeff != 0 && rest != pool.integer(1_i32) {
                             let coeff_pow = pool.pow(pool.integer(coeff), pool.integer(n.clone()));
@@ -958,12 +982,18 @@ impl RewriteRule for FlattenMul {
         let mut flat = Vec::new();
         let mut changed = false;
         for &a in &args {
-            match pool.get(a) {
-                ExprData::Mul(inner) => {
+            // Borrow the child: cloning it here allocated a `Vec` per child on
+            // every visit, and these two rules are tried on every node.
+            let nested = pool.with(a, |d| match d {
+                ExprData::Mul(inner) => Some(inner.clone()),
+                _ => None,
+            });
+            match nested {
+                Some(inner) => {
                     flat.extend_from_slice(&inner);
                     changed = true;
                 }
-                _ => flat.push(a),
+                None => flat.push(a),
             }
         }
         if !changed {
@@ -989,12 +1019,18 @@ impl RewriteRule for FlattenAdd {
         let mut flat = Vec::new();
         let mut changed = false;
         for &a in &args {
-            match pool.get(a) {
-                ExprData::Add(inner) => {
+            // Borrow the child: cloning it here allocated a `Vec` per child on
+            // every visit, and these two rules are tried on every node.
+            let nested = pool.with(a, |d| match d {
+                ExprData::Add(inner) => Some(inner.clone()),
+                _ => None,
+            });
+            match nested {
+                Some(inner) => {
                     flat.extend_from_slice(&inner);
                     changed = true;
                 }
-                _ => flat.push(a),
+                None => flat.push(a),
             }
         }
         if !changed {
@@ -1072,7 +1108,7 @@ impl RewriteRule for ExpandMul {
         // Find the first Add factor
         let add_pos = args
             .iter()
-            .position(|&a| matches!(pool.get(a), ExprData::Add(_)))?;
+            .position(|&a| pool.with(a, |d| matches!(d, ExprData::Add(_))))?;
 
         let add_args = match pool.get(args[add_pos]) {
             ExprData::Add(v) => v,
@@ -1247,11 +1283,14 @@ impl RewriteRule for CollectExp {
         let mut exp_args: Vec<ExprId> = Vec::new();
         let mut other: Vec<ExprId> = Vec::new();
         for &a in &args {
-            match pool.get(a) {
+            match pool.with(a, |d| match d {
                 ExprData::Func { name, args: fargs } if name == "exp" && fargs.len() == 1 => {
-                    exp_args.push(fargs[0]);
+                    Some(fargs[0])
                 }
-                _ => other.push(a),
+                _ => None,
+            }) {
+                Some(inner) => exp_args.push(inner),
+                None => other.push(a),
             }
         }
 


### PR DESCRIPTION
Three independent, behaviour-preserving optimizations, one per commit so any regression is bisectable. No API changes.

## 1. Cache multiplicative commutativity at intern time (`c70f4db`)

`ExprPool::mul` consults `mult_tree_is_commutative` to decide whether it may canonically sort its arguments, and that predicate **walked the entire subtree on every call** — making construction of a nested product quadratic in its size.

Commutativity is a bottom-up property, and hash-consing guarantees a node's children are interned before the node itself, so the flag is now computed once per node from its children's cached flags and stored alongside the node. Queries become an array read. `mult_tree_is_commutative` keeps its signature and delegates.

| depth | before | after |
|---|---|---|
| 2000 | 23.8 ms | 0.48 ms |
| 4000 | 95.1 ms | 1.03 ms |
| 8000 | **373.4 ms** | **2.17 ms** |

Growth per doubling of depth drops from 4x (quadratic) to 2.1x (linear); a product is no longer 150x more expensive to build than the equivalent sum. A test checks the cached flag against the previous full-walk implementation, retained as an oracle, over commutative and non-commutative subtrees including deeply nested ones.

## 2. Reuse unchanged nodes in the sequential engine (`3e68304`)

`simplify_children` rebuilt every node it visited even when each child simplified to itself, re-hashing the whole node for nothing. It now returns the original `ExprId` when no child moved — guarded on the argument list already being sorted for `add`/`mul`, whose rebuild would otherwise canonicalise. `simplify_node` also borrows the node instead of cloning it.

The same rule already applied in `simplify_par` and `simplify_redex`; this brings the sequential path — the default everywhere, including the PyPI wheel — in line.

## 3. Borrow in hot rule predicates (`a5d983a`)

Thirteen rules are scanned per node and each `pool.get` cloned the whole `ExprData` just to inspect it. `is_zero`/`is_one` were the worst: they cloned the node *and* the bignum inside it to compare against 0. `FlattenMul`/`FlattenAdd` — the first two rules tried on every node — cloned every child to test whether it was nested. All now borrow; the remaining `pool.get` sites bind data the rule goes on to consume, where the clone is the work rather than overhead.

## Combined effect on simplification

Min of 5 interleaved rounds (binaries run round-robin so drift cancels), single-threaded:

| workload | base | +1 | +2 | +3 | total |
|---|---|---|---|---|---|
| many medium chains (1024 x 32) | 116.31 | 117.73 | 115.22 | **100.57** | 1.16x |
| wide sum of canonical terms (4096 x 8) | 32.22 | 32.43 | 29.03 | **25.94** | 1.24x |
| wide sum, independent terms (1024 x 8) | 27.97 | 27.45 | 28.24 | **23.64** | 1.18x |
| wide sum, independent terms (4096 x 4) | 61.59 | 62.55 | 61.49 | **53.47** | 1.15x |
| wide sum over a shared DAG (1024) | 2.41 | 2.40 | 2.31 | **2.01** | 1.20x |
| deep chain (2000 levels) | 37.56 | 36.24 | 36.30 | **35.49** | 1.06x |

**Optimization 1 does not show up in this table, and that is expected**: the harness builds the expression before starting the clock, so it measures simplification only. Its win is on construction (the 172x above), which every caller that builds products pays — and which the simplifier itself pays whenever a rewrite reconstructs a `Mul`.

Measurements come from a shared 32-core box with other users active; earlier single-sweep numbers moved by up to 60% run to run, which is why these are interleaved minima. Treat the ratios as reliable and the absolute milliseconds as approximate.

## Testing

- `cargo test --workspace` — 1704 passed, 0 failed
- `cargo test --workspace --features parallel` — 1685 passed, 0 failed
- `cargo clippy --all-targets`, `--features egraph`, `--features parallel`, each with `-D warnings` — clean
- `cargo fmt --all -- --check` — clean

Two new tests cover the commutativity cache; the existing suite covers the rest, since all three changes are meant to be invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved expression simplification efficiency by reducing unnecessary reconstruction and repeated processing.
  * Accelerated checks for multiplication commutativity, including for deeply nested expressions.
  * Preserved expression identity when simplification does not change a result.

* **Bug Fixes**
  * Ensured noncommutative multiplication consistently preserves operand order.

* **Tools**
  * Added a benchmark example for comparing expression-building performance at increasing depths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->