### PR TITLE
chore(cuda): lint the CUDA features, and fix what that surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,15 @@ jobs:
       - name: cargo clippy (jit feature)
         run: cargo clippy --all-targets --features jit -- -D warnings
 
+      # The CUDA-adjacent features were never linted, so lints accumulated
+      # unnoticed until someone built them on a GPU box. cudarc uses
+      # fallback-dynamic-loading, so this compiles on a runner with no CUDA
+      # toolkit — only `libcuda.so.1` at *runtime* is unavailable, and clippy
+      # never runs anything. The `cuda` feature additionally needs LLVM and is
+      # linted in the GPU nightly instead.
+      - name: cargo clippy (groebner-cuda feature)
+        run: cargo clippy --all-targets --features groebner-cuda -- -D warnings
+
       - name: cargo test
         run: cargo test --all
 

--- a/.github/workflows/cuda_nightly.yml
+++ b/.github/workflows/cuda_nightly.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Linted here rather than in main CI because `cuda` pulls in the LLVM
+      # JIT, which the ordinary runners are not provisioned for.
+      - name: cargo clippy (cuda + groebner-cuda)
+        run: cargo clippy --all-targets --features cuda,groebner-cuda -- -D warnings
+
       - name: Build and run CUDA tests
         env:
           ALKAHEST_GPU_TESTS: "1"

--- a/alkahest-core/benches/symbolic_gpu_bench.rs
+++ b/alkahest-core/benches/symbolic_gpu_bench.rs
@@ -357,7 +357,7 @@ fn bench_macaulay_reduce() -> Vec<BenchRecord> {
             if v == &0 {
                 0
             } else {
-                (v.significant_bits() as u32).max(1)
+                v.significant_bits().max(1)
             }
         }
         polys

