### PR TITLE
perf(simplify): rule-kind prefilter and shape-based strategy dispatch

### DIFF
--- a/alkahest-core/examples/simplify_three_way.rs
+++ b/alkahest-core/examples/simplify_three_way.rs
@@ -6,6 +6,7 @@
 //!   cargo run --release --features parallel --example simplify_three_way
 
 use alkahest_cas::kernel::{Domain, ExprId, ExprPool};
+use alkahest_cas::simplify::dispatch::simplify_auto;
 use alkahest_cas::simplify::parallel::simplify_par;
 use alkahest_cas::simplify::redex::simplify_redex;
 use alkahest_cas::simplify::simplify;
@@ -112,12 +113,13 @@ fn run(name: &str, build: &dyn Fn(&ExprPool) -> ExprId, threads: &[usize], reps:
     // Agreement check before timing anything else.
     let pool = ExprPool::new();
     let e = build(&pool);
-    let (a, b, c) = (
+    let (a, b, c, d) = (
         simplify(e, &pool).value,
         simplify_par(e, &pool).value,
         simplify_redex(e, &pool).value,
+        simplify_auto(e, &pool).value,
     );
-    let agree = a == b && b == c;
+    let agree = a == b && b == c && c == d;
 
     println!(
         "\n=== {name} ===   agreement: {}",
@@ -125,8 +127,8 @@ fn run(name: &str, build: &dyn Fn(&ExprPool) -> ExprId, threads: &[usize], reps:
     );
     println!("  {:<10} {:>9.2} ms", "sequential", ms(seq));
     println!(
-        "  {:<10} {:>9} {:>9}   (speedup vs sequential)",
-        "threads", "fork-join", "level"
+        "  {:<10} {:>9} {:>9} {:>9}   (speedup vs sequential)",
+        "threads", "fork-join", "level", "auto"
     );
 
     for &nt in threads {
@@ -140,13 +142,18 @@ fn run(name: &str, build: &dyn Fn(&ExprPool) -> ExprId, threads: &[usize], reps:
         let lvl = time_op(reps, build, &|e, pool| {
             tp.install(|| simplify_redex(e, pool).value)
         });
+        let auto = time_op(reps, build, &|e, pool| {
+            tp.install(|| simplify_auto(e, pool).value)
+        });
         println!(
-            "  t={:<8} {:>7.2}ms {:>7.2}ms   fork-join {:.2}x  level {:.2}x",
+            "  t={:<8} {:>7.2}ms {:>7.2}ms {:>7.2}ms   fork-join {:.2}x  level {:.2}x  auto {:.2}x",
             nt,
             ms(par),
             ms(lvl),
+            ms(auto),
             seq.as_secs_f64() / par.as_secs_f64(),
             seq.as_secs_f64() / lvl.as_secs_f64(),
+            seq.as_secs_f64() / auto.as_secs_f64(),
         );
     }
 }

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -171,6 +171,8 @@ pub use ball::{AcbBall, ArbBall, IntervalEval, DEFAULT_PREC};
 
 // Phase 23 — Parallel simplification
 #[cfg(feature = "parallel")]
+pub use simplify::dispatch::{choose_strategy, simplify_auto, simplify_auto_with_config, Strategy};
+#[cfg(feature = "parallel")]
 pub use simplify::parallel::{simplify_par, simplify_par_with_config};
 #[cfg(feature = "parallel")]
 pub use simplify::redex::{simplify_redex, simplify_redex_with_config};
@@ -374,6 +376,10 @@ pub mod experimental {
         inverse_z_transform, z_shift_advance, z_shift_delay, z_transform, ZTransformError,
     };
 
+    #[cfg(feature = "parallel")]
+    pub use crate::simplify::dispatch::{
+        choose_strategy, simplify_auto, simplify_auto_with_config, Strategy,
+    };
     #[cfg(feature = "parallel")]
     pub use crate::simplify::parallel::{simplify_par, simplify_par_with_config};
     #[cfg(feature = "parallel")]

--- a/alkahest-core/src/simplify/dispatch.rs
+++ b/alkahest-core/src/simplify/dispatch.rs
@@ -1,0 +1,293 @@
+//! Picks a parallel simplification strategy from the shape of the expression.
+//!
+//! Feature-gated behind `--features parallel`.
+//!
+//! [`super::parallel::simplify_par`] and [`super::redex::simplify_redex`] win on
+//! different shapes, and the difference is large — up to 4x either way — so the
+//! choice matters more than tuning either one.  Fork-join keeps each chain on a
+//! single worker and wins when the expression is wide, because a whole subtree
+//! stays in one core's cache.  Level scheduling wins when it is deep, because
+//! fork-join only forks on `Add`/`Mul` nodes with four or more children and a
+//! deep chain gives it nothing to fork on.
+//!
+//! The advantage is also conditional on having cores to spend: at four workers
+//! level scheduling was faster on every shape measured, including the widest,
+//! so fork-join is only considered from [`MIN_WORKERS_FOR_FORK_JOIN`] up.
+//!
+//! The shape discriminator is average level width — nodes divided by height:
+//!
+//! | shape | nodes / height | pick |
+//! |---|---|---|
+//! | deep chain (2000 levels, width 1) | ~1 | level-scheduled |
+//! | wide sum, independent terms (1024 x 8) | ~980 | fork-join |
+//! | many medium chains (1024 x 32) | ~1000 | fork-join |
+//!
+//! # Caveat on the threshold
+//!
+//! [`WIDTH_THRESHOLD`] is calibrated on synthetic shapes, not on a profile of
+//! real workloads.  The extremes it separates are unambiguous — a chain and a
+//! wide sum differ by three orders of magnitude in average width — but where
+//! exactly to cut between them is a guess, and expressions near the boundary
+//! are close enough in cost that the choice matters little either way.  Treat
+//! the constant as provisional until it can be checked against real traces.
+
+#![cfg(feature = "parallel")]
+
+use crate::deriv::log::DerivedExpr;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::simplify::engine::SimplifyConfig;
+
+/// Average level width at or above which fork-join is preferred.
+///
+/// Fork-join only parallelises `Add`/`Mul` nodes with at least four children,
+/// so it needs real width to beat level scheduling.
+pub const WIDTH_THRESHOLD: f64 = 8.0;
+
+/// Worker count below which level scheduling is preferred regardless of shape.
+///
+/// Fork-join's advantage on wide expressions comes from keeping a whole subtree
+/// in one core's cache, and it only pays once there are enough cores to cover
+/// the width. Measured on a 32-core machine, level scheduling was faster on
+/// *every* shape at four workers — including the widest — while fork-join won
+/// the wide shapes at sixteen and above.
+pub const MIN_WORKERS_FOR_FORK_JOIN: usize = 8;
+
+/// Which parallel simplifier [`simplify_auto`] selected.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Strategy {
+    /// [`super::parallel::simplify_par`] — recursive fork-join.
+    ForkJoin,
+    /// [`super::redex::simplify_redex`] — level-scheduled redex bag.
+    LevelScheduled,
+}
+
+/// Simplify with whichever parallel strategy suits the expression's shape.
+///
+/// Results are identical to [`crate::simplify::simplify`] either way; only the
+/// schedule differs.  Note that the derivation log is deterministic only when
+/// [`Strategy::LevelScheduled`] is chosen.
+pub fn simplify_auto(expr: ExprId, pool: &ExprPool) -> DerivedExpr<ExprId> {
+    simplify_auto_with_config(expr, pool, &SimplifyConfig::default())
+}
+
+/// Like [`simplify_auto`] but with a custom [`SimplifyConfig`].
+pub fn simplify_auto_with_config(
+    expr: ExprId,
+    pool: &ExprPool,
+    config: &SimplifyConfig,
+) -> DerivedExpr<ExprId> {
+    match choose_strategy(expr, pool) {
+        Strategy::ForkJoin => super::parallel::simplify_par_with_config(expr, pool, config),
+        Strategy::LevelScheduled => super::redex::simplify_redex_with_config(expr, pool, config),
+    }
+}
+
+/// The strategy [`simplify_auto`] would use for `expr`.
+///
+/// Exposed so callers can log or override the decision, and so tests can check
+/// it without timing anything.
+pub fn choose_strategy(expr: ExprId, pool: &ExprPool) -> Strategy {
+    // Below this many workers level scheduling wins whatever the shape, so
+    // skip the shape probe entirely rather than pay a traversal to learn
+    // something that cannot change the answer.
+    if rayon::current_num_threads() < MIN_WORKERS_FOR_FORK_JOIN {
+        return Strategy::LevelScheduled;
+    }
+    let (nodes, height) = shape(expr, pool);
+    let average_width = nodes as f64 / height.max(1) as f64;
+    if average_width >= WIDTH_THRESHOLD {
+        Strategy::ForkJoin
+    } else {
+        Strategy::LevelScheduled
+    }
+}
+
+/// Count the distinct nodes reachable from `root` and the height of the DAG.
+///
+/// Iterative, so it cannot overflow the stack on the deep expressions this is
+/// meant to detect.  Costs one traversal, which is small next to the many
+/// rule-matching passes that follow.
+fn shape(root: ExprId, pool: &ExprPool) -> (usize, u32) {
+    let n = pool.len();
+    let mut height = vec![u32::MAX; n];
+    let mut pushed = vec![false; n];
+    let mut stack: Vec<(ExprId, bool)> = vec![(root, false)];
+    let mut nodes = 0_usize;
+    let mut max_height = 0_u32;
+
+    while let Some((id, expanded)) = stack.pop() {
+        let i = id.0 as usize;
+        if expanded {
+            let h = pool.with(id, |data| {
+                let mut h = 0_u32;
+                for_each_child(data, |c| {
+                    let ch = height[c.0 as usize];
+                    debug_assert_ne!(ch, u32::MAX, "child measured after its parent");
+                    h = h.max(ch.saturating_add(1));
+                });
+                h
+            });
+            height[i] = h;
+            max_height = max_height.max(h);
+            nodes += 1;
+            continue;
+        }
+        if pushed[i] {
+            continue;
+        }
+        pushed[i] = true;
+        stack.push((id, true));
+        pool.with(id, |data| {
+            for_each_child(data, |c| {
+                if !pushed[c.0 as usize] {
+                    stack.push((c, false));
+                }
+            })
+        });
+    }
+
+    // Height counts edges; a single node is one level deep.
+    (nodes, max_height + 1)
+}
+
+/// Children a rewrite pass descends into, matching `simplify_children`.
+fn for_each_child(data: &ExprData, mut f: impl FnMut(ExprId)) {
+    match data {
+        ExprData::Add(args) | ExprData::Mul(args) => args.iter().copied().for_each(f),
+        ExprData::Func { args, .. } | ExprData::Predicate { args, .. } => {
+            args.iter().copied().for_each(f)
+        }
+        ExprData::Pow { base, exp } => {
+            f(*base);
+            f(*exp);
+        }
+        ExprData::Piecewise { branches, default } => {
+            branches.iter().for_each(|&(_, v)| f(v));
+            f(*default);
+        }
+        ExprData::Forall { body, .. } | ExprData::Exists { body, .. } => f(*body),
+        ExprData::BigO(arg) => f(*arg),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+    use crate::simplify::simplify;
+
+    fn p() -> ExprPool {
+        ExprPool::new()
+    }
+
+    fn junk(pool: &ExprPool, x: ExprId, depth: usize) -> ExprId {
+        let one = pool.integer(1_i32);
+        let zero = pool.integer(0_i32);
+        let mut e = x;
+        for _ in 0..depth {
+            e = pool.mul(vec![e, one]);
+            e = pool.add(vec![e, zero]);
+        }
+        e
+    }
+
+    /// Run inside a pool with enough workers that `choose_strategy` is deciding
+    /// on shape rather than falling back to the low-worker rule.
+    fn with_workers<R: Send>(f: impl FnOnce() -> R + Send) -> R {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(MIN_WORKERS_FOR_FORK_JOIN)
+            .build()
+            .unwrap()
+            .install(f)
+    }
+
+    #[test]
+    fn deep_chain_picks_level_scheduling() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let deep = junk(&pool, x, 300);
+        assert_eq!(
+            with_workers(|| choose_strategy(deep, &pool)),
+            Strategy::LevelScheduled
+        );
+    }
+
+    #[test]
+    fn wide_sum_picks_fork_join() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let args: Vec<ExprId> = (0..256)
+            .map(|i| {
+                let x = pool.symbol(format!("x{i}"), Domain::Real);
+                pool.add(vec![x, zero])
+            })
+            .collect();
+        let wide = pool.add(args);
+        assert_eq!(
+            with_workers(|| choose_strategy(wide, &pool)),
+            Strategy::ForkJoin
+        );
+    }
+
+    #[test]
+    fn few_workers_pick_level_scheduling() {
+        let pool = p();
+        let zero = pool.integer(0_i32);
+        let args: Vec<ExprId> = (0..256)
+            .map(|i| {
+                let x = pool.symbol(format!("y{i}"), Domain::Real);
+                pool.add(vec![x, zero])
+            })
+            .collect();
+        let wide = pool.add(args);
+        // Wide enough for fork-join on shape alone, but not enough workers.
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(MIN_WORKERS_FOR_FORK_JOIN - 1)
+            .build()
+            .unwrap();
+        assert_eq!(
+            tp.install(|| choose_strategy(wide, &pool)),
+            Strategy::LevelScheduled
+        );
+    }
+
+    /// Whichever branch is taken, the answer must match the sequential engine.
+    #[test]
+    fn auto_matches_sequential_on_both_shapes() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let deep = junk(&pool, x, 200);
+        let zero = pool.integer(0_i32);
+        let args: Vec<ExprId> = (0..64)
+            .map(|i| {
+                let s = pool.symbol(format!("z{i}"), Domain::Real);
+                junk(&pool, s, 4)
+            })
+            .collect();
+        let wide = pool.add(args);
+        for expr in [deep, wide] {
+            let seq = simplify(expr, &pool).value;
+            let auto = with_workers(|| simplify_auto(expr, &pool).value);
+            assert_eq!(seq, auto);
+        }
+        let _ = zero;
+    }
+
+    #[test]
+    fn shape_measures_width_and_height() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        // A chain of `Add(e, 0)` nodes: one node per level plus the leaves.
+        let deep = junk(&pool, x, 10);
+        let (nodes, height) = shape(deep, &pool);
+        assert!(
+            height >= 20,
+            "chain should be at least 20 levels, got {height}"
+        );
+        assert!(
+            (nodes as f64 / height as f64) < WIDTH_THRESHOLD,
+            "a chain must read as narrow"
+        );
+    }
+}

