### PR TITLE
fix(ball): make rigorous enclosures actually enclose

### DIFF
--- a/alkahest-core/src/ball/mod.rs
+++ b/alkahest-core/src/ball/mod.rs
@@ -394,11 +394,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().exp());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // `lo`/`hi` are themselves rounded to `prec`; without this the ball is
+        // exact-looking (`rad == 0`) for an exact input, which is a false
+        // rigorous claim about a transcendental value.
+        b.add_rounding_error();
+        b
     }
 
     pub fn log(&self) -> Option<Self> {
@@ -410,11 +415,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().ln());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     pub fn sqrt(&self) -> Option<Self> {
@@ -426,11 +436,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().sqrt());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     /// tan([m-r, m+r]) — Lipschitz constant: sec²(m+r) (may blow up near π/2).
@@ -457,11 +472,16 @@ impl ArbBall {
         }
         let sum = Float::with_val(prec, &lo_tan + &hi_tan);
         let diff = Float::with_val(prec, &hi_tan - &lo_tan);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     pub fn sinh(&self) -> Self {
@@ -470,11 +490,14 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().sinh());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     pub fn cosh(&self) -> Self {
@@ -496,11 +519,14 @@ impl ArbBall {
         };
         let sum = Float::with_val(prec, &min_val + &max_val);
         let diff = Float::with_val(prec, &max_val - &min_val);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     pub fn tanh(&self) -> Self {
@@ -510,11 +536,14 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().tanh());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     pub fn asin(&self) -> Option<Self> {
@@ -526,11 +555,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().asin());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     pub fn acos(&self) -> Option<Self> {
@@ -543,11 +577,16 @@ impl ArbBall {
         // acos is decreasing, so lo/hi swap
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &lo - &hi);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     pub fn atan(&self) -> Self {
@@ -556,11 +595,14 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().atan());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     /// asinh([m-r, m+r]) — monotone increasing on all of ℝ.
@@ -570,11 +612,14 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().asinh());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     /// acosh([m-r, m+r]) — monotone increasing on `[1, ∞)`. Returns `None` if
@@ -588,11 +633,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().acosh());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     /// atanh([m-r, m+r]) — monotone increasing on `(-1, 1)`. Returns `None` if
@@ -606,11 +656,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, self.hi().atanh());
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     pub fn erf(&self) -> Self {
@@ -647,11 +702,16 @@ impl ArbBall {
         let hi = Float::with_val(prec, w_hi);
         let sum = Float::with_val(prec, &lo + &hi);
         let diff = Float::with_val(prec, &hi - &lo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     /// Digamma ψ(x).  Returns `None` when the ball contains a non-positive
@@ -673,11 +733,16 @@ impl ArbBall {
         fhi.digamma_mut();
         let sum = Float::with_val(prec, &flo + &fhi);
         let diff = Float::with_val(prec, &fhi - &flo);
-        Some(ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        })
+        };
+        // Endpoints are rounded to `prec`; without this a ball built from an
+        // exact input reports `rad == 0`, falsely claiming an irrational result
+        // is exactly representable.
+        b.add_rounding_error();
+        Some(b)
     }
 
     /// Bessel function of the first kind Jₙ(x) for integer order `n`.
@@ -689,11 +754,14 @@ impl ArbBall {
         fhi.jn_mut(n);
         let sum = Float::with_val(prec, &flo + &fhi);
         let diff = Float::with_val(prec, &fhi - &flo);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     pub fn abs_ball(&self) -> Self {
@@ -721,11 +789,14 @@ impl ArbBall {
         let hi_floor = Float::with_val(prec, self.hi().floor());
         let diff = Float::with_val(prec, &hi_floor - &lo_floor);
         let sum = Float::with_val(prec, &lo_floor + &hi_floor);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 
     pub fn ceil_ball(&self) -> Self {
@@ -734,11 +805,14 @@ impl ArbBall {
         let hi_ceil = Float::with_val(prec, self.hi().ceil());
         let diff = Float::with_val(prec, &hi_ceil - &lo_ceil);
         let sum = Float::with_val(prec, &lo_ceil + &hi_ceil);
-        ArbBall {
+        let mut b = ArbBall {
             mid: sum / 2_f64,
             rad: diff / 2_f64,
             prec,
-        }
+        };
+        // Endpoints are rounded to `prec`; see `exp`.
+        b.add_rounding_error();
+        b
     }
 }
 
@@ -1139,5 +1213,64 @@ mod tests {
         let z = AcbBall::from_f64(3.0, 4.0, 128);
         let m = z.modulus();
         assert!(m.contains(5.0));
+    }
+}
+
+#[cfg(test)]
+mod rounding_soundness_tests {
+    use super::*;
+
+    const PREC: u32 = 128;
+
+    /// Every transcendental op must carry a rounding term.
+    ///
+    /// `exp`/`log`/`sqrt`/`tan`/`asin`/`acos`/`atan`/`asinh`/`atanh` built their
+    /// result from `f(lo)` and `f(hi)` at finite precision and took the spread
+    /// as the radius. Given an *exact* input those endpoints coincide, so the
+    /// radius came out exactly zero — claiming a transcendental value is
+    /// exactly representable. `sin`/`cos` already added the term.
+    #[test]
+    fn transcendental_ops_never_report_zero_radius_on_exact_input() {
+        let half = ArbBall::from_f64(0.5, PREC);
+        let two = ArbBall::from_f64(2.0, PREC);
+
+        let mut zero_radius: Vec<&str> = Vec::new();
+        let mut check = |name: &'static str, b: ArbBall| {
+            if b.rad == 0 {
+                zero_radius.push(name);
+            }
+        };
+
+        check("exp", half.exp());
+        check("sin", half.sin());
+        check("cos", half.cos());
+        check("log", two.log().expect("log 2 defined"));
+        check("sqrt", two.sqrt().expect("sqrt 2 defined"));
+        check("tan", half.tan().expect("tan 0.5 defined"));
+        check("asin", half.asin().expect("asin 0.5 defined"));
+        check("acos", half.acos().expect("acos 0.5 defined"));
+        check("atan", half.atan());
+        check("asinh", half.asinh());
+        check("atanh", half.atanh().expect("atanh 0.5 defined"));
+
+        assert!(
+            zero_radius.is_empty(),
+            "these ops claim an irrational result is exact: {zero_radius:?}"
+        );
+    }
+
+    /// The radius must stay at the working-precision scale, not balloon.
+    ///
+    /// Soundness is trivially achievable by making every ball enormous; this
+    /// pins that the fix did not take that route.
+    #[test]
+    fn rounding_term_stays_at_precision_scale() {
+        let b = ArbBall::from_f64(0.5, PREC).exp();
+        let bound = Float::with_val(PREC, 1e-30);
+        assert!(
+            b.rad < bound,
+            "radius {} is far above the 2^-prec scale",
+            b.rad
+        );
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -6114,19 +6114,32 @@ impl PyArbBall {
         self.inner.mid_f64()
     }
 
+    /// Radius, rounded **up** to `f64`.
+    ///
+    /// Nearest-rounding here would report a radius smaller than the true one
+    /// and turn a valid enclosure into an invalid one at the Python boundary.
     #[getter]
     fn rad(&self) -> f64 {
-        self.inner.rad_f64()
+        self.inner.rad.to_f64_round(rug::float::Round::Up)
     }
 
+    /// Lower endpoint, rounded **down** to `f64`.
+    ///
+    /// The ball is computed at `prec` bits — far finer than `f64` — so a
+    /// nearest-rounded endpoint can land *inside* the true interval. A caller
+    /// writing `lo <= v <= hi` would then get `False` for a value the ball
+    /// genuinely encloses, which defeats the entire purpose of rigorous
+    /// arithmetic. Rounding outward keeps the `f64` view a valid enclosure of
+    /// the exact one, at the cost of being at most one ulp wider.
     #[getter]
     fn lo(&self) -> f64 {
-        self.inner.lo().to_f64()
+        self.inner.lo().to_f64_round(rug::float::Round::Down)
     }
 
+    /// Upper endpoint, rounded **up** to `f64`. See [`lo`].
     #[getter]
     fn hi(&self) -> f64 {
-        self.inner.hi().to_f64()
+        self.inner.hi().to_f64_round(rug::float::Round::Up)
     }
 
     fn contains(&self, v: f64) -> bool {

--- a/tests/test_ball_enclosure_soundness.py
+++ b/tests/test_ball_enclosure_soundness.py
@@ -1,0 +1,138 @@
+"""Ball arithmetic must actually enclose the value it claims to enclose.
+
+``ArbBall`` is the library's rigorous-numerics surface: the whole reason to
+reach for it instead of a float is that ``lo <= true value <= hi`` is a
+*guarantee*, not an approximation. A ball that excludes its own true value is
+the worst kind of silent error — a claimed proof that is false — because a
+caller's only defence against it is the guarantee itself.
+
+Two independent bugs, both found by auditing this surface and both fixed:
+
+1. ``exp``/``log``/``sqrt`` (and ``tan``, ``asin``, ``acos``, ``atan``,
+   ``asinh``, ``atanh``) built their result from ``f(lo)`` and ``f(hi)``
+   evaluated at finite precision and took the spread as the radius, without
+   ever accounting for the rounding of those two endpoint computations. Given
+   an *exact* input the two endpoints coincided, so the radius came out
+   exactly zero — asserting that a transcendental value is exactly
+   representable. ``sin``/``cos`` were unaffected: they already added the
+   rounding term.
+
+2. The Python accessors ``lo``/``hi``/``rad`` rounded to ``f64`` to *nearest*.
+   The ball is computed at far more than double precision, so a nearest-
+   rounded endpoint can land strictly inside the true interval, and
+   ``lo <= v <= hi`` then rejects a value the ball genuinely encloses. They
+   now round outward.
+
+The constants below are correct to 40 significant digits and are compared with
+:mod:`decimal`, deliberately not ``mpmath`` — mpmath lives in the ``ci-extras``
+group and is not installed for the Tier 1a run that must catch a regression
+here.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, getcontext
+
+import alkahest as ak
+import pytest
+
+getcontext().prec = 60
+
+#: value → 40-significant-digit truth.
+_TRUTH = {
+    "exp(0.5)": Decimal("1.648721270700128146848650787814163571654"),
+    "exp(1)": Decimal("2.718281828459045235360287471352662497757"),
+    "log(2)": Decimal("0.6931471805599453094172321214581765680755"),
+    "log(0.5)": Decimal("-0.6931471805599453094172321214581765680755"),
+    "sqrt(2)": Decimal("1.414213562373095048801688724209698078570"),
+    "sqrt(0.5)": Decimal("0.7071067811865475244008443621048490392848"),
+    "sin(0.5)": Decimal("0.4794255386042030002732879352155713880818"),
+    "sin(1)": Decimal("0.8414709848078965066525023216302989996226"),
+    "cos(0.5)": Decimal("0.8775825618903727161162815826038296519916"),
+    "cos(1)": Decimal("0.5403023058681397174009366074429766037323"),
+}
+
+
+@pytest.fixture
+def pool() -> ak.ExprPool:
+    return ak.ExprPool()
+
+
+@pytest.fixture
+def x(pool: ak.ExprPool) -> ak.Expr:
+    return pool.symbol("x")
+
+
+def _cases(x):
+    return [
+        ("exp(0.5)", ak.exp(x), 0.5),
+        ("exp(1)", ak.exp(x), 1.0),
+        ("log(2)", ak.log(x), 2.0),
+        ("log(0.5)", ak.log(x), 0.5),
+        ("sqrt(2)", ak.sqrt(x), 2.0),
+        ("sqrt(0.5)", ak.sqrt(x), 0.5),
+        ("sin(0.5)", ak.sin(x), 0.5),
+        ("sin(1)", ak.sin(x), 1.0),
+        ("cos(0.5)", ak.cos(x), 0.5),
+        ("cos(1)", ak.cos(x), 1.0),
+    ]
+
+
+def test_enclosures_contain_the_true_value(pool, x):
+    """``lo <= true <= hi`` for every case. This is the guarantee."""
+    failures = []
+    for name, expr, at in _cases(x):
+        ball = ak.interval_eval(expr, {x: ak.ArbBall(at)})
+        lo, hi, truth = Decimal(ball.lo), Decimal(ball.hi), _TRUTH[name]
+        if not (lo <= truth <= hi):
+            failures.append(f"{name}: [{lo}, {hi}] excludes {truth}")
+    assert not failures, "ball excluded its own true value:\n" + "\n".join(failures)
+
+
+def test_transcendental_results_are_not_claimed_exact(pool, x):
+    """A ball over an irrational result must carry a non-zero radius.
+
+    This is the shape of bug 1 stated directly: ``rad == 0`` means "exactly
+    representable", which is false for every value here.
+    """
+    zero_radius = [
+        name
+        for name, expr, at in _cases(x)
+        if ak.interval_eval(expr, {x: ak.ArbBall(at)}).rad == 0.0
+    ]
+    assert not zero_radius, f"irrational results reported as exact: {zero_radius}"
+
+
+def test_endpoints_round_outward(pool, x):
+    """The ``f64`` view must not be narrower than the ball it reports.
+
+    Rounding to nearest would let ``hi`` fall below the true upper endpoint.
+    Checked structurally so it holds regardless of precision: the interval
+    must contain the midpoint and have non-negative width.
+    """
+    for name, expr, at in _cases(x):
+        ball = ak.interval_eval(expr, {x: ak.ArbBall(at)})
+        assert ball.lo <= ball.mid <= ball.hi, f"{name}: midpoint outside [lo, hi]"
+        assert ball.hi - ball.lo >= 0.0, f"{name}: negative width"
+        assert ball.rad >= 0.0, f"{name}: negative radius"
+
+
+def test_added_rounding_term_stays_at_precision_scale(pool, x):
+    """The fix must buy soundness without materially widening the balls.
+
+    Note the library does *not* claim exactness even for exactly-representable
+    results: `x*x` at 3 is 9, and `rad` is already ~5e-38 on account of the
+    rounding term `mul` has always added. That is sound (a wider ball is never
+    wrong, only less useful), and unchanged here.
+
+    What this pins is the magnitude: the radius must stay at the working-
+    precision scale rather than growing to something that would make the
+    enclosure useless. A future change that widens balls by orders of
+    magnitude to paper over an unsoundness would fail here.
+    """
+    for expr, at, value in [(x * x, 3.0, 9.0), (ak.exp(x), 1.0, 2.718281828459045)]:
+        ball = ak.interval_eval(expr, {x: ak.ArbBall(at)})
+        assert ball.lo <= value <= ball.hi
+        assert ball.rad < 1e-25 * max(1.0, abs(value)), (
+            f"radius {ball.rad} is far above the working-precision scale"
+        )


### PR DESCRIPTION
Two independent soundness bugs in `ArbBall`, found auditing the surface the autoresearch plan singles out as *the* rigorous differentiator.

The whole reason to reach for a ball instead of a float is that `lo <= true value <= hi` is a **guarantee**. A ball that excludes its own true value is a claimed proof that is false — and a caller's only defence against it is the guarantee itself.

## Bug 1 — transcendental ops claimed exactness

`exp`, `log`, `sqrt`, `tan`, `asin`, `acos`, `atan`, `asinh`, `atanh` built their result from `f(lo)` and `f(hi)` at finite precision and took the spread as the radius, **never accounting for the rounding of those two endpoint computations**. Given an *exact* input the endpoints coincide, so:

```python
interval_eval(exp(x), {x: ArbBall(0.5)}).rad   ->  0.0
```

— asserting e^0.5 is exactly representable. `sin`/`cos` were unaffected; they already added the term.

## Bug 2 — the Python accessors rounded inward

`lo`/`hi`/`rad` converted to `f64` to **nearest**. The ball is computed at 128 bits, so a nearest-rounded endpoint can land strictly *inside* the true interval, and `lo <= v <= hi` then rejects a value the ball genuinely encloses. `lo` now rounds down; `hi` and `rad` round up. At most one ulp wider, and sound.

**Either bug alone breaks containment**, which is why `sin`/`cos` also failed the end-to-end check despite being internally correct.

## Verification

Checked against 40-significant-digit truth at several points:

| | before | after |
|---|---|---|
| enclosures containing the true value | **0 / 16** | **16 / 16** |

## Tests, at both levels

Either layer could reintroduce this, so both are pinned:

- **Rust** — no transcendental op may report `rad == 0` on exact input (all 11 ops).
- **Python** — containment against hardcoded 40-digit constants, using `decimal` rather than `mpmath` deliberately: mpmath is in the `ci-extras` group and is *not* installed for the Tier 1a run that has to catch a regression here.

Both also pin that the radius stays at the working-precision scale. Soundness is trivially achievable by making every ball enormous; this checks that is not what happened.

## Not changed

`mul`/`add` already widen exactly-representable results — `x*x` at 3 has radius ~5e-38, on `main` too. Sound, just conservative. Confirmed unchanged by this PR.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --all`, `pytest tests/` (2058 passed, 60 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interval accuracy for transcendental and special-function calculations by ensuring results include an appropriate precision-scale radius.
  * Prevented exact inputs from incorrectly producing zero-radius results.
  * Improved Python-facing lower, upper, and radius values with outward rounding to preserve valid enclosures.

* **Tests**
  * Added coverage verifying enclosure soundness, nonzero radii, midpoint containment, and precision-scale rounding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->