--- a/alkahest-core/src/jit/nvptx.rs
+++ b/alkahest-core/src/jit/nvptx.rs
@@ -159,9 +159,9 @@ impl CudaCompiledFn {
             .runtime
             .lock()
             .map_err(|_| CudaError::LaunchError("runtime cache poisoned".to_string()))?;
-        if !cache.contains_key(&device_ordinal) {
+        if let std::collections::hash_map::Entry::Vacant(e) = cache.entry(device_ordinal) {
             let rt = runtime::load_ptx(device_ordinal, &self.ptx)?;
-            cache.insert(device_ordinal, rt);
+            e.insert(rt);
         }
         let rt = cache.get(&device_ordinal).unwrap();
 
@@ -188,9 +188,9 @@ impl CudaCompiledFn {
             .runtime
             .lock()
             .map_err(|_| CudaError::LaunchError("runtime cache poisoned".to_string()))?;
-        if !cache.contains_key(&device_ordinal) {
+        if let std::collections::hash_map::Entry::Vacant(e) = cache.entry(device_ordinal) {
             let rt = runtime::load_ptx(device_ordinal, &self.ptx)?;
-            cache.insert(device_ordinal, rt);
+            e.insert(rt);
         }
         let rt = cache.get(&device_ordinal).unwrap();
         runtime::launch_raw(rt, self.n_inputs, device_in, device_out, n_pts)
@@ -514,7 +514,7 @@ mod codegen {
                 // Fast path: small positive integer exponent → unrolled multiplies.
                 if let ExprData::Integer(n) = pool.get(exp) {
                     let n_i64 = n.0.to_f64() as i64;
-                    if n_i64 >= 0 && n_i64 <= 16 && (n_i64 as f64) == n.0.to_f64() {
+                    if (0..=16).contains(&n_i64) && (n_i64 as f64) == n.0.to_f64() {
                         let mut acc = f64_t.const_float(1.0);
                         for _ in 0..n_i64 {
                             acc = builder
@@ -627,6 +627,14 @@ mod codegen {
     /// Emit the `!nvvm.annotations` metadata entry that flags our function
     /// as a PTX kernel. Inkwell 0.9 doesn't expose named-metadata APIs, so
     /// we drop to llvm-sys directly.
+    /// NVVM requires the `nvvm.annotations` metadata node to mark a function as
+    /// a kernel, and inkwell exposes no safe wrapper for it. The `*InContext`
+    /// builders are deprecated upstream in favour of `*InContext2`, but those
+    /// take an explicit length and are not surfaced by inkwell's re-export at
+    /// the LLVM 15 version this crate pins. Migrating is a change to codegen,
+    /// not a lint fix, so the deprecation is acknowledged rather than papered
+    /// over by widening the lint level for the whole module.
+    #[allow(deprecated)]
     fn emit_nvvm_kernel_annotation<'ctx>(
         ctx: &'ctx Context,
         module: &Module<'ctx>,
@@ -721,6 +729,14 @@ mod codegen {
 
     /// Run a minimal whole-module cleanup: inline libdevice helpers into the
     /// kernel, then DCE everything the kernel doesn't reach.
+    ///
+    /// Uses the legacy pass manager, which inkwell deprecates in favour of
+    /// `PassBuilderOptions` + `Module::run_passes`. Switching pass pipelines
+    /// changes what the NVPTX backend actually emits, so it belongs in its own
+    /// change with the GPU suite run against it — not in a lint sweep. The
+    /// allow is scoped to this function so a *new* deprecated use elsewhere
+    /// still fails the build.
+    #[allow(deprecated)]
     fn run_libdevice_cleanup_passes<'ctx>(module: &Module<'ctx>) {
         use inkwell::passes::PassManager;
         let pm: PassManager<Module<'_>> = PassManager::create(());
@@ -752,11 +768,8 @@ mod codegen {
 #[cfg(feature = "cuda")]
 mod runtime {
     use super::{CudaError, DeviceRuntime};
-    use cudarc::driver::{
-        sys as cu_sys, CudaContext, CudaFunction, CudaModule, LaunchConfig, PushKernelArg,
-    };
+    use cudarc::driver::{sys as cu_sys, CudaContext, LaunchConfig, PushKernelArg};
     use cudarc::nvrtc::Ptx;
-    use std::sync::Arc;
 
     pub fn load_ptx(device: usize, ptx: &str) -> Result<DeviceRuntime, CudaError> {
         let ctx = CudaContext::new(device)
@@ -860,7 +873,7 @@ mod runtime {
     fn kernel_config(n_pts: usize) -> LaunchConfig {
         let block: u32 = 256;
         let n = n_pts as u32;
-        let grid = (n + block - 1) / block;
+        let grid = n.div_ceil(block);
         LaunchConfig {
             grid_dim: (grid.max(1), 1, 1),
             block_dim: (block, 1, 1),

--- a/alkahest-core/src/poly/groebner/cuda.rs
+++ b/alkahest-core/src/poly/groebner/cuda.rs
@@ -447,7 +447,7 @@ impl MacaulayMatrix {
 
             // GPU: eliminate column from all other rows in parallel
             let block: u32 = 256;
-            let grid = ((self.n_rows as u32) + block - 1) / block;
+            let grid = (self.n_rows as u32).div_ceil(block);
             let cfg = LaunchConfig {
                 grid_dim: (grid.max(1), 1, 1),
                 block_dim: (block, 1, 1),
@@ -534,11 +534,11 @@ impl CrtLifter {
                     let cv_mod = cv_abs % &p_int;
                     // Adjust sign
                     let cv_mod = if *cur_val < 0 && cv_mod != 0 {
-                        Integer::from(&p_int - cv_mod)
+                        &p_int - cv_mod
                     } else {
                         cv_mod
                     };
-                    let mut d = Integer::from(&rv - cv_mod);
+                    let mut d = &rv - cv_mod;
                     if d < 0 {
                         d += &p_int;
                     }
@@ -551,7 +551,7 @@ impl CrtLifter {
                     mod_inv(m_mod_u64, p)
                 };
                 let step = Integer::from(&diff * inv_m) % &p_int;
-                let add = Integer::from(&*cur_mod * step);
+                let add = &*cur_mod * step;
                 *cur_val += &add;
                 *cur_mod *= &p_int;
                 // Reduce to centered representation
@@ -606,7 +606,7 @@ impl CrtLifter {
 /// Returns `(upper, basis_lms)` where:
 /// - `upper` is the list of shifted basis elements that serve as reductors,
 /// - `basis_lms` is the set of their leading monomials (used after RREF to
-///    identify which rows are "new" vs. already-basis-covered).
+///   identify which rows are "new" vs. already-basis-covered).
 ///
 /// Termination: each iteration adds one monomial to `covered` (LMs of upper
 /// rows). All new terms introduced have total degree ≤ the monomial being
@@ -636,7 +636,7 @@ fn symbolic_preprocess_upper(
             .filter(|m| !covered.contains(*m))
             .find(|m| {
                 basis.iter().any(|g| {
-                    g.leading_exp(order).map_or(false, |lm| {
+                    g.leading_exp(order).is_some_and(|lm| {
                         lm.len() == m.len() && lm.iter().zip(m.iter()).all(|(a, b)| a <= b)
                     })
                 })
@@ -652,7 +652,7 @@ fn symbolic_preprocess_upper(
         let g = basis
             .iter()
             .find(|g| {
-                g.leading_exp(order).map_or(false, |lm| {
+                g.leading_exp(order).is_some_and(|lm| {
                     lm.len() == m.len() && lm.iter().zip(m.iter()).all(|(a, b)| a <= b)
                 })
             })
@@ -781,7 +781,7 @@ pub fn reduce_batch(
                             return false;
                         }
                         let lm = p.leading_exp(order);
-                        lm.map_or(false, |l| !basis_lms.contains(&l))
+                        lm.is_some_and(|l| !basis_lms.contains(&l))
                     })
                     .map(|p| p.make_monic(order))
                     .collect();
@@ -867,10 +867,10 @@ pub fn compute_groebner_basis_gpu(
             pairs.clear();
             for i in 0..basis.len() {
                 for j in (i + 1)..basis.len() {
-                    if !product_criterion(&basis[i], &basis[j], order) {
-                        if i >= new_start || j >= new_start {
-                            pairs.push((i, j));
-                        }
+                    if !product_criterion(&basis[i], &basis[j], order)
+                        && (i >= new_start || j >= new_start)
+                    {
+                        pairs.push((i, j));
                     }
                 }
             }
@@ -879,7 +879,7 @@ pub fn compute_groebner_basis_gpu(
         }
     }
 
-    Ok(interreduce_gpu(basis, order, device_id)?)
+    interreduce_gpu(basis, order, device_id)
 }
 
 fn product_criterion(f: &GbPoly, g: &GbPoly, order: MonomialOrder) -> bool {
@@ -1012,7 +1012,7 @@ mod tests {
         let mut lifter = CrtLifter::new(1, n_cols, monomials, 1, order);
 
         for &p in &PRIMES[..5] {
-            let mat = MacaulayMatrix::build(&[poly.clone()], order, p).unwrap();
+            let mat = MacaulayMatrix::build(std::slice::from_ref(&poly), order, p).unwrap();
             lifter.add_image(&mat);
         }
 

--- a/alkahest-core/tests/groebner_cuda.rs
+++ b/alkahest-core/tests/groebner_cuda.rs
@@ -51,7 +51,7 @@ fn gpu_available() -> bool {
     let requested = std::env::var("ALKAHEST_GPU_TESTS").ok().as_deref() == Some("1");
     let device_ok = cudarc::driver::CudaContext::new(0).is_ok();
     assert!(
-        !(requested && !device_ok),
+        !requested || device_ok,
         "ALKAHEST_GPU_TESTS=1 asserts a CUDA device is present, but none could be \
          initialised. Refusing to report success for GPU tests that cannot run."
     );

--- a/alkahest-core/tests/nvptx_gpu.rs
+++ b/alkahest-core/tests/nvptx_gpu.rs
@@ -29,7 +29,7 @@ fn device_available() -> bool {
     let device_ok = cudarc::driver::CudaContext::new(0).is_ok();
     let requested = std::env::var("ALKAHEST_GPU_TESTS").ok().as_deref() == Some("1");
     assert!(
-        !(requested && !device_ok),
+        !requested || device_ok,
         "ALKAHEST_GPU_TESTS=1 asserts a CUDA device is present, but none could be \
          initialised. Refusing to report success for GPU tests that cannot run."
     );

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -438,14 +438,6 @@ fn io_error_to_py(e: IoError) -> PyErr {
     })
 }
 
-#[cfg(feature = "groebner-cuda")]
-fn gpu_groebner_error_to_py(e: alkahest_core::experimental::GpuGroebnerError) -> PyErr {
-    Python::with_gil(|py| {
-        let exc_type = py.get_type_bound::<PySolverError>();
-        make_structured_err(py, &exc_type, &e)
-    })
-}
-
 fn integrate_error_to_py(e: IntegrationError) -> PyErr {
     // A budget/cancellation trip is not an integration failure — raise the
     // dedicated `BudgetExceededError` (E-BUDGET-*) instead of `IntegrationError`


### PR DESCRIPTION
`cargo clippy` was never run with `cuda` or `groebner-cuda` enabled, so lints accumulated in code nobody linted until it was built on a GPU box.

This is the **third instance of the same pattern** this session, after the egraph tests CI never ran (#269) and the GPU tests that passed without a GPU (#281): a check that exists, looks green, and covers nothing.

## What surfaced

The 13 lints noted in #281 were only the visible part — clippy stops at the first failing target, so once the lib compiled, more appeared from tests and benches.

Mechanical (`cargo clippy --fix` plus a few by hand): `div_ceil`, redundant `Integer::from`, `map_or` simplifications, `contains_key`+`insert`, manual `RangeInclusive::contains`, a collapsible `if`, an unneeded `Ok(..?)`, `std::slice::from_ref`, an overindented doc list item, two unused imports.

## Two judgement calls, not blind fixes

**The `inkwell` deprecations are not migrated.** Switching from the legacy `PassManager` to `PassBuilderOptions` + `Module::run_passes` changes what the NVPTX backend actually emits, and the `*InContext2` replacements are not surfaced by inkwell at the LLVM 15 version this crate pins. That belongs in its own change, with the GPU suite run against it.

Both sites carry a **scoped** `#[allow(deprecated)]` with the reasoning, so a *new* deprecated use elsewhere still fails the build — rather than a module-wide allow that would hide future ones.

**`gpu_groebner_error_to_py` was dead.** No GPU Gröbner entry point is exposed to Python at all, so nothing could call it. Removed; git has it if a binding ever lands.

## The root cause, so it cannot recur

- **main CI** now lints `--features groebner-cuda`. cudarc uses `fallback-dynamic-loading`, so it compiles on a runner with no CUDA toolkit — only `libcuda.so.1` is missing at *runtime*, and clippy runs nothing. **This PR's own CI run is the test of that claim.**
- **the GPU nightly** lints `--features cuda,groebner-cuda`, since `cuda` additionally pulls in the LLVM JIT the ordinary runners lack.

## Verified

Clippy clean under `default`, `groebner-cuda`, and `cuda,groebner-cuda`. `cargo test --all` green.

GPU suites re-verified on this machine's RTX 3090s after the changes: `groebner_cuda` 12/12 and `nvptx_gpu` 5/5 with the devices present, and still **failing loudly** when `ALKAHEST_GPU_TESTS=1` is set with the devices hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)