--- a/alkahest-core/src/simplify/engine.rs
+++ b/alkahest-core/src/simplify/engine.rs
@@ -89,6 +89,47 @@ pub fn default_rules() -> Vec<Box<dyn RewriteRule>> {
 // Internal: bottom-up traversal — simplify children, then current node
 // ---------------------------------------------------------------------------
 
+/// Apply `rules` to `expr` repeatedly until none fires, returning the fixed
+/// point and the steps taken.
+///
+/// Rules whose [`NodeKinds`] mask excludes this node's kind are skipped without
+/// calling `apply`.  The engine tries every rule on every node, and each
+/// `apply` re-inspects the node before deciding it does not match, so the bit
+/// test replaces most of that work.  Debug builds verify that a skipped rule
+/// really would not have fired.
+pub(crate) fn apply_rules(
+    expr: ExprId,
+    pool: &ExprPool,
+    rules: &[Box<dyn RewriteRule>],
+) -> (ExprId, DerivationLog) {
+    let mut current = expr;
+    let mut log = DerivationLog::new();
+    loop {
+        let kind = crate::simplify::rules::node_kind(current, pool);
+        let mut fired = false;
+        for rule in rules {
+            if !rule.node_kinds().contains(kind) {
+                debug_assert!(
+                    rule.apply(current, pool).is_none(),
+                    "rule `{}` was skipped by its node_kinds mask but would have fired",
+                    rule.name()
+                );
+                continue;
+            }
+            if let Some((next, step_log)) = rule.apply(current, pool) {
+                log = log.merge(step_log);
+                current = next;
+                fired = true;
+                break; // restart from first rule after any change
+            }
+        }
+        if !fired {
+            break;
+        }
+    }
+    (current, log)
+}
+
 /// Memoised bottom-up simplification.
 ///
 /// `memo` maps an input `ExprId` to the `ExprId` of its simplified form within
@@ -118,22 +159,7 @@ fn simplify_node(
     });
 
     // 2. Apply rules to rebuilt node until no rule fires
