### PR TITLE
chore: drop three unused internals, pin the forward-AD equivalence

### DIFF
--- a/alkahest-core/src/dae/mod.rs
+++ b/alkahest-core/src/dae/mod.rs
@@ -257,8 +257,6 @@ pub fn pantelides(dae: &DAE, pool: &ExprPool) -> Result<PantelidesResult, DaeErr
 
 struct Matching {
     eq_to_var: Vec<Option<usize>>,
-    #[allow(dead_code)]
-    var_to_eq: Vec<Option<usize>>,
 }
 
 /// Build an incidence list: `result[i]` = set of variable indices that equation `i` depends on.
@@ -316,10 +314,7 @@ fn maximum_matching(adj: &[Vec<usize>], n_eq: usize, n_var: usize) -> Matching {
             eq_to_var[eq] = Some(var);
         }
     }
-    Matching {
-        eq_to_var,
-        var_to_eq,
-    }
+    Matching { eq_to_var }
 }
 
 /// Differentiate `equation` with respect to time, using `d(var)/dt = deriv`.

--- a/alkahest-core/src/diff/forward.rs
+++ b/alkahest-core/src/diff/forward.rs
@@ -72,31 +72,12 @@ impl DualValue {
         DualValue::new(value, tangent)
     }
 
-    #[allow(dead_code)]
-    fn neg(self, pool: &ExprPool) -> Self {
-        let neg_one = pool.integer(-1_i32);
-        let value = pool.mul(vec![neg_one, self.value]);
-        let tangent = pool.mul(vec![neg_one, self.tangent]);
-        DualValue::new(value, tangent)
-    }
-
-    #[allow(dead_code)]
-    fn sub(self, rhs: Self, pool: &ExprPool) -> Self {
-        self.add(rhs.neg(pool), pool)
-    }
-
-    /// Division: d(a/b) = (b·da - a·db) / b²
-    #[allow(dead_code)]
-    fn div(self, rhs: Self, pool: &ExprPool) -> Self {
-        let value = pool.mul(vec![self.value, pool.pow(rhs.value, pool.integer(-1_i32))]);
-        let bda = pool.mul(vec![rhs.value, self.tangent]);
-        let adb = pool.mul(vec![self.value, rhs.tangent]);
-        let neg_one = pool.integer(-1_i32);
-        let numerator = pool.add(vec![bda, pool.mul(vec![neg_one, adb])]);
-        let b_sq = pool.pow(rhs.value, pool.integer(2_i32));
-        let tangent = pool.mul(vec![numerator, pool.pow(b_sq, pool.integer(-1_i32))]);
-        DualValue::new(value, tangent)
-    }
+    // No `neg`, `sub` or `div`: the kernel has no `Neg`, `Sub` or `Div` node.
+    // Subtraction is `Add([a, Mul([-1, b])])` and division is `Mul([a, Pow(b, -1)])`,
+    // so both reach this evaluator through `add`, `mul` and `pow_int` alone.  The
+    // quotient rule falls out of the product rule composed with `pow_int(-1)`:
+    // `d(a·b⁻¹) = b⁻¹·da + a·(−b⁻²·db) = (b·da − a·db)/b²`.  See the
+    // `forward_diff_subtraction_*` and `forward_diff_division_*` tests.
 
     /// Power rule for integer exponent n: d(f^n) = n * f^(n-1) * f'
     fn pow_int(self, n: rug::Integer, pool: &ExprPool) -> Self {
@@ -443,6 +424,55 @@ mod tests {
         let fwd_poly = UniPoly::from_symbolic(fwd, x, &pool).unwrap();
         let sym_poly = UniPoly::from_symbolic(sym, x, &pool).unwrap();
         assert_eq!(fwd_poly.coefficients_i64(), sym_poly.coefficients_i64());
+    }
+
+    // The kernel has no `Sub` or `Div` node, so subtraction and division reach
+    // forward mode as `Add`/`Mul`/`Pow` over canonical forms.  These two tests
+    // pin that down: they are the reason `DualValue` needs no `sub`/`div`/`neg`.
+
+    #[test]
+    fn forward_diff_subtraction_agrees_with_symbolic() {
+        // d/dx (x² − 3x) = 2x − 3, where `− 3x` is `Mul([-3, x])`.
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.mul(vec![pool.integer(-3_i32), x]),
+        ]);
+        let fwd = diff_forward(expr, x, &pool).unwrap().value;
+        let sym = sym_diff(expr, x, &pool).unwrap().value;
+        let fwd_poly = UniPoly::from_symbolic(fwd, x, &pool).unwrap();
+        let sym_poly = UniPoly::from_symbolic(sym, x, &pool).unwrap();
+        assert_eq!(fwd_poly.coefficients_i64(), sym_poly.coefficients_i64());
+        assert_eq!(fwd_poly.coefficients_i64(), vec![-3, 2]);
+    }
+
+    #[test]
+    fn forward_diff_division_agrees_with_symbolic() {
+        // d/dx ((x+1)/x) = −1/x², where the quotient is `Mul([x+1, Pow(x, -1)])`.
+        // Compared by exact rational evaluation, since neither derivative is a
+        // polynomial and the two spellings need not be structurally identical.
+        use crate::eval::eval_exact_rational;
+        use rug::Rational;
+        use std::collections::HashMap;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let numer = pool.add(vec![x, pool.integer(1_i32)]);
+        let expr = pool.mul(vec![numer, pool.pow(x, pool.integer(-1_i32))]);
+        let fwd = diff_forward(expr, x, &pool).unwrap().value;
+        let sym = sym_diff(expr, x, &pool).unwrap().value;
+
+        for pt in [2_i32, 3, 5, -4] {
+            let mut b = HashMap::new();
+            b.insert(x, Rational::from(pt));
+            let fv = eval_exact_rational(fwd, &pool, &b).unwrap();
+            let sv = eval_exact_rational(sym, &pool, &b).unwrap();
+            // Closed form: −1/x².
+            let expected = Rational::from((-1, pt as i64 * pt as i64));
+            assert_eq!(fv, sv, "forward vs symbolic disagree at x = {pt}");
+            assert_eq!(fv, expected, "forward wrong at x = {pt}");
+        }
     }
 
     #[test]

