### PR TITLE
feat(pslq): refuse integer relations the input precision cannot justify

### DIFF
--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1,4 +1,5 @@
 import functools as _functools
+import math
 from contextlib import suppress as _suppress
 from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from importlib.metadata import version as _meta_version
@@ -1127,6 +1128,164 @@ def rsolve(equation, n, seq_name, initials=None):
     return _native_rsolve(_coerce_expr(equation), _coerce_expr(n), seq_name, initials)
 
 
+# ---------------------------------------------------------------------------
+# Integer relations (PSLQ/LLL) — input-precision guard
+# ---------------------------------------------------------------------------
+
+_native_guess_relation = guess_relation
+
+#: A Python ``float`` carries 53 bits of mantissa, ~15.95 decimal digits.
+_FLOAT_SIGNIFICAND_BITS = 53
+
+#: bits per decimal digit, ``log2(10)``.
+_BITS_PER_DIGIT = 3.321928094887362
+
+#: The engine's own minimum working precision (``E-PSLQ-003``).
+_MIN_ENGINE_BITS = 64
+
+
+def _supplied_bits(value) -> float:
+    """How much precision *value* is *known* to carry, in bits.
+
+    Only ``float`` is constrained. A float is 53 bits of mantissa no matter how
+    it is printed, and that is knowable with certainty.
+
+    Everything else is reported as exact, deliberately. A decimal string is
+    exactly the rational it spells — ``"1"`` is one, not "one to one significant
+    figure" — so a relation among supplied strings is a true statement about the
+    values supplied. Whether those values are the constants the caller *meant*
+    is not something this library can know, and guessing would refuse honest
+    exact-rational searches like ``["1", "2", "3"]``.
+    """
+    if isinstance(value, float):
+        return float(_FLOAT_SIGNIFICAND_BITS)
+    return math.inf
+
+
+class _RelationPrecisionError(PslqError):
+    """``E-PSLQ-004`` — inputs carry less precision than the search requested.
+
+    A subclass of the native :class:`PslqError` so ``except ak.PslqError``
+    catches it like any other integer-relation failure, while still carrying its
+    own stable code.
+    """
+
+    def __init__(self, message: str, remediation: str):
+        super().__init__(message)
+        self.code = "E-PSLQ-004"
+        self.remediation = remediation
+
+
+def _relation_is_credible(constants, coeffs) -> tuple[bool, float, float]:
+    """Judge a *found* relation against the precision its inputs actually have.
+
+    This is the standard experimental-mathematics criterion, and it uses
+    evidence rather than guessing what the caller meant. Pinning down `n`
+    coefficients of magnitude `H` consumes about `n·log10(H)` digits of
+    agreement. If that exceeds the digits the inputs carry, the relation was
+    *purchasable* from the available precision and is evidence of nothing.
+
+    Only ``float`` inputs constrain anything — see :func:`_supplied_bits`. With
+    exact inputs there is nothing to be sceptical of: the relation holds of the
+    values supplied, exactly.
+
+    Returns ``(credible, available_digits, consumed_digits)``.
+    """
+    supplied = math.inf
+    for c in constants:
+        bits = _supplied_bits(c)
+        if bits < supplied:
+            supplied = bits
+    if not math.isfinite(supplied):
+        return True, math.inf, 0.0
+    available = supplied / _BITS_PER_DIGIT
+    # NB: `abs`/`min`/`max` in this module's namespace are the *symbolic*
+    # constructors, so the builtins are unavailable here.
+    biggest = 1
+    for a in coeffs:
+        magnitude = -a if a < 0 else a
+        if magnitude > biggest:
+            biggest = magnitude
+    consumed = len(coeffs) * math.log10(biggest) if biggest > 1 else 0.0
+    return consumed <= available, available, consumed
+
+
+def relation_confidence(constants, coeffs) -> dict:
+    """Judge a found relation against the precision its inputs actually carry.
+
+    Pinning down ``n`` coefficients of magnitude ``H`` takes about
+    ``n·log10(H)`` digits of agreement. When that exceeds the digits the inputs
+    have, the relation was *purchasable* from the available precision — the
+    search would have found something whatever the constants were — and it is
+    evidence of nothing.
+
+    Only ``float`` inputs constrain anything (53 bits, ~16 digits, however they
+    are printed). Decimal strings and ints are exactly the values they spell, so
+    a relation among them holds exactly and there is nothing to be sceptical of.
+
+    Returns ``available_digits``, ``consumed_digits``, ``spare_digits`` and
+    ``credible``.
+
+    >>> import alkahest as ak
+    >>> ak.relation_confidence([1.0, 2.0, 3.0], [1, 1, -1])["credible"]
+    True
+    >>> ak.relation_confidence([0.1, 0.2, 0.7], [60771139, 67263243, 11653676])["credible"]
+    False
+    """
+    credible, available, consumed = _relation_is_credible(constants, coeffs)
+    return {
+        "available_digits": available,
+        "consumed_digits": consumed,
+        "spare_digits": available - consumed,
+        "credible": credible,
+    }
+
+
+def guess_relation(constants, precision_bits=664, max_abs_coeff=None, check_precision=True):
+    """Search for integers ``aᵢ`` with ``Σ aᵢ·constantsᵢ ≈ 0``.
+
+    Raises :class:`PslqError` (``E-PSLQ-004``) when the relation found is larger
+    than the inputs' precision can justify, rather than returning a number that
+    is an artifact of how the inputs were written.
+
+    Passing ``float`` values — 53 bits, ~16 digits — while searching at the
+    664-bit default zero-pads them into exact rationals, among which exact
+    integer relations genuinely exist::
+
+        guess_relation([float(pi), float(e), float(log(2))])
+        # was: [-60771139, 67263243, 11653676]   ← confident and meaningless
+        # now: raises E-PSLQ-004
+
+    The same constants supplied as 200-digit decimal strings correctly return
+    ``None``. In an autoresearch loop the old behaviour is a false lemma every
+    later step inherits, so a refusal is the only honest answer.
+
+    The test is on the *result*, not the input, so small relations among floats
+    still come back: ``[1.0, 2.0, 3.0]`` needs almost no precision to pin down
+    and is returned normally. See :func:`relation_confidence` for the numbers.
+
+    Pass ``check_precision=False`` to accept a relation among the supplied
+    values themselves.
+    """
+    coeffs = _native_guess_relation(constants, precision_bits, max_abs_coeff)
+    if coeffs is None or not check_precision:
+        return coeffs
+    credible, available, consumed = _relation_is_credible(constants, coeffs)
+    if not credible:
+        raise _RelationPrecisionError(
+            f"the relation {coeffs} needs ~{consumed:.0f} digits of agreement to pin "
+            f"down, but the inputs carry only ~{available:.0f}; a relation this size is "
+            "purchasable from the available precision and is evidence of nothing",
+            (
+                "supply the constants as high-precision decimal strings — a float "
+                f"carries only ~{_FLOAT_SIGNIFICAND_BITS} bits (~{available:.0f} digits) "
+                "however it is printed; pass check_precision=False to accept a relation "
+                "among the supplied values themselves"
+            ),
+        )
+    return coeffs
+
+
 _native_poly_normal = poly_normal
 
 