-    let mut current = rebuilt;
-    let mut rule_log = DerivationLog::new();
-    loop {
-        let mut fired = false;
-        for rule in rules {
-            if let Some((new_expr, step_log)) = rule.apply(current, pool) {
-                rule_log = rule_log.merge(step_log);
-                current = new_expr;
-                fired = true;
-                break; // restart from first rule after any change
-            }
-        }
-        if !fired {
-            break;
-        }
-    }
+    let (current, rule_log) = apply_rules(rebuilt, pool, rules);
 
     let result = DerivedExpr::with_log(current, child_log.merge(rule_log));
     memo.insert(expr, result.value);

--- a/alkahest-core/src/simplify/mod.rs
+++ b/alkahest-core/src/simplify/mod.rs
@@ -26,5 +26,5 @@ pub use engine::{
     rules_for_config, simplify, simplify_batch, simplify_expanded, simplify_log_exp,
     simplify_trig_normal_form, simplify_with, simplify_with_pattern_rules, SimplifyConfig,
 };
-pub use rules::RewriteRule;
+pub use rules::{node_kind, NodeKinds, RewriteRule};
 pub use rulesets::{PatternRule, PatternRuleSet};

--- a/alkahest-core/src/simplify/mod.rs
+++ b/alkahest-core/src/simplify/mod.rs
@@ -1,6 +1,8 @@
 pub mod assumptions;
 pub mod colored_egraph;
 pub mod discrimination_net;