--- a/alkahest-core/src/simplify/colored_egraph.rs
+++ b/alkahest-core/src/simplify/colored_egraph.rs
@@ -85,14 +85,17 @@ pub struct ColoredEgraph {
     context: ColorUnionFind,
     /// All expression nodes reachable from the input.
     nodes: HashSet<ExprId>,
-    /// Assumptions attached to the context layer.
-    #[allow(dead_code)]
-    assumptions: Vec<SideCondition>,
 }
 
 impl ColoredEgraph {
     /// Build a colored e-graph from `expr`, collecting all DAG nodes.
-    pub fn from_expr(expr: ExprId, pool: &ExprPool, assumptions: &[SideCondition]) -> Self {
+    ///
+    /// `_assumptions` is unused: the e-graph itself is assumption-agnostic, and
+    /// [`simplify_colored`] checks declared assumptions against each rule's side
+    /// conditions via [`assumptions_satisfy`] before requesting a context merge.
+    /// The parameter is retained because it is part of the released signature and
+    /// because gating merges inside the union-find would need it.
+    pub fn from_expr(expr: ExprId, pool: &ExprPool, _assumptions: &[SideCondition]) -> Self {
         let mut nodes = HashSet::new();
         collect_nodes(expr, pool, &mut nodes);
         let mut root = ColorUnionFind::default();
@@ -105,7 +108,6 @@ impl ColoredEgraph {
             root,
             context,
             nodes,
-            assumptions: assumptions.to_vec(),
         }
     }
 


### PR DESCRIPTION
Follow-up to #264, clearing the remaining dead-code findings. All three are private items — no public API change.

### `ColoredEgraph::assumptions`

The field was cloned from the constructor argument on every `from_expr` call and never read. Worth stating plainly since the type is new: this is **redundancy, not a missing check**. `simplify_colored` validates each rule's side conditions against the caller's declared assumptions via `assumptions_satisfy` before requesting a context merge, using its own parameter — so assumption handling was never going through this field. Dropping it removes a `Vec<SideCondition>` allocation per e-graph construction.

The `from_expr` parameter is **kept**: `ColoredEgraph` is re-exported at the crate root, so removing it would break `cargo semver-checks`, and gating merges inside the union-find rather than at the rule site would need it.

### `DualValue::{neg, sub, div}`

Unreachable by construction. The kernel has no `Neg`, `Sub` or `Div` node — subtraction is `Add([a, Mul([-1, b])])`, division is `Mul([a, Pow(b, -1)])` — so both reach forward mode through `add`, `mul` and `pow_int` alone. The quotient rule already falls out of the product rule composed with `pow_int(-1)`:

```
d(a·b⁻¹) = b⁻¹·da + a·(−b⁻²·db) = (b·da − a·db)/b²
```

which is exactly what `div` recomputed. These were the one case where building the code out was worth considering, and it isn't: it would add a second path that no expression can reach.

### Tests

That equivalence turned out to be **untested** — the forward-mode suite covered constants, powers, `sin`, `exp` and `log`, but never a subtraction or a quotient. Two tests now pin it:

- `forward_diff_subtraction_agrees_with_symbolic` — `d/dx (x² − 3x)`, compared coefficient-wise against the symbolic differentiator and against the expected `[-3, 2]`.
- `forward_diff_division_agrees_with_symbolic` — `d/dx ((x+1)/x)`, compared by **exact rational** evaluation at four points against both the symbolic result and the closed form `−1/x²`. Exact rather than float, and pointwise rather than structural, because the two spellings need not be structurally identical.

### `dae::Matching::var_to_eq`

The reverse map is the augmenting-path matching's own working state and is still built inside `maximum_matching`, which derives `eq_to_var` from it. Only the struct *field* was unused, and it was an exact inverse of the field the caller actually reads.

## Verification

- `cargo fmt` applied
- `cargo check --workspace --all-targets` clean; a `--force-warn dead_code` pass reports no new unreachable items
- `cargo test --workspace` — 1687 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved differentiation correctness for subtraction and division, including exact rational evaluations across multiple points.
  * Retained assumption validation during colored simplification while avoiding unnecessary assumption state.
* **Refactor**
  * Simplified internal matching results by removing unused reverse mappings.
  * Streamlined arithmetic handling by representing subtraction and division through existing kernel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->