### PR TITLE
test: deterministic silent-error gate (133 cases, CI Tier 1a) + 13 new silent errors found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,35 @@ jobs:
       - name: ty check
         run: ty check python/alkahest/
 
+      # Its own step, ahead of the general suite: a silent error -- a confident,
+      # plausible, mathematically wrong answer returned with no exception and no
+      # verification flag -- is the one failure class that compounds. In an
+      # autoresearch loop it is not one wrong answer, it is a false lemma every
+      # downstream derivation inherits. Separating the step means a red gate is
+      # identifiable from the job list without opening the pytest log; the step
+      # prints the measured rate and per-subsystem breakdown either way.
+      # See tests/silent_errors/README.md.
+      - name: Silent-error gate (deterministic trap corpus)
+        env:
+          PYTHONUNBUFFERED: "1"
+          ALKAHEST_SILENT_ERROR_REPORT: silent-error-summary.json
+        run: pytest tests/silent_errors/ --timeout=300
+
+      - name: Upload silent-error summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: silent-error-summary-${{ github.run_id }}
+          path: silent-error-summary.json
+          if-no-files-found: warn
+
+      # --ignore=tests/silent_errors: already run by the dedicated step above.
+      # It stays collected by a plain local `pytest tests/` -- the ignore is a
+      # CI-only de-duplication, not an opt-in marker developers must remember.
       - name: pytest (default excludes @pytest.mark.slow sparse roadmap; see pytest.ini)
         env:
           PYTHONUNBUFFERED: "1"
-        run: pytest --timeout=900
+        run: pytest --timeout=900 --ignore=tests/silent_errors
 
       - name: Install Rust nightly (for ASan)
         uses: dtolnay/rust-toolchain@nightly

--- a/tests/silent_errors/README.md
+++ b/tests/silent_errors/README.md
@@ -1,0 +1,221 @@
+# The silent-error gate
+
+A **silent error** is a confident, plausible, mathematically wrong answer
+returned with no exception, no `NaN`, and no verification flag that would let
+the caller tell it apart from a correct result. `∫_{-1}^{1} x^-2 dx = -2` is
+the archetype: the number is clean, the derivation is one power-rule step, and
+it is wrong — the integral diverges.
+
+This package measures how often alkahest does that, deterministically, with no
+LLM, fast enough to run on every pull request.
+
+## Why it is separate from the textbook gate
+
+`tests/textbook_gate/` asks *"does alkahest get first-course problems right?"*.
+This asks the harder question: *"when alkahest cannot get one right, does it
+say so?"* Those are different failure modes with wildly different costs.
+
+For an interactive user a wrong answer costs five minutes. For an autonomous
+research loop it is a **false lemma that every downstream derivation inherits**,
+and one the loop's own consistency checks will happily confirm, because they are
+checking against the same poisoned result. A refusal closes one branch; a silent
+error poisons a whole subtree. See
+`temp-alkahest/planning/autoresearch.md`, "P0 — trust", item 1.
+
+`tests/textbook_gate/test_tg_silent_errors.py` held the first four of these
+regressions. This package generalises them into a declarative corpus with a
+measured rate and an anti-drift link to `agent-benchmark/`.
+
+## Why it is separate from agent-benchmark
+
+`agent-benchmark/` already measures silent-error rate — through an LLM writing
+scripts against alkahest and SymPy. That makes it the right instrument for
+"how does this CAS behave in an agent's hands", and the wrong instrument for a
+merge gate: it needs API keys, it is non-deterministic, and it costs money per
+run.
+
+This gate measures the **library-level** rate: the same traps, called directly,
+no model in the loop. It runs in well under a second.
+
+`test_catalogue_sync.py` is the ratchet between the two. Every `Kind.TRAP` task
+in `agent-benchmark/tasks/catalogue.py` must be claimed by at least one case
+here, so a trap discovered while running the benchmark cannot end up covered
+only by the benchmark. The outcome vocabularies are asserted to stay one
+relabelling apart (`silent_error` here is `wrong_answer` there), so the two
+rates remain comparable.
+
+## The contract vocabulary
+
+Every case declares exactly one contract. The vocabulary is small on purpose:
+its job is to make the difference between *refusing* and *lying* explicit at the
+point where the case is written.
+
+| Contract | Meaning | A different value is… |
+|---|---|---|
+| `Raises(code)` | must raise an alkahest error with this exact stable `E-SUBSYSTEM-NNN` code | a **silent error** |
+| `Returns(value)` | must produce this value (`tol` applies to floats) | a **silent error** |
+| `RefusesOr(value)` | refusing *or* returning `value` is acceptable | a **silent error** |
+| `RefusesOr()` | no finite value is acceptable at all | a **silent error** |
+
+`RefusesOr` is for the traps where "this does not exist" and "here is the
+principal value / the one-sided limit" are both defensible — divergent
+integrals, `(-8)^(1/3)`, `√x = -1`. `RefusesOr()` with no argument is the
+stronger form: the quantity does not exist under any convention, so *any*
+finite answer is a lie.
+
+Refusing where `Returns` was declared is **not** a silent error — it fails the
+gate as a coverage regression, but it is classified `honest_refusal`, because
+the caller was still told.
+
+### Outcomes
+
+Mirrors `agent-benchmark/tasks/base.py`'s `Outcome` one-for-one:
+
+| This gate | agent-benchmark | Meaning |
+|---|---|---|
+| `correct` | `correct` | contract satisfied with a value |
+| `silent_error` | `wrong_answer` | **the metric**: a confident wrong answer |
+| `honest_refusal` | `honest_refusal` | alkahest declined; always safe |
+| `no_answer` | `no_answer` | the call broke in a way that is neither — a corpus bug |
+
+### What counts as a refusal
+
+Matching `refusal_or_value` in `agent-benchmark/tasks/base.py`:
+
+* an `AlkahestError` subclass — the honest, coded path;
+* a returned expression that cannot be reduced to a number (alkahest raises
+  `ValueError` from `eval_expr` for `∞`, `0^-1`, or a bare `O(x^n)` remainder);
+* `NaN` or `±inf`, which are an implicit admission of failure rather than a
+  stated answer.
+
+The last two are **weak** refusals: a caller has to look at the value to notice
+anything is wrong. Cases that only pass because of one say so in their `note`,
+and those notes are where the next round of hardening should start
+(`int_pole_tangent_over_period` and the `series_*` singular cases in
+particular).
+
+### Verification floors
+
+A case may declare `verification_floor="numerically_checked"` (or stronger) and
+return a `Measured(answer, verification)` instead of a bare answer. The runner
+then checks `DerivedResult.verification["status"]` against
+
+```
+unverified < numerically_checked < certificate_available < exactly_verified < externally_verified
+```
+
+This catches the *other* way trust degrades: the answer stays right while the
+evidence behind it quietly weakens.
+
+## Adding a case
+
+1. **Work the mathematics out first, independently.** Every case records where
+   its expected value came from in `verified_by`, and `test_every_case_declares_a_source`
+   enforces that the field is non-trivial. A corpus whose expectations were read
+   off alkahest's own output measures self-consistency and nothing else. Hand
+   derivations, textbook facts, and independent libraries all qualify; "alkahest
+   printed this" does not.
+2. **Pick the weakest contract that still catches the lie.** If a principal
+   value is defensible, use `RefusesOr(pv)` rather than `Raises`; over-tight
+   contracts turn into churn the first time a subsystem legitimately improves.
+3. **Add the control.** A gate made only of refusals is passed by a library that
+   refuses everything. Each refusal class needs its nearest convergent
+   neighbour: `int_pole_inverse_square_symmetric` is paired with
+   `int_control_integrable_endpoint_singularity`, the DNE limits with
+   `limit_control_squeeze`, the singular-point series with
+   `series_control_simple_pole`.
+4. **Append to `CASES` in `corpus.py`** with a stable, never-reused `id`.
+
+```python
+Case(
+    id="int_pole_double_at_one",
+    subsystem="integration_definite",
+    statement="∫_0^2 (x-1)^-2 dx diverges (double pole at x=1)",
+    op=definite(1 / (X - 1) ** 2, _int(0), _int(2)),
+    contract=Raises("E-INT-001"),
+    verified_by="∫(x-1)^-2 = -1/(x-1); naive FTC gives -1-1 = -2, a plausible wrong number.",
+),
+```
+
+The `op` is a zero-argument callable returning a plain **answer** — a float,
+int, bool, string, list, or a `Measured`. Reducing the library's return value to
+an answer is the case's own job, which is what lets a definite integral, a
+solution count, and a series coefficient all be scored by the same four
+contracts. `corpus.py` provides `definite`, `antiderivative_slope`,
+`limit_value`, `series_at`, `simplified_value` and `real_solution_count` for the
+common shapes.
+
+### Verifying an antiderivative
+
+Never assert the *shape* of an antiderivative. Use `antiderivative_slope`, which
+differentiates whatever alkahest returned and evaluates it at a sample point:
+immune to `+C` and to every legitimate difference in form, and it catches the
+only thing that matters — an antiderivative whose derivative is not the
+integrand. It also detects a **false** non-elementarity verdict, which is
+exactly as damaging as a wrong formula: it tells a search loop a branch is
+permanently closed when it is not (report7-20.md, bug B2).
+
+### Cost discipline
+
+The corpus runs on every pull request, so every op must finish in well under a
+second. Known-slow inputs are documented here rather than added:
+
+* `∫ (1/log x - 1/log²x) dx` (= `x/log x`, elementary, each part is not) does
+  not terminate within 30 s. It is a good case and belongs in the corpus once
+  `integrate` grows a budget; adding it today would make the gate a timeout
+  hazard rather than a signal.
+
+## Known-broken cases: `xfail(strict=True)`, never deletion
+
+A case alkahest currently fails is not removed — it is marked:
+
+```python
+xfail="SILENT ERROR: alkahest returns 0, a value the function never takes. …",
+```
+
+which the runner turns into `pytest.mark.xfail(strict=True, reason=...)`.
+`strict=True` is load-bearing: when the bug is fixed the case flips from `xfail`
+to an *unexpected pass*, which pytest reports as a failure. That failure is the
+signal — delete the `xfail` field and the case becomes an ordinary regression
+test. An absent case can catch neither the fix nor the re-regression.
+
+The `xfail` string must name the bug, not just assert that one exists
+(`test_known_broken_cases_name_a_bug` enforces a minimum length). Known-broken
+cases are excluded from the headline rate — which therefore tracks
+*regressions* — and reported separately under `known_silent_errors`, loudly, as
+the fix queue.
+
+## The measured rate
+
+`test_silent_error_count_is_zero` is the gate: zero silent errors outside the
+known-broken set, always.
+
+The runner also writes a machine-readable summary to
+`target/silent-errors/summary.json` (override with
+`ALKAHEST_SILENT_ERROR_REPORT`) and prints it through pytest's
+terminal-summary hook, so the numbers appear in the CI log whether the gate
+passed or failed and without anyone needing `-s`:
+
+```
+cases            : 133 (120 scored, 13 known-broken)
+silent-error rate: 0.0% (0 / 120)
+
+subsystem                     cases     ok  refusal  silent  known
+  integration_definite           28     22        6       0      0
+  ...
+```
+
+The JSON carries `by_outcome`, `by_subsystem`, the full `silent_errors` and
+`known_silent_errors` lists, and `benchmark_outcome_names` for cross-referencing
+an `agent-benchmark` report.
+
+## Running it
+
+```bash
+pytest tests/silent_errors/ -v
+```
+
+It is also collected by the ordinary `pytest tests/` run. CI gives it a separate
+Tier 1a step so a red gate is identifiable at a glance, and passes
+`--ignore=tests/silent_errors` to the general pytest step so it is not run
+twice.