+#[cfg(feature = "parallel")]
+pub mod dispatch;
 pub mod egraph;
 pub mod engine;
 #[cfg(feature = "parallel")]

--- a/alkahest-core/src/simplify/parallel.rs
+++ b/alkahest-core/src/simplify/parallel.rs
@@ -83,7 +83,11 @@ thread_local! {
 type Memo = DashMap<ExprId, ExprId>;
 
 /// Shared rule list handed to every worker.
-type Rules = Arc<Vec<Box<dyn RewriteRule + Send + Sync>>>;
+///
+/// `RewriteRule` requires `Send + Sync`, so `Box<dyn RewriteRule>` is already
+/// shareable; spelling the auto traits again would only prevent this list from
+/// being passed to the shared rule loop in `engine`.
+type Rules = Arc<Vec<Box<dyn RewriteRule>>>;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -105,7 +109,7 @@ pub fn simplify_par_with_config(
     pool: &ExprPool,
     config: &SimplifyConfig,
 ) -> DerivedExpr<ExprId> {
-    let rules: Rules = Arc::new(rules_for_config_par(config));
+    let rules: Rules = Arc::new(crate::simplify::rules_for_config(config));
     let mut current = expr;
     let mut full_log = DerivationLog::new();
     for _ in 0..config.max_iterations {
@@ -156,22 +160,8 @@ fn simplify_node_par(
             simplify_children_par(expr, data, pool, rules, memo)
         });
 
-        let mut current = rebuilt;
-        let mut rule_log = DerivationLog::new();
-        loop {
-            let mut fired = false;
-            for rule in rules.as_ref() {
-                if let Some((new_expr, step_log)) = rule.apply(current, pool) {
-                    rule_log = rule_log.merge(step_log);
-                    current = new_expr;
-                    fired = true;
-                    break;
-                }
-            }
-            if !fired {
-                break;
-            }
-        }
+        let (current, rule_log) =
+            crate::simplify::engine::apply_rules(rebuilt, pool, rules.as_ref());
         DerivedExpr::with_log(current, child_log.merge(rule_log))
     });
 

