### PR TITLE
fix: two defects in previously-unaudited subsystems (LLL hang, Pauli/Clifford commutativity)

### DIFF
--- a/alkahest-core/src/algebra/noncommutative.rs
+++ b/alkahest-core/src/algebra/noncommutative.rs
@@ -17,9 +17,24 @@ pub fn imag_unit_atom(pool: &ExprPool) -> ExprId {
     pool.symbol_commutative("ImagUnit", Domain::Complex, true)
 }
 
+/// Name of a **non-commutative** symbol, or `None`.
+///
+/// The commutativity requirement is load-bearing, not decoration. These product
+/// tables are order-sensitive — `σxσy = iσz` but `σyσx = −iσz` — while a
+/// commutative `Mul` sorts its operands, so `sx*sy` and `sy*sx` are literally
+/// the same expression. Firing the table on that shared form hands back one
+/// answer for two different products, so one of the two readings is always
+/// wrong, with nothing to distinguish it.
+///
+/// Matching by name alone did exactly that for a commutative symbol that
+/// happened to be called `sx` — a plausible name for something unrelated.
 fn symbol_name(expr: ExprId, pool: &ExprPool) -> Option<String> {
     pool.with(expr, |d| match d {
-        ExprData::Symbol { name, .. } => Some(name.clone()),
+        ExprData::Symbol {
+            name,
+            commutative: false,
+            ..
+        } => Some(name.clone()),
         _ => None,
     })
 }
@@ -163,5 +178,67 @@ mod tests {
         let a = p.symbol_commutative("A", Domain::Real, false);
         let b = p.symbol_commutative("B", Domain::Real, false);
         assert_ne!(p.mul(vec![a, b]), p.mul(vec![b, a]));
+    }
+}
+
+#[cfg(test)]
+mod commutativity_guard_tests {
+    use super::*;
+    use crate::simplify::engine::{rules_for_config, simplify_with, SimplifyConfig};
+
+    fn run(expr: ExprId, pool: &ExprPool, extra: Vec<Box<dyn RewriteRule>>) -> ExprId {
+        let mut rules = rules_for_config(&SimplifyConfig::default());
+        rules.extend(extra);
+        simplify_with(expr, pool, &rules, SimplifyConfig::default()).value
+    }
+
+    /// The product tables must not fire on *commutative* symbols.
+    ///
+    /// A commutative `Mul` sorts its operands, so `sx*sy` and `sy*sx` are the
+    /// same expression. `σxσy = iσz` and `σyσx = −iσz` differ in sign, so
+    /// applying the table to that shared form returns one answer for two
+    /// different products — one of the readings is necessarily wrong, and
+    /// nothing in the result says which.
+    ///
+    /// Matching by name alone did exactly that for any commutative symbol that
+    /// happened to be named `sx`.
+    #[test]
+    fn pauli_table_ignores_commutative_symbols() {
+        let pool = ExprPool::new();
+        let sx = pool.symbol_commutative("sx", Domain::Complex, true);
+        let sy = pool.symbol_commutative("sy", Domain::Complex, true);
+        let product = pool.mul(vec![sx, sy]);
+
+        let out = run(product, &pool, pauli_product_rules());
+        assert_eq!(
+            out, product,
+            "Pauli table fired on commutative symbols, where operand order is not recoverable"
+        );
+    }
+
+    #[test]
+    fn clifford_rules_ignore_commutative_symbols() {
+        let pool = ExprPool::new();
+        let e1 = pool.symbol_commutative("cliff_e1", Domain::Real, true);
+        let e2 = pool.symbol_commutative("cliff_e2", Domain::Real, true);
+        let product = pool.mul(vec![e1, e2]);
+
+        let out = run(product, &pool, clifford_orthogonal_rules());
+        assert_eq!(out, product, "Clifford rules fired on commutative symbols");
+    }
+
+    /// The genuine non-commutative path is untouched by the guard.
+    #[test]
+    fn noncommutative_generators_still_reduce() {
+        let pool = ExprPool::new();
+        let sx = pool.symbol_commutative("sx", Domain::Complex, false);
+        let sy = pool.symbol_commutative("sy", Domain::Complex, false);
+
+        let xy = run(pool.mul(vec![sx, sy]), &pool, pauli_product_rules());
+        let yx = run(pool.mul(vec![sy, sx]), &pool, pauli_product_rules());
+        assert_ne!(
+            xy, yx,
+            "sigma_x sigma_y and sigma_y sigma_x must differ in sign"
+        );
     }
 }