@@ -1689,6 +1848,8 @@ __all__ = [
     # V2-4
     "real_roots",
     "refine_root",
+    # Integer-relation input-precision guard
+    "relation_confidence",
     # V5-12 — certificate ledger
     "require_certificate",
     # Session-level provenance: claim graph for autoresearch loops

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -19,7 +19,7 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
     E-SOLVE-010 … E-SOLVE-011  SolverError  (GPU Gröbner)
     E-JIT-001   … E-JIT-003    JitError
     E-LAT-001 … E-LAT-004      LatticeError
-    E-PSLQ-001 … E-PSLQ-003    PslqError
+    E-PSLQ-001 … E-PSLQ-004    PslqError  (004 = input precision below requested)
     E-CAD-001                  CadError
     E-ROOT-001 … E-ROOT-002    RealRootError (V2-4 VAS real root isolation)
     E-RES-001 … E-RES-003      ResultantError (V2-2)
@@ -286,15 +286,20 @@ class LatticeError(AlkahestError):
 
 
 class PslqError(AlkahestError):
-    """Integer-relation heuristic failed (input, coefficient bound, or lattice step)."""
+    """Integer-relation heuristic failed (input, coefficient bound, or lattice step).
+
+    ``E-PSLQ-004`` is raised when the supplied constants carry less precision
+    than the search requests — see :func:`alkahest.guess_relation`.
+    """
 
     def __init__(
         self,
         message: str,
         remediation: str | None = None,
         span: tuple[int, int] | None = None,
+        code: str = "E-PSLQ-001",
     ):
-        super().__init__(message, code="E-PSLQ-001", remediation=remediation, span=span)
+        super().__init__(message, code=code, remediation=remediation, span=span)
 
 
 class CadError(AlkahestError):

--- a/tests/test_relation_precision_guard.py
+++ b/tests/test_relation_precision_guard.py
@@ -1,0 +1,128 @@
+"""Integer-relation search must not manufacture relations from thin input.
+
+``guess_relation`` accepts ``float`` values — 53 bits, ~16 significant digits —
+while defaulting to ``precision_bits=664``, about 200 digits. The floats get
+zero-padded to that width, which turns them into *exact rationals*, and exact
+integer relations among exact rationals genuinely exist. The search dutifully
+found them and returned them as if they were discoveries::
+
+    guess_relation([float(pi), float(e), float(log(2))])
+    ->  [-60771139, 67263243, 11653676]
+
+Nothing about that result distinguishes it from a real find. The same three
+constants supplied as 200-digit decimal strings correctly return ``None``.
+
+In an autoresearch loop this is the poisoned-branch case the whole silent-error
+discipline exists to prevent: stage 3 asks "is this constant a rational
+combination of these?", gets a confident yes, and every later step inherits a
+false lemma.
+
+The guard judges the *relation that was found*, not the input alone: pinning
+down `n` coefficients of magnitude `H` takes about `n·log10(H)` digits of
+agreement, and when that exceeds the digits the inputs carry, the relation was
+purchasable from the available precision and is evidence of nothing.
+
+Testing the result rather than guessing the caller's intent is what lets
+`[1.0, 2.0, 3.0]` keep working: that relation costs almost no precision to pin
+down, so it is returned normally even though the inputs are floats.
+"""
+
+from __future__ import annotations
+
+import math
+
+import alkahest as ak
+import pytest
+
+#: pi, e and log 2 to 60 significant digits — no integer relation is known.
+PI_60 = "3.14159265358979323846264338327950288419716939937510582097494"
+E_60 = "2.71828182845904523536028747135266249775724709369995957496697"
+LOG2_60 = "0.693147180559945309417232121458176568075500134360255254120680"
+
+#: sqrt(2) and twice it, to 60 digits — relation [-2, 1] holds exactly.
+SQRT2_60 = "1.41421356237309504880168872420969807856967187537694806841301"
+TWO_SQRT2_60 = "2.82842712474619009760337744841939615713934375075389613682602"
+
+#: 60 digits is ~199 bits; search below that so the guard is satisfied.
+BITS_60_DIGITS = 190
+
+
+class TestRefusesUnderprecisedInput:
+    def test_floats_at_default_precision_are_refused(self):
+        """The reported silent error, now an honest refusal."""
+        with pytest.raises(ak.PslqError) as excinfo:
+            ak.guess_relation([float(math.pi), float(math.e), float(math.log(2))])
+        assert excinfo.value.code == "E-PSLQ-004"
+
+    def test_a_true_small_relation_is_not_collateral_damage(self):
+        """`[0.5, 0.3333333, 1.0]` -> `[-2, 0, 1]` is *correct*, and must survive.
+
+        `-2(0.5) + 0 + 1(1.0) = 0` holds exactly, and costs no precision to pin
+        down. An earlier draft of this guard refused it, which was
+        over-correction: the fault it hunts is a relation too *large* to be
+        justified, not any relation among floats.
+        """
+        coeffs = ak.guess_relation([0.5, 0.3333333, 1.0])
+        assert coeffs is not None
+        assert sum(c * v for c, v in zip(coeffs, [0.5, 0.3333333, 1.0])) == pytest.approx(
+            0.0, abs=1e-12
+        )
+
+    def test_refusal_explains_what_to_do(self):
+        """A refusal an agent cannot act on is barely better than a wrong answer."""
+        with pytest.raises(ak.PslqError) as excinfo:
+            ak.guess_relation([float(math.pi), float(math.e)])
+        remediation = excinfo.value.remediation
+        assert remediation is not None
+        assert "decimal strings" in remediation
+
+    def test_small_relations_among_floats_are_kept(self):
+        """The criterion is the relation's size, not the input's type.
+
+        `[1.0, 2.0, 3.0]` are floats, but `1 + 2 - 3 = 0` costs essentially no
+        precision to pin down, so refusing it would be over-correction. This is
+        the case that caught an earlier, intent-guessing version of the guard.
+        """
+        assert ak.guess_relation([1.0, 2.0, 3.0], precision_bits=384) is not None
+
+
+class TestGenuinePrecisionIsUnaffected:
+    def test_true_relation_is_still_found(self):
+        coeffs = ak.guess_relation([SQRT2_60, TWO_SQRT2_60], precision_bits=BITS_60_DIGITS)
+        assert coeffs is not None
+        a, b = coeffs
+        assert a * 2 + b * 1 == 0 or (a, b) == (-2, 1) or (a, b) == (2, -1)
+
+    def test_unrelated_constants_still_return_none(self):
+        """The correct answer for pi, e, log 2 — and the one the bug hid."""
+        assert ak.guess_relation([PI_60, E_60, LOG2_60], precision_bits=BITS_60_DIGITS) is None
+
+    def test_search_at_the_precision_actually_supplied(self):
+        """Fewer digits is fine as long as the request matches the data."""
+        coeffs = ak.guess_relation([SQRT2_60[:32], TWO_SQRT2_60[:32]], precision_bits=99)
+        assert coeffs is not None
+
+
+class TestOptOutAndReporting:
+    def test_check_precision_false_restores_old_behaviour(self):
+        """Deliberate opt-out for a relation among the supplied rationals themselves."""
+        coeffs = ak.guess_relation([float(math.pi), float(math.e)], check_precision=False)
+        assert coeffs is not None
+
+    def test_relation_confidence_reports_the_shortfall(self):
+        verdict = ak.relation_confidence([0.1, 0.2, 0.7], [60771139, 67263243, 11653676])
+        assert verdict["credible"] is False
+        assert verdict["available_digits"] == pytest.approx(16.0, abs=0.5)
+        assert verdict["consumed_digits"] > verdict["available_digits"]
+
+    def test_relation_confidence_accepts_a_cheap_relation(self):
+        verdict = ak.relation_confidence([1.0, 2.0, 3.0], [1, 1, -1])
+        assert verdict["credible"] is True
+        assert verdict["spare_digits"] > 0
+
+    def test_exact_inputs_are_never_doubted(self):
+        """Strings and ints spell exact rationals, so a relation among them holds."""
+        for constants in ([PI_60, E_60], [1, 2, 3], ["1", "2", "3"]):
+            verdict = ak.relation_confidence(constants, [10**9, -(10**9), 1])
+            assert verdict["credible"] is True
+            assert verdict["available_digits"] == math.inf


### PR DESCRIPTION
`guess_relation` accepts `float` values — 53 bits, ~16 significant digits — while defaulting to `precision_bits=664`, about 200 digits. The floats are zero-padded to that width, which makes them **exact rationals**, and exact integer relations among exact rationals genuinely exist. The search found them and returned them as discoveries:

```python
guess_relation([float(pi), float(e), float(log(2))])
->  [-60771139, 67263243, 11653676]     # confident, plausible, meaningless
```

The same three constants as 200-digit decimal strings correctly return `None`.

In an autoresearch loop this is the poisoned-branch case the silent-error discipline exists to prevent — and it sits at the *first stage* of the plan's item-8 demo loop ("compute a constant to high precision, run `guess_relation`, get a conjectured closed form").

## The criterion is evidence, not intent

Pinning down `n` coefficients of magnitude `H` takes about `n·log10(H)` digits of agreement. When that exceeds the digits the inputs carry, the relation was **purchasable** from the available precision — the search would have found *something* whatever the constants were.

Judging the result rather than the input is what lets legitimate uses through:

| input | relation | consumed / available digits | outcome |
|---|---|---|---|
| `[float(pi), float(e), float(log2)]` | 8-digit coefficients | 23.5 / 16 | **refused** `E-PSLQ-004` |
| `[1.0, 2.0, 3.0]` | `[-1,-1,1]` | 0 / 16 | returned |
| `["1","2","3"]` | `[-1,-1,1]` | exact inputs | returned |
| 200-digit `[1, π, 2π]` | `[0,-2,1]` | exact inputs | returned |

New `relation_confidence(constants, coeffs)` reports `available_digits`, `consumed_digits`, `spare_digits`, `credible`.

## Two earlier drafts were wrong, recorded because the failure mode is instructive

I first guarded on the **input alone** — refuse when `precision_bits` exceeds the input's carried bits. That rejected `["1","2","3"]` (exact strings, caught by an existing test) and `[1.0, 2.0, 3.0]` (a true relation). It also pre-empted the native `TypeError` for `[1+2j]`.

The lesson: the library cannot know which real number a caller *meant*, so any intent-guessing rule refuses honest work. Only `float` constrains anything, and only the size of the found relation is evidence.

## Scope

Only `float` is treated as precision-limited. A decimal string spells an exact rational, so a relation among strings holds exactly and there is nothing to doubt.

`PslqError` gains an optional `code` (default unchanged). The refusal is a **subclass of the native error**, so `except ak.PslqError` still catches it while carrying `E-PSLQ-004`.

`check_precision=False` accepts a relation among the supplied values themselves.

## Gates

`cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --all`, `pytest tests/` (2090 passed), `ruff check`/`format`, `__all__` complete. 10 new tests.

Found by the round-3 audit: `temp-alkahest/testing/silent-error-audit-round3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)