--- a/alkahest-core/src/simplify/redex.rs
+++ b/alkahest-core/src/simplify/redex.rs
@@ -179,24 +179,7 @@ fn reduce_node(
     table: &[AtomicU32],
 ) -> DerivationLog {
     let rebuilt = pool.with(id, |data| rebuild(id, data, pool, table));
-
-    let mut current = rebuilt;
-    let mut log = DerivationLog::new();
-    loop {
-        let mut fired = false;
-        for rule in rules {
-            if let Some((next, step_log)) = rule.apply(current, pool) {
-                log = log.merge(step_log);
-                current = next;
-                fired = true;
-                break;
-            }
-        }
-        if !fired {
-            break;
-        }
-    }
-
+    let (current, log) = crate::simplify::engine::apply_rules(rebuilt, pool, rules);
     table[id.0 as usize].store(current.0, Ordering::Relaxed);
     log
 }

--- a/alkahest-core/src/simplify/rules.rs
+++ b/alkahest-core/src/simplify/rules.rs
@@ -19,10 +19,74 @@ pub(super) fn as_rational(expr: ExprId, pool: &ExprPool) -> Option<rug::Rational
 // RewriteRule trait
 // ---------------------------------------------------------------------------
 
+/// The set of node kinds a rewrite rule can possibly fire on, as a bitmask.
+///
+/// The rule engine tries every rule on every node, and each `apply` re-inspects
+/// the node before deciding it does not match.  A rule that only rewrites
+/// `Mul` nodes can declare so, and the engine skips it with a bit test.
+///
+/// Kinds correspond to [`ExprData`] variants; the leaf kinds that no built-in
+/// rule dispatches on individually share [`NodeKinds::OTHER`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct NodeKinds(u16);
+
+impl NodeKinds {
+    pub const ADD: NodeKinds = NodeKinds(1 << 0);
+    pub const MUL: NodeKinds = NodeKinds(1 << 1);
+    pub const POW: NodeKinds = NodeKinds(1 << 2);
+    pub const FUNC: NodeKinds = NodeKinds(1 << 3);
+    pub const INTEGER: NodeKinds = NodeKinds(1 << 4);
+    pub const RATIONAL: NodeKinds = NodeKinds(1 << 5);
+    pub const FLOAT: NodeKinds = NodeKinds(1 << 6);
+    pub const SYMBOL: NodeKinds = NodeKinds(1 << 7);
+    /// Piecewise, Predicate, Forall, Exists, BigO, RootSum.
+    pub const OTHER: NodeKinds = NodeKinds(1 << 8);
+    /// Every kind — the default, meaning "no useful prefilter".
+    pub const ALL: NodeKinds = NodeKinds(u16::MAX);
+
+    /// Union of two masks, usable in `const` position.
+    pub const fn or(self, other: NodeKinds) -> NodeKinds {
+        NodeKinds(self.0 | other.0)
+    }
+
+    /// Whether this mask admits `kind`.
+    pub fn contains(self, kind: NodeKinds) -> bool {
+        self.0 & kind.0 != 0
+    }
+}
+
+/// The [`NodeKinds`] bit for the node `expr` currently holds.
+///
+/// Allocation-free, unlike [`super::discrimination_net::expr_head`], which
+/// clones the node and builds a `String` for `Func`/`Symbol`.
+pub fn node_kind(expr: ExprId, pool: &ExprPool) -> NodeKinds {
+    pool.with(expr, |data| match data {
+        ExprData::Add(_) => NodeKinds::ADD,
+        ExprData::Mul(_) => NodeKinds::MUL,
+        ExprData::Pow { .. } => NodeKinds::POW,
+        ExprData::Func { .. } => NodeKinds::FUNC,
+        ExprData::Integer(_) => NodeKinds::INTEGER,
+        ExprData::Rational(_) => NodeKinds::RATIONAL,
+        ExprData::Float(_) => NodeKinds::FLOAT,
+        ExprData::Symbol { .. } => NodeKinds::SYMBOL,
+        _ => NodeKinds::OTHER,
+    })
+}
+
 pub trait RewriteRule: Send + Sync {
     fn name(&self) -> &'static str;
     /// Try to apply the rule to `expr`. Returns `None` if the rule does not match.
     fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)>;