--- a/alkahest-core/src/lattice/lll.rs
+++ b/alkahest-core/src/lattice/lll.rs
@@ -141,6 +141,15 @@ fn gram_schmidt_rows(
     (mu, star, b_norm_sq)
 }
 
+/// True when `|x| > 1/2` exactly, in rational arithmetic.
+///
+/// Deliberately exact rather than a float comparison: the whole point is the
+/// behaviour *at* ±1/2, which is where a float epsilon would decide arbitrarily.
+fn exceeds_half(x: &Rational) -> bool {
+    let two_abs = Rational::from(x * Integer::from(2)).abs();
+    two_abs > 1
+}
+
 fn nearest_integer_rational(x: &Rational) -> Integer {
     Float::with_val(4096u32, x)
         .round()
@@ -188,6 +197,18 @@ fn size_reduce_single(
             continue;
         }
         let mij = &mu[k][j];
+        // LLL's size-reduction condition is `|μ| > 1/2`, *strictly*. Reducing at
+        // exactly ±1/2 does not terminate: `round` takes ±1/2 away from zero, so
+        // subtracting that multiple flips μ to ∓1/2, which rounds back and
+        // reduces again — an endless two-cycle.
+        //
+        // `lll_reduce_rows([[1, 1], [0, 1]])` hung forever on exactly this: μ is
+        // 1/2, the row alternates between `(0,1)` and `(-1,0)`, and the outer
+        // loop's iteration guard never advances because control never leaves the
+        // inner size-reduction loop.
+        if !exceeds_half(mij) {
+            continue;
+        }
         let q = nearest_integer_rational(mij);
         if q == 0 {
             continue;
@@ -234,6 +255,9 @@ fn lll_reduce_once(
     let mut k: usize = 1;
     let mut guard: usize = 0;
     const MAX_LLL_SWAPS: usize = 2_000_000;
+    // Each pass strictly shrinks one coefficient, so a well-behaved basis needs
+    // far fewer than this; the bound only has to be unreachable in practice.
+    const MAX_SIZE_REDUCTIONS_PER_ROW: usize = 100_000;
     loop {
         if k >= n {
             break;
@@ -243,7 +267,21 @@ fn lll_reduce_once(
             return Err(LatticeError::IterationLimit { iterations: guard });
         }
         // Size-reduce row k until stable (against each successive Gram–Schmidt refresh).
+        //
+        // Bounded independently of the outer guard. The outer `guard` counts
+        // *swaps*, so it cannot advance while this loop is spinning — a
+        // non-terminating size reduction hangs the whole call with no error, no
+        // budget and no way for a caller to recover. One documented cycle
+        // (reducing at |μ| = 1/2) is fixed at source in `size_reduce_single`;
+        // this is the backstop that turns any other into a reported failure.
+        let mut inner_guard: usize = 0;
         loop {
+            inner_guard += 1;
+            if inner_guard > MAX_SIZE_REDUCTIONS_PER_ROW {
+                return Err(LatticeError::IterationLimit {
+                    iterations: inner_guard,
+                });
+            }
             let (mu_ref, _, b_norm_sq) = gram_schmidt_rows(&basis);
             if !size_reduce_single(&mut basis, &mu_ref, &b_norm_sq, k) {
                 break;
@@ -355,5 +393,102 @@ mod tests {
             max_row_norm_squared(&reduced) <= max_row_norm_squared(&rows),
             "maximum squared row norm should shrink on this scaffold"
         );
+    }
+}
+
+#[cfg(test)]
+mod size_reduction_termination_tests {
+    use super::*;
+
+    fn rows(v: &[&[i64]]) -> Vec<Vec<Integer>> {
+        v.iter()
+            .map(|r| r.iter().map(|&x| Integer::from(x)).collect())
+            .collect()
+    }
+
+    /// Bases whose size reduction used to spin forever.
+    ///
+    /// Each has some `μ` exactly equal to ±1/2. `round` takes that away from
+    /// zero, subtracting the multiple flips μ to ∓1/2, and the next pass undoes
+    /// the previous one. The outer loop's swap guard never advanced because
+    /// control never left the inner size-reduction loop, so the call hung with
+    /// no error and no budget — for `[[1,1],[0,1]]`, a 2×2 unimodular basis.
+    #[test]
+    fn bases_with_mu_exactly_one_half_terminate() {
+        for basis in [
+            rows(&[&[1, 1], &[0, 1]]),
+            rows(&[&[1, 1], &[1, 2]]),
+            rows(&[&[1, 1], &[1, 0]]),
+            rows(&[&[1, 1], &[2, 1]]),
+            rows(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 10]]),
+        ] {
+            let reduced = lattice_reduce_rows(&basis).expect("must terminate and succeed");
+            assert_eq!(reduced.len(), basis.len());
+        }
+    }
+
+    /// `|μ| > 1/2` is the reduction condition — exactly 1/2 is already reduced.
+    #[test]
+    fn exceeds_half_is_strict() {
+        let half = Rational::from((1, 2));
+        let neg_half = Rational::from((-1, 2));
+        assert!(!exceeds_half(&half), "1/2 is already size-reduced");
+        assert!(!exceeds_half(&neg_half), "-1/2 is already size-reduced");
+        assert!(exceeds_half(&Rational::from((3, 5))));
+        assert!(exceeds_half(&Rational::from((-3, 5))));
+        assert!(!exceeds_half(&Rational::from((2, 5))));
+        assert!(!exceeds_half(&Rational::from(0)));
+    }
+
+    /// Reduction must preserve the lattice, not merely terminate.
+    ///
+    /// A basis of the *same* lattice has the same absolute determinant; a
+    /// "fix" that returned something quickly but spanned a different lattice
+    /// would pass the termination test above and be far worse than a hang.
+    #[test]
+    fn reduction_preserves_the_determinant() {
+        for basis in [
+            rows(&[&[1, 1], &[0, 1]]),
+            rows(&[&[1, 2], &[3, 4]]),
+            rows(&[&[2, 0], &[0, 3]]),
+            rows(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 10]]),
+        ] {
+            let reduced = lattice_reduce_rows(&basis).expect("reduces");
+            assert_eq!(
+                det_abs(&reduced),
+                det_abs(&basis),
+                "reduced basis spans a different lattice"
+            );
+        }
+    }
+
+    /// |det| of a square integer matrix, by exact fraction-free elimination.
+    fn det_abs(m: &[Vec<Integer>]) -> Rational {
+        let n = m.len();
+        let mut a: Vec<Vec<Rational>> = m
+            .iter()
+            .map(|r| r.iter().map(Rational::from).collect())
+            .collect();
+        let mut det = Rational::from(1);
+        for i in 0..n {
+            let Some(p) = (i..n).find(|&r| a[r][i] != 0) else {
+                return Rational::from(0);
+            };
+            if p != i {
+                a.swap(i, p);
+                det = -det;
+            }
+            det *= &a[i][i].clone();
+            let inv = a[i][i].clone();
+            for r in (i + 1)..n {
+                let f = Rational::from(&a[r][i] / &inv);
+                let pivot_row: Vec<Rational> = a[i][i..n].to_vec();
+                for (offset, ai) in pivot_row.iter().enumerate() {
+                    let sub = Rational::from(&f * ai);
+                    a[r][i + offset] -= sub;
+                }
+            }
+        }
+        det.abs()
     }
 }


### PR DESCRIPTION
Two independent defects found auditing subsystems `report7-20.md` lists as never audited. Separate commits, separate tests; kept in one PR because they are the same audit pass and neither touches the other's code.

---

## 1. LLL hangs forever on |μ| = 1/2

```python
alkahest.lattice.lll_reduce_rows([[1, 1], [0, 1]])   # never returns
```

A 2×2 unimodular integer basis. **No error, no budget, no way to recover** — for an autonomous loop that is worse than a wrong answer, since nothing downstream ever runs and there is no exception to catch. Also hangs on `[[1,1],[1,2]]`, `[[1,1],[1,0]]`, `[[1,1],[2,1]]`, `[[1,2,3],[4,5,6],[7,8,10]]`.

**Cause.** LLL's size-reduction condition is `|μ| > 1/2`, **strictly**. The code reduced whenever the nearest integer to `μ` was nonzero. At exactly ±1/2, `round` goes away from zero, so subtracting that multiple flips `μ` to ∓1/2 — which rounds back and reduces again. An endless two-cycle; for `[[1,1],[0,1]]` the row alternates between `(0,1)` and `(-1,0)`.

**The existing guard could not fire.** `MAX_LLL_SWAPS` counts *swaps*, and control never leaves the inner size-reduction loop to reach it.

Fixed by testing `|μ| > 1/2` exactly in rational arithmetic (a float epsilon would decide the ±1/2 case arbitrarily, and that case *is* the bug), plus an independent inner-loop bound so any other non-terminating reduction surfaces as `E-LAT-004` rather than a hang.

**Correctness, not just termination** — a fix that returned quickly but spanned a different lattice would be worse than the hang. Verified over **118 random non-singular integer bases** (dim 2–4): absolute determinant preserved and every reduced row an exact integer combination of the originals. **Zero violations.**

| input | before | after |
|---|---|---|
| `[[1,1],[0,1]]` | hangs | `[[0,1],[1,0]]` |
| `[[1,2,3],[4,5,6],[7,8,10]]` | hangs | `[[0,0,1],[-1,1,0],[2,1,0]]` |
| `[[1,2],[3,4]]` | `[[1,0],[0,2]]` | unchanged |

---

## 2. Pauli/Clifford tables fired on commutative symbols

The tables matched symbols by **name alone**, so a commutative symbol that happened to be called `sx` got Pauli semantics.

This cannot be right for a structural reason: a commutative `Mul` sorts its operands, so `sx*sy` and `sy*sx` are *literally the same expression* — while the table they trigger is order-sensitive (`σxσy = iσz`, `σyσx = −iσz`). One answer is returned for two different products, so one reading is always wrong:

```python
q = ExprPool(); sx = q.symbol('sx'); sy = q.symbol('sy')   # commutative
simplify_pauli(sx*sy)  ->  ImagUnit*sz
simplify_pauli(sy*sx)  ->  ImagUnit*sz      # should be -ImagUnit*sz
```

Clifford was worse: `e1*e2` reduced to `-1*e1*e2` — asserting `e1e2 = 0` — and `e1*e2 + e2*e1` returned `-2*e1*e2` instead of `0`.

`symbol_name` now matches only `commutative: false` symbols, so the tables apply exactly where operand order survives.

**The documented usage was correct throughout** and is unaffected: with `commutative=False` symbols, `sx*sy -> i·sz`, `sy*sx -> -i·sz`, `e1e2 + e2e1 -> 0`. Pinned by a test asserting the two orders still differ.

---

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --all`, `pytest tests/` (2079 passed, 45 skipped). Six new Rust tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)