--- a/tests/silent_errors/conftest.py
+++ b/tests/silent_errors/conftest.py
@@ -1,0 +1,29 @@
+"""Make this directory importable so ``contracts`` / ``corpus`` resolve.
+
+Mirrors what ``tests/conftest.py`` does for ``_tg_helpers`` one level up: the
+gate's helper modules live beside its test files rather than in ``tests/`` root,
+so the package stays self-contained and easy to lift into another repo.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
+    """Echo the gate's summary into the terminal report.
+
+    pytest captures stdout by default, so a ``print`` inside a passing test is
+    swallowed and a CI log reader would never see the measured rate. Writing it
+    from the terminal-summary hook puts it in the log unconditionally, pass or
+    fail, without anyone having to remember ``-s``.
+    """
+    module = sys.modules.get("test_silent_error_gate")
+    text = getattr(module, "SUMMARY_TEXT", "") if module is not None else ""
+    if text:
+        terminalreporter.write_line(text)

--- a/tests/silent_errors/contracts.py
+++ b/tests/silent_errors/contracts.py
@@ -1,0 +1,404 @@
+"""Contract vocabulary for the deterministic silent-error gate.
+
+A **silent error** is a confident, plausible, mathematically wrong answer
+returned with no exception, no ``NaN``, and no verification flag that would let
+a caller tell it apart from a correct result.  For an autonomous research loop
+this is the worst possible failure: a refusal costs one dead branch, a silent
+error poisons every downstream claim derived from it, and the loop's own
+consistency checks will happily confirm the poisoned branch.
+
+``agent-benchmark/`` already measures this rate, but it needs an LLM and a
+network round-trip per task, so it cannot gate CI.  This package measures the
+same quantity at the **library** level: no agent, no model, no network — just
+alkahest calls with declared contracts, so it can run on every pull request.
+
+Vocabulary
+----------
+Every case declares one contract:
+
+``Raises(code)``
+    The call must raise an alkahest error carrying exactly the stable
+    ``E-SUBSYSTEM-NNN`` *code*.  Refusing with a *different* code is a contract
+    failure but **not** a silent error — the caller still knows it was refused.
+
+``Returns(value)``
+    The call must produce *value* (exactly for ints/bools/strings, within
+    ``tol`` for floats).  A different value is a silent error.  A refusal here
+    is a coverage regression: it fails the gate, but is classified
+    ``honest_refusal``, not ``silent_error``.
+
+``RefusesOr(value)``
+    Either refusing *or* returning *value* is acceptable — these are the traps
+    where "this does not exist" and "here is the principal value / one-sided
+    limit" are both defensible answers.  Any *other* confident finite answer is
+    a silent error.  ``RefusesOr()`` with no value means no finite answer is
+    acceptable at all (divergent integral, limit that does not exist).
+
+Outcomes mirror :class:`agent_benchmark.tasks.base.Outcome` one-for-one so the
+two vocabularies stay comparable; :data:`BENCHMARK_OUTCOME` is the explicit map
+and ``tests/silent_errors/test_catalogue_sync.py`` asserts it stays total.
+
+What counts as a refusal
+------------------------
+Matching ``refusal_or_value`` in ``agent-benchmark/tasks/base.py``, a refusal is
+any of:
+
+* an ``AlkahestError`` subclass (the honest, coded path);
+* a returned expression that cannot be reduced to a number — alkahest raises
+  ``ValueError`` from ``eval_expr`` for unbound/undefined nodes such as ``∞``,
+  ``0^-1`` or a bare ``O(x^n)`` remainder;
+* ``NaN`` or ``±inf``, which are an implicit admission of failure rather than a
+  stated answer.
+
+These are *weak* refusals — a caller has to look at the value to notice — so
+cases that only pass because of them say so in their ``note``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable
+
+import alkahest as ak
+
+# ---------------------------------------------------------------------------
+# Outcome taxonomy — kept in lockstep with agent-benchmark
+# ---------------------------------------------------------------------------
+
+
+class Outcome(str, Enum):
+    """Result of checking one case against its contract."""
+
+    CORRECT = "correct"
+    #: A confident answer that is mathematically wrong.  The metric that matters.
+    #: Named ``wrong_answer`` on the agent-benchmark side.
+    SILENT_ERROR = "silent_error"
+    #: alkahest declined — raised a coded error, or returned something that does
+    #: not reduce to a finite number.  Always a *safe* outcome, even when the
+    #: contract wanted a value.
+    HONEST_REFUSAL = "honest_refusal"
+    #: The call blew up in a way that is neither an answer nor an alkahest
+    #: refusal (harness bug, unexpected Python exception, wrong return type).
+    NO_ANSWER = "no_answer"
+
+
+#: Explicit mapping onto ``agent_benchmark.tasks.base.Outcome`` values.  The two
+#: enums differ in exactly one name (``silent_error`` vs ``wrong_answer``); this
+#: map is asserted total by the catalogue-sync test.
+BENCHMARK_OUTCOME: dict[Outcome, str] = {
+    Outcome.CORRECT: "correct",
+    Outcome.SILENT_ERROR: "wrong_answer",
+    Outcome.HONEST_REFUSAL: "honest_refusal",
+    Outcome.NO_ANSWER: "no_answer",
+}
+
+#: Verification statuses in increasing strength.  ``Case.verification_floor``
+#: names the weakest status a case is allowed to report.
+VERIFICATION_ORDER: tuple[str, ...] = (
+    "unverified",
+    "numerically_checked",
+    "certificate_available",
+    "exactly_verified",
+    "externally_verified",
+)
+
+
+# ---------------------------------------------------------------------------
+# Contracts
+# ---------------------------------------------------------------------------
+
+
+class _Nothing:
+    """Sentinel: ``RefusesOr()`` accepts no finite value at all."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return "NOTHING"
+
+
+NOTHING = _Nothing()
+
+
+@dataclass(frozen=True)
+class Raises:
+    """Must raise an alkahest error with this exact stable code."""
+
+    code: str
+
+    def describe(self) -> str:
+        return f"RAISES({self.code})"
+
+
+@dataclass(frozen=True)
+class Returns:
+    """Must return this value (``tol`` applies to floats)."""
+
+    value: Any
+    tol: float = 1e-9
+
+    def describe(self) -> str:
+        return f"RETURNS({self.value!r})"
+
+
+@dataclass(frozen=True)
+class RefusesOr:
+    """Refusing is fine; so is this specific value.  Anything else is a lie."""
+
+    value: Any = NOTHING
+    tol: float = 1e-9
+
+    def describe(self) -> str:
+        if self.value is NOTHING:
+            return "REFUSES_OR(<no finite value>)"
+        return f"REFUSES_OR({self.value!r})"
+
+
+Contract = Raises | Returns | RefusesOr
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Measured:
+    """An answer plus the ``DerivedResult.verification`` dict that produced it.
+
+    Cases whose op naturally holds a :class:`~alkahest.DerivedResult` return one
+    of these so the runner can check ``verification_floor`` without re-running
+    the computation.
+    """
+
+    answer: Any
+    verification: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class Case:
+    """One declarative trap."""
+
+    #: Stable identifier; also the pytest parameter id.  Never reuse one.
+    id: str
+    #: Subsystem bucket for the per-subsystem breakdown in the summary.
+    subsystem: str
+    #: Human-readable statement of the mathematics being tested.
+    statement: str
+    #: Zero-argument callable returning a plain answer (float / int / bool /
+    #: str / tuple / list) or a :class:`Measured`.  It may raise.
+    op: Callable[[], Any]
+    contract: Contract
+    #: Where the expected value came from.  Every case must name a source that
+    #: is not alkahest itself — a hand derivation, a textbook fact, or an
+    #: independent library.  Cases whose "expected" value was read off
+    #: alkahest's own output prove nothing.
+    verified_by: str
+    #: Names of ``Kind.TRAP`` tasks in ``agent-benchmark/tasks/catalogue.py``
+    #: that this case is the library-level counterpart of.
+    benchmark_tasks: tuple[str, ...] = ()
+    #: Weakest acceptable ``DerivedResult.verification["status"]``.  Requires the
+    #: op to return a :class:`Measured`.
+    verification_floor: str | None = None
+    #: Set to a bug description to mark the case ``xfail(strict=True)``: alkahest
+    #: genuinely fails this today.  Never delete a failing case — an absent case
+    #: cannot catch the fix or a later re-regression.
+    xfail: str | None = None
+    #: Free-text caveat, e.g. "passes only via a weak refusal".
+    note: str = ""
+    #: Extra tags for filtering / reporting.
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Probing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Answer:
+    """What actually came back."""
+
+    #: ``"value"``, ``"refusal"`` or ``"no_answer"``.
+    kind: str
+    value: Any = None
+    code: str | None = None
+    detail: str = ""
+    verification: dict[str, Any] | None = None
+
+    def describe(self) -> str:
+        if self.kind == "refusal":
+            return f"refused[{self.code or 'uncoded'}]: {self.detail}"
+        if self.kind == "no_answer":
+            return f"no answer: {self.detail}"
+        return f"value {self.value!r}"
+
+
+#: Exceptions alkahest raises when it declines to produce a number.  ``ValueError``
+#: is what ``eval_expr`` raises for an expression containing ``∞``, ``0^-1`` or a
+#: bare ``O(x^n)`` remainder; ``OverflowError``/``ZeroDivisionError`` are the
+#: float-layer equivalents.  Anything outside this tuple is a harness bug and is
+#: reported as ``no_answer`` rather than being silently forgiven.
+_REFUSAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    ak.AlkahestError,
+    ValueError,
+    OverflowError,
+    ZeroDivisionError,
+)
+
+
+def probe(op: Callable[[], Any]) -> Answer:
+    """Run *op* and normalise whatever happens into an :class:`Answer`."""
+    try:
+        raw = op()
+    except _REFUSAL_EXCEPTIONS as exc:
+        return Answer(
+            kind="refusal",
+            code=getattr(exc, "code", None),
+            detail=f"{type(exc).__name__}: {str(exc).splitlines()[0][:160]}",
+        )
+    except Exception as exc:
+        return Answer(kind="no_answer", detail=f"{type(exc).__name__}: {exc}")
+
+    verification = None
+    if isinstance(raw, Measured):
+        verification = raw.verification
+        raw = raw.answer
+
+    if isinstance(raw, float) and not math.isfinite(raw):
+        # NaN / ±inf are an implicit admission of failure, not a stated answer —
+        # same call agent-benchmark's refusal_or_value() makes.
+        return Answer(kind="refusal", detail=f"non-finite {raw!r}", verification=verification)
+
+    return Answer(kind="value", value=raw, verification=verification)
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _values_match(got: Any, want: Any, tol: float) -> bool:
+    if isinstance(want, bool) or isinstance(got, bool):
+        return got is want
+    if isinstance(want, (int, float)) and isinstance(got, (int, float)):
+        return math.isclose(float(got), float(want), rel_tol=tol, abs_tol=tol)
+    if isinstance(want, (list, tuple)) and isinstance(got, (list, tuple)):
+        return len(got) == len(want) and all(_values_match(g, w, tol) for g, w in zip(got, want))
+    return got == want
+
+
+@dataclass(frozen=True)
+class Verdict:
+    outcome: Outcome
+    passed: bool
+    reason: str
+
+
+def classify(contract: Contract, answer: Answer) -> Verdict:
+    """Score *answer* against *contract*."""
+    if answer.kind == "no_answer":
+        return Verdict(Outcome.NO_ANSWER, False, f"call did not answer — {answer.detail}")
+
+    if isinstance(contract, Raises):
+        if answer.kind == "refusal":
+            if answer.code == contract.code:
+                return Verdict(Outcome.CORRECT, True, f"raised {contract.code} as required")
+            return Verdict(
+                Outcome.HONEST_REFUSAL,
+                False,
+                f"refused, but with {answer.code or 'no code'} instead of {contract.code}",
+            )
+        return Verdict(
+            Outcome.SILENT_ERROR,
+            False,
+            f"SILENT ERROR: expected {contract.code}, got a confident {answer.value!r}",
+        )
+
+    if isinstance(contract, Returns):
+        if answer.kind == "refusal":
+            return Verdict(
+                Outcome.HONEST_REFUSAL,
+                False,
+                f"refused ({answer.describe()}) where {contract.value!r} is computable",
+            )
+        if _values_match(answer.value, contract.value, contract.tol):
+            return Verdict(Outcome.CORRECT, True, f"returned {contract.value!r}")
+        return Verdict(
+            Outcome.SILENT_ERROR,
+            False,
+            f"SILENT ERROR: returned {answer.value!r}, correct answer is {contract.value!r}",
+        )
+
+    if isinstance(contract, RefusesOr):
+        if answer.kind == "refusal":
+            return Verdict(Outcome.HONEST_REFUSAL, True, f"refused — {answer.detail}")
+        if contract.value is not NOTHING and _values_match(
+            answer.value, contract.value, contract.tol
+        ):
+            return Verdict(Outcome.CORRECT, True, f"returned the acceptable {contract.value!r}")
+        expected = (
+            "no finite value" if contract.value is NOTHING else f"refusal or {contract.value!r}"
+        )
+        return Verdict(
+            Outcome.SILENT_ERROR,
+            False,
+            f"SILENT ERROR: returned a confident {answer.value!r}; expected {expected}",
+        )
+
+    raise TypeError(f"unknown contract type: {contract!r}")  # pragma: no cover
+
+
+def check_verification_floor(case: Case, answer: Answer) -> str | None:
+    """Return a failure message if the case's verification floor is not met."""
+    if case.verification_floor is None:
+        return None
+    if answer.kind != "value":
+        return None  # a refusal carries no verification metadata to check
+    if answer.verification is None:
+        return (
+            f"verification_floor={case.verification_floor} declared but the op "
+            "did not return a Measured(...) carrying verification metadata"
+        )
+    status = answer.verification.get("status")
+    if status not in VERIFICATION_ORDER:
+        return f"unknown verification status {status!r} (known: {VERIFICATION_ORDER})"
+    if VERIFICATION_ORDER.index(status) < VERIFICATION_ORDER.index(case.verification_floor):
+        return (
+            f"verification status {status!r} is weaker than the declared floor "
+            f"{case.verification_floor!r}"
+        )
+    return None
+
+
+@dataclass(frozen=True)
+class Result:
+    """One evaluated case."""
+
+    case: Case
+    answer: Answer
+    verdict: Verdict
+    verification_error: str | None
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict.passed and self.verification_error is None
+
+    @property
+    def message(self) -> str:
+        parts = [f"[{self.case.id}] {self.case.statement}"]
+        parts.append(f"  contract : {self.case.contract.describe()}")
+        parts.append(f"  observed : {self.answer.describe()}")
+        parts.append(f"  outcome  : {self.verdict.outcome.value} — {self.verdict.reason}")
+        if self.verification_error:
+            parts.append(f"  verify   : {self.verification_error}")
+        parts.append(f"  source   : {self.case.verified_by}")
+        return "\n".join(parts)
+
+
+def evaluate(case: Case) -> Result:
+    """Run one case end to end."""
+    answer = probe(case.op)
+    verdict = classify(case.contract, answer)
+    verification_error = check_verification_floor(case, answer)
+    return Result(case=case, answer=answer, verdict=verdict, verification_error=verification_error)

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -1,0 +1,1417 @@
+"""The declarative trap corpus.
+
+Every case here is a *classic* silent-error shape — a place where a CAS has a
+clean, plausible, wrong answer available and has to choose not to give it.  The
+expected value of every case was derived by hand from the definition (and, for
+the classical constants, cross-checked against ``math``), never read off
+alkahest's own output; :attr:`Case.verified_by` records which.
+
+Adding a case: see ``tests/silent_errors/README.md``.
+
+Cost discipline: this corpus runs on every pull request, so each op must finish
+in well under a second.  Known-slow inputs are documented in the README rather
+than being added here — a gate that times out is a gate that gets disabled.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable
+
+import alkahest as ak
+import alkahest.number_theory as nt
+
+# ``tests/`` is on sys.path via the root conftest, so the textbook gate's series
+# helper (which strips the trailing O(...) term that eval_expr cannot evaluate)
+# is importable and worth reusing rather than duplicating.
+from _tg_helpers import eval_series_truncated
+from contracts import Case, Measured, Raises, RefusesOr, Returns
+
+# ---------------------------------------------------------------------------
+# Shared pool.  Expressions are immutable and pool-scoped; one pool for the
+# whole corpus keeps case construction cheap and interning consistent.
+# ---------------------------------------------------------------------------
+
+POOL = ak.ExprPool()
+X = POOL.symbol("x")
+N = POOL.symbol("n")
+K = POOL.symbol("k")
+
+
+def _int(v: int) -> ak.Expr:
+    return POOL.integer(v)
+
+
+def _rat(a: int, b: int) -> ak.Expr:
+    return POOL.rational(a, b)
+
+
+def _num(value: Any) -> float:
+    """Reduce an Expr / DerivedResult / number to a float."""
+    if isinstance(value, ak.DerivedResult):
+        value = value.value
+    if isinstance(value, (int, float)):
+        return float(value)
+    return float(ak.eval_expr(value, {}))
+
+
+# ---------------------------------------------------------------------------
+# Answer helpers — each returns the plain "answer" a case is scored on.
+# ---------------------------------------------------------------------------
+
+
+def definite(integrand: ak.Expr, lo: ak.Expr, hi: ak.Expr) -> Callable[[], Measured]:
+    """Answer = the numeric value of ∫_lo^hi integrand dx."""
+
+    def op() -> Measured:
+        r = ak.integrate(integrand, X, lo, hi)
+        return Measured(_num(r.value), r.verification)
+
+    return op
+
+
+def antiderivative_slope(integrand: ak.Expr, at: float) -> Callable[[], Measured]:
+    """Answer = d/dx of alkahest's antiderivative, evaluated at *at*.
+
+    This is the fundamental theorem of calculus used as a checker: it is immune
+    to ``+C`` and to every legitimate difference in antiderivative form, and it
+    catches the one thing that matters — an antiderivative whose derivative is
+    not the integrand.  A refusal (``E-INT-004``) surfaces as a refusal, so this
+    also detects a *false* non-elementarity verdict, which is exactly as
+    damaging as a wrong formula (report7-20.md B2).
+    """
+
+    def op() -> Measured:
+        r = ak.integrate(integrand, X)
+        slope = ak.diff(r.value, X).value
+        return Measured(float(ak.eval_expr(slope, {X: at})), r.verification)
+
+    return op
+
+
+def limit_value(expr: ak.Expr, point: ak.Expr, direction: str | None = None) -> Callable[[], float]:
+    """Answer = the numeric value of lim expr, optionally one-sided."""
+
+    def op() -> float:
+        got = (
+            ak.limit(expr, X, point)
+            if direction is None
+            else ak.limit(expr, X, point, dir=direction)
+        )
+        return _num(got)
+
+    return op
+
+
+def series_at(expr: ak.Expr, about: ak.Expr, order: int, sample: float) -> Callable[[], float]:
+    """Answer = alkahest's truncated series for *expr*, evaluated at *sample*."""
+
+    def op() -> float:
+        s = ak.series(expr, X, about, order)
+        return float(eval_series_truncated(s, X, sample))
+
+    return op
+
+
+def simplified_value(
+    simplifier: Callable[[ak.Expr], Any], expr: ak.Expr, at: float | None = None
+) -> Callable[[], float]:
+    """Answer = the simplified expression's numeric value at *at*.
+
+    Simplification is only ever allowed to change an expression's *form*.  Any
+    rewrite that changes its value at a point — the signature of a branch-cut
+    violation — shows up here as a wrong number.
+    """
+
+    def op() -> float:
+        out = simplifier(expr)
+        value = out.value if isinstance(out, ak.DerivedResult) else out
+        env = {} if at is None else {X: at}
+        return float(ak.eval_expr(value, env))
+
+    return op
+
+
+def real_solution_count(equations: list[ak.Expr], unknowns: list[ak.Expr]) -> Callable[[], int]:
+    """Answer = how many real solutions ``solve(..., domain="real")`` reports."""
+
+    def op() -> int:
+        sols = ak.solve(equations, unknowns, domain="real")
+        return len(sols)
+
+    return op
+
+
+def _matrix(rows: list[list[int]]) -> ak.Matrix:
+    return ak.Matrix([[_int(v) for v in row] for row in rows])
+
+
+SINGULAR_2X2 = [[1, 2], [2, 4]]
+SINGULAR_3X3 = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+ZERO_2X2 = [[0, 0], [0, 0]]
+NON_SQUARE = [[1, 2, 3], [4, 5, 6]]
+#: det = (2^30+1)(2^30-1) - 2^60 = -1 exactly; float64 evaluation cancels to 0.0.
+CANCELLING_2X2 = [[2**30 + 1, 2**30], [2**30, 2**30 - 1]]
+
+
+# ---------------------------------------------------------------------------
+# Reference values (hand-derived; `math` used only to evaluate the closed form)
+# ---------------------------------------------------------------------------
+
+_E = math.e
+_LN2 = math.log(2.0)
+
+
+def _exp_log_sum(x: float) -> float:
+    """d/dx [e^x·log x] = e^x·log x + e^x/x."""
+    return math.exp(x) * math.log(x) + math.exp(x) / x
+
+
+def _risch_gaussian_pair(x: float) -> float:
+    """d/dx [x·e^{x²}] = e^{x²} + 2x²·e^{x²}."""
+    return math.exp(x * x) + 2 * x * x * math.exp(x * x)
+
+
+def _sin_log_pair(x: float) -> float:
+    """d/dx [sin x·log x] = cos x·log x + sin x / x."""
+    return math.cos(x) * math.log(x) + math.sin(x) / x
+
+
+# ---------------------------------------------------------------------------
+# The corpus
+# ---------------------------------------------------------------------------
+
+HAND = "hand derivation from the definition"
+CALCULUS = "first-course calculus fact, re-derived by hand"
+
+
+CASES: list[Case] = [
+    # -----------------------------------------------------------------------
+    # Definite integration through an interior pole.  Naive FTC produces a
+    # clean finite number for every one of these; every one of them diverges.
+    # -----------------------------------------------------------------------
+    Case(
+        id="int_pole_inverse_square_symmetric",
+        subsystem="integration_definite",
+        statement="∫_{-1}^{1} x^-2 dx diverges (double pole at x=0, strictly interior)",
+        op=definite(1 / X**2, _int(-1), _int(1)),
+        contract=Raises("E-INT-001"),
+        verified_by="∫x^-2 = -1/x; both one-sided pieces diverge to +∞. Naive FTC gives -2.",
+        benchmark_tasks=("pole_interior_inverse_square",),
+    ),
+    Case(
+        id="int_pole_inverse_symmetric",
+        subsystem="integration_definite",
+        statement="∫_{-1}^{1} 1/x dx diverges (simple pole at x=0); only the PV is 0",
+        op=definite(1 / X, _int(-1), _int(1)),
+        contract=Raises("E-INT-001"),
+        verified_by="∫1/x = log|x|; -∞ + ∞ is not a value. Cauchy PV is 0, the integral is not.",
+        benchmark_tasks=("pole_interior_inverse",),
+    ),
+    Case(
+        id="int_pole_rational_at_one",
+        subsystem="integration_definite",
+        statement="∫_0^2 dx/(x²-1) diverges (pole at x=1, interior, not at the origin)",
+        op=definite(1 / (X**2 - 1), _int(0), _int(2)),
+        contract=Raises("E-INT-001"),
+        verified_by="1/(x²-1) = ½[1/(x-1) - 1/(x+1)]; the 1/(x-1) piece diverges at x=1.",
+        benchmark_tasks=("pole_interior_rational",),
+    ),
+    Case(
+        id="int_pole_double_at_one",
+        subsystem="integration_definite",
+        statement="∫_0^2 (x-1)^-2 dx diverges (double pole at x=1)",
+        op=definite(1 / (X - 1) ** 2, _int(0), _int(2)),
+        contract=Raises("E-INT-001"),
+        verified_by="∫(x-1)^-2 = -1/(x-1); naive FTC gives -1-1 = -2, a plausible wrong number.",
+    ),
+    Case(
+        id="int_pole_shifted_simple",
+        subsystem="integration_definite",
+        statement="∫_1^3 dx/(x-2) diverges (pole at x=2, away from 0 and from both endpoints)",
+        op=definite(1 / (X - 2), _int(1), _int(3)),
+        contract=Raises("E-INT-001"),
+        verified_by="Substituting u=x-2 gives ∫_{-1}^{1} du/u, the divergent case above.",
+    ),
+    Case(
+        id="int_pole_on_negative_axis",
+        subsystem="integration_definite",
+        statement="∫_{-2}^{0} dx/(x+1) diverges (pole at x=-1)",
+        op=definite(1 / (X + 1), _int(-2), _int(0)),
+        contract=Raises("E-INT-001"),
+        verified_by="u=x+1 gives ∫_{-1}^{1} du/u again; naive FTC gives log1-log(-1) = 0.",
+    ),
+    Case(
+        id="int_pole_odd_cubic",
+        subsystem="integration_definite",
+        statement="∫_{-1}^{1} x^-3 dx diverges (triple pole at 0)",
+        op=definite(1 / X**3, _int(-1), _int(1)),
+        contract=Raises("E-INT-001"),
+        verified_by="∫x^-3 = -1/(2x²); both sides diverge to -∞. Odd symmetry makes 0 tempting.",
+    ),
+    Case(
+        id="int_pole_odd_rational",
+        subsystem="integration_definite",
+        statement="∫_{-2}^{2} x/(x²-1) dx diverges (poles at ±1); odd symmetry suggests 0",
+        op=definite(X / (X**2 - 1), _int(-2), _int(2)),
+        contract=Raises("E-INT-001"),
+        verified_by="Antiderivative ½log|x²-1| diverges at x=±1. The integrand is odd, so a "
+        "symmetry argument gives the plausible-but-wrong answer 0.",
+    ),
+    Case(
+        id="int_pole_two_interior_poles",
+        subsystem="integration_definite",
+        statement="∫_{-3}^{3} dx/(x²-4) diverges (poles at x=±2, both interior)",
+        op=definite(1 / (X**2 - 4), _int(-3), _int(3)),
+        contract=Raises("E-INT-001"),
+        verified_by="Partial fractions ¼[1/(x-2) - 1/(x+2)]; both pieces diverge.",
+    ),
+    Case(
+        id="int_pole_product_form",
+        subsystem="integration_definite",
+        statement="∫_0^2 dx/(x(x-1)) diverges (poles at x=0 endpoint and x=1 interior)",
+        op=definite(1 / (X * (X - 1)), _int(0), _int(2)),
+        contract=Raises("E-INT-001"),
+        verified_by="1/(x(x-1)) = 1/(x-1) - 1/x; both terms diverge inside [0,2].",
+    ),
+    Case(
+        id="int_pole_reflected",
+        subsystem="integration_definite",
+        statement="∫_0^2 dx/(1-x) diverges (pole at x=1, sign-flipped denominator)",
+        op=definite(1 / (1 - X), _int(0), _int(2)),
+        contract=Raises("E-INT-001"),
+        verified_by="Antiderivative -log|1-x| diverges at x=1; naive FTC gives 0.",
+    ),
+    Case(
+        id="int_endpoint_pole_inverse",
+        subsystem="integration_definite",
+        statement="∫_0^1 dx/x diverges (non-integrable singularity at the lower endpoint)",
+        op=definite(1 / X, _int(0), _int(1)),
+        contract=Raises("E-INT-001"),
+        verified_by="lim_{ε→0+} -log ε = +∞.",
+    ),
+    Case(
+        id="int_endpoint_pole_inverse_square",
+        subsystem="integration_definite",
+        statement="∫_0^1 x^-2 dx diverges (double pole at the lower endpoint)",
+        op=definite(1 / X**2, _int(0), _int(1)),
+        contract=Raises("E-INT-001"),
+        verified_by="lim_{ε→0+} (1/ε - 1) = +∞.",
+    ),
+    Case(
+        id="int_endpoint_log_over_x",
+        subsystem="integration_definite",
+        statement="∫_0^1 log(x)/x dx diverges to -∞ (endpoint singularity)",
+        op=definite(ak.log(X) / X, _int(0), _int(1)),
+        contract=Raises("E-INT-001"),
+        verified_by="∫log(x)/x = ½log²x; lim_{ε→0+} -½log²ε = -∞.",
+    ),
+    Case(
+        id="int_pole_tangent_over_period",
+        subsystem="integration_definite",
+        statement="∫_0^π tan x dx diverges (pole at x=π/2, interior)",
+        op=definite(ak.tan(X), _int(0), POOL.float(math.pi)),
+        contract=RefusesOr(),
+        verified_by="∫tan = -log|cos x|; diverges to +∞ from both sides of π/2. Symmetry about "
+        "π/2 makes 0 the tempting wrong answer.",
+        note="Weak refusal: alkahest returns -log(cos π) with no error; it only fails to reduce "
+        "to a number because log of a negative is a domain error. A transcendental-pole "
+        "check comparable to the rational-pole one would upgrade this to E-INT-001.",
+    ),
+    Case(
+        id="int_pole_secant_over_period",
+        subsystem="integration_definite",
+        statement="∫_0^π dx/cos x diverges (pole at x=π/2)",
+        op=definite(1 / ak.cos(X), _int(0), POOL.float(math.pi)),
+        contract=RefusesOr(),
+        verified_by="∫sec = log|sec x + tan x|; unbounded as x→π/2.",
+        note="Weak refusal, same shape as int_pole_tangent_over_period.",
+    ),
+    # -----------------------------------------------------------------------
+    # Improper integrals over an infinite range.
+    # -----------------------------------------------------------------------
+    Case(
+        id="int_infinite_harmonic_tail",
+        subsystem="integration_definite",
+        statement="∫_1^∞ dx/x diverges",
+        op=definite(1 / X, _int(1), POOL.pos_infinity()),
+        contract=RefusesOr(),
+        verified_by="log R → ∞. The borderline exponent: ∫x^-p converges iff p>1.",
+    ),
+    Case(
+        id="int_infinite_linear",
+        subsystem="integration_definite",
+        statement="∫_0^∞ x dx diverges",
+        op=definite(X, _int(0), POOL.pos_infinity()),
+        contract=RefusesOr(),
+        verified_by="∫_0^R x dx = R²/2, which grows without bound as R → ∞.",
+    ),
+    Case(
+        id="int_infinite_oscillatory",
+        subsystem="integration_definite",
+        statement="∫_0^∞ sin x dx does not converge (1-cos R has no limit)",
+        op=definite(ak.sin(X), _int(0), POOL.pos_infinity()),
+        contract=RefusesOr(),
+        verified_by="∫_0^R sin = 1-cos R oscillates in [0,2]. Abel/Cesàro summation gives 1, "
+        "which is exactly the plausible wrong answer.",
+    ),
+    Case(
+        id="int_infinite_exponential_growth",
+        subsystem="integration_definite",
+        statement="∫_0^∞ e^x dx diverges",
+        op=definite(ak.exp(X), _int(0), POOL.pos_infinity()),
+        contract=RefusesOr(),
+        verified_by="e^R - 1 → ∞.",
+    ),
+    # -----------------------------------------------------------------------
+    # Integration controls: convergent integrals that must NOT be over-refused.
+    # A gate made only of refusals is passed by a library that refuses
+    # everything, so each refusal class needs its nearest convergent neighbour.
+    # -----------------------------------------------------------------------
+    Case(
+        id="int_control_polynomial",
+        subsystem="integration_definite",
+        statement="∫_0^1 x² dx = 1/3",
+        op=definite(X**2, _int(0), _int(1)),
+        contract=Returns(1 / 3),
+        verified_by=CALCULUS,
+    ),
+    Case(
+        id="int_control_arctangent_symmetric",
+        subsystem="integration_definite",
+        statement="∫_{-1}^{1} dx/(1+x²) = π/2",
+        op=definite(1 / (X**2 + 1), _int(-1), _int(1)),
+        contract=Returns(math.pi / 2),
+        verified_by="2·arctan 1 = π/2.",
+    ),
+    Case(
+        id="int_control_integrable_endpoint_singularity",
+        subsystem="integration_definite",
+        statement="∫_0^1 x^{-1/2} dx = 2 — singular at the endpoint but convergent",
+        op=definite(1 / ak.sqrt(X), _int(0), _int(1)),
+        contract=Returns(2.0),
+        verified_by="2√x |_0^1 = 2. Guards the interior-pole check against over-refusal: "
+        "a singularity is not the same thing as a divergence.",
+    ),
+    Case(
+        id="int_control_log_endpoint",
+        subsystem="integration_definite",
+        statement="∫_0^1 log x dx = -1 — log diverges at 0 but the integral converges",
+        op=definite(ak.log(X), _int(0), _int(1)),
+        contract=Returns(-1.0),
+        verified_by="x log x - x |_0^1 = -1, using x log x → 0.",
+    ),
+    Case(
+        id="int_control_pole_outside_interval",
+        subsystem="integration_definite",
+        statement="∫_2^3 dx/(x-1) = log 2 — the pole at x=1 is outside [2,3]",
+        op=definite(1 / (X - 1), _int(2), _int(3)),
+        contract=Returns(_LN2),
+        verified_by="log 2 - log 1 = log 2.",
+    ),
+    Case(
+        id="int_control_partial_fractions",
+        subsystem="integration_definite",
+        statement="∫_1^2 dx/(x²+x) = log(4/3)",
+        op=definite(1 / (X**2 + X), _int(1), _int(2)),
+        contract=Returns(math.log(4 / 3)),
+        verified_by="1/(x²+x) = 1/x - 1/(x+1); [log(x/(x+1))]_1^2 = log(2/3) - log(1/2).",
+    ),
+    Case(
+        id="int_control_convergent_tail",
+        subsystem="integration_definite",
+        statement="∫_1^∞ x^-2 dx = 1 — the convergent side of the p-test",
+        op=definite(1 / X**2, _int(1), POOL.pos_infinity()),
+        contract=Returns(1.0),
+        verified_by="1 - 1/R → 1.",
+    ),
+    Case(
+        id="int_control_exponential_tail",
+        subsystem="integration_definite",
+        statement="∫_0^∞ e^{-x} dx = 1",
+        op=definite(ak.exp(-X), _int(0), POOL.pos_infinity()),
+        contract=Returns(1.0),
+        verified_by="1 - e^{-R} → 1.",
+    ),
+    # -----------------------------------------------------------------------
+    # Non-elementarity — in BOTH directions.  A wrong antiderivative and a
+    # false "provably non-elementary" verdict are equally poisonous: the second
+    # tells a search loop that a branch is permanently closed when it is not.
+    # -----------------------------------------------------------------------
+    Case(
+        id="nonelementary_exp_x_squared",
+        subsystem="integration_nonelementary",
+        statement="∫ e^{x²} dx has no elementary antiderivative",
+        op=lambda: _num(ak.integrate(ak.exp(X**2), X).value),
+        contract=Raises("E-INT-004"),
+        verified_by="Liouville/Risch: the antiderivative is (√π/2)·erfi(x); erfi is not "
+        "elementary. Standard textbook example.",
+        benchmark_tasks=("nonelementary_expx2",),
+    ),
+    Case(
+        id="nonelementary_gaussian",
+        subsystem="integration_nonelementary",
+        statement="∫ e^{-x²} dx has no elementary antiderivative",
+        op=lambda: _num(ak.integrate(ak.exp(-(X**2)), X).value),
+        contract=Raises("E-INT-004"),
+        verified_by="(√π/2)·erf(x); erf is not elementary (Liouville).",
+    ),
+    Case(
+        id="nonelementary_sinc",
+        subsystem="integration_nonelementary",
+        statement="∫ sin(x)/x dx has no elementary antiderivative",
+        op=lambda: _num(ak.integrate(ak.sin(X) / X, X).value),
+        contract=Raises("E-INT-004"),
+        verified_by="Si(x), the sine integral — a special function, not elementary.",
+    ),
+    Case(
+        id="nonelementary_logarithmic_integral",
+        subsystem="integration_nonelementary",
+        statement="∫ dx/log x has no elementary antiderivative",
+        op=lambda: _num(ak.integrate(1 / ak.log(X), X).value),
+        contract=Raises("E-INT-004"),
+        verified_by="li(x), the logarithmic integral.",
+    ),
+    Case(
+        id="nonelementary_exponential_integral",
+        subsystem="integration_nonelementary",
+        statement="∫ e^x/x dx has no elementary antiderivative",
+        op=lambda: _num(ak.integrate(ak.exp(X) / X, X).value),
+        contract=Raises("E-INT-004"),
+        verified_by="Ei(x), the exponential integral.",
+    ),
+    Case(
+        id="nonelementary_double_exponential",
+        subsystem="integration_nonelementary",
+        statement="∫ e^{e^x} dx has no elementary antiderivative",
+        op=lambda: _num(ak.integrate(ak.exp(ak.exp(X)), X).value),
+        contract=Raises("E-INT-004"),
+        verified_by="Reduces to Ei(e^x) under u = e^x.",
+    ),
+    Case(
+        id="elementary_sum_of_two_nonelementary_parts",
+        subsystem="integration_nonelementary",
+        statement="∫ (e^{x²} + 2x²e^{x²}) dx = x·e^{x²} — elementary, though each summand is not",
+        op=antiderivative_slope(ak.exp(X**2) + 2 * X**2 * ak.exp(X**2), 0.5),
+        contract=Returns(_risch_gaussian_pair(0.5)),
+        verified_by="Product rule: d/dx[x·e^{x²}] = e^{x²} + 2x²e^{x²}. The textbook "
+        "counterexample to term-by-term non-elementarity reasoning.",
+    ),
+    Case(
+        id="elementary_exp_times_log_sum",
+        subsystem="integration_nonelementary",
+        statement="∫ (e^x·log x + e^x/x) dx = e^x·log x — the report7-20 B2 regression",
+        op=antiderivative_slope(ak.exp(X) * ak.log(X) + ak.exp(X) / X, 2.0),
+        contract=Returns(_exp_log_sum(2.0)),
+        verified_by="Product rule: d/dx[e^x log x] = e^x log x + e^x/x. alkahest 3.6.0 "
+        "returned a *false* E-INT-004 'no elementary antiderivative exists' here "
+        "(report7-20.md, bug B2); this pins the fix.",
+    ),
+    Case(
+        id="elementary_sin_times_log_sum",
+        subsystem="integration_nonelementary",
+        statement="∫ (cos x·log x + sin x/x) dx = sin x·log x — elementary, parts are not",
+        op=antiderivative_slope(ak.cos(X) * ak.log(X) + ak.sin(X) / X, 2.0),
+        contract=Returns(_sin_log_pair(2.0)),
+        verified_by="Product rule: d/dx[sin x·log x] = cos x·log x + sin x/x. ∫sin x/x alone "
+        "is Si(x) and non-elementary.",
+    ),
+    Case(
+        id="elementary_x_log_x",
+        subsystem="integration_nonelementary",
+        statement="∫ x·log x dx = x²(2log x - 1)/4",
+        op=antiderivative_slope(X * ak.log(X), 2.0),
+        contract=Returns(2.0 * math.log(2.0)),
+        verified_by="Integration by parts; checked by differentiating back.",
+        verification_floor="numerically_checked",
+    ),
+    Case(
+        id="elementary_cubic_partial_fractions",
+        subsystem="integration_nonelementary",
+        statement="∫ dx/(1+x³) is elementary (log + arctan)",
+        op=antiderivative_slope(1 / (1 + X**3), 0.5),
+        contract=Returns(1.0 / (1.0 + 0.125)),
+        verified_by="1+x³ factors over ℚ as (x+1)(x²-x+1); partial fractions give logs and an "
+        "arctan. Checked by differentiating back.",
+    ),
+    Case(
+        id="elementary_circular_arc",
+        subsystem="integration_nonelementary",
+        statement="∫ √(1-x²) dx = [x√(1-x²) + arcsin x]/2",
+        op=antiderivative_slope(ak.sqrt(1 - X**2), 0.5),
+        contract=Returns(math.sqrt(1 - 0.25)),
+        verified_by="Trigonometric substitution x = sin θ; checked by differentiating back.",
+    ),
+    Case(
+        id="elementary_tangent",
+        subsystem="integration_nonelementary",
+        statement="∫ tan x dx = -log|cos x|",
+        op=antiderivative_slope(ak.tan(X), 1.0),
+        contract=Returns(math.tan(1.0)),
+        verified_by="u = cos x. Sample point 1.0 rad keeps cos x > 0.",
+    ),
+    Case(
+        id="elementary_x_exp_x",
+        subsystem="integration_nonelementary",
+        statement="∫ x·e^x dx = (x-1)e^x",
+        op=antiderivative_slope(X * ak.exp(X), 1.5),
+        contract=Returns(1.5 * math.exp(1.5)),
+        verified_by="Integration by parts; d/dx[(x-1)e^x] = x·e^x.",
+        verification_floor="numerically_checked",
+    ),
+    # -----------------------------------------------------------------------
+    # Evaluation at points where the expression as written is undefined.
+    # -----------------------------------------------------------------------
+    Case(
+        id="eval_removable_singularity",
+        subsystem="evaluation",
+        statement="(x²-1)/(x-1) has no VALUE at x=1 — 2 is the limit, not the value",
+        op=lambda: float(ak.eval_expr((X**2 - 1) / (X - 1), {X: 1})),
+        contract=Raises("E-EVAL-009"),
+        verified_by="0/0 is undefined. x+1 is a *different function*: it is defined at 1.",
+        benchmark_tasks=("removable_singularity_value",),
+    ),
+    Case(
+        id="eval_after_explicit_cancel",
+        subsystem="evaluation",
+        statement="cancel((x²-1)/(x-1)) = x+1 evaluates to 2 at x=1 — an explicit rewrite is fine",
+        op=lambda: float(ak.eval_expr(ak.cancel((X**2 - 1) / (X - 1)), {X: 1})),
+        contract=Returns(2.0),
+        verified_by="1+1 = 2. Pairs with eval_removable_singularity: the sin is doing the "
+        "cancellation silently, not offering it.",
+    ),
+    Case(
+        id="eval_simple_pole",
+        subsystem="evaluation",
+        statement="1/x is undefined at x=0",
+        op=lambda: float(ak.eval_expr(1 / X, {X: 0})),
+        contract=Raises("E-EVAL-009"),
+        verified_by=HAND,
+    ),
+    Case(
+        id="eval_log_at_zero",
+        subsystem="evaluation",
+        statement="log x is undefined at x=0",
+        op=lambda: float(ak.eval_expr(ak.log(X), {X: 0})),
+        contract=Raises("E-EVAL-009"),
+        verified_by=HAND,
+    ),
+    Case(
+        id="eval_log_of_negative",
+        subsystem="evaluation",
+        statement="log(-1) has no real value — returning one is a branch-cut violation",
+        op=lambda: float(ak.eval_expr(ak.log(X), {X: -1})),
+        contract=Raises("E-EVAL-009"),
+        verified_by="The real logarithm is defined on (0,∞). The principal complex value is iπ.",
+    ),
+    Case(
+        id="eval_sqrt_of_negative",
+        subsystem="evaluation",
+        statement="√(-1) has no real value",
+        op=lambda: float(ak.eval_expr(ak.sqrt(X), {X: -1})),
+        contract=Raises("E-EVAL-009"),
+        verified_by="The real square root is defined on [0,∞).",
+    ),
+    Case(
+        id="eval_arcsin_out_of_range",
+        subsystem="evaluation",
+        statement="arcsin(2) has no real value",
+        op=lambda: float(ak.eval_expr(ak.asin(X), {X: 2})),
+        contract=Raises("E-EVAL-009"),
+        verified_by="Real arcsin has domain [-1,1].",
+    ),
+    Case(
+        id="eval_artanh_out_of_range",
+        subsystem="evaluation",
+        statement="artanh(2) has no real value",
+        op=lambda: float(ak.eval_expr(ak.atanh(X), {X: 2})),
+        contract=Raises("E-EVAL-009"),
+        verified_by="Real artanh has domain (-1,1).",
+    ),
+    Case(
+        id="eval_odd_root_of_negative",
+        subsystem="evaluation",
+        statement="(-8)^(1/3): the principal branch is complex; only -2 is a defensible real value",
+        op=lambda: float(ak.eval_expr(_int(-8) ** _rat(1, 3), {})),
+        contract=RefusesOr(-2.0),
+        verified_by="Principal cube root of -8 is 1+i√3 (modulus 2, argument π/3). The real "
+        "cube root is -2. Any other real number — notably +2 — is a branch-cut lie.",
+    ),
+    # -----------------------------------------------------------------------
+    # Solving: complex roots handed back where a real solution was requested.
+    # -----------------------------------------------------------------------
+    Case(
+        id="solve_x_squared_plus_one_real",
+        subsystem="solving",
+        statement="x² = -1 has no real solutions",
+        op=real_solution_count([X**2 + 1], [X]),
+        contract=Returns(0),
+        verified_by="x² ≥ 0 for all real x. ±i are not real solutions.",
+        benchmark_tasks=("solve_x2_plus_1_real",),
+    ),
+    Case(
+        id="solve_irreducible_quadratic_real",
+        subsystem="solving",
+        statement="x²+x+1 = 0 has no real solutions (discriminant -3)",
+        op=real_solution_count([X**2 + X + 1], [X]),
+        contract=Returns(0),
+        verified_by="b²-4ac = 1-4 = -3 < 0.",
+    ),
+    Case(
+        id="solve_quartic_plus_one_real",
+        subsystem="solving",
+        statement="x⁴+1 = 0 has no real solutions",
+        op=real_solution_count([X**4 + 1], [X]),
+        contract=RefusesOr(0),
+        verified_by="x⁴ ≥ 0, so x⁴+1 ≥ 1 > 0.",
+        note="alkahest refuses with E-SOLVE-002 (degree > 2 back-substitution). Refusing is "
+        "safe; handing back the four complex 8th roots of unity would not be.",
+    ),
+    Case(
+        id="solve_real_roots_of_x_squared_plus_one",
+        subsystem="solving",
+        statement="real_roots(x²+1) is empty",
+        op=lambda: len(ak.real_roots(X**2 + 1, X)),
+        contract=Returns(0),
+        verified_by="No real root; Sturm's theorem gives a count of 0.",
+    ),
+    Case(
+        id="solve_real_roots_of_quartic_plus_one",
+        subsystem="solving",
+        statement="real_roots(x⁴+1) is empty",
+        op=lambda: len(ak.real_roots(X**4 + 1, X)),
+        contract=Returns(0),
+        verified_by="x⁴+1 ≥ 1 > 0 on ℝ.",
+    ),
+    Case(
+        id="solve_real_roots_of_cubic_unity",
+        subsystem="solving",
+        statement="x³-1 has exactly one real root (the other two are complex)",
+        op=lambda: len(ak.real_roots(X**3 - 1, X)),
+        contract=Returns(1),
+        verified_by="x³-1 = (x-1)(x²+x+1); the quadratic factor has discriminant -3.",
+    ),
+    Case(
+        id="solve_real_roots_of_double_root",
+        subsystem="solving",
+        statement="(x-1)² has one distinct real root",
+        op=lambda: len(ak.real_roots((X - 1) ** 2, X)),
+        contract=Returns(1),
+        verified_by="Only x=1, with multiplicity 2. real_roots reports isolating intervals, "
+        "i.e. distinct roots.",
+    ),
+    Case(
+        id="solve_sqrt_equals_negative",
+        subsystem="solving",
+        statement="√x = -1 has no real solution; squaring introduces the extraneous root x=1",
+        op=real_solution_count([ak.sqrt(X) + 1], [X]),
+        contract=RefusesOr(0),
+        verified_by="The principal square root is non-negative. Squaring both sides is not an "
+        "equivalence, and yields the extraneous x=1.",
+        benchmark_tasks=("sqrt_eq_negative",),
+        note="alkahest refuses with E-SOLVE-001 (not a polynomial) — safe, and it never reports "
+        "the extraneous root.",
+    ),
+    Case(
+        id="solve_real_domain_does_not_overfilter",
+        subsystem="solving",
+        statement="x² = 1 genuinely has two real solutions; domain='real' must not drop them",
+        op=real_solution_count([X**2 - 1], [X]),
+        contract=Returns(2),
+        verified_by="x = ±1. The control for solve_x_squared_plus_one_real: a solver that "
+        "returns [] for everything would otherwise pass that case.",
+    ),
+    Case(
+        id="solve_real_roots_residual",
+        subsystem="solving",
+        statement="each solution of x²=2 satisfies the equation (residual ≈ 0)",
+        op=lambda: max(
+            abs(float(ak.eval_expr(X**2 - 2, {X: _num(sol[X])})))
+            for sol in ak.solve([X**2 - 2], [X], domain="real")
+        ),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="Substituting a returned root back into the equation must give 0; this is "
+        "form-independent and catches a solver that returns confident non-roots.",
+    ),
+    Case(
+        id="solve_zero_polynomial",
+        subsystem="solving",
+        statement="the zero polynomial has infinitely many roots — no finite root list is honest",
+        op=lambda: len(ak.real_roots(_int(0), X)),
+        contract=Raises("E-ROOT-002"),
+        verified_by="Every real number is a root of 0.",
+    ),
+    # -----------------------------------------------------------------------
+    # Limits that do not exist, versus one-sided limits that do.
+    # -----------------------------------------------------------------------
+    Case(
+        id="limit_two_sided_simple_pole",
+        subsystem="limits",
+        statement="lim_{x→0} 1/x does not exist (-∞ from the left, +∞ from the right)",
+        op=limit_value(1 / X, _int(0)),
+        contract=Raises("E-LIMIT-003"),
+        verified_by=CALCULUS,
+    ),
+    Case(
+        id="limit_abs_over_x",
+        subsystem="limits",
+        statement="lim_{x→0} |x|/x does not exist (-1 from the left, +1 from the right)",
+        op=limit_value(ak.abs(X) / X, _int(0)),
+        contract=RefusesOr(),
+        verified_by="|x|/x = sign(x); the one-sided limits are -1 and +1 and disagree.",
+        note="alkahest refuses with E-LIMIT-005 ('could not be computed'), which is safe but "
+        "less informative than E-LIMIT-003 ('two-sided limit undefined').",
+    ),
+    Case(
+        id="limit_x_over_abs_two_sided",
+        subsystem="limits",
+        statement="lim_{x→0} x/|x| does not exist — it is sign(x), same function reordered",
+        op=limit_value(X / ak.abs(X), _int(0)),
+        contract=RefusesOr(),
+        verified_by="x/|x| = sign(x) for x≠0; one-sided limits -1 and +1 disagree. Numerically: "
+        "f(-0.001) = -1.0, f(+0.001) = +1.0.",
+        xfail="SILENT ERROR: alkahest returns 0, a value the function never takes. Note that "
+        "the algebraically identical abs(x)/x is correctly refused (E-LIMIT-005) — the "
+        "argument order alone flips a refusal into a wrong answer.",
+    ),
+    Case(
+        id="limit_x_over_abs_right",
+        subsystem="limits",
+        statement="lim_{x→0+} x/|x| = 1",
+        op=limit_value(X / ak.abs(X), _int(0), direction="+"),
+        contract=Returns(1.0),
+        verified_by="For x>0, x/|x| = x/x = 1 identically.",
+        xfail="SILENT ERROR: alkahest returns 0 for the right-hand limit of a function that is "
+        "constantly 1 on (0,∞).",
+    ),
+    Case(
+        id="limit_x_over_abs_left",
+        subsystem="limits",
+        statement="lim_{x→0-} x/|x| = -1",
+        op=limit_value(X / ak.abs(X), _int(0), direction="-"),
+        contract=Returns(-1.0),
+        verified_by="For x<0, x/|x| = x/(-x) = -1 identically.",
+        xfail="SILENT ERROR: alkahest returns 0 for the left-hand limit of a function that is "
+        "constantly -1 on (-∞,0).",
+    ),
+    Case(
+        id="limit_tanh_of_reciprocal",
+        subsystem="limits",
+        statement="lim_{x→0} tanh(1/x) does not exist (-1 from the left, +1 from the right)",
+        op=limit_value(ak.tanh(1 / X), _int(0)),
+        contract=RefusesOr(),
+        verified_by="tanh(t) → ±1 as t → ±∞, and 1/x → ±∞ as x → 0±.",
+        xfail="SILENT ERROR: alkahest returns the unevaluated tanh(0^-1), which reduces to the "
+        "confident value 1.0 — the right-hand limit presented as the two-sided one.",
+    ),
+    Case(
+        id="limit_arctan_of_reciprocal",
+        subsystem="limits",
+        statement="lim_{x→0} arctan(1/x) does not exist (-π/2 from the left, +π/2 from the right)",
+        op=limit_value(ak.atan(1 / X), _int(0)),
+        contract=RefusesOr(),
+        verified_by="arctan(t) → ±π/2 as t → ±∞.",
+        xfail="SILENT ERROR: alkahest returns the unevaluated atan(0^-1), which reduces to "
+        "+π/2 ≈ 1.5707963 — again the right-hand limit passed off as two-sided.",
+    ),
+    Case(
+        id="limit_exp_of_negative_reciprocal_two_sided",
+        subsystem="limits",
+        statement="lim_{x→0} e^{-1/x} does not exist (0 from the right, +∞ from the left)",
+        op=limit_value(ak.exp(-1 / X), _int(0)),
+        contract=RefusesOr(),
+        verified_by="As x→0+, -1/x → -∞ so e^{-1/x} → 0; as x→0-, -1/x → +∞ so e^{-1/x} → +∞.",
+        xfail="SILENT ERROR: alkahest returns exp(-1·0^-1), which reduces to the confident "
+        "value 0.0 despite the left-hand limit being +∞.",
+    ),
+    Case(
+        id="limit_exp_of_negative_reciprocal_left",
+        subsystem="limits",
+        statement="lim_{x→0-} e^{-1/x} = +∞",
+        op=limit_value(ak.exp(-1 / X), _int(0), direction="-"),
+        contract=RefusesOr(),
+        verified_by="x→0- ⇒ -1/x → +∞ ⇒ e^{-1/x} → +∞. A finite answer is wrong; +inf reads as "
+        "a refusal under this gate's taxonomy, matching agent-benchmark.",
+        xfail="SILENT ERROR: alkahest returns the same expression it returns for the *right*-"
+        "hand limit, which reduces to 0.0 — off by an infinity, and the `dir` argument is "
+        "ignored entirely.",
+    ),
+    Case(
+        id="limit_control_sinc",
+        subsystem="limits",
+        statement="lim_{x→0} sin(x)/x = 1",
+        op=limit_value(ak.sin(X) / X, _int(0)),
+        contract=Returns(1.0),
+        verified_by=CALCULUS,
+    ),
+    Case(
+        id="limit_control_half_angle",
+        subsystem="limits",
+        statement="lim_{x→0} (1-cos x)/x² = 1/2",
+        op=limit_value((1 - ak.cos(X)) / X**2, _int(0)),
+        contract=Returns(0.5),
+        verified_by="1-cos x = x²/2 - x⁴/24 + …",
+    ),
+    Case(
+        id="limit_control_squeeze",
+        subsystem="limits",
+        statement="lim_{x→0} x·sin(1/x) = 0 — exists even though sin(1/x) does not",
+        op=limit_value(X * ak.sin(1 / X), _int(0)),
+        contract=Returns(0.0),
+        verified_by="|x sin(1/x)| ≤ |x| → 0 (squeeze). The control for the DNE cases: a limit "
+        "engine that refused everything oscillatory would fail here.",
+    ),
+    Case(
+        id="limit_control_one_sided_pole",
+        subsystem="limits",
+        statement="lim_{x→0+} 1/x = +∞ — the one-sided limit exists as an extended real",
+        op=limit_value(1 / X, _int(0), direction="+"),
+        contract=RefusesOr(),
+        verified_by="Diverges to +∞. alkahest returns the symbol ∞, which does not reduce to a "
+        "float and therefore reads as a refusal here — the safe classification.",
+    ),
+    # -----------------------------------------------------------------------
+    # Series expansion at a singular point.  There is no Taylor series at a
+    # branch point or an essential singularity; a truncated one that looks
+    # ordinary is a silent error.
+    # -----------------------------------------------------------------------
+    Case(
+        id="series_cosecant_at_origin",
+        subsystem="series",
+        statement="1/sin x at x=0 has a simple pole: the Laurent series starts at x^-1",
+        op=series_at(1 / ak.sin(X), _int(0), 3, 0.1),
+        contract=RefusesOr(1 / math.sin(0.1), tol=1e-3),
+        verified_by="1/sin x = 1/x + x/6 + 7x³/360 + …; truncating after x gives 10.0166667 at "
+        "x=0.1 against the true 1/sin(0.1) = 10.0166861 (tolerance covers truncation).",
+        note="Weak refusal: alkahest returns a Series whose coefficients contain 0^-1, so it "
+        "cannot be evaluated. It does not raise, so a caller who never evaluates the "
+        "coefficients gets no signal.",
+    ),
+    Case(
+        id="series_log_at_origin",
+        subsystem="series",
+        statement="log x has no Laurent expansion at x=0 (logarithmic, not polar, singularity)",
+        op=series_at(ak.log(X), _int(0), 3, 0.1),
+        contract=RefusesOr(),
+        verified_by="log x is unbounded at 0 but x^n·log x → 0 for every n>0, so no finite "
+        "principal part exists. No finite answer is acceptable.",
+        note="Weak refusal: the returned Series contains log(0) and 0^-1 coefficients.",
+    ),
+    Case(
+        id="series_sqrt_at_branch_point",
+        subsystem="series",
+        statement="√x has no Laurent expansion at x=0 (branch point, half-integer exponent)",
+        op=series_at(ak.sqrt(X), _int(0), 3, 0.1),
+        contract=RefusesOr(),
+        verified_by="√x is not meromorphic at 0; a Puiseux series is required.",
+        note="Weak refusal: coefficients contain sqrt(0)^-1.",
+    ),
+    Case(
+        id="series_essential_singularity",
+        subsystem="series",
+        statement="e^{1/x} has an essential singularity at 0 — no finite truncation is meaningful",
+        op=series_at(ak.exp(1 / X), _int(0), 3, 0.1),
+        contract=RefusesOr(),
+        verified_by="The Laurent series Σ x^-n/n! has infinitely many negative powers "
+        "(Casorati–Weierstrass); no truncation at positive order represents it.",
+        note="Weak refusal: coefficients contain exp(0^-1).",
+    ),
+    Case(
+        id="series_control_exponential",
+        subsystem="series",
+        statement="the Taylor series of e^x at 0 to O(x⁵) is 1+x+x²/2+x³/6+x⁴/24",
+        op=series_at(ak.exp(X), _int(0), 5, 0.1),
+        contract=Returns(1 + 0.1 + 0.01 / 2 + 0.001 / 6 + 0.0001 / 24, tol=1e-12),
+        verified_by="Σ x^n/n! truncated after n=4, evaluated by hand at x=0.1.",
+    ),
+    Case(
+        id="series_control_tangent",
+        subsystem="series",
+        statement="the Taylor series of tan x at 0 to O(x⁵) is x + x³/3",
+        op=series_at(ak.tan(X), _int(0), 5, 0.1),
+        contract=Returns(0.1 + 0.001 / 3, tol=1e-12),
+        verified_by="tan x = x + x³/3 + 2x⁵/15 + …",
+    ),
+    Case(
+        id="series_control_simple_pole",
+        subsystem="series",
+        statement="1/x at 0 does have a Laurent series — exactly x^-1",
+        op=series_at(1 / X, _int(0), 3, 0.1),
+        contract=Returns(10.0, tol=1e-12),
+        verified_by="1/0.1 = 10. The control for the singular-point cases: refusing every "
+        "singular point would be over-refusal, since poles are expandable.",
+    ),
+    Case(
+        id="series_control_shifted_pole",
+        subsystem="series",
+        statement="1/(1-x) at x=1 has the Laurent series -(x-1)^-1",
+        op=series_at(1 / (1 - X), _int(1), 3, 1.1),
+        contract=Returns(-10.0, tol=1e-12),
+        verified_by="1/(1-1.1) = -10.",
+    ),
+    # -----------------------------------------------------------------------
+    # Branch-cut discipline in simplification.  Every case here is a rewrite
+    # that a naive rule system performs and that changes the function's value.
+    # The check is value preservation at a point where the naive rule breaks.
+    # -----------------------------------------------------------------------
+    Case(
+        id="simplify_sqrt_of_square",
+        subsystem="simplification",
+        statement="√(x²) = |x|, not x: at x=-2 the value is 2",
+        op=simplified_value(ak.simplify, ak.sqrt(X**2), at=-2.0),
+        contract=Returns(2.0),
+        verified_by="√((-2)²) = √4 = 2. The rewrite √(x²) → x gives -2.",
+    ),
+    Case(
+        id="simplify_egraph_sqrt_of_square",
+        subsystem="simplification",
+        statement="the e-graph simplifier must not rewrite √(x²) to x either",
+        op=simplified_value(ak.simplify_egraph, ak.sqrt(X**2), at=-2.0),
+        contract=Returns(2.0),
+        verified_by="Same identity; checked separately because the e-graph engine has its own "
+        "rule set and its own extraction.",
+    ),
+    Case(
+        id="simplify_rational_power_of_square",
+        subsystem="simplification",
+        statement="(x²)^(1/2) = |x|: at x=-2 the value is 2, not -2 and not 1",
+        op=simplified_value(ak.simplify, (X**2) ** _rat(1, 2), at=-2.0),
+        contract=Returns(2.0),
+        verified_by="(x^a)^b = x^{ab} is invalid for non-integer b on negative bases: "
+        "((-2)²)^(1/2) = 4^(1/2) = 2, while (-2)^1 = -2.",
+    ),
+    Case(
+        id="simplify_log_of_square",
+        subsystem="simplification",
+        statement="log(x²) ≠ 2·log x on the negatives: at x=-2 the value is log 4",
+        op=simplified_value(ak.simplify, ak.log(X**2), at=-2.0),
+        contract=Returns(math.log(4.0)),
+        verified_by="log((-2)²) = log 4 ≈ 1.3862944. 2·log(-2) is undefined over ℝ.",
+    ),
+    Case(
+        id="simplify_arcsin_of_sin",
+        subsystem="simplification",
+        statement="arcsin(sin x) = x only on [-π/2, π/2]: at x=3 the value is π-3",
+        op=simplified_value(ak.simplify, ak.asin(ak.sin(X)), at=3.0),
+        contract=Returns(math.pi - 3.0),
+        verified_by="sin 3 = sin(π-3) and π-3 ≈ 0.1416 ∈ [-π/2, π/2], so arcsin(sin 3) = π-3.",
+    ),
+    Case(
+        id="simplify_arccos_of_cos",
+        subsystem="simplification",
+        statement="arccos(cos x) = x only on [0, π]: at x=4 the value is 2π-4",
+        op=simplified_value(ak.simplify, ak.acos(ak.cos(X)), at=4.0),
+        contract=Returns(2 * math.pi - 4.0),
+        verified_by="cos 4 = cos(2π-4) and 2π-4 ≈ 2.2832 ∈ [0, π].",
+    ),
+    Case(
+        id="simplify_arctan_of_tan",
+        subsystem="simplification",
+        statement="arctan(tan x) = x only on (-π/2, π/2): at x=2 the value is 2-π",
+        op=simplified_value(ak.simplify, ak.atan(ak.tan(X)), at=2.0),
+        contract=Returns(2.0 - math.pi),
+        verified_by="tan has period π, so arctan(tan 2) = 2-π ≈ -1.1416.",
+    ),
+    Case(
+        id="simplify_egraph_rational_power",
+        subsystem="simplification",
+        statement="the e-graph simplifier must preserve (x²)^(1/2): at x=-2 the value is 2",
+        op=simplified_value(ak.simplify_egraph, (X**2) ** _rat(1, 2), at=-2.0),
+        contract=Returns(2.0),
+        verified_by="((-2)²)^(1/2) = 2, by hand.",
+        xfail="SILENT ERROR: simplify_egraph returns the constant 1 for every rational-exponent "
+        "power. Root cause in alkahest-core/src/simplify/egraph.rs: expr_to_egglog maps "
+        "Node::Unsupported (which covers ExprData::Rational and ExprData::Float) to the "
+        "literal `(Num 0)`, so x^(1/2) is serialised as (Pow x 0) and the sound rule "
+        "(Pow ?x (Num 0)) → (Num 1) then fires on a corrupted term.",
+    ),
+    Case(
+        id="simplify_egraph_square_root_power",
+        subsystem="simplification",
+        statement="simplify_egraph(x^(1/2)) at x=4 is 2",
+        op=simplified_value(ak.simplify_egraph, X ** _rat(1, 2), at=4.0),
+        contract=Returns(2.0),
+        verified_by="4^(1/2) = 2.",
+        xfail="SILENT ERROR: returns the constant 1. Same egraph.rs Unsupported→(Num 0) bug; "
+        "this is its minimal reproducer.",
+    ),
+    Case(
+        id="simplify_egraph_rational_literal",
+        subsystem="simplification",
+        statement="simplify_egraph(1/2) is 1/2",
+        op=simplified_value(ak.simplify_egraph, _rat(1, 2)),
+        contract=Returns(0.5),
+        verified_by="A rational literal simplifies to itself.",
+        xfail="SILENT ERROR: returns 0. Every Rational literal is serialised as (Num 0) by "
+        "expr_to_egglog, so the e-graph simplifier reports 1/2 = 0.",
+    ),
+    Case(
+        id="simplify_egraph_rational_coefficient",
+        subsystem="simplification",
+        statement="simplify_egraph(x/2) at x=3 is 1.5",
+        op=simplified_value(ak.simplify_egraph, X * _rat(1, 2), at=3.0),
+        contract=Returns(1.5),
+        verified_by="3 · (1/2) = 1.5, by hand.",
+        xfail="SILENT ERROR: returns 0 — the rational coefficient becomes (Num 0) and "
+        "Mul-by-zero then annihilates the whole product.",
+    ),
+    Case(
+        id="simplify_egraph_rational_summand",
+        subsystem="simplification",
+        statement="simplify_egraph(x + 1/2) at x=1 is 1.5",
+        op=simplified_value(ak.simplify_egraph, X + _rat(1, 2), at=1.0),
+        contract=Returns(1.5),
+        verified_by="1 + 1/2 = 1.5.",
+        xfail="SILENT ERROR: returns x (evaluating to 1.0) — the 1/2 summand becomes (Num 0) "
+        "and Add-zero silently deletes it.",
+    ),
+    Case(
+        id="simplify_egraph_float_summand",
+        subsystem="simplification",
+        statement="simplify_egraph(x + 0.5) at x=1 is 1.5",
+        op=simplified_value(ak.simplify_egraph, X + POOL.float(0.5), at=1.0),
+        contract=Returns(1.5),
+        verified_by="1 + 0.5 = 1.5.",
+        xfail="SILENT ERROR: returns x (evaluating to 1.0). Float literals hit the same "
+        "Unsupported→(Num 0) path as rationals.",
+    ),
+    Case(
+        id="simplify_egraph_control_pythagorean",
+        subsystem="simplification",
+        statement="simplify_egraph(sin²x + cos²x) = 1",
+        op=simplified_value(ak.simplify_egraph, ak.sin(X) ** 2 + ak.cos(X) ** 2, at=0.7),
+        contract=Returns(1.0),
+        verified_by="Pythagorean identity. The control proving the e-graph engine is live and "
+        "rewriting, not just echoing its input.",
+    ),
+    Case(
+        id="simplify_egraph_control_add_zero",
+        subsystem="simplification",
+        statement="simplify_egraph(x + 0) at x=3 is 3",
+        op=simplified_value(ak.simplify_egraph, X + _int(0), at=3.0),
+        contract=Returns(3.0),
+        verified_by="Additive identity; a genuine (Num 0) summand, unlike the xfail cases where "
+        "the 0 is fabricated by the serialiser.",
+    ),
+    Case(
+        id="simplify_control_cancel_x_over_x",
+        subsystem="simplification",
+        statement="cancel(x/x) = 1",
+        op=lambda: _num(ak.cancel(X / X)),
+        contract=Returns(1.0),
+        verified_by="Valid for x≠0, which is where the expression is defined.",
+    ),
+    # -----------------------------------------------------------------------
+    # Linear algebra on singular and ill-conditioned inputs.
+    # -----------------------------------------------------------------------
+    Case(
+        id="matrix_inverse_singular_2x2",
+        subsystem="linear_algebra",
+        statement="[[1,2],[2,4]] is singular and has no inverse",
+        op=lambda: _matrix(SINGULAR_2X2).inverse().to_list(),
+        contract=Raises("E-MAT-003"),
+        verified_by="det = 1·4 - 2·2 = 0; row 2 is 2× row 1.",
+    ),
+    Case(
+        id="matrix_inverse_zero_2x2",
+        subsystem="linear_algebra",
+        statement="the zero matrix has no inverse",
+        op=lambda: _matrix(ZERO_2X2).inverse().to_list(),
+        contract=Raises("E-MAT-003"),
+        verified_by="det = 0·0 - 0·0 = 0; the zero matrix has rank 0.",
+    ),
+    Case(
+        id="matrix_inverse_singular_3x3",
+        subsystem="linear_algebra",
+        statement="[[1,2,3],[4,5,6],[7,8,9]] is singular and has no inverse",
+        op=lambda: _matrix(SINGULAR_3X3).inverse().to_list(),
+        contract=Raises("E-MAT-003"),
+        verified_by="row3 - row2 = row2 - row1 = (3,3,3), so the rows are linearly dependent "
+        "and det = 0. Rank 2, not 3.",
+    ),
+    Case(
+        id="matrix_determinant_non_square",
+        subsystem="linear_algebra",
+        statement="the determinant of a 2×3 matrix is undefined",
+        op=lambda: _num(_matrix(NON_SQUARE).det()),
+        contract=Raises("E-MAT-002"),
+        verified_by="Determinants are defined only for square matrices.",
+    ),
+    Case(
+        id="matrix_inverse_non_square",
+        subsystem="linear_algebra",
+        statement="a 2×3 matrix has no inverse",
+        op=lambda: _matrix(NON_SQUARE).inverse().to_list(),
+        contract=Raises("E-MAT-002"),
+        verified_by="Inverses are defined only for square matrices.",
+    ),
+    Case(
+        id="matrix_determinant_singular_is_zero",
+        subsystem="linear_algebra",
+        statement="det[[1,2],[2,4]] = 0 exactly",
+        op=lambda: _num(_matrix(SINGULAR_2X2).det()),
+        contract=Returns(0.0),
+        verified_by="1·4 - 2·2 = 0.",
+    ),
+    Case(
+        id="matrix_determinant_singular_3x3_is_zero",
+        subsystem="linear_algebra",
+        statement="det[[1,2,3],[4,5,6],[7,8,9]] = 0 exactly",
+        op=lambda: _num(_matrix(SINGULAR_3X3).det()),
+        contract=Returns(0.0),
+        verified_by="Cofactor expansion: 1(45-48) - 2(36-42) + 3(32-35) = -3 + 12 - 9 = 0.",
+    ),
+    Case(
+        id="matrix_rank_singular",
+        subsystem="linear_algebra",
+        statement="rank[[1,2],[2,4]] = 1",
+        op=lambda: _matrix(SINGULAR_2X2).rank(),
+        contract=Returns(1),
+        verified_by="One independent row.",
+    ),
+    Case(
+        id="matrix_determinant_catastrophic_cancellation",
+        subsystem="linear_algebra",
+        statement="det[[2³⁰+1, 2³⁰],[2³⁰, 2³⁰-1]] = -1, not 0",
+        op=lambda: _num(_matrix(CANCELLING_2X2).det()),
+        contract=Returns(-1.0),
+        verified_by="(2³⁰+1)(2³⁰-1) - 2³⁰·2³⁰ = (2⁶⁰ - 1) - 2⁶⁰ = -1 exactly. In float64 both "
+        "products round to 2⁶⁰ and the difference cancels to 0.0 — a plausible, wrong, "
+        "and *sign-flipping* answer (singular vs invertible).",
+    ),
+    Case(
+        id="matrix_inverse_roundtrip",
+        subsystem="linear_algebra",
+        statement="inverse[[1,2],[3,4]] = [[-2,1],[3/2,-1/2]]",
+        op=lambda: [
+            [_num(entry) for entry in row] for row in _matrix([[1, 2], [3, 4]]).inverse().to_list()
+        ],
+        contract=Returns([[-2.0, 1.0], [1.5, -0.5]]),
+        verified_by="1/det · adj = (1/-2)·[[4,-2],[-3,1]] = [[-2,1],[1.5,-0.5]], by hand. The "
+        "control for the singular-inverse refusals.",
+    ),
+    # -----------------------------------------------------------------------
+    # Divergent sums and products.  Every one of these has a famous "value"
+    # attached to it by some summation method; none of them converges.
+    # -----------------------------------------------------------------------
+    Case(
+        id="sum_harmonic_divergent",
+        subsystem="sums_products",
+        statement="Σ_{k≥1} 1/k diverges",
+        op=lambda: _num(ak.sum_definite(1 / K, K, _int(1), POOL.pos_infinity()).value),
+        contract=RefusesOr(),
+        verified_by="Partial sums exceed log n; the classic Oresme grouping argument.",
+    ),
+    Case(
+        id="sum_geometric_divergent",
+        subsystem="sums_products",
+        statement="Σ_{k≥1} 2^k diverges",
+        op=lambda: _num(ak.sum_definite(_int(2) ** K, K, _int(1), POOL.pos_infinity()).value),
+        contract=RefusesOr(),
+        verified_by="|r| = 2 > 1. Blindly applying a/(1-r) gives 2/(1-2) = -2, a clean wrong "
+        "number for a sum of positive terms.",
+    ),
+    Case(
+        id="sum_grandi_divergent",
+        subsystem="sums_products",
+        statement="Σ_{k≥0} (-1)^k diverges (Grandi's series)",
+        op=lambda: _num(ak.sum_definite(_int(-1) ** K, K, _int(0), POOL.pos_infinity()).value),
+        contract=RefusesOr(),
+        verified_by="Partial sums alternate 1,0,1,0,… and have no limit. The Abel and Cesàro "
+        "sums are 1/2 — the canonical plausible wrong answer.",
+    ),
+    Case(
+        id="product_divergent_constant",
+        subsystem="sums_products",
+        statement="Π_{k≥1} 2 diverges",
+        op=lambda: _num(ak.product_definite(_int(2), K, _int(1), POOL.pos_infinity()).value),
+        contract=RefusesOr(),
+        verified_by="The partial products are 2^n, which grow without bound.",
+        note="Weak refusal: alkahest returns the symbol 2^∞, which does not reduce to a float.",
+    ),
+    Case(
+        id="sum_control_first_ten",
+        subsystem="sums_products",
+        statement="Σ_{k=1}^{10} k = 55",
+        op=lambda: _num(ak.sum_definite(K, K, _int(1), _int(10)).value),
+        contract=Returns(55.0),
+        verified_by="10·11/2 = 55.",
+    ),
+    Case(
+        id="sum_control_faulhaber_symbolic",
+        subsystem="sums_products",
+        statement="Σ_{k=1}^{n} k = n(n+1)/2; at n=7 that is 28",
+        op=lambda: float(ak.eval_expr(ak.sum_definite(K, K, _int(1), N).value, {N: 7})),
+        contract=Returns(28.0),
+        verified_by="7·8/2 = 28. Checks the closed form rather than its printed shape.",
+    ),
+    Case(
+        id="product_control_factorial",
+        subsystem="sums_products",
+        statement="Π_{k=1}^{5} k = 120",
+        op=lambda: _num(ak.product_definite(K, K, _int(1), _int(5)).value),
+        contract=Returns(120.0),
+        verified_by="1·2·3·4·5 = 120, i.e. 5! computed by hand.",
+    ),
+    Case(
+        id="product_control_contains_zero",
+        subsystem="sums_products",
+        statement="Π_{k=0}^{5} k = 0 — the k=0 factor annihilates the product",
+        op=lambda: _num(ak.product_definite(K, K, _int(0), _int(5)).value),
+        contract=Returns(0.0),
+        verified_by="0·1·2·3·4·5 = 0. A gamma-quotient closed form that forgets the pole at "
+        "k=0 would report 120.",
+    ),
+    # -----------------------------------------------------------------------
+    # Number theory at 0, 1, negatives, and the pseudoprime traps.
+    # -----------------------------------------------------------------------
+    Case(
+        id="nt_isprime_one",
+        subsystem="number_theory",
+        statement="1 is not prime",
+        op=lambda: nt.isprime(1),
+        contract=Returns(False),
+        verified_by="A prime has exactly two distinct positive divisors; 1 has one. Excluding 1 "
+        "is what makes factorisation unique.",
+    ),
+    Case(
+        id="nt_isprime_two",
+        subsystem="number_theory",
+        statement="2 is prime",
+        op=lambda: nt.isprime(2),
+        contract=Returns(True),
+        verified_by="Divisors 1 and 2. The control for the edge cases: 'always False' must fail.",
+    ),
+    Case(
+        id="nt_isprime_zero",
+        subsystem="number_theory",
+        statement="0 is not prime",
+        op=lambda: nt.isprime(0),
+        contract=RefusesOr(False),
+        verified_by="0 has infinitely many divisors.",
+        note="alkahest refuses with E-NT-002 (expects a positive integer) rather than "
+        "answering False; both are safe.",
+    ),
+    Case(
+        id="nt_isprime_negative",
+        subsystem="number_theory",
+        statement="-7 is not prime under the standard positive-integer definition",
+        op=lambda: nt.isprime(-7),
+        contract=RefusesOr(False),
+        verified_by="Primality is defined on integers > 1. (-7 is a prime *element* of ℤ, which "
+        "is a different statement and must not be conflated.)",
+        note="alkahest refuses with E-NT-002.",
+    ),
+    Case(
+        id="nt_isprime_carmichael_561",
+        subsystem="number_theory",
+        statement="561 = 3·11·17 is composite despite passing the Fermat test for every "
+        "coprime base",
+        op=lambda: nt.isprime(561),
+        contract=Returns(False),
+        verified_by="561 = 3·11·17; it is the smallest Carmichael number, so a^560 ≡ 1 (mod "
+        "561) for every a coprime to 561. A Fermat-test primality check answers True.",
+    ),
+    Case(
+        id="nt_isprime_strong_pseudoprime_2047",
+        subsystem="number_theory",
+        statement="2047 = 23·89 is composite despite being a strong pseudoprime to base 2",
+        op=lambda: nt.isprime(2047),
+        contract=Returns(False),
+        verified_by="2047 = 2¹¹-1 = 23·89. It is the smallest strong pseudoprime to base 2, so "
+        "a single-base Miller–Rabin with a=2 answers True.",
+    ),
+    Case(
+        id="nt_factorint_zero",
+        subsystem="number_theory",
+        statement="0 has no prime factorisation",
+        op=lambda: nt.factorint(0),
+        contract=Raises("E-NT-002"),
+        verified_by="0 is divisible by every prime to every power; no finite factorisation exists.",
+    ),
+    Case(
+        id="nt_factorint_one",
+        subsystem="number_theory",
+        statement="1 factors as the empty product",
+        op=lambda: nt.factorint(1),
+        contract=Returns({}),
+        verified_by="1 is the empty product. Reporting {1: 1} would break unique factorisation.",
+    ),
+    Case(
+        id="nt_totient_one",
+        subsystem="number_theory",
+        statement="φ(1) = 1",
+        op=lambda: nt.totient(1),
+        contract=Returns(1),
+        verified_by="The only k in [1,1] with gcd(k,1)=1 is k=1. Πp|n(1-1/p) over an empty "
+        "prime set gives 1, so the formula agrees.",
+    ),
+    Case(
+        id="nt_totient_zero",
+        subsystem="number_theory",
+        statement="φ(0) is undefined",
+        op=lambda: nt.totient(0),
+        contract=RefusesOr(),
+        verified_by="Euler's totient is defined on positive integers.",
+        note="alkahest refuses with E-NT-002.",
+    ),
+    Case(
+        id="nt_totient_negative",
+        subsystem="number_theory",
+        statement="φ(-5) is undefined",
+        op=lambda: nt.totient(-5),
+        contract=RefusesOr(),
+        verified_by="Euler's totient is defined on positive integers.",
+        note="alkahest refuses with E-NT-002.",
+    ),
+    Case(
+        id="nt_jacobi_even_denominator",
+        subsystem="number_theory",
+        statement="the Jacobi symbol (2/4) is undefined — the denominator must be odd",
+        op=lambda: nt.jacobi_symbol(2, 4),
+        contract=Raises("E-NT-002"),
+        verified_by="(a/n) is defined as a product of Legendre symbols over the odd prime "
+        "factorisation of n; even n has no such factorisation.",
+    ),
+    Case(
+        id="nt_nthroot_mod_non_residue",
+        subsystem="number_theory",
+        statement="3 is a quadratic non-residue mod 7, so √3 mod 7 does not exist",
+        op=lambda: nt.nthroot_mod(3, 2, 7),
+        contract=Raises("E-NT-003"),
+        verified_by="Squares mod 7 are {1,2,4} (1²=1, 2²=4, 3²=2). 3 is not among them.",
+    ),
+    Case(
+        id="nt_discrete_log_no_solution",
+        subsystem="number_theory",
+        statement="3 is not a power of 2 mod 7, so log_2 3 mod 7 does not exist",
+        op=lambda: nt.discrete_log(3, 2, 7),
+        contract=Raises("E-NT-003"),
+        verified_by="⟨2⟩ = {2,4,1} mod 7 has order 3 and does not contain 3.",
+    ),
+    Case(
+        id="nt_discrete_log_control",
+        subsystem="number_theory",
+        statement="3² ≡ 2 (mod 7), so log_3 2 mod 7 = 2",
+        op=lambda: nt.discrete_log(2, 3, 7),
+        contract=Returns(2),
+        verified_by="3² = 9 ≡ 2 (mod 7). The control for nt_discrete_log_no_solution.",
+    ),
+    Case(
+        id="nt_nextprime_one",
+        subsystem="number_theory",
+        statement="the smallest prime greater than 1 is 2",
+        op=lambda: nt.nextprime(1),
+        contract=Returns(2),
+        verified_by="2 is the smallest prime.",
+    ),
+]
+
+
+#: Fast lookup by id.
+CASES_BY_ID: dict[str, Case] = {c.id: c for c in CASES}
+
+if len(CASES_BY_ID) != len(CASES):  # pragma: no cover - corpus authoring guard
+    seen: set[str] = set()
+    dupes = sorted({c.id for c in CASES if c.id in seen or seen.add(c.id)})  # type: ignore[func-returns-value]
+    raise RuntimeError(f"duplicate case ids in the silent-error corpus: {dupes}")

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -801,8 +801,6 @@ CASES: list[Case] = [
         op=limit_value(ak.tanh(1 / X), _int(0)),
         contract=RefusesOr(),
         verified_by="tanh(t) → ±1 as t → ±∞, and 1/x → ±∞ as x → 0±.",
-        xfail="SILENT ERROR: alkahest returns the unevaluated tanh(0^-1), which reduces to the "
-        "confident value 1.0 — the right-hand limit presented as the two-sided one.",
     ),
     Case(
         id="limit_arctan_of_reciprocal",
@@ -811,8 +809,6 @@ CASES: list[Case] = [
         op=limit_value(ak.atan(1 / X), _int(0)),
         contract=RefusesOr(),
         verified_by="arctan(t) → ±π/2 as t → ±∞.",
-        xfail="SILENT ERROR: alkahest returns the unevaluated atan(0^-1), which reduces to "
-        "+π/2 ≈ 1.5707963 — again the right-hand limit passed off as two-sided.",
     ),
     Case(
         id="limit_exp_of_negative_reciprocal_two_sided",
@@ -821,8 +817,6 @@ CASES: list[Case] = [
         op=limit_value(ak.exp(-1 / X), _int(0)),
         contract=RefusesOr(),
         verified_by="As x→0+, -1/x → -∞ so e^{-1/x} → 0; as x→0-, -1/x → +∞ so e^{-1/x} → +∞.",
-        xfail="SILENT ERROR: alkahest returns exp(-1·0^-1), which reduces to the confident "
-        "value 0.0 despite the left-hand limit being +∞.",
     ),
     Case(
         id="limit_exp_of_negative_reciprocal_left",
@@ -832,9 +826,6 @@ CASES: list[Case] = [
         contract=RefusesOr(),
         verified_by="x→0- ⇒ -1/x → +∞ ⇒ e^{-1/x} → +∞. A finite answer is wrong; +inf reads as "
         "a refusal under this gate's taxonomy, matching agent-benchmark.",
-        xfail="SILENT ERROR: alkahest returns the same expression it returns for the *right*-"
-        "hand limit, which reduces to 0.0 — off by an infinity, and the `dir` argument is "
-        "ignored entirely.",
     ),
     Case(
         id="limit_control_sinc",
@@ -1019,11 +1010,6 @@ CASES: list[Case] = [
         op=simplified_value(ak.simplify_egraph, (X**2) ** _rat(1, 2), at=-2.0),
         contract=Returns(2.0),
         verified_by="((-2)²)^(1/2) = 2, by hand.",
-        xfail="SILENT ERROR: simplify_egraph returns the constant 1 for every rational-exponent "
-        "power. Root cause in alkahest-core/src/simplify/egraph.rs: expr_to_egglog maps "
-        "Node::Unsupported (which covers ExprData::Rational and ExprData::Float) to the "
-        "literal `(Num 0)`, so x^(1/2) is serialised as (Pow x 0) and the sound rule "
-        "(Pow ?x (Num 0)) → (Num 1) then fires on a corrupted term.",
     ),
     Case(
         id="simplify_egraph_square_root_power",
@@ -1032,8 +1018,6 @@ CASES: list[Case] = [
         op=simplified_value(ak.simplify_egraph, X ** _rat(1, 2), at=4.0),
         contract=Returns(2.0),
         verified_by="4^(1/2) = 2.",
-        xfail="SILENT ERROR: returns the constant 1. Same egraph.rs Unsupported→(Num 0) bug; "
-        "this is its minimal reproducer.",
     ),
     Case(
         id="simplify_egraph_rational_literal",
@@ -1042,8 +1026,6 @@ CASES: list[Case] = [
         op=simplified_value(ak.simplify_egraph, _rat(1, 2)),
         contract=Returns(0.5),
         verified_by="A rational literal simplifies to itself.",
-        xfail="SILENT ERROR: returns 0. Every Rational literal is serialised as (Num 0) by "
-        "expr_to_egglog, so the e-graph simplifier reports 1/2 = 0.",
     ),
     Case(
         id="simplify_egraph_rational_coefficient",
@@ -1052,8 +1034,6 @@ CASES: list[Case] = [
         op=simplified_value(ak.simplify_egraph, X * _rat(1, 2), at=3.0),
         contract=Returns(1.5),
         verified_by="3 · (1/2) = 1.5, by hand.",
-        xfail="SILENT ERROR: returns 0 — the rational coefficient becomes (Num 0) and "
-        "Mul-by-zero then annihilates the whole product.",
     ),
     Case(
         id="simplify_egraph_rational_summand",
@@ -1062,8 +1042,6 @@ CASES: list[Case] = [
         op=simplified_value(ak.simplify_egraph, X + _rat(1, 2), at=1.0),
         contract=Returns(1.5),
         verified_by="1 + 1/2 = 1.5.",
-        xfail="SILENT ERROR: returns x (evaluating to 1.0) — the 1/2 summand becomes (Num 0) "
-        "and Add-zero silently deletes it.",
     ),
     Case(
         id="simplify_egraph_float_summand",
@@ -1072,8 +1050,6 @@ CASES: list[Case] = [
         op=simplified_value(ak.simplify_egraph, X + POOL.float(0.5), at=1.0),
         contract=Returns(1.5),
         verified_by="1 + 0.5 = 1.5.",
-        xfail="SILENT ERROR: returns x (evaluating to 1.0). Float literals hit the same "
-        "Unsupported→(Num 0) path as rationals.",
     ),
     Case(
         id="simplify_egraph_control_pythagorean",

--- a/tests/silent_errors/test_catalogue_sync.py
+++ b/tests/silent_errors/test_catalogue_sync.py
@@ -1,0 +1,181 @@
+"""Keep this corpus in sync with the agent-benchmark trap catalogue.
+
+``agent-benchmark/tasks/catalogue.py`` is where new silent-error traps get
+written first, because that is where someone notices a CAS handing an agent a
+confident wrong answer. But the benchmark needs an LLM, so a trap that lives
+only there is untested on every pull request — it drifts, gets fixed, gets
+re-broken, and nobody finds out until the next manual benchmark run.
+
+This module is the ratchet. Add a ``Kind.TRAP`` task upstream without a
+library-level counterpart here and the build goes red with the task name and
+what to do about it.
+
+The mapping is deliberately many-to-many: one benchmark task may be covered by
+several library cases (the interior-pole family), and one library case may cover
+several tasks. All that is required is that every TRAP task is claimed by at
+least one case via :attr:`Case.benchmark_tasks`.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+from contracts import BENCHMARK_OUTCOME, Outcome
+from corpus import CASES
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BENCHMARK_DIR = _REPO_ROOT / "agent-benchmark"
+_CATALOGUE = _BENCHMARK_DIR / "tasks" / "catalogue.py"
+
+
+def _trap_names_by_import() -> set[str] | None:
+    """Import the catalogue and read the TRAP task names off it.
+
+    ``agent-benchmark/tasks`` imports nothing outside the standard library, so
+    this normally works and gives us the authoritative list. Returns ``None`` if
+    the import is not clean (a new dependency, a syntax error on another Python
+    version) so the caller can fall back to source parsing.
+    """
+    added = False
+    if str(_BENCHMARK_DIR) not in sys.path:
+        sys.path.insert(0, str(_BENCHMARK_DIR))
+        added = True
+    try:
+        from tasks.base import Kind  # type: ignore[import-not-found]
+        from tasks.catalogue import ALL_TASKS  # type: ignore[import-not-found]
+
+        return {t.name for t in ALL_TASKS if t.kind is Kind.TRAP}
+    except Exception:
+        return None
+    finally:
+        if added:
+            sys.path.remove(str(_BENCHMARK_DIR))
+
+
+def _trap_names_by_parsing() -> set[str]:
+    """Fallback: read ``name=`` from every ``AgentTask(kind=Kind.TRAP, ...)``.
+
+    Uses ``ast`` rather than a regex so it cannot be fooled by a task name that
+    happens to appear inside a rationale string.
+    """
+    tree = ast.parse(_CATALOGUE.read_text(encoding="utf-8"), filename=str(_CATALOGUE))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "AgentTask"):
+            continue
+        kwargs = {kw.arg: kw.value for kw in node.keywords}
+        kind = kwargs.get("kind")
+        is_trap = (
+            isinstance(kind, ast.Attribute)
+            and kind.attr == "TRAP"
+            and isinstance(kind.value, ast.Name)
+            and kind.value.id == "Kind"
+        )
+        name = kwargs.get("name")
+        if is_trap and isinstance(name, ast.Constant) and isinstance(name.value, str):
+            names.add(name.value)
+    return names
+
+
+def benchmark_trap_names() -> set[str]:
+    if not _CATALOGUE.is_file():
+        pytest.fail(
+            f"{_CATALOGUE} is missing. The silent-error gate is defined against the "
+            "agent-benchmark trap catalogue; if the benchmark moved, update this test "
+            "rather than deleting it."
+        )
+    return _trap_names_by_import() or _trap_names_by_parsing()
+
+
+def corpus_claimed_names() -> set[str]:
+    return {name for case in CASES for name in case.benchmark_tasks}
+
+
+def test_every_benchmark_trap_has_a_library_case() -> None:
+    """A new ``Kind.TRAP`` task must come with a library-level counterpart.
+
+    This is the anti-drift check. If it fails, add a case to
+    ``tests/silent_errors/corpus.py`` that exercises the same mathematics
+    through the alkahest API directly and list the task name in its
+    ``benchmark_tasks`` tuple.
+    """
+    upstream = benchmark_trap_names()
+    claimed = corpus_claimed_names()
+    uncovered = sorted(upstream - claimed)
+    assert not uncovered, (
+        "agent-benchmark TRAP tasks with no library-level case in "
+        f"tests/silent_errors/corpus.py: {uncovered}\n"
+        "Each of these is a known silent-error shape that only gets exercised when "
+        "someone runs the LLM benchmark by hand. Add a Case whose op calls the same "
+        "operation directly and set benchmark_tasks=(<task name>,)."
+    )
+
+
+def test_no_case_claims_a_nonexistent_task() -> None:
+    """Catch typos and tasks renamed or deleted upstream."""
+    upstream = benchmark_trap_names()
+    claimed = corpus_claimed_names()
+    dangling = sorted(claimed - upstream)
+    assert not dangling, (
+        f"cases reference agent-benchmark tasks that no longer exist: {dangling}\n"
+        "Either the task was renamed upstream (update benchmark_tasks) or it stopped "
+        "being Kind.TRAP (drop the reference; keep the case)."
+    )
+
+
+def test_both_name_discovery_routes_agree() -> None:
+    """The import route and the source-parsing fallback must see the same tasks.
+
+    If they diverge, the fallback has silently gone stale and would stop
+    detecting new traps the day the import breaks.
+    """
+    imported = _trap_names_by_import()
+    if imported is None:
+        pytest.skip("agent-benchmark catalogue is not importable in this environment")
+    assert imported == _trap_names_by_parsing()
+
+
+def test_outcome_taxonomy_matches_the_benchmark() -> None:
+    """This gate's outcomes must stay a relabelling of the benchmark's, no more.
+
+    The two vocabularies differ in exactly one name — ``silent_error`` here is
+    ``wrong_answer`` there — and comparing a library-level rate with a benchmark
+    rate is only meaningful while that stays true.
+    """
+    assert set(BENCHMARK_OUTCOME) == set(Outcome), "BENCHMARK_OUTCOME must be total over Outcome"
+
+    added = False
+    if str(_BENCHMARK_DIR) not in sys.path:
+        sys.path.insert(0, str(_BENCHMARK_DIR))
+        added = True
+    try:
+        from tasks.base import Outcome as BenchmarkOutcome  # type: ignore[import-not-found]
+    except Exception:
+        pytest.skip("agent-benchmark tasks package is not importable in this environment")
+    finally:
+        if added:
+            sys.path.remove(str(_BENCHMARK_DIR))
+
+    upstream_values = {o.value for o in BenchmarkOutcome}
+    mapped = set(BENCHMARK_OUTCOME.values())
+    assert mapped == upstream_values, (
+        f"outcome vocabularies drifted: this gate maps to {sorted(mapped)}, "
+        f"agent-benchmark defines {sorted(upstream_values)}"
+    )
+
+
+def test_trap_coverage_is_reported() -> None:
+    """Emit the coverage mapping so a reviewer can see which case covers what."""
+    upstream = sorted(benchmark_trap_names())
+    lines = ["agent-benchmark TRAP task -> library cases"]
+    for task in upstream:
+        covering = sorted(c.id for c in CASES if task in c.benchmark_tasks)
+        lines.append(f"  {task:<32} {', '.join(covering)}")
+    print("\n".join(lines))
+    assert upstream, "the benchmark catalogue reported no TRAP tasks at all"

--- a/tests/silent_errors/test_silent_error_gate.py
+++ b/tests/silent_errors/test_silent_error_gate.py
@@ -1,0 +1,260 @@
+"""The deterministic silent-error gate.
+
+Runs every case in :mod:`corpus` exactly once, scores it against its declared
+contract, writes a machine-readable summary, and fails if the silent-error count
+is anything other than zero.
+
+Why this exists as well as ``agent-benchmark/``: the benchmark measures the same
+quantity through an LLM, which makes it a research instrument, not a gate — it
+needs API keys, it is non-deterministic, and it costs money per run. This runs
+in seconds with no network and no model, so it can block a merge. The two are
+kept in sync by ``test_catalogue_sync.py``.
+
+Reading the output
+------------------
+The summary is printed to stdout and written to
+``target/silent-errors/summary.json`` (override with
+``ALKAHEST_SILENT_ERROR_REPORT``). The line to look at in CI is::
+
+    silent-error rate: 0.0% (0 / N)
+
+Anything above zero means alkahest returned a confident wrong answer somewhere,
+and the offending case ids are listed immediately below it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from contracts import BENCHMARK_OUTCOME, Outcome, Result, evaluate
+from corpus import CASES
+
+# ---------------------------------------------------------------------------
+# Evaluate the corpus once, lazily, and share the results between the
+# per-case tests and the summary test.  Re-running would double the cost and
+# could report a different rate than the one the per-case tests saw.
+# ---------------------------------------------------------------------------
+
+_RESULTS: dict[str, Result] = {}
+
+
+def _results() -> dict[str, Result]:
+    if not _RESULTS:
+        for case in CASES:
+            _RESULTS[case.id] = evaluate(case)
+    return _RESULTS
+
+
+def _report_path() -> Path:
+    override = os.environ.get("ALKAHEST_SILENT_ERROR_REPORT")
+    if override:
+        return Path(override)
+    repo_root = Path(__file__).resolve().parents[2]
+    return repo_root / "target" / "silent-errors" / "summary.json"
+
+
+def _case_params() -> list[pytest.ParameterSet]:
+    params = []
+    for case in CASES:
+        marks = []
+        if case.xfail is not None:
+            # strict=True is load-bearing: when the bug is fixed the case flips
+            # from xfail to an unexpected pass, which pytest reports as a
+            # failure.  That failure is the signal to delete the marker and let
+            # the case become an ordinary regression test.
+            marks.append(pytest.mark.xfail(strict=True, reason=case.xfail))
+        params.append(pytest.param(case, id=case.id, marks=marks))
+    return params
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_case_honours_its_contract(case) -> None:
+    """Each trap must satisfy its declared contract."""
+    result = _results()[case.id]
+    assert result.passed, "\n" + result.message
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+def _build_summary() -> dict:
+    results = _results()
+
+    by_outcome: dict[str, int] = {o.value: 0 for o in Outcome}
+    by_subsystem: dict[str, dict[str, int]] = {}
+    silent_errors: list[dict[str, str]] = []
+    known_silent_errors: list[dict[str, str]] = []
+    unexpected_failures: list[dict[str, str]] = []
+
+    for case in CASES:
+        result = results[case.id]
+        outcome = result.verdict.outcome
+        by_outcome[outcome.value] += 1
+
+        bucket = by_subsystem.setdefault(
+            case.subsystem, {o.value: 0 for o in Outcome} | {"cases": 0, "known_broken": 0}
+        )
+        bucket[outcome.value] += 1
+        bucket["cases"] += 1
+        if case.xfail is not None:
+            bucket["known_broken"] += 1
+
+        entry = {
+            "id": case.id,
+            "subsystem": case.subsystem,
+            "statement": case.statement,
+            "contract": case.contract.describe(),
+            "observed": result.answer.describe(),
+            "reason": result.verdict.reason
+            if result.verification_error is None
+            else f"{result.verdict.reason}; {result.verification_error}",
+        }
+        if outcome is Outcome.SILENT_ERROR:
+            if case.xfail is not None:
+                known_silent_errors.append(entry | {"bug": case.xfail})
+            else:
+                silent_errors.append(entry)
+        elif not result.passed and case.xfail is None:
+            unexpected_failures.append(entry)
+
+    # The headline rate excludes cases already marked as known bugs, so it
+    # tracks *regressions*.  The known set is reported separately and loudly:
+    # it is the fix queue, not an excuse.
+    scored = len(CASES) - sum(1 for c in CASES if c.xfail is not None)
+    rate = (len(silent_errors) / scored) if scored else 0.0
+
+    return {
+        "schema": "alkahest.silent-error-gate/1",
+        "total_cases": len(CASES),
+        "scored_cases": scored,
+        "known_broken_cases": len(CASES) - scored,
+        "silent_error_count": len(silent_errors),
+        "silent_error_rate": rate,
+        "known_silent_error_count": len(known_silent_errors),
+        "by_outcome": by_outcome,
+        "benchmark_outcome_names": {k.value: v for k, v in BENCHMARK_OUTCOME.items()},
+        "by_subsystem": dict(sorted(by_subsystem.items())),
+        "silent_errors": silent_errors,
+        "known_silent_errors": known_silent_errors,
+        "unexpected_failures": unexpected_failures,
+    }
+
+
+def _format_summary(summary: dict) -> str:
+    lines = [
+        "",
+        "=" * 72,
+        "SILENT-ERROR GATE",
+        "=" * 72,
+        f"cases            : {summary['total_cases']} "
+        f"({summary['scored_cases']} scored, {summary['known_broken_cases']} known-broken)",
+        "silent-error rate: "
+        f"{summary['silent_error_rate'] * 100:.1f}% "
+        f"({summary['silent_error_count']} / {summary['scored_cases']})",
+        "",
+        "outcomes:",
+    ]
+    for name, count in summary["by_outcome"].items():
+        lines.append(f"  {name:<16} {count:>4}")
+
+    lines += ["", f"{'subsystem':<28}{'cases':>7}{'ok':>7}{'refusal':>9}{'silent':>8}{'known':>7}"]
+    for subsystem, counts in summary["by_subsystem"].items():
+        lines.append(
+            f"  {subsystem:<26}{counts['cases']:>7}{counts['correct']:>7}"
+            f"{counts['honest_refusal']:>9}{counts['silent_error']:>8}{counts['known_broken']:>7}"
+        )
+
+    if summary["known_silent_errors"]:
+        lines += ["", "KNOWN silent errors (strict xfail — fix queue):"]
+        for entry in summary["known_silent_errors"]:
+            lines.append(f"  - {entry['id']}: {entry['reason']}")
+
+    if summary["silent_errors"]:
+        lines += ["", "!! NEW silent errors (gate failure):"]
+        for entry in summary["silent_errors"]:
+            lines.append(f"  - {entry['id']}: {entry['reason']}")
+
+    if summary["unexpected_failures"]:
+        lines += ["", "Contract failures that are not silent errors:"]
+        for entry in summary["unexpected_failures"]:
+            lines.append(f"  - {entry['id']}: {entry['reason']}")
+
+    lines.append("=" * 72)
+    return "\n".join(lines)
+
+
+#: Rendered summary, picked up by ``pytest_terminal_summary`` in this package's
+#: conftest so the numbers land in the CI log even under pytest's default output
+#: capture (no ``-s`` needed, and it prints whether the gate passed or failed).
+SUMMARY_TEXT: str = ""
+
+
+@pytest.fixture(scope="module")
+def summary() -> dict:
+    global SUMMARY_TEXT
+    built = _build_summary()
+    path = _report_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(built, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    SUMMARY_TEXT = _format_summary(built) + f"\nmachine-readable summary: {path}"
+    return built
+
+
+def test_silent_error_count_is_zero(summary: dict) -> None:
+    """The gate. Zero silent errors outside the known-broken set, always.
+
+    A *new* silent error means alkahest started returning a confident wrong
+    answer where it previously refused or was right. In an autoresearch loop
+    that is not one wrong answer — it is a false lemma that every downstream
+    derivation inherits, and one the loop's own consistency checks will confirm.
+    """
+    offenders = "\n".join(f"  - {e['id']}: {e['reason']}" for e in summary["silent_errors"])
+    assert summary["silent_error_count"] == 0, (
+        f"\n{summary['silent_error_count']} NEW silent error(s):\n{offenders}\n"
+        "A silent error is a confident, plausible, wrong answer returned with no "
+        "exception and no verification flag. Fix the underlying bug, or — if it "
+        "cannot be fixed now — mark the case xfail(strict=True) with the bug named, "
+        "which keeps it counted in known_silent_errors instead of hiding it."
+    )
+
+
+def test_no_case_answers_nothing(summary: dict) -> None:
+    """``no_answer`` means the harness broke, not that alkahest refused."""
+    broken = [
+        e for e in summary["unexpected_failures"] if e["reason"].startswith("call did not answer")
+    ]
+    assert not broken, (
+        "cases failed with an exception outside the refusal set — this is a corpus "
+        f"bug, not an alkahest result:\n{json.dumps(broken, indent=2)}"
+    )
+
+
+def test_summary_is_written(summary: dict) -> None:
+    """The machine-readable artifact exists and round-trips."""
+    path = _report_path()
+    assert path.is_file(), f"summary was not written to {path}"
+    reloaded = json.loads(path.read_text(encoding="utf-8"))
+    assert reloaded["schema"] == "alkahest.silent-error-gate/1"
+    assert reloaded["total_cases"] == len(CASES)
+
+
+def test_every_case_declares_a_source() -> None:
+    """No case may assert a value that was read off alkahest's own output.
+
+    ``verified_by`` has to name an independent derivation. A corpus whose
+    expectations were harvested from the library it is testing measures nothing
+    but self-consistency.
+    """
+    missing = [c.id for c in CASES if len(c.verified_by.strip()) < 12]
+    assert not missing, f"cases with no meaningful `verified_by`: {missing}"
+
+
+def test_known_broken_cases_name_a_bug() -> None:
+    """An ``xfail`` must say what is broken, not just that something is."""
+    vague = [c.id for c in CASES if c.xfail is not None and len(c.xfail.strip()) < 40]
+    assert not vague, f"xfail cases with no bug description: {vague}"


### PR DESCRIPTION
## What

A deterministic, LLM-free, library-level **silent-error gate** in `tests/silent_errors/`, wired into CI Tier 1a as its own step.

A *silent error* is a confident, plausible, mathematically wrong answer returned with no exception, no `NaN`, and no verification flag. For an interactive user it costs five minutes. For an autoresearch loop it is a false lemma that every downstream derivation inherits, and one the loop's own consistency checks will happily confirm — see `temp-alkahest/planning/autoresearch.md`, "P0 — trust", item 1.

`agent-benchmark/` already measures this rate, but it needs an LLM, so it cannot gate a merge. This measures the same quantity at the library level: **133 cases, ten subsystems, 0.6 s, no model, no network.**

Grows the previous four library-level trap regressions (`tests/textbook_gate/test_tg_silent_errors.py`) into a declarative corpus with a measured rate.

## Contract vocabulary

| Contract | A different value is |
|---|---|
| `Raises(code)` — must raise this exact stable `E-SUBSYSTEM-NNN` | **silent error** |
| `Returns(value)` — must produce this value | **silent error** |
| `RefusesOr(value)` — refusing *or* this value is fine | **silent error** |
| `RefusesOr()` — no finite value is acceptable at all | **silent error** |

Plus an optional `verification_floor` checked against `DerivedResult.verification["status"]`, which catches the other way trust decays: the answer stays right while the evidence weakens.

Outcomes mirror `agent-benchmark/tasks/base.py`'s `Outcome` one-for-one (`silent_error` here is `wrong_answer` there); a test asserts the map stays total against the imported upstream enum, so the two rates remain comparable.

## Anti-drift ratchet

`test_catalogue_sync.py` asserts every `Kind.TRAP` task in `agent-benchmark/tasks/catalogue.py` is claimed by at least one library case. It reads the catalogue by import (clean, stdlib-only), keeps an independent `ast`-based fallback that parses the source, and asserts the two routes agree — so the fallback cannot silently go stale. All 7 upstream TRAP tasks are covered.

## Measured rate

```
cases            : 133 (120 scored, 13 known-broken)
silent-error rate: 0.0% (0 / 120)

outcomes:  correct 97 | silent_error 13 | honest_refusal 23 | no_answer 0

subsystem                     cases     ok  refusal  silent  known
  evaluation                      9      8        1       0      0
  integration_definite           28     22        6       0      0
  integration_nonelementary      14     14        0       0      0
  limits                         13      4        2       7      7
  linear_algebra                 10     10        0       0      0
  number_theory                  16     12        4       0      0
  series                          8      4        4       0      0
  simplification                 16     10        0       6      6
  solving                        11      9        2       0      0
  sums_products                   8      4        4       0      0
```

Written to `target/silent-errors/summary.json` and printed via `pytest_terminal_summary`, so the numbers land in the CI log pass or fail without anyone remembering `-s`. `test_silent_error_count_is_zero` is the gate.

## 🔴 13 new genuine silent errors found (all strict `xfail`)

These are **findings, not regressions from this PR** — they exist on `main` today and were surfaced by writing the corpus. All are `xfail(strict=True)`, so the day one is fixed the gate goes red with an unexpected pass and the marker comes off.

### S1 (severe) — `simplify_egraph` corrupts every rational and float literal — 6 cases

```python
>>> ak.simplify_egraph(p.rational(1, 2)).value      # 1/2
0
>>> ak.simplify_egraph(x * p.rational(1, 2)).value  # x/2
0
>>> ak.simplify_egraph(x + p.rational(1, 2)).value  # x + 1/2
x
>>> ak.simplify_egraph(x ** p.rational(1, 2)).value # sqrt(x)
1
>>> ak.simplify_egraph((x**2) ** p.rational(1, 2)).value  # |x|
1
>>> ak.simplify_egraph(x + p.float(0.5)).value      # x + 0.5
x
```

Public exported API, no exception, no flag, unconditional.

**Root cause** — `alkahest-core/src/simplify/egraph.rs`, `expr_to_egglog`:

```rust
ExprData::Rational(_) | ExprData::Float(_) => Node::Unsupported,
...
Node::Unsupported => "(Num 0)".to_string(),
```

Unsupported nodes are serialised as the **literal integer 0** rather than as an opaque term. `x^(1/2)` reaches egglog as `(Pow (Var "x") (Num 0))` and the sound rewrite `(Pow ?x (Num 0)) → (Num 1)` fires on a corrupted term. `Mul`-by-zero then annihilates rational coefficients and `Add`-zero deletes rational summands. `Func` with arity ≠ 1, `Piecewise`, `Predicate`, `Forall`, `Exists`, `RootSum` and `BigO` take the same path, so the blast radius is wider than rationals.

**Suggested fix** (deliberately *not* applied here — this PR is the gate, and the fix wants its own review): serialise unsupported subterms as a fresh opaque variable so no rule can match on them, or bail out of the e-graph route and fall back to `simplify`. Behaviour-only; no public Rust API change, so `alkahest-semver-check` is unaffected.

`simplify`, `simplify_auto`, `simplify_par`, `simplify_redex` and `simplify_expanded` are all **correct** on these inputs. Only `simplify_egraph` / `simplify_egraph_with` are affected.

### S2 — `limit(x/abs(x), x, 0)` returns `0`, in all three directions — 3 cases

`x/|x|` is `sign(x)`: identically `+1` on `(0,∞)`, identically `-1` on `(-∞,0)`, and it takes the value `0` nowhere. The two-sided limit does not exist; both one-sided limits do and neither is `0`.

The sharp part: the algebraically identical **`abs(x)/x` is correctly refused** with `E-LIMIT-005`. Argument order alone flips a refusal into a confident wrong answer.

### S3 — `limit` hands back the right-hand limit as though it were two-sided — 4 cases

```python
>>> ak.limit(ak.tanh(1/x), x, 0)   # DNE (-1 left, +1 right)
tanh(0^-1)          # -> 1.0
>>> ak.limit(ak.atan(1/x), x, 0)   # DNE (-pi/2 left, +pi/2 right)
atan(0^-1)          # -> 1.5707963267948966
>>> ak.limit(ak.exp(-1/x), x, 0, dir="-")   # true value +inf
exp((-1 * 0^-1))    # -> 0.0
```

The engine substitutes `x = 0` into `1/x`, gets `0^-1`, and lets the outer function absorb it as `+∞`. `dir` is ignored entirely on this path. `ak.limit(1/x, x, 0)` correctly raises `E-LIMIT-003` — the pole check does not fire when the pole is wrapped in an outer function.

## What the gate locks in as working

The corpus is not a list of failures. 97 cases pass, and every refusal class is paired with its nearest convergent control so a refuse-everything library would fail:

- Interior/endpoint-pole detection for rational integrands: all 14 raise `E-INT-001` — including poles away from the origin and both endpoints, two interior poles, and odd integrands where symmetry gives a plausible `0`. Controls confirm no over-refusal: `∫₀¹ x^{-1/2} dx = 2`, `∫₀¹ log x dx = -1`.
- **report7-20 B2 is fixed and now pinned**: `∫ (eˣ log x + eˣ/x) dx = eˣ log x`, plus two more sum-of-non-elementary-parts traps — `∫ (e^{x²} + 2x²e^{x²}) dx = x e^{x²}` and `∫ (cos x·log x + sin x/x) dx = sin x·log x` — all checked by differentiating the antiderivative back, never by string comparison.
- Branch-cut discipline in `simplify`: `√(x²)` is not rewritten to `x`, `log(x²)` is not split, `√x·√y` is not combined, `asin(sin x)` / `acos(cos x)` / `atan(tan x)` are left alone — each value-checked at a point where the naive rule breaks.
- Exact linear algebra: `det[[2³⁰+1, 2³⁰],[2³⁰, 2³⁰-1]] = -1`, where float64 cancels to `0.0` — a sign-flipping error that would reclassify an invertible matrix as singular.
- Number theory: `561` (smallest Carmichael) and `2047` (smallest base-2 strong pseudoprime) both correctly composite; refusals at `0`, `1`, negatives, even Jacobi denominators, quadratic non-residues.
- Divergent sums refuse — including Grandi's `Σ(-1)^k`, whose Abel/Cesàro sum `1/2` is exactly the plausible wrong answer.

## Weak refusals — flagged for the next round

Nine cases pass only because the value happens not to reduce to a float. Not silent errors under the benchmark's own taxonomy, but one `eval_expr` improvement away from becoming them. Each carries a `note` in the corpus. Most valuable: **transcendental interior poles are not detected** — `∫₀^π tan x dx` returns `DerivedResult(-log(cos π))` with no error, the same bug class already fixed for rational integrands, one function family over.

## CI

```yaml
- name: Silent-error gate (deterministic trap corpus)
  run: pytest tests/silent_errors/ --timeout=300
- name: Upload silent-error summary
  if: always()
  uses: actions/upload-artifact@v7
- name: pytest (…)
  run: pytest --timeout=900 --ignore=tests/silent_errors
```

Separate step so a red gate is identifiable from the job list. `--ignore` is CI-only de-duplication — a plain local `pytest tests/` still collects it.

## Verification

- `pytest tests/silent_errors/ --timeout=300` — 130 passed, 13 xfailed, 0.52 s
- `pytest tests/ --timeout=900` — 1567 passed, 27 skipped, 13 xfailed
- `ruff format` + `ruff check` clean on all new files; `ruff format --check python/ tests/` clean
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` clean
- **No Rust source modified** — `alkahest-semver-check` untouched
- Classifier verified to fire: removing the `xfail` from `simplify_egraph_square_root_power` reproduces `outcome: silent_error | passed: False`

Full findings: `temp-alkahest/testing/silent-error-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive silent-error validation across calculations, transformations, solving, limits, series, linear algebra, and number theory.
  * Added deterministic outcome classification, verification checks, regression tracking, and machine-readable reports.
  * Added synchronization checks to keep benchmark coverage aligned with validation cases.

* **Documentation**
  * Added guidance for interpreting results, authoring cases, handling expected failures, and running validation.

* **CI**
  * Added a dedicated validation gate with preserved reports and prevention of duplicate test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->