+
+    /// Node kinds this rule can rewrite.
+    ///
+    /// The engine skips `apply` entirely for nodes outside this mask, so an
+    /// over-narrow answer silently disables the rule; debug builds assert that
+    /// a skipped rule really would not have fired.  The default admits every
+    /// kind, so implementations outside this crate keep working unchanged.
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::ALL
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -229,6 +293,9 @@ fn rebuild_exp_term(exp: &rug::Integer, base: ExprId, pool: &ExprPool) -> ExprId
 pub struct AddZero;
 
 impl RewriteRule for AddZero {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::ADD
+    }
     fn name(&self) -> &'static str {
         "add_zero"
     }
@@ -258,6 +325,9 @@ impl RewriteRule for AddZero {
 pub struct MulOne;
 
 impl RewriteRule for MulOne {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
     fn name(&self) -> &'static str {
         "mul_one"
     }
@@ -287,6 +357,9 @@ impl RewriteRule for MulOne {
 pub struct MulZero;
 
 impl RewriteRule for MulZero {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
     fn name(&self) -> &'static str {
         "mul_zero"
     }
@@ -329,6 +402,9 @@ impl RewriteRule for MulZero {
 pub struct PowOne;
 
 impl RewriteRule for PowOne {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::POW
+    }
     fn name(&self) -> &'static str {
         "pow_one"
     }
@@ -352,6 +428,9 @@ impl RewriteRule for PowOne {
 pub struct SqrtInteger;
 
 impl RewriteRule for SqrtInteger {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::FUNC
+    }
     fn name(&self) -> &'static str {
         "sqrt_integer"
     }
@@ -395,6 +474,9 @@ fn integer_sqrt_u64(n: u64) -> Option<u64> {
 pub struct PowZero;
 
 impl RewriteRule for PowZero {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::POW
+    }
     fn name(&self) -> &'static str {
         "pow_zero"
     }
@@ -460,6 +542,13 @@ fn intern_rational(r: rug::Rational, pool: &ExprPool) -> ExprId {
 pub struct ConstFold;
 
 impl RewriteRule for ConstFold {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::ADD
+            .or(NodeKinds::MUL)
+            .or(NodeKinds::POW)
+            .or(NodeKinds::FUNC)
+            .or(NodeKinds::RATIONAL)
+    }
     fn name(&self) -> &'static str {
         "const_fold"
     }
@@ -795,6 +884,9 @@ fn even_power_sign_fold(base: ExprId, exp: ExprId, pool: &ExprPool) -> Option<Ex
 pub struct SubSelf;
 
 impl RewriteRule for SubSelf {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::ADD
+    }
     fn name(&self) -> &'static str {
         "collect_add_terms"
     }
@@ -864,6 +956,9 @@ impl RewriteRule for SubSelf {
 pub struct DivSelf;
 
 impl RewriteRule for DivSelf {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
     fn name(&self) -> &'static str {
         "collect_mul_factors"
     }
@@ -970,6 +1065,9 @@ impl RewriteRule for DivSelf {
 pub struct FlattenMul;
 
 impl RewriteRule for FlattenMul {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
     fn name(&self) -> &'static str {
         "flatten_mul"
     }
@@ -1007,6 +1105,9 @@ impl RewriteRule for FlattenMul {
 pub struct FlattenAdd;
 
 impl RewriteRule for FlattenAdd {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::ADD
+    }
     fn name(&self) -> &'static str {
         "flatten_add"
     }
@@ -1048,6 +1149,9 @@ impl RewriteRule for FlattenAdd {
 pub struct CanonicalOrder;
 
 impl RewriteRule for CanonicalOrder {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::ADD.or(NodeKinds::MUL)
+    }
     fn name(&self) -> &'static str {
         "canonical_order"
     }
@@ -1095,6 +1199,9 @@ impl RewriteRule for CanonicalOrder {
 pub struct ExpandMul;
 
 impl RewriteRule for ExpandMul {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
     fn name(&self) -> &'static str {
         "expand_mul"
     }
@@ -1191,6 +1298,9 @@ impl ExpandPow {
 }
 
 impl RewriteRule for ExpandPow {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::POW
+    }
     fn name(&self) -> &'static str {
         "expand_pow"
     }
@@ -1237,6 +1347,9 @@ impl RewriteRule for ExpandPow {
 pub struct ExpPow;
 
 impl RewriteRule for ExpPow {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::POW
+    }
     fn name(&self) -> &'static str {
         "exp_pow"
     }
@@ -1270,6 +1383,9 @@ impl RewriteRule for ExpPow {
 pub struct CollectExp;
 
 impl RewriteRule for CollectExp {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
     fn name(&self) -> &'static str {
         "collect_exp"
     }
@@ -1323,6 +1439,9 @@ impl RewriteRule for CollectExp {
 pub struct PrimitiveFold;
 
 impl RewriteRule for PrimitiveFold {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::FUNC
+    }
     fn name(&self) -> &'static str {
         "primitive_simplify"
     }


### PR DESCRIPTION
The two follow-ups flagged at the end of #261, one per commit.

## 1. Skip rules that cannot match the node's kind (`d8de5ed`)

The engine tried all thirteen rules on every node, and each `apply` re-inspected the node before deciding it did not match — `MulZero` looking at `Add` nodes, `FlattenAdd` looking at `Pow` nodes, and so on.

`RewriteRule` gains a **provided** `node_kinds` method returning a bitmask of the `ExprData` kinds it can rewrite; the engine tests that bit before calling `apply`. The default admits every kind, so implementations outside this crate are unaffected and the trait stays object-safe and semver-clean.

Sequential simplification, min over 5 interleaved rounds:

| workload | before | after | gain |
|---|---|---|---|
| wide sum of canonical terms (4096 x 8) | 26.54 ms | 12.94 ms | **2.05x** |
| many medium chains (1024 x 32) | 99.55 ms | 60.34 ms | 1.65x |
| wide sum, independent terms (1024 x 8) | 23.36 ms | 13.37 ms | 1.75x |
| wide sum, independent terms (4096 x 4) | 52.74 ms | 31.27 ms | 1.69x |
| wide sum over a shared DAG (1024) | 1.95 ms | 1.45 ms | 1.34x |
| deep chain (2000 levels) | 34.94 ms | 28.29 ms | 1.24x |

**On the correctness hazard:** a too-narrow mask silently disables a rule. Debug builds therefore assert that any rule skipped by its mask really would have returned `None`, so the entire test suite doubles as a check on all seventeen declarations — 1709 tests pass in debug with those assertions live.

`node_kind` reads the discriminant through `ExprPool::with` and allocates nothing, unlike `discrimination_net::expr_head`, which clones the node and builds a `String` for `Func`/`Symbol` — far too expensive for a per-node prefilter, which is why that index was not reused here.

The rule loop is now shared by the sequential, fork-join and level-scheduled engines instead of being written out three times.

## 2. Shape-based strategy dispatch (`9d9644e`)

`simplify_auto` dispatches on worker count and average level width (reachable nodes / DAG height). Below `MIN_WORKERS_FOR_FORK_JOIN` the shape probe is skipped entirely — level scheduling was faster on every shape at four workers, so no traversal could change the answer.

Measured against an oracle that always picks the better of the two, six shapes at 4/16/32 workers:

| policy | mean penalty | worst case |
|---|---|---|
| always fork-join | 85% | 711% |
| always level-scheduled | 32% | 155% |
| `simplify_auto` | **12%** | **60%** |

Worth ~3x over the better fixed choice, and it removes the 8x cliff of sending a deep chain to fork-join.

### Honest limits on this one

The first heuristic I wrote was **wrong**: it used width alone with a single-worker exception, and mispredicted at four workers, where level scheduling wins even on the widest shapes. The worker-count term fixed that; the numbers above are post-fix.

The thresholds are calibrated on synthetic shapes, not a profile of real workloads, and the box is shared — repeated runs of the same binary vary by tens of percent, and one measurement in the table shows `auto` beating both strategies it dispatches to, which is only possible as noise. The extremes are unambiguous (a chain and a wide sum differ by three orders of magnitude in average width), but the exact cut points are provisional and documented as such in the module. `choose_strategy` is public so callers can inspect or override.

## Testing

- `cargo test --workspace` — 1709 passed, 0 failed
- `cargo test --workspace --features parallel` — 1685 passed
- `cargo test --workspace --features "parallel egraph"` — 1709 passed
- `cargo clippy --all-targets` / `--features egraph` / `--features parallel`, each `-D warnings` — clean (`--features jit` cannot build locally, no LLVM 15)
- `cargo fmt --all -- --check` — clean

Five new dispatch tests assert the strategy choice without timing, plus agreement with the sequential engine on both shapes; the prefilter is covered by the debug assertion across the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)