### PR TITLE
test(cuda): fail when a GPU was promised but is not there

### DIFF
--- a/alkahest-core/tests/groebner_cuda.rs
+++ b/alkahest-core/tests/groebner_cuda.rs
@@ -30,8 +30,32 @@ fn poly(terms: &[(&[u32], i64)]) -> GbPoly {
     }
 }
 
+/// Whether the GPU-only tests should run — and a hard failure when they were
+/// asked for but cannot happen.
+///
+/// The distinction matters. `ALKAHEST_GPU_TESTS=1` is set by
+/// `.github/workflows/cuda_nightly.yml`, which runs on a `[self-hosted,
+/// gpu-3090]` runner; setting it is an assertion that a GPU *is* present. If
+/// the device is then missing or the driver is broken, the run must fail — that
+/// is the runner being broken, and it is the only signal anyone would get.
+///
+/// Previously this only read the environment variable and the tests returned
+/// early on failure, so they reported `ok` in three situations that are not the
+/// same thing: no GPU wanted, no GPU present, and a GPU present but unusable.
+/// With the devices hidden (`CUDA_VISIBLE_DEVICES=""`) the suite still went
+/// green while silently falling back to the CPU 32 times.
+///
+/// Main CI never reaches this code — `ci.yml` does not enable the `cuda` or
+/// `groebner-cuda` features — so failing here cannot hold up ordinary PRs.
 fn gpu_available() -> bool {
-    std::env::var("ALKAHEST_GPU_TESTS").ok().as_deref() == Some("1")
+    let requested = std::env::var("ALKAHEST_GPU_TESTS").ok().as_deref() == Some("1");
+    let device_ok = cudarc::driver::CudaContext::new(0).is_ok();
+    assert!(
+        !(requested && !device_ok),
+        "ALKAHEST_GPU_TESTS=1 asserts a CUDA device is present, but none could be \
+         initialised. Refusing to report success for GPU tests that cannot run."
+    );
+    requested && device_ok
 }
 
 // ---------------------------------------------------------------------------

--- a/alkahest-core/tests/nvptx_gpu.rs
+++ b/alkahest-core/tests/nvptx_gpu.rs
@@ -14,8 +14,26 @@ const N_SMOKE: usize = 1 << 20;
 /// Points for the bandwidth test — 16M × 8B in × 8B out ≈ 256 MB traffic.
 const N_BW: usize = 16 << 20;
 
+/// Whether the device tests should run, failing loudly when one was promised.
+///
+/// `ALKAHEST_GPU_TESTS=1` is set by `.github/workflows/cuda_nightly.yml` on a
+/// `[self-hosted, gpu-3090]` runner and asserts that a GPU is present. Skipping
+/// quietly in that case would report success for a job whose entire purpose is
+/// to exercise hardware: with the devices hidden the whole suite finished in
+/// 0.27 s and passed, versus 1.48 s of real work.
+///
+/// Without the variable the tests still skip, so `cargo test --features cuda`
+/// remains usable on a developer machine with no GPU. Main CI never builds
+/// these features at all, so this cannot block ordinary PRs.
 fn device_available() -> bool {
-    cudarc::driver::CudaContext::new(0).is_ok()
+    let device_ok = cudarc::driver::CudaContext::new(0).is_ok();
+    let requested = std::env::var("ALKAHEST_GPU_TESTS").ok().as_deref() == Some("1");
+    assert!(
+        !(requested && !device_ok),
+        "ALKAHEST_GPU_TESTS=1 asserts a CUDA device is present, but none could be \
+         initialised. Refusing to report success for GPU tests that cannot run."
+    );
+    device_ok
 }
 
 #[test]


### PR DESCRIPTION
Both GPU suites reported success in three situations that are not the same thing: **no GPU wanted**, **no GPU present**, and **a GPU present but unusable**.

With devices hidden (`CUDA_VISIBLE_DEVICES=""`):

- `nvptx_gpu` went green in **0.27 s** instead of 1.48 s — every test returns early and reports `ok`.
- `groebner_cuda` passed while **silently falling back to the CPU 32 times**. `compute_groebner_basis_gpu` warns on stderr and continues, which `cargo test` swallows for passing tests. Two of its three GPU tests would pass on a machine with no GPU at all.

## This was not protecting ordinary CI

Worth stating plainly, since it is the natural worry: **`ci.yml` never enables the `cuda` or `groebner-cuda` features**, so these tests are not built there and cannot hold up a PR.

The only job that runs them is `cuda_nightly.yml`, on a `[self-hosted, gpu-3090]` runner with `ALKAHEST_GPU_TESTS=1` — a job whose entire purpose is to exercise hardware, and the one place a vacuous pass actually costs something. A missing device there means the runner is broken, and this was the only signal anyone would get.

## The fix

Separate "not asked" from "asked but impossible":

- `ALKAHEST_GPU_TESTS=1` **asserts** a device is present. If none can be initialised, the tests fail rather than report success.
- Without the variable they still skip, so `cargo test --features cuda` stays usable on a developer machine with no GPU.

## Verified across all four combinations, both suites

| gate | GPU | groebner_cuda | nvptx_gpu |
|---|---|---|---|
| ON | present | 12 pass, 2.93 s (real work) | 5 pass, 1.44 s |
| ON | hidden | **FAILED — 3 failed** | **FAILED — 4 failed** |
| OFF | hidden | skips cleanly, 0.09 s | skips cleanly, 0.11 s |
| OFF | present | unchanged | unchanged |

## Hardware results on this machine's RTX 3090s

Both suites pass for real:

- `groebner_cuda` **12/12 with zero CPU fallbacks**, GPU basis agreeing with CPU F4 by mutual reduction.
- `nvptx_gpu` **5/5**, including the two-device test; 6.35 ms/launch on 1M points.

## Follow-up noted, not done here

`cargo clippy --features groebner-cuda` reports **13 pre-existing lints** in `poly/groebner/cuda.rs`, none from this change. That feature is never linted in CI, which is why they accumulated. Fixing them is unrelated to this gate and would bloat the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)