### PR TITLE
feat(holonomic): creative telescoping via Zeilberger's algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **Creative telescoping — Zeilberger's algorithm** (P1 mathematics item 7):
+  `alkahest.zeilberger(term, n, k, max_order=…, max_degree=…)` takes a proper
+  hypergeometric term `F(n, k)` and returns a `ZeilbergerCertificate` carrying
+  a P-recursive recurrence `Σ_i a_i(n)·F(n+i,k) = G(n,k+1) − G(n,k)` together
+  with the rational certificate `R` (`G = R·F`) — so `S(n) = Σ_k F(n,k)`
+  satisfies `Σ_i a_i(n)·S(n+i) = 0`. This is the first operation in the CAS
+  that is both a *decision procedure* over its class and a *certificate
+  emitter*, which is what makes discovery→proof automatic in an agent loop
+  rather than heuristic. New `alkahest_core::holonomic` module: exact `Q(n)`
+  and `Q(n)(k)` arithmetic towers, proper-hypergeometric recognition
+  (`gamma`, `factorial`, `binomial`, `pochhammer` heads), and the Gosper-style
+  reduction over `Q(n)`. Every certificate is re-checked as an exact
+  `Q(n)(k)` identity before return; a candidate that fails is discarded, never
+  returned with a caveat. Refuses via `HolonomicError` with stable codes —
+  `E-HOLO-001` (outside the proper hypergeometric class), `E-HOLO-002` (search
+  bounds exhausted), `E-HOLO-003` (candidate failed exact verification),
+  `E-HOLO-004` (malformed call). See
+  [`docs/mdbook/src/telescoping.md`](docs/mdbook/src/telescoping.md).
+
 - **Docs: autoresearch / search-plumbing guide.** New mdBook chapter
   [`search-plumbing.md`](docs/mdbook/src/search-plumbing.md) ties budgets,
   batch APIs, compact `DerivedResult` envelopes, claim graphs, and certificate

--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -182,6 +182,11 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-BUDGET-002", class: "BudgetError", cause: Cause::Resource, remediation: Some("raise Budget(max_steps=...), or accept a partial/heuristic result for this candidate instead of an exact one") },
     ErrorSpec { code: "E-BUDGET-003", class: "BudgetError", cause: Cause::Resource, remediation: Some("call alkahest.clear_cancel() (Python) or budget::clear_cancel() (Rust) before starting the next candidate") },
     // E-DOMAIN — reserved; DomainError is Python-only pending Rust implementation
+    // E-HOLO — HolonomicError (P1 item 7: creative telescoping / Zeilberger's algorithm)
+    ErrorSpec { code: "E-HOLO-001", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("rewrite the term as R(n,k)*z**k*w**n*prod(gamma(a*n + b*k + c)**e) with integer a, b and rational c; supported function heads are gamma, factorial, binomial, pochhammer") },
+    ErrorSpec { code: "E-HOLO-002", class: "HolonomicError", cause: Cause::Resource,    remediation: Some("raise max_order and/or max_degree in ZeilbergerOpts; if the term genuinely has no such recurrence within reach, Zeilberger's algorithm does not apply") },
+    ErrorSpec { code: "E-HOLO-003", class: "HolonomicError", cause: Cause::Internal,    remediation: Some("internal: report the term as a minimal failing example") },
+    ErrorSpec { code: "E-HOLO-004", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("n and k must be distinct symbols; max_order and max_degree must be positive") },
 ];
 
 #[cfg(test)]

--- a/alkahest-core/src/holonomic/hyperterm.rs
+++ b/alkahest-core/src/holonomic/hyperterm.rs
@@ -1,0 +1,684 @@
+//! Recognising *proper hypergeometric terms* and computing their exact shift ratios.
+//!
+//! A proper hypergeometric term in `(n, k)` is
+//!
+//! ```text
+//! F(n, k) = R(n, k) · z^k · w^n · ∏_j Γ(a_j·n + b_j·k + c_j)^(e_j)
+//! ```
+//!
+//! with `R ∈ Q(n, k)`, `z, w ∈ Q \ {0}`, `a_j, b_j ∈ Z`, `c_j ∈ Q`, `e_j ∈ Z`.
+//! This is exactly the class for which both shift quotients
+//! `F(n, k+1)/F(n, k)` and `F(n+i, k)/F(n, k)` are *rational functions* that can
+//! be written down exactly — which is what Zeilberger's algorithm consumes.
+//!
+//! The parser is deliberately strict: anything it cannot place in this class is
+//! refused rather than approximated.
+
+use super::qfield::{rn_add, rn_int, rn_is_zero, rn_mul, rn_one, rn_rat, rn_var, PolyK, RatK, Rn};
+use super::HolonomicError;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use rug::Rational;
+
+/// One `Γ(a·n + b·k + c)^e` factor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GammaFactor {
+    pub a: i64,
+    pub b: i64,
+    pub c: Rational,
+    pub e: i32,
+}
+
+/// A parsed proper hypergeometric term.
+#[derive(Clone, Debug)]
+pub struct ProperTerm {
+    /// Rational-function prefactor `R(n, k)`.
+    pub rat: RatK,
+    /// Base of the `z^k` factor.
+    pub z: Rational,
+    /// Base of the `w^n` factor.
+    pub w: Rational,
+    pub gammas: Vec<GammaFactor>,
+}
+
+/// Largest integer exponent accepted on a sub-term (guards against blow-up).
+const MAX_POW: i32 = 32;
+
+impl ProperTerm {
+    fn one() -> Self {
+        ProperTerm {
+            rat: RatK::one(),
+            z: Rational::from(1),
+            w: Rational::from(1),
+            gammas: Vec::new(),
+        }
+    }
+
+    fn from_ratk(r: RatK) -> Self {
+        ProperTerm {
+            rat: r,
+            z: Rational::from(1),
+            w: Rational::from(1),
+            gammas: Vec::new(),
+        }
+    }
+
+    fn mul(&self, other: &ProperTerm) -> ProperTerm {
+        let mut gammas = self.gammas.clone();
+        gammas.extend(other.gammas.iter().cloned());
+        ProperTerm {
+            rat: self.rat.mul(&other.rat),
+            z: self.z.clone() * other.z.clone(),
+            w: self.w.clone() * other.w.clone(),
+            gammas,
+        }
+    }
+
+    fn pow(&self, e: i32) -> Option<ProperTerm> {
+        if e.unsigned_abs() > MAX_POW as u32 {
+            return None;
+        }
+        let gammas = self
+            .gammas
+            .iter()
+            .map(|g| {
+                Some(GammaFactor {
+                    a: g.a,
+                    b: g.b,
+                    c: g.c.clone(),
+                    e: g.e.checked_mul(e)?,
+                })
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(ProperTerm {
+            rat: self.rat.pow_i32(e)?,
+            z: rat_pow(&self.z, e)?,
+            w: rat_pow(&self.w, e)?,
+            gammas,
+        })
+    }
+
+    /// `F(n, k+1) / F(n, k)` as an exact element of `Q(n, k)`.
+    pub fn ratio_k(&self) -> Result<RatK, HolonomicError> {
+        let shifted = self.rat.shift_k(1);
+        let mut acc = shifted.div(&self.rat).ok_or_else(|| {
+            HolonomicError::NotProperHypergeometric("term vanishes identically".into())
+        })?;
+        acc = acc.mul(&RatK::from_rn(rn_rat(self.z.clone())));
+        for g in &self.gammas {
+            let arg = gamma_arg_poly(g);
+            let step = gamma_shift_ratio(&arg, g.b)?;
+            acc = acc.mul(&step.pow_i32(g.e).ok_or_else(|| {
+                HolonomicError::NotProperHypergeometric("gamma factor is identically zero".into())
+            })?);
+        }
+        Ok(acc)
+    }
+
+    /// `F(n+i, k) / F(n, k)` as an exact element of `Q(n, k)`.
+    pub fn ratio_n(&self, i: i64) -> Result<RatK, HolonomicError> {
+        if i == 0 {
+            return Ok(RatK::one());
+        }
+        let shifted = self.rat.shift_n(i);
+        let mut acc = shifted.div(&self.rat).ok_or_else(|| {
+            HolonomicError::NotProperHypergeometric("term vanishes identically".into())
+        })?;
+        acc = acc.mul(&RatK::from_rn(rn_rat(rat_pow_i64(&self.w, i)?)));
+        for g in &self.gammas {
+            let arg = gamma_arg_poly(g);
+            let shift = g
+                .a
+                .checked_mul(i)
+                .ok_or_else(|| HolonomicError::SearchExhausted("gamma shift overflow".into()))?;
+            let step = gamma_shift_ratio(&arg, shift)?;
+            acc = acc.mul(&step.pow_i32(g.e).ok_or_else(|| {
+                HolonomicError::NotProperHypergeometric("gamma factor is identically zero".into())
+            })?);
+        }
+        Ok(acc)
+    }
+
+    /// Parse an expression into the proper hypergeometric class.
+    pub fn parse(
+        expr: ExprId,
+        n: ExprId,
+        k: ExprId,
+        pool: &ExprPool,
+    ) -> Result<ProperTerm, HolonomicError> {
+        parse_rec(expr, n, k, pool, 0)
+    }
+}
+
+fn gamma_arg_poly(g: &GammaFactor) -> PolyK {
+    // a·n + b·k + c  as a polynomial in k over Q(n)
+    let const_term = rn_add(&rn_mul(&rn_int(g.a), &rn_var()), &rn_rat(g.c.clone()));
+    PolyK::from_coeffs(vec![const_term, rn_int(g.b)])
+}
+
+/// `Γ(x + s) / Γ(x)` for integer `s`, as an exact rational function.
+fn gamma_shift_ratio(x: &PolyK, s: i64) -> Result<RatK, HolonomicError> {
+    if s == 0 {
+        return Ok(RatK::one());
+    }
+    if s.unsigned_abs() > 512 {
+        return Err(HolonomicError::SearchExhausted(format!(
+            "gamma argument shift {s} exceeds the supported limit of 512"
+        )));
+    }
+    let mut prod = PolyK::one();
+    if s > 0 {
+        for t in 0..s {
+            prod = prod.mul(&x.add(&PolyK::constant(rn_int(t))));
+        }
+        Ok(RatK::from_poly(prod))
+    } else {
+        for t in 1..=(-s) {
+            prod = prod.mul(&x.add(&PolyK::constant(rn_int(-t))));
+        }
+        RatK::from_poly(prod)
+            .inv()
+            .ok_or_else(|| HolonomicError::NotProperHypergeometric("gamma pole".into()))
+    }
+}
+
+fn rat_pow(q: &Rational, e: i32) -> Option<Rational> {
+    rat_pow_i64(q, e as i64).ok()
+}
+
+fn rat_pow_i64(q: &Rational, e: i64) -> Result<Rational, HolonomicError> {
+    if e == 0 {
+        return Ok(Rational::from(1));
+    }
+    if e.unsigned_abs() > 1024 {
+        return Err(HolonomicError::SearchExhausted(
+            "exponential factor exponent exceeds the supported limit".into(),
+        ));
+    }
+    if *q == 0 {
+        if e < 0 {
+            return Err(HolonomicError::NotProperHypergeometric(
+                "zero base raised to a negative power".into(),
+            ));
+        }
+        return Ok(Rational::from(0));
+    }
+    let base = if e < 0 { q.clone().recip() } else { q.clone() };
+    let mut acc = Rational::from(1);
+    for _ in 0..e.unsigned_abs() {
+        acc *= base.clone();
+    }
+    Ok(acc)
+}
+
+const MAX_PARSE_DEPTH: usize = 64;
+
+fn parse_rec(
+    expr: ExprId,
+    n: ExprId,
+    k: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<ProperTerm, HolonomicError> {
+    if depth > MAX_PARSE_DEPTH {
+        return Err(HolonomicError::NotProperHypergeometric(
+            "expression nests deeper than the parser supports".into(),
+        ));
+    }
+    // Fast path: a purely rational sub-expression.
+    if let Some(r) = as_ratk(expr, n, k, pool, 0) {
+        return Ok(ProperTerm::from_ratk(r));
+    }
+    match pool.get(expr) {
+        ExprData::Mul(args) => {
+            let mut acc = ProperTerm::one();
+            for a in args {
+                acc = acc.mul(&parse_rec(a, n, k, pool, depth + 1)?);
+            }
+            Ok(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            if let Some(e) = as_i32(exp, pool) {
+                let b = parse_rec(base, n, k, pool, depth + 1)?;
+                return b.pow(e).ok_or_else(|| {
+                    HolonomicError::NotProperHypergeometric(format!(
+                        "exponent {e} is outside the supported range (|e| ≤ {MAX_POW})"
+                    ))
+                });
+            }
+            // c^(α·n + β·k + γ) with rational c
+            let Some(c) = as_rational(base, pool) else {
+                return Err(HolonomicError::NotProperHypergeometric(format!(
+                    "power with symbolic exponent needs a rational base, got {}",
+                    pool.display(base)
+                )));
+            };
+            if c == 0 {
+                return Err(HolonomicError::NotProperHypergeometric(
+                    "0 raised to a symbolic power".into(),
+                ));
+            }
+            let (alpha, beta, gamma) = affine_parts(exp, n, k, pool).ok_or_else(|| {
+                HolonomicError::NotProperHypergeometric(format!(
+                    "exponent {} is not integer-affine in the two indices",
+                    pool.display(exp)
+                ))
+            })?;
+            if *gamma.clone().denom() != 1 {
+                return Err(HolonomicError::NotProperHypergeometric(
+                    "constant part of an exponential exponent must be an integer".into(),
+                ));
+            }
+            let gi: i64 = gamma
+                .numer()
+                .to_i64()
+                .ok_or_else(|| HolonomicError::SearchExhausted("exponent too large".into()))?;
+            Ok(ProperTerm {
+                rat: RatK::from_rn(rn_rat(rat_pow_i64(&c, gi)?)),
+                z: rat_pow_i64(&c, beta)?,
+                w: rat_pow_i64(&c, alpha)?,
+                gammas: Vec::new(),
+            })
+        }
+        ExprData::Func { name, args } => parse_func(&name, &args, n, k, pool),
+        other => Err(HolonomicError::NotProperHypergeometric(format!(
+            "unsupported node {other:?} in {}",
+            pool.display(expr)
+        ))),
+    }
+}
+
+fn parse_func(
+    name: &str,
+    args: &[ExprId],
+    n: ExprId,
+    k: ExprId,
+    pool: &ExprPool,
+) -> Result<ProperTerm, HolonomicError> {
+    let gamma_of = |arg: ExprId, e: i32| -> Result<GammaFactor, HolonomicError> {
+        let (a, b, c) = affine_parts(arg, n, k, pool).ok_or_else(|| {
+            HolonomicError::NotProperHypergeometric(format!(
+                "gamma argument {} is not integer-affine in the two indices",
+                pool.display(arg)
+            ))
+        })?;
+        Ok(GammaFactor { a, b, c, e })
+    };
+    let one_plus = |arg: ExprId| -> ExprId { pool.add(vec![arg, pool.integer(1_i32)]) };
+    match (name, args.len()) {
+        ("gamma", 1) => Ok(ProperTerm {
+            rat: RatK::one(),
+            z: Rational::from(1),
+            w: Rational::from(1),
+            gammas: vec![gamma_of(args[0], 1)?],
+        }),
+        ("factorial", 1) => Ok(ProperTerm {
+            rat: RatK::one(),
+            z: Rational::from(1),
+            w: Rational::from(1),
+            gammas: vec![gamma_of(one_plus(args[0]), 1)?],
+        }),
+        ("binomial", 2) => {
+            let top = one_plus(args[0]);
+            let bot = one_plus(args[1]);
+            let rest = pool.add(vec![
+                args[0],
+                pool.mul(vec![args[1], pool.integer(-1_i32)]),
+                pool.integer(1_i32),
+            ]);
+            Ok(ProperTerm {
+                rat: RatK::one(),
+                z: Rational::from(1),
+                w: Rational::from(1),
+                gammas: vec![gamma_of(top, 1)?, gamma_of(bot, -1)?, gamma_of(rest, -1)?],
+            })
+        }
+        ("pochhammer", 2) => {
+            // (a)_m = Γ(a + m)/Γ(a)
+            let sum = pool.add(vec![args[0], args[1]]);
+            Ok(ProperTerm {
+                rat: RatK::one(),
+                z: Rational::from(1),
+                w: Rational::from(1),
+                gammas: vec![gamma_of(sum, 1)?, gamma_of(args[0], -1)?],
+            })
+        }
+        _ => Err(HolonomicError::NotProperHypergeometric(format!(
+            "function `{name}/{}` is not part of the proper hypergeometric class \
+             (supported: gamma, factorial, binomial, pochhammer)",
+            args.len()
+        ))),
+    }
+}
+
+/// Evaluate an expression inside the field `Q(n)(k)`, or `None` if it leaves it.
+pub fn as_ratk(expr: ExprId, n: ExprId, k: ExprId, pool: &ExprPool, depth: usize) -> Option<RatK> {
+    if depth > MAX_PARSE_DEPTH {
+        return None;
+    }
+    if expr == k {
+        return Some(RatK::k());
+    }
+    if expr == n {
+        return Some(RatK::from_rn(rn_var()));
+    }
+    match pool.get(expr) {
+        ExprData::Integer(i) => Some(RatK::from_rn(rn_rat(Rational::from(i.0.clone())))),
+        ExprData::Rational(r) => Some(RatK::from_rn(rn_rat(r.0.clone()))),
+        ExprData::Add(args) => {
+            let mut acc = RatK::zero();
+            for a in args {
+                acc = acc.add(&as_ratk(a, n, k, pool, depth + 1)?);
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc = RatK::one();
+            for a in args {
+                acc = acc.mul(&as_ratk(a, n, k, pool, depth + 1)?);
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            let e = as_i32(exp, pool)?;
+            if e.unsigned_abs() > MAX_POW as u32 {
+                return None;
+            }
+            as_ratk(base, n, k, pool, depth + 1)?.pow_i32(e)
+        }
+        _ => None,
+    }
+}
+
+fn as_rational(expr: ExprId, pool: &ExprPool) -> Option<Rational> {
+    match pool.get(expr) {
+        ExprData::Integer(i) => Some(Rational::from(i.0.clone())),
+        ExprData::Rational(r) => Some(r.0.clone()),
+        _ => None,
+    }
+}
+
+fn as_i32(expr: ExprId, pool: &ExprPool) -> Option<i32> {
+    match pool.get(expr) {
+        ExprData::Integer(i) => i.0.to_i32(),
+        _ => None,
+    }
+}
+
+/// Decompose an expression as `a·n + b·k + c` with `a, b ∈ Z` and `c ∈ Q`.
+pub fn affine_parts(
+    expr: ExprId,
+    n: ExprId,
+    k: ExprId,
+    pool: &ExprPool,
+) -> Option<(i64, i64, Rational)> {
+    let r = as_ratk(expr, n, k, pool, 0)?;
+    if r.den.degree() != 0 {
+        return None;
+    }
+    let den_c = r.den.coeff(0);
+    if rn_is_zero(&den_c) {
+        return None;
+    }
+    let inv = super::qfield::rn_inv(&den_c)?;
+    let num = r.num.scale(&inv);
+    if num.degree() > 1 {
+        return None;
+    }
+    let b_rn = num.coeff(1);
+    let b = rn_as_rational(&b_rn)?;
+    if *b.clone().denom() != 1 {
+        return None;
+    }
+    let b_i = b.numer().to_i64()?;
+    let (a, c) = rn_as_linear(&num.coeff(0))?;
+    if *a.clone().denom() != 1 {
+        return None;
+    }
+    let a_i = a.numer().to_i64()?;
+    Some((a_i, b_i, c))
+}
+
+fn rn_as_rational(r: &Rn) -> Option<Rational> {
+    if r.num.degree() > 0 || r.den.degree() > 0 {
+        return None;
+    }
+    let num = r
+        .num
+        .coeffs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0));
+    let den = r
+        .den
+        .coeffs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0));
+    if den == 0 {
+        return None;
+    }
+    Some(num / den)
+}
+
+/// Write `r ∈ Q(n)` as `a·n + c`, or `None` if it is not linear in `n`.
+fn rn_as_linear(r: &Rn) -> Option<(Rational, Rational)> {
+    if r.den.degree() > 0 {
+        return None;
+    }
+    let den = r
+        .den
+        .coeffs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0));
+    if den == 0 {
+        return None;
+    }
+    if r.num.degree() > 1 {
+        return None;
+    }
+    let c0 = r
+        .num
+        .coeffs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0));
+    let c1 = r
+        .num
+        .coeffs
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0));
+    Some((c1 / den.clone(), c0 / den))
+}
+
+// ---------------------------------------------------------------------------
+// Algebra → expression bridge
+// ---------------------------------------------------------------------------
+
+fn rational_to_expr(pool: &ExprPool, q: &Rational) -> ExprId {
+    let (num, den) = (q.numer().clone(), q.denom().clone());
+    if den == 1 {
+        pool.integer(num)
+    } else {
+        pool.rational(num, den)
+    }
+}
+
+/// A `Q[n]` polynomial as an expression in `n`.
+pub fn ratuni_to_expr(
+    pool: &ExprPool,
+    n: ExprId,
+    p: &crate::matrix::normal_form::RatUniPoly,
+) -> ExprId {
+    let mut terms = Vec::new();
+    for (deg, c) in p.coeffs.iter().enumerate() {
+        if *c == 0 {
+            continue;
+        }
+        let ce = rational_to_expr(pool, c);
+        let t = match deg {
+            0 => ce,
+            1 => pool.mul(vec![ce, n]),
+            d => pool.mul(vec![ce, pool.pow(n, pool.integer(d as i64))]),
+        };
+        terms.push(t);
+    }
+    match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    }
+}
+
+/// An element of `Q(n)` as an expression in `n`.
+pub fn rn_to_expr(pool: &ExprPool, n: ExprId, r: &Rn) -> ExprId {
+    let num = ratuni_to_expr(pool, n, &r.num);
+    if r.den.degree() == 0 && r.den.coeffs.first().map(|c| *c == 1).unwrap_or(false) {
+        return num;
+    }
+    let den = ratuni_to_expr(pool, n, &r.den);
+    pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))])
+}
+
+/// A `Q(n)[k]` polynomial as an expression in `n` and `k`.
+pub fn polyk_to_expr(pool: &ExprPool, n: ExprId, k: ExprId, p: &PolyK) -> ExprId {
+    let mut terms = Vec::new();
+    for (deg, c) in p.coeffs.iter().enumerate() {
+        if rn_is_zero(c) {
+            continue;
+        }
+        let ce = rn_to_expr(pool, n, c);
+        let t = match deg {
+            0 => ce,
+            1 => pool.mul(vec![ce, k]),
+            d => pool.mul(vec![ce, pool.pow(k, pool.integer(d as i64))]),
+        };
+        terms.push(t);
+    }
+    match terms.len() {
+        0 => pool.integer(0_i32),
+        1 => terms[0],
+        _ => pool.add(terms),
+    }
+}
+
+/// An element of `Q(n, k)` as an expression.
+pub fn ratk_to_expr(pool: &ExprPool, n: ExprId, k: ExprId, r: &RatK) -> ExprId {
+    let num = polyk_to_expr(pool, n, k, &r.num);
+    if r.den.degree() == 0 {
+        let c = r.den.coeff(0);
+        if rn_is_zero(&c) {
+            return num;
+        }
+        if r.den.eq_poly(&PolyK::one()) {
+            return num;
+        }
+    }
+    let den = polyk_to_expr(pool, n, k, &r.den);
+    pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))])
+}
+
+/// Convenience: `1` as a `Q(n)` element (used by callers building terms).
+pub fn rn_unit() -> Rn {
+    rn_one()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn nk(pool: &ExprPool) -> (ExprId, ExprId) {
+        (
+            pool.symbol("n", Domain::Real),
+            pool.symbol("k", Domain::Real),
+        )
+    }
+
+    fn binom(pool: &ExprPool, n: ExprId, k: ExprId) -> ExprId {
+        let g1 = pool.func("gamma", vec![pool.add(vec![n, pool.integer(1_i32)])]);
+        let g2 = pool.func("gamma", vec![pool.add(vec![k, pool.integer(1_i32)])]);
+        let g3 = pool.func(
+            "gamma",
+            vec![pool.add(vec![
+                n,
+                pool.mul(vec![k, pool.integer(-1_i32)]),
+                pool.integer(1_i32),
+            ])],
+        );
+        pool.mul(vec![
+            g1,
+            pool.pow(g2, pool.integer(-1_i32)),
+            pool.pow(g3, pool.integer(-1_i32)),
+        ])
+    }
+
+    #[test]
+    fn binomial_ratios_are_exact() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let t = ProperTerm::parse(binom(&pool, n, k), n, k, &pool).expect("parse C(n,k)");
+        // F(n,k+1)/F(n,k) = (n-k)/(k+1)
+        let rk = t.ratio_k().expect("k ratio");
+        let want = RatK {
+            num: PolyK::from_coeffs(vec![rn_var(), rn_int(-1)]),
+            den: PolyK::from_coeffs(vec![rn_one(), rn_one()]),
+        }
+        .normalize();
+        assert!(rk.eq_ratk(&want), "got {rk:?}");
+        // F(n+1,k)/F(n,k) = (n+1)/(n+1-k)
+        let rn1 = t.ratio_n(1).expect("n ratio");
+        let want2 = RatK {
+            num: PolyK::constant(rn_add(&rn_var(), &rn_one())),
+            den: PolyK::from_coeffs(vec![rn_add(&rn_var(), &rn_one()), rn_int(-1)]),
+        }
+        .normalize();
+        assert!(rn1.eq_ratk(&want2), "got {rn1:?}");
+    }
+
+    #[test]
+    fn binomial_func_head_parses_like_gammas() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let via_func = ProperTerm::parse(pool.func("binomial", vec![n, k]), n, k, &pool)
+            .expect("parse binomial()");
+        let via_gamma = ProperTerm::parse(binom(&pool, n, k), n, k, &pool).expect("parse gammas");
+        assert!(via_func
+            .ratio_k()
+            .unwrap()
+            .eq_ratk(&via_gamma.ratio_k().unwrap()));
+        assert!(via_func
+            .ratio_n(1)
+            .unwrap()
+            .eq_ratk(&via_gamma.ratio_n(1).unwrap()));
+    }
+
+    #[test]
+    fn geometric_factor_is_recognised() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        // (-1)^k · 2^n
+        let e = pool.mul(vec![
+            pool.pow(pool.integer(-1_i32), k),
+            pool.pow(pool.integer(2_i32), n),
+        ]);
+        let t = ProperTerm::parse(e, n, k, &pool).expect("parse");
+        assert_eq!(t.z, Rational::from(-1));
+        assert_eq!(t.w, Rational::from(2));
+        assert!(t.ratio_k().unwrap().eq_ratk(&RatK::from_rn(rn_int(-1))));
+        assert!(t.ratio_n(1).unwrap().eq_ratk(&RatK::from_rn(rn_int(2))));
+    }
+
+    #[test]
+    fn non_hypergeometric_input_is_refused() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let e = pool.func("sin", vec![k]);
+        assert!(ProperTerm::parse(e, n, k, &pool).is_err());
+        // symbolic base with symbolic exponent
+        let x = pool.symbol("x", Domain::Real);
+        let e2 = pool.pow(x, k);
+        assert!(ProperTerm::parse(e2, n, k, &pool).is_err());
+    }
+}

--- a/alkahest-core/src/holonomic/mod.rs
+++ b/alkahest-core/src/holonomic/mod.rs
@@ -9,14 +9,14 @@
 //!   (rational prefactor times `z^k w^n` times a product of
 //!   `Γ(a·n + b·k + c)^e` factors with integer `a, b`) and their exact shift
 //!   ratios `F(n,k+1)/F(n,k)` and `F(n+i,k)/F(n,k)`.
-//! - [`zeilberger`] — Zeilberger's creative-telescoping algorithm: given a
+//! - [`mod@zeilberger`] — Zeilberger's creative-telescoping algorithm: given a
 //!   proper hypergeometric `F(n, k)`, find a P-recursive relation
 //!   `Σ_i a_i(n)·F(n+i,k) = G(n,k+1) − G(n,k)` with `G = R·F` and `R` an
 //!   exact rational-function certificate.
 //!
 //! Every certificate this module returns is checked as an *exact* identity
 //! in `Q(n)(k)` before it is handed back to the caller — see
-//! [`zeilberger::zeilberger`] — so a successful call is a proof, not a
+//! [`zeilberger::zeilberger()`] — so a successful call is a proof, not a
 //! heuristic match.  When the search is inconclusive (order/degree bounds
 //! exhausted) or the input is outside the supported class, the module
 //! refuses via [`HolonomicError`] rather than guessing.

--- a/alkahest-core/src/holonomic/mod.rs
+++ b/alkahest-core/src/holonomic/mod.rs
@@ -1,0 +1,108 @@
+//! Holonomic (D-finite) machinery: creative telescoping, Zeilberger's
+//! algorithm, and exact `Q(n)` / `Q(n)(k)` arithmetic in support of both.
+//!
+//! # Scope of this module
+//!
+//! - [`qfield`] — exact arithmetic in the field `Q(n)` and the polynomial /
+//!   rational-function towers `Q(n)[k]`, `Q(n)(k)` built on top of it.
+//! - [`hyperterm`] — recognition of *proper hypergeometric terms* `F(n, k)`
+//!   (rational prefactor times `z^k w^n` times a product of
+//!   `Γ(a·n + b·k + c)^e` factors with integer `a, b`) and their exact shift
+//!   ratios `F(n,k+1)/F(n,k)` and `F(n+i,k)/F(n,k)`.
+//! - [`zeilberger`] — Zeilberger's creative-telescoping algorithm: given a
+//!   proper hypergeometric `F(n, k)`, find a P-recursive relation
+//!   `Σ_i a_i(n)·F(n+i,k) = G(n,k+1) − G(n,k)` with `G = R·F` and `R` an
+//!   exact rational-function certificate.
+//!
+//! Every certificate this module returns is checked as an *exact* identity
+//! in `Q(n)(k)` before it is handed back to the caller — see
+//! [`zeilberger::zeilberger`] — so a successful call is a proof, not a
+//! heuristic match.  When the search is inconclusive (order/degree bounds
+//! exhausted) or the input is outside the supported class, the module
+//! refuses via [`HolonomicError`] rather than guessing.
+//!
+//! Ore-operator closure (`ore.rs`) and recurrence/ODE guessing from finite
+//! data (`guess.rs`) are tracked as follow-up work and are not part of this
+//! module yet; see `ROADMAP.md` (P1 item 7).
+
+pub mod hyperterm;
+pub mod qfield;
+pub mod zeilberger;
+
+pub use hyperterm::{GammaFactor, ProperTerm};
+pub use qfield::{PolyK, RatK, Rn};
+pub use zeilberger::{zeilberger, ZeilbergerOpts, ZeilbergerResult};
+
+use std::fmt;
+
+/// Errors from the holonomic subsystem (proper-hypergeometric recognition
+/// and Zeilberger's algorithm).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HolonomicError {
+    /// The input expression does not fit the proper hypergeometric class
+    /// this module supports (rational prefactor times `z^k w^n` times
+    /// `Γ(a·n + b·k + c)^e` factors with `a, b ∈ ℤ`).
+    NotProperHypergeometric(String),
+    /// The bounded search (order and/or certificate degree) was exhausted
+    /// without finding a certificate that passed exact verification.
+    SearchExhausted(String),
+    /// A candidate certificate was found by the search but failed the exact
+    /// `Q(n)(k)` identity check. This should not happen for a correct
+    /// implementation on a genuinely proper hypergeometric input; it is
+    /// refused rather than returned unverified.
+    CertificateVerificationFailed(String),
+    /// Malformed call (e.g. `n` and `k` not distinct, non-positive bounds).
+    InvalidInput(String),
+}
+
+impl fmt::Display for HolonomicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HolonomicError::NotProperHypergeometric(s) => {
+                write!(f, "holonomic: not a proper hypergeometric term: {s}")
+            }
+            HolonomicError::SearchExhausted(s) => {
+                write!(f, "holonomic: search exhausted: {s}")
+            }
+            HolonomicError::CertificateVerificationFailed(s) => {
+                write!(f, "holonomic: certificate failed exact verification: {s}")
+            }
+            HolonomicError::InvalidInput(s) => {
+                write!(f, "holonomic: invalid input: {s}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HolonomicError {}
+
+impl crate::errors::AlkahestError for HolonomicError {
+    fn code(&self) -> &'static str {
+        match self {
+            HolonomicError::NotProperHypergeometric(_) => "E-HOLO-001",
+            HolonomicError::SearchExhausted(_) => "E-HOLO-002",
+            HolonomicError::CertificateVerificationFailed(_) => "E-HOLO-003",
+            HolonomicError::InvalidInput(_) => "E-HOLO-004",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        Some(match self {
+            HolonomicError::NotProperHypergeometric(_) => {
+                "rewrite the term as R(n,k)*z**k*w**n*prod(gamma(a*n + b*k + c)**e) with \
+                 integer a, b and rational c; supported function heads are gamma, factorial, \
+                 binomial, pochhammer"
+            }
+            HolonomicError::SearchExhausted(_) => {
+                "raise max_order and/or max_degree in ZeilbergerOpts; if the term genuinely \
+                 has no such recurrence within reach, Zeilberger's algorithm does not apply"
+            }
+            HolonomicError::CertificateVerificationFailed(_) => {
+                "internal: report the term as a minimal failing example"
+            }
+            HolonomicError::InvalidInput(_) => {
+                "n and k must be distinct symbols; max_order and max_degree must be positive"
+            }
+        })
+    }
+}

--- a/alkahest-core/src/holonomic/qfield.rs
+++ b/alkahest-core/src/holonomic/qfield.rs
@@ -8,7 +8,7 @@
 //!
 //! Nothing here is approximate: every operation is exact rational arithmetic,
 //! which is what makes the final certificate check in
-//! [`super::zeilberger`] a proof rather than a spot check.
+//! [`super::zeilberger::zeilberger()`] a proof rather than a spot check.
 
 use crate::matrix::normal_form::RatUniPoly;
 use crate::sum::RatFunc;

--- a/alkahest-core/src/holonomic/qfield.rs
+++ b/alkahest-core/src/holonomic/qfield.rs
@@ -1,0 +1,663 @@
+//! Exact arithmetic in `Q(n)` and `Q(n)(k)`.
+//!
+//! Creative telescoping needs a *field* of coefficients for the linear algebra
+//! (the unknowns `a_i(n)` and the certificate coefficients live in `Q(n)`) and a
+//! ring of polynomials over it (the `k`-side of the Gosper equation).  This
+//! module supplies both, on top of [`RatUniPoly`] (dense `Q[x]`) and
+//! [`RatFunc`] (reduced `Q(x)`), which already exist for Gosper summation.
+//!
+//! Nothing here is approximate: every operation is exact rational arithmetic,
+//! which is what makes the final certificate check in
+//! [`super::zeilberger`] a proof rather than a spot check.
+
+use crate::matrix::normal_form::RatUniPoly;
+use crate::sum::RatFunc;
+use rug::{Integer, Rational};
+
+/// An element of `Q(n)` — a reduced rational function in the outer variable.
+pub type Rn = RatFunc;
+
+pub fn rn_zero() -> Rn {
+    RatFunc::zero()
+}
+
+pub fn rn_one() -> Rn {
+    RatFunc::one()
+}
+
+pub fn rn_int(i: i64) -> Rn {
+    RatFunc::scalar(Rational::from(i))
+}
+
+pub fn rn_rat(q: Rational) -> Rn {
+    RatFunc::scalar(q)
+}
+
+/// The generator `n` itself.
+pub fn rn_var() -> Rn {
+    RatFunc::from_poly(RatUniPoly::x())
+}
+
+pub fn rn_poly(p: RatUniPoly) -> Rn {
+    RatFunc::from_poly(p).normalize()
+}
+
+pub fn rn_is_zero(a: &Rn) -> bool {
+    a.num.is_zero()
+}
+
+pub fn rn_add(a: &Rn, b: &Rn) -> Rn {
+    a.clone() + b.clone()
+}
+
+pub fn rn_neg(a: &Rn) -> Rn {
+    -a.clone()
+}
+
+pub fn rn_sub(a: &Rn, b: &Rn) -> Rn {
+    a.clone() + (-b.clone())
+}
+
+pub fn rn_mul(a: &Rn, b: &Rn) -> Rn {
+    a.mul_ratfunc(b)
+}
+
+pub fn rn_inv(a: &Rn) -> Option<Rn> {
+    a.inv()
+}
+
+pub fn rn_div(a: &Rn, b: &Rn) -> Option<Rn> {
+    Some(rn_mul(a, &rn_inv(b)?))
+}
+
+pub fn rn_eq(a: &Rn, b: &Rn) -> bool {
+    rn_is_zero(&rn_sub(a, b))
+}
+
+/// `a(n + i)`.
+pub fn rn_shift(a: &Rn, i: i64) -> Rn {
+    if i == 0 {
+        return a.clone();
+    }
+    a.compose_affine_arg(&Rational::from(1), &Rational::from(i))
+}
+
+fn poly_deriv(p: &RatUniPoly) -> RatUniPoly {
+    if p.coeffs.len() <= 1 {
+        return RatUniPoly::zero();
+    }
+    let coeffs: Vec<Rational> = p
+        .coeffs
+        .iter()
+        .enumerate()
+        .skip(1)
+        .map(|(i, c)| c.clone() * Rational::from(i as i64))
+        .collect();
+    RatUniPoly { coeffs }.trim()
+}
+
+/// `d/dn` of a rational function.
+pub fn rn_deriv(a: &Rn) -> Rn {
+    let nu = poly_deriv(&a.num);
+    let dv = poly_deriv(&a.den);
+    let num = &(&nu * &a.den) - &(&a.num * &dv);
+    let den = &a.den * &a.den;
+    RatFunc { num, den }.normalize()
+}
+
+fn poly_eval(p: &RatUniPoly, x: &Rational) -> Rational {
+    let mut acc = Rational::from(0);
+    for c in p.coeffs.iter().rev() {
+        acc *= x.clone();
+        acc += c.clone();
+    }
+    acc
+}
+
+/// Evaluate at a rational point; `None` at a pole.
+pub fn rn_eval(a: &Rn, x: &Rational) -> Option<Rational> {
+    let d = poly_eval(&a.den, x);
+    if d == 0 {
+        return None;
+    }
+    Some(poly_eval(&a.num, x) / d)
+}
+
+/// Clear denominators across a slice of `Q(n)` elements, returning integer
+/// primitive polynomials in `n` that are proportional to the input.
+///
+/// The scaling is common to all entries, so a linear relation with these
+/// coefficients holds exactly when it held for the input.
+pub fn clear_denominators(items: &[Rn]) -> Vec<RatUniPoly> {
+    // Common denominator: product of denominators reduced by pairwise gcd.
+    let mut common = RatUniPoly::one();
+    for it in items {
+        if it.den.is_zero() {
+            continue;
+        }
+        let g = common.gcd(&it.den);
+        let (q, _) = RatUniPoly::div_rem(&it.den, &g);
+        common = &common * &q;
+    }
+    let mut out: Vec<RatUniPoly> = Vec::with_capacity(items.len());
+    for it in items {
+        let (mult, _) = RatUniPoly::div_rem(&common, &it.den);
+        out.push((&it.num * &mult).trim());
+    }
+    make_primitive(&mut out);
+    out
+}
+
+/// Scale a family of rational polynomials by one common rational so that all
+/// coefficients are integers with overall content 1 and a positive leading
+/// coefficient on the last non-zero entry.
+pub fn make_primitive(polys: &mut [RatUniPoly]) {
+    let mut den_lcm = Integer::from(1);
+    for p in polys.iter() {
+        for c in &p.coeffs {
+            den_lcm = den_lcm.lcm(&c.clone().denom().clone());
+        }
+    }
+    let scale = Rational::from(den_lcm);
+    for p in polys.iter_mut() {
+        for c in p.coeffs.iter_mut() {
+            *c *= scale.clone();
+        }
+    }
+    let mut content = Integer::from(0);
+    for p in polys.iter() {
+        for c in &p.coeffs {
+            content = content.gcd(&c.clone().numer().clone());
+        }
+    }
+    if content != 0 && content != 1 {
+        let inv = Rational::from((Integer::from(1), content));
+        for p in polys.iter_mut() {
+            for c in p.coeffs.iter_mut() {
+                *c *= inv.clone();
+            }
+        }
+    }
+    let sign_ref = polys
+        .iter()
+        .rev()
+        .find(|p| !p.is_zero())
+        .map(|p| p.leading_coeff());
+    if let Some(lc) = sign_ref {
+        if lc < 0 {
+            for p in polys.iter_mut() {
+                for c in p.coeffs.iter_mut() {
+                    *c *= Rational::from(-1);
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Q(n)[k]
+// ---------------------------------------------------------------------------
+
+/// A polynomial in `k` with coefficients in `Q(n)` (ascending order).
+#[derive(Clone, Debug)]
+pub struct PolyK {
+    pub coeffs: Vec<Rn>,
+}
+
+impl PolyK {
+    pub fn zero() -> Self {
+        PolyK { coeffs: vec![] }
+    }
+
+    pub fn one() -> Self {
+        PolyK {
+            coeffs: vec![rn_one()],
+        }
+    }
+
+    pub fn constant(c: Rn) -> Self {
+        PolyK { coeffs: vec![c] }.trim()
+    }
+
+    /// The polynomial `k`.
+    pub fn k() -> Self {
+        PolyK {
+            coeffs: vec![rn_zero(), rn_one()],
+        }
+    }
+
+    pub fn from_coeffs(coeffs: Vec<Rn>) -> Self {
+        PolyK { coeffs }.trim()
+    }
+
+    pub fn trim(mut self) -> Self {
+        while self.coeffs.last().map(rn_is_zero).unwrap_or(false) {
+            self.coeffs.pop();
+        }
+        self
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.coeffs.iter().all(rn_is_zero)
+    }
+
+    /// Degree, or `-1` for the zero polynomial.
+    pub fn degree(&self) -> i32 {
+        let mut d = self.coeffs.len() as i32 - 1;
+        while d >= 0 && rn_is_zero(&self.coeffs[d as usize]) {
+            d -= 1;
+        }
+        d
+    }
+
+    pub fn coeff(&self, i: usize) -> Rn {
+        self.coeffs.get(i).cloned().unwrap_or_else(rn_zero)
+    }
+
+    pub fn leading_coeff(&self) -> Rn {
+        let d = self.degree();
+        if d < 0 {
+            rn_zero()
+        } else {
+            self.coeff(d as usize)
+        }
+    }
+
+    pub fn add(&self, other: &PolyK) -> PolyK {
+        let n = self.coeffs.len().max(other.coeffs.len());
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            out.push(rn_add(&self.coeff(i), &other.coeff(i)));
+        }
+        PolyK { coeffs: out }.trim()
+    }
+
+    pub fn neg(&self) -> PolyK {
+        PolyK {
+            coeffs: self.coeffs.iter().map(rn_neg).collect(),
+        }
+    }
+
+    pub fn sub(&self, other: &PolyK) -> PolyK {
+        self.add(&other.neg())
+    }
+
+    pub fn mul(&self, other: &PolyK) -> PolyK {
+        if self.is_zero() || other.is_zero() {
+            return PolyK::zero();
+        }
+        let mut out = vec![rn_zero(); self.coeffs.len() + other.coeffs.len() - 1];
+        for (i, a) in self.coeffs.iter().enumerate() {
+            if rn_is_zero(a) {
+                continue;
+            }
+            for (j, b) in other.coeffs.iter().enumerate() {
+                if rn_is_zero(b) {
+                    continue;
+                }
+                out[i + j] = rn_add(&out[i + j], &rn_mul(a, b));
+            }
+        }
+        PolyK { coeffs: out }.trim()
+    }
+
+    pub fn scale(&self, c: &Rn) -> PolyK {
+        if rn_is_zero(c) {
+            return PolyK::zero();
+        }
+        PolyK {
+            coeffs: self.coeffs.iter().map(|a| rn_mul(a, c)).collect(),
+        }
+        .trim()
+    }
+
+    /// Euclidean division over the field `Q(n)`.
+    pub fn div_rem(a: &PolyK, b: &PolyK) -> Option<(PolyK, PolyK)> {
+        if b.is_zero() {
+            return None;
+        }
+        let db = b.degree();
+        let lb = b.leading_coeff();
+        let lb_inv = rn_inv(&lb)?;
+        let mut rem = a.clone().trim();
+        let mut quot = vec![rn_zero(); ((a.degree() - db).max(-1) + 1).max(0) as usize];
+        while rem.degree() >= db && !rem.is_zero() {
+            let shift = (rem.degree() - db) as usize;
+            let t = rn_mul(&rem.leading_coeff(), &lb_inv);
+            if shift >= quot.len() {
+                quot.resize(shift + 1, rn_zero());
+            }
+            quot[shift] = rn_add(&quot[shift], &t);
+            let mut sub_coeffs = vec![rn_zero(); shift];
+            sub_coeffs.extend(b.coeffs.iter().map(|c| rn_mul(c, &t)));
+            let sub = PolyK { coeffs: sub_coeffs };
+            rem = rem.sub(&sub);
+        }
+        Some((PolyK { coeffs: quot }.trim(), rem.trim()))
+    }
+
+    pub fn exact_div(a: &PolyK, b: &PolyK) -> Option<PolyK> {
+        let (q, r) = PolyK::div_rem(a, b)?;
+        if r.is_zero() {
+            Some(q)
+        } else {
+            None
+        }
+    }
+
+    /// Monic gcd over `Q(n)`.
+    pub fn gcd(a: &PolyK, b: &PolyK) -> PolyK {
+        let mut x = a.clone().trim();
+        let mut y = b.clone().trim();
+        if x.degree() < y.degree() {
+            std::mem::swap(&mut x, &mut y);
+        }
+        while !y.is_zero() {
+            let Some((_, r)) = PolyK::div_rem(&x, &y) else {
+                return PolyK::one();
+            };
+            x = y;
+            y = r;
+        }
+        if x.is_zero() {
+            PolyK::zero()
+        } else {
+            x.monic()
+        }
+    }
+
+    pub fn monic(&self) -> PolyK {
+        let lc = self.leading_coeff();
+        match rn_inv(&lc) {
+            Some(inv) => self.scale(&inv),
+            None => self.clone(),
+        }
+    }
+
+    /// `p(k + j)`.
+    pub fn shift_k(&self, j: i64) -> PolyK {
+        if j == 0 || self.is_zero() {
+            return self.clone().trim();
+        }
+        let kj = PolyK {
+            coeffs: vec![rn_int(j), rn_one()],
+        };
+        let mut acc = PolyK::zero();
+        let mut pow = PolyK::one();
+        for c in &self.coeffs {
+            acc = acc.add(&pow.scale(c));
+            pow = pow.mul(&kj);
+        }
+        acc.trim()
+    }
+
+    /// `p` with `n ↦ n + i` applied to every coefficient.
+    pub fn shift_n(&self, i: i64) -> PolyK {
+        if i == 0 {
+            return self.clone();
+        }
+        PolyK {
+            coeffs: self.coeffs.iter().map(|c| rn_shift(c, i)).collect(),
+        }
+        .trim()
+    }
+
+    pub fn eq_poly(&self, other: &PolyK) -> bool {
+        self.sub(other).is_zero()
+    }
+
+    /// `lcm` via `a·b/gcd`.
+    pub fn lcm(a: &PolyK, b: &PolyK) -> PolyK {
+        if a.is_zero() || b.is_zero() {
+            return PolyK::zero();
+        }
+        let g = PolyK::gcd(a, b);
+        let prod = a.mul(b);
+        PolyK::exact_div(&prod, &g).unwrap_or(prod)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Q(n)(k)
+// ---------------------------------------------------------------------------
+
+/// A rational function in `k` over `Q(n)` — i.e. an element of `Q(n, k)`.
+#[derive(Clone, Debug)]
+pub struct RatK {
+    pub num: PolyK,
+    pub den: PolyK,
+}
+
+impl RatK {
+    pub fn zero() -> Self {
+        RatK {
+            num: PolyK::zero(),
+            den: PolyK::one(),
+        }
+    }
+
+    pub fn one() -> Self {
+        RatK {
+            num: PolyK::one(),
+            den: PolyK::one(),
+        }
+    }
+
+    pub fn from_poly(p: PolyK) -> Self {
+        RatK {
+            num: p,
+            den: PolyK::one(),
+        }
+        .normalize()
+    }
+
+    pub fn from_rn(c: Rn) -> Self {
+        RatK::from_poly(PolyK::constant(c))
+    }
+
+    pub fn k() -> Self {
+        RatK::from_poly(PolyK::k())
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.num.is_zero()
+    }
+
+    pub fn normalize(mut self) -> Self {
+        if self.num.is_zero() {
+            return RatK::zero();
+        }
+        if self.den.is_zero() {
+            return self;
+        }
+        let g = PolyK::gcd(&self.num, &self.den);
+        if g.degree() > 0 {
+            if let Some(n2) = PolyK::exact_div(&self.num, &g) {
+                if let Some(d2) = PolyK::exact_div(&self.den, &g) {
+                    self.num = n2;
+                    self.den = d2;
+                }
+            }
+        }
+        // Make the denominator monic in k with a `Q(n)` leading coefficient of 1.
+        let lc = self.den.leading_coeff();
+        if let Some(inv) = rn_inv(&lc) {
+            self.num = self.num.scale(&inv);
+            self.den = self.den.scale(&inv);
+        }
+        self
+    }
+
+    pub fn add(&self, other: &RatK) -> RatK {
+        RatK {
+            num: self.num.mul(&other.den).add(&other.num.mul(&self.den)),
+            den: self.den.mul(&other.den),
+        }
+        .normalize()
+    }
+
+    pub fn neg(&self) -> RatK {
+        RatK {
+            num: self.num.neg(),
+            den: self.den.clone(),
+        }
+    }
+
+    pub fn sub(&self, other: &RatK) -> RatK {
+        self.add(&other.neg())
+    }
+
+    pub fn mul(&self, other: &RatK) -> RatK {
+        RatK {
+            num: self.num.mul(&other.num),
+            den: self.den.mul(&other.den),
+        }
+        .normalize()
+    }
+
+    pub fn inv(&self) -> Option<RatK> {
+        if self.num.is_zero() {
+            return None;
+        }
+        Some(
+            RatK {
+                num: self.den.clone(),
+                den: self.num.clone(),
+            }
+            .normalize(),
+        )
+    }
+
+    pub fn div(&self, other: &RatK) -> Option<RatK> {
+        Some(self.mul(&other.inv()?))
+    }
+
+    pub fn pow_i32(&self, e: i32) -> Option<RatK> {
+        if e == 0 {
+            return Some(RatK::one());
+        }
+        let base = if e < 0 { self.inv()? } else { self.clone() };
+        let mut acc = RatK::one();
+        for _ in 0..e.unsigned_abs() {
+            acc = acc.mul(&base);
+        }
+        Some(acc)
+    }
+
+    pub fn shift_k(&self, j: i64) -> RatK {
+        RatK {
+            num: self.num.shift_k(j),
+            den: self.den.shift_k(j),
+        }
+        .normalize()
+    }
+
+    pub fn shift_n(&self, i: i64) -> RatK {
+        RatK {
+            num: self.num.shift_n(i),
+            den: self.den.shift_n(i),
+        }
+        .normalize()
+    }
+
+    pub fn eq_ratk(&self, other: &RatK) -> bool {
+        self.sub(other).is_zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rn_of(coeffs: &[i64]) -> Rn {
+        rn_poly(
+            RatUniPoly {
+                coeffs: coeffs.iter().map(|c| Rational::from(*c)).collect(),
+            }
+            .trim(),
+        )
+    }
+
+    #[test]
+    fn rn_basic_field_ops() {
+        let n = rn_var();
+        let one = rn_one();
+        let a = rn_add(&n, &one); // n + 1
+        let b = rn_sub(&n, &one); // n - 1
+        let prod = rn_mul(&a, &b); // n^2 - 1
+        assert!(rn_eq(&prod, &rn_of(&[-1, 0, 1])));
+        let q = rn_div(&prod, &a).expect("nonzero divisor");
+        assert!(rn_eq(&q, &b));
+        assert!(rn_eq(&rn_shift(&n, 2), &rn_of(&[2, 1])));
+    }
+
+    #[test]
+    fn rn_derivative_and_eval() {
+        // d/dn (1/n) = -1/n^2
+        let n = rn_var();
+        let inv = rn_inv(&n).expect("n != 0");
+        let d = rn_deriv(&inv);
+        let expected = rn_neg(&rn_inv(&rn_mul(&n, &n)).unwrap());
+        assert!(rn_eq(&d, &expected));
+        assert_eq!(
+            rn_eval(&inv, &Rational::from(4)).unwrap(),
+            Rational::from((1, 4))
+        );
+        assert!(rn_eval(&inv, &Rational::from(0)).is_none());
+    }
+
+    #[test]
+    fn polyk_div_rem_and_gcd() {
+        // (k^2 - 1) = (k - 1)(k + 1)
+        let k = PolyK::k();
+        let one = PolyK::one();
+        let a = k.sub(&one);
+        let b = k.add(&one);
+        let p = a.mul(&b);
+        let (q, r) = PolyK::div_rem(&p, &a).expect("divide");
+        assert!(r.is_zero());
+        assert!(q.eq_poly(&b));
+        let g = PolyK::gcd(&p, &b);
+        assert!(g.eq_poly(&b.monic()));
+    }
+
+    #[test]
+    fn polyk_shift_in_both_variables() {
+        // p = k + n  ⇒  p(k+1) = k + n + 1, p with n↦n+1 = k + n + 1
+        let p = PolyK::from_coeffs(vec![rn_var(), rn_one()]);
+        let want = PolyK::from_coeffs(vec![rn_add(&rn_var(), &rn_one()), rn_one()]);
+        assert!(p.shift_k(1).eq_poly(&want));
+        assert!(p.shift_n(1).eq_poly(&want));
+    }
+
+    #[test]
+    fn ratk_arithmetic_is_exact() {
+        // 1/(k+n) + 1/(k-n) = 2k/(k^2 - n^2)
+        let n = rn_var();
+        let kp = PolyK::from_coeffs(vec![n.clone(), rn_one()]);
+        let km = PolyK::from_coeffs(vec![rn_neg(&n), rn_one()]);
+        let a = RatK::from_poly(kp.clone()).inv().unwrap();
+        let b = RatK::from_poly(km.clone()).inv().unwrap();
+        let s = a.add(&b);
+        let want = RatK {
+            num: PolyK::k().scale(&rn_int(2)),
+            den: kp.mul(&km),
+        }
+        .normalize();
+        assert!(s.eq_ratk(&want));
+    }
+
+    #[test]
+    fn clear_denominators_makes_integer_primitive() {
+        let n = rn_var();
+        let half = rn_rat(Rational::from((1, 2)));
+        let items = vec![rn_mul(&half, &n), rn_div(&rn_one(), &n).unwrap()];
+        let out = clear_denominators(&items);
+        assert_eq!(out.len(), 2);
+        for p in &out {
+            for c in &p.coeffs {
+                assert_eq!(*c.clone().denom(), Integer::from(1));
+            }
+        }
+    }
+}

--- a/alkahest-core/src/holonomic/zeilberger.rs
+++ b/alkahest-core/src/holonomic/zeilberger.rs
@@ -1,0 +1,559 @@
+//! Zeilberger's algorithm: creative telescoping for proper hypergeometric terms.
+//!
+//! Given a proper hypergeometric term `F(n, k)` (see [`super::hyperterm`]),
+//! this searches for a **P-recursive** (holonomic) relation
+//!
+//! ```text
+//! Σ_{i=0}^{J} a_i(n)·F(n+i, k) = G(n, k+1) − G(n, k),    G(n,k) = R(n,k)·F(n,k)
+//! ```
+//!
+//! with polynomial coefficients `a_i(n)` (not all zero, `a_J ≢ 0`) and an
+//! exact rational-function certificate `R(n,k)`. Summing both sides over `k`
+//! telescopes the right-hand side, so if `S(n) = Σ_k F(n,k)` then
+//! `Σ_i a_i(n)·S(n+i) = 0`: this is exactly the classical route from
+//! `Σ_k C(n,k) = 2^n` (order 1) to `Σ_k C(n,k)^2 = C(2n,n)` (order 1, higher
+//! degree certificate) and beyond.
+//!
+//! # Method
+//!
+//! This is the standard Gosper-style reduction (Petkovšek–Wilf–Zeilberger,
+//! *A=B*, ch. 6; Koepf, *Hypergeometric Summation*, ch. 7), generalized from
+//! `Q` to the field `Q(n)` using the [`super::qfield`] towers:
+//!
+//! 1. Write `p(n,k) = F(n,k+1)/F(n,k)` (a fixed element of `Q(n)(k)`,
+//!    independent of the unknown `a_i`) and, for each `i`, `c_i(n,k) =
+//!    F(n+i,k)/F(n,k)` — both computed exactly by [`super::hyperterm::ProperTerm`].
+//! 2. Take `D(k)`, a common denominator of the `c_i` over `Q(n)[k]` (known and
+//!    `a_i`-independent), and work with `W(n,k) = F(n,k)/D(k)`. Then
+//!    `Σ_i a_i·F(n+i,k) = N(k)·W(n,k)` where `N(k) = Σ_i a_i·D(k)·c_i(k)` is a
+//!    *polynomial*, linear in the unknowns. Decompose the shift ratio of `W`,
+//!    `ρ(k) = p(k)·D(k)/D(k+1)`, into Gosper normal form
+//!    `ρ = A(k)·C(k+1) / (B(k)·C(k))` over `Q(n)[k]` — the same shifted-gcd
+//!    construction as [`crate::sum::gosper::gosper_normal_form`], lifted to
+//!    the field `Q(n)`. (Normal-forming `p` itself instead of `ρ` loses the
+//!    `D` bookkeeping and the equation below has no polynomial solution even
+//!    for `F = C(n,k)`.)
+//! 3. Gosper's key equation for the term `N(k)·W(k)` is then the *polynomial*
+//!    identity `A(k)·X(k+1) − B(k−1)·X(k) = C(k)·N(k)`, linear in the unknowns
+//!    `{a_i}` and the coefficients of `X`, with
+//!    `G(n,k) = R(n,k)·F(n,k)`, `R = B(k−1)·X(k) / (C(k)·D(k))`.
+//! 4. For increasing order `J = 1, 2, …` and certificate degree `d = 0, 1,
+//!    …`, normalize the leading recurrence coefficient `a_J = 1` and solve
+//!    the resulting linear system **over the field `Q(n)`** (Gaussian
+//!    elimination with `Q(n)`-valued pivots) for the remaining `a_i` and the
+//!    coefficients of `X`.
+//! 5. [`super::qfield::clear_denominators`] turns the solved `a_i(n) ∈ Q(n)`
+//!    into an integer-content-primitive polynomial family sharing one common
+//!    scale `S(n)`; `R` is rescaled by the same `S(n)` (a `k`-independent
+//!    factor, so this preserves the identity exactly).
+//! 6. The *only* thing that makes a candidate a result: the rescaled
+//!    `(a_i, R)` pair is plugged back in and checked as an exact `Q(n)(k)`
+//!    identity (§ non-negotiable discipline — never return an unverified
+//!    certificate). Only a verified candidate is returned; a verification
+//!    failure discards the candidate and the search continues.
+
+use super::hyperterm::{ratk_to_expr, ratuni_to_expr, ProperTerm};
+use super::qfield::{
+    clear_denominators, rn_div, rn_inv, rn_is_zero, rn_mul, rn_one, rn_poly, rn_sub, rn_zero,
+    PolyK, RatK, Rn,
+};
+use super::HolonomicError;
+use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
+use crate::kernel::{ExprId, ExprPool};
+use crate::matrix::normal_form::RatUniPoly;
+
+/// Search bounds for [`zeilberger`].
+#[derive(Debug, Clone, Copy)]
+pub struct ZeilbergerOpts {
+    /// Largest recurrence order `J` to try (searched from 1 upward).
+    pub max_order: usize,
+    /// Largest certificate-polynomial degree (in `k`) to try per order.
+    pub max_degree: usize,
+}
+
+impl Default for ZeilbergerOpts {
+    fn default() -> Self {
+        ZeilbergerOpts {
+            max_order: 4,
+            max_degree: 16,
+        }
+    }
+}
+
+/// A verified Zeilberger certificate: `Σ_i coeffs[i](n)·F(n+i,k) = ΔG`,
+/// `G(n,k) = certificate(n,k)·F(n,k)`.
+#[derive(Debug, Clone)]
+pub struct ZeilbergerResult {
+    /// Recurrence order `J`; `coeffs.len() == order + 1`.
+    pub order: usize,
+    /// `a_0(n), …, a_J(n)` as expressions in `n`; integer-content-primitive,
+    /// `a_J` not identically zero.
+    pub coeffs: Vec<ExprId>,
+    /// `R(n,k)` as an expression in `n, k`, with `G(n,k) = R(n,k)·F(n,k)`.
+    pub certificate: ExprId,
+}
+
+/// `k^j` as an element of `Q(n)[k]`.
+fn k_mono(j: usize) -> PolyK {
+    let mut coeffs = vec![rn_zero(); j + 1];
+    coeffs[j] = rn_one();
+    PolyK::from_coeffs(coeffs)
+}
+
+/// Generalization of [`crate::sum::gosper::gosper_normal_form`] from `Q` to
+/// the field `Q(n)`: writes `p/q = Z·A(k)·C(k+1) / (B(k)·C(k))` with
+/// `gcd(A(k), B(k+h))` a unit for every `h ≥ 0`, `Z` folded into `A`.
+fn gosper_normal_form_qn(mut p: PolyK, mut q: PolyK) -> Option<(PolyK, PolyK, PolyK)> {
+    if p.is_zero() {
+        return Some((PolyK::zero(), PolyK::one(), PolyK::one()));
+    }
+    if q.is_zero() {
+        return None;
+    }
+    let lc_p = p.leading_coeff();
+    let lc_q = q.leading_coeff();
+    let z_scale = rn_div(&lc_p, &lc_q)?;
+    p = p.scale(&rn_inv(&lc_p)?);
+    q = q.scale(&rn_inv(&lc_q)?);
+
+    let mut a = p;
+    let mut b = q;
+    let mut c = PolyK::one();
+
+    let bound = (a.degree().max(0) + b.degree().max(0)).max(1) as usize + 32;
+
+    loop {
+        let mut found = false;
+        // `i = 0` matters: the normal form requires `gcd(A(k), B(k+h))` to be a
+        // unit for every `h ≥ 0`, *including* a plain common factor at `h = 0`.
+        // Starting at `i = 1` leaves such a factor in both `A` and `B` — which
+        // silently breaks the ansatz, so the linear system at the true minimal
+        // order has no solution and the search runs on to a larger order.
+        for i in 0..=bound {
+            let bshift = b.shift_k(i as i64);
+            let d = PolyK::gcd(&a, &bshift);
+            if d.is_zero() || d.degree() == 0 {
+                continue;
+            }
+            let Some(an) = PolyK::exact_div(&a, &d) else {
+                continue;
+            };
+            let dsmi = d.shift_k(-(i as i64));
+            let Some(bn) = PolyK::exact_div(&b, &dsmi) else {
+                continue;
+            };
+            a = an;
+            b = bn;
+            let mut prod = PolyK::one();
+            for j in 1..=i {
+                prod = prod.mul(&d.shift_k(-(j as i64)));
+            }
+            c = c.mul(&prod);
+            found = true;
+            break;
+        }
+        if !found {
+            break;
+        }
+    }
+    a = a.scale(&z_scale);
+    Some((a, b, c))
+}
+
+/// Gaussian elimination over the field `Q(n)` (as opposed to `Q`): same
+/// structure as `sum::gosper::rational_gaussian_solve`, generalized to `Rn`
+/// pivots/division. A zero column is a free variable, set to zero. Returns
+/// `None` when the system is inconsistent.
+fn field_gaussian_solve(mut mat: Vec<Vec<Rn>>, mut rhs: Vec<Rn>) -> Option<Vec<Rn>> {
+    let nrows = mat.len();
+    if nrows == 0 {
+        return Some(vec![]);
+    }
+    let ncols = mat[0].len();
+    let mut row = 0;
+    for col in 0..ncols {
+        if row >= nrows {
+            break;
+        }
+        let pr = (row..nrows).find(|&r| !rn_is_zero(&mat[r][col]));
+        let Some(pr) = pr else {
+            continue;
+        };
+        mat.swap(row, pr);
+        rhs.swap(row, pr);
+        let inv = rn_inv(&mat[row][col])?;
+        for entry in mat[row].iter_mut().skip(col) {
+            *entry = rn_mul(entry, &inv);
+        }
+        rhs[row] = rn_mul(&rhs[row], &inv);
+        let pivot_row = mat[row].clone();
+        let pivot_rhs = rhs[row].clone();
+        for r in 0..nrows {
+            if r == row {
+                continue;
+            }
+            let v = mat[r][col].clone();
+            if rn_is_zero(&v) {
+                continue;
+            }
+            for (entry, pivot) in mat[r].iter_mut().zip(pivot_row.iter()).skip(col) {
+                *entry = rn_sub(entry, &rn_mul(pivot, &v));
+            }
+            rhs[r] = rn_sub(&rhs[r], &rn_mul(&pivot_rhs, &v));
+        }
+        row += 1;
+    }
+
+    for (r, mrow) in mat.iter().enumerate() {
+        let all_zero = mrow.iter().all(rn_is_zero);
+        if all_zero && !rn_is_zero(&rhs[r]) {
+            return None;
+        }
+    }
+
+    let mut sol = vec![rn_zero(); ncols];
+    for r in (0..nrows).rev() {
+        let first = mat[r].iter().position(|e| !rn_is_zero(e));
+        if let Some(j) = first {
+            let mut sum = rhs[r].clone();
+            for cidx in (j + 1)..ncols {
+                sum = rn_sub(&sum, &rn_mul(&mat[r][cidx], &sol[cidx]));
+            }
+            sol[j] = rn_div(&sum, &mat[r][j])?;
+        }
+    }
+    Some(sol)
+}
+
+/// Solve Gosper's key equation
+///
+/// ```text
+/// A(k)·X(k+1) − B(k−1)·X(k) = C(k)·N(k),    N(k) = Σ_i a_i·C_i(k)
+/// ```
+///
+/// for a degree-`d` polynomial `X` and the recurrence coefficients
+/// `a_0..a_{order-1}` (with `a_order` normalized to `1`, so its term moves to
+/// the right-hand side). `c_ci[i]` is `C(k)·C_i(k)`. Comparing coefficients of
+/// each power of `k` gives a linear system over the field `Q(n)`; a solution
+/// exists iff the candidate `(order, d)` pair admits a certificate.
+/// Returns `(x_coeffs, lam_below_order)` on success.
+fn try_solve(
+    aa: &PolyK,
+    b_eq: &PolyK,
+    c_ci: &[PolyK],
+    order: usize,
+    d: usize,
+) -> Option<(Vec<Rn>, Vec<Rn>)> {
+    // BX_j(k) = A·(k+1)^j − B(k−1)·k^j, for j = 0..=d
+    let mut bx: Vec<PolyK> = Vec::with_capacity(d + 1);
+    for j in 0..=d {
+        let kp1j = k_mono(j).shift_k(1);
+        let kj = k_mono(j);
+        let term_a = aa.mul(&kp1j);
+        let term_b = b_eq.mul(&kj);
+        bx.push(term_a.sub(&term_b));
+    }
+
+    // max degree across every basis polynomial (including the RHS mover, c_ci[order]).
+    let mut max_deg = 0i32;
+    for p in &bx {
+        max_deg = max_deg.max(p.degree());
+    }
+    for p in c_ci {
+        max_deg = max_deg.max(p.degree());
+    }
+    if max_deg < 0 {
+        max_deg = 0;
+    }
+    let n_eq = (max_deg as usize) + 1;
+    let n_var = (d + 1) + order; // x_0..x_d, lam_0..lam_{order-1}
+
+    let mut mat = vec![vec![rn_zero(); n_var]; n_eq];
+    let mut rhs = vec![rn_zero(); n_eq];
+
+    for (m, row) in mat.iter_mut().enumerate() {
+        for (j, bxj) in bx.iter().enumerate() {
+            row[j] = bxj.coeff(m);
+        }
+        for i in 0..order {
+            row[(d + 1) + i] = super::qfield::rn_neg(&c_ci[i].coeff(m));
+        }
+        rhs[m] = c_ci[order].coeff(m);
+    }
+
+    let sol = field_gaussian_solve(mat, rhs)?;
+    let x_coeffs = sol[..=d].to_vec();
+    let lam_below = sol[(d + 1)..].to_vec();
+    Some((x_coeffs, lam_below))
+}
+
+/// Zeilberger's algorithm: find a verified P-recursive relation for a
+/// proper hypergeometric term `F(n, k)` (see module docs).
+///
+/// Refuses with [`HolonomicError`] rather than guessing when `term` is not
+/// a proper hypergeometric term in `(n, k)`, or when the bounded search in
+/// `opts` finds no certificate that passes exact verification.
+pub fn zeilberger(
+    term: ExprId,
+    n: ExprId,
+    k: ExprId,
+    pool: &ExprPool,
+    opts: &ZeilbergerOpts,
+) -> Result<DerivedExpr<ZeilbergerResult>, HolonomicError> {
+    if n == k {
+        return Err(HolonomicError::InvalidInput(
+            "the outer index n and the summation index k must be distinct symbols".into(),
+        ));
+    }
+    if opts.max_order == 0 || opts.max_degree == 0 {
+        return Err(HolonomicError::InvalidInput(
+            "max_order and max_degree must both be at least 1".into(),
+        ));
+    }
+
+    let f = ProperTerm::parse(term, n, k, pool)?;
+    let p = f.ratio_k()?;
+    for order in 1..=opts.max_order {
+        let c: Vec<RatK> = (0..=order as i64)
+            .map(|i| f.ratio_n(i))
+            .collect::<Result<_, _>>()?;
+
+        // `D(k)`: a common denominator of the shift quotients `c_i`, over
+        // `Q(n)[k]` and independent of the unknown `a_i`. Working with
+        // `W(n,k) = F(n,k)/D(k)` is what keeps the Gosper equation polynomial:
+        // `Σ_i a_i·F(n+i,k) = N(k)·W(n,k)` with `N = Σ_i a_i·C_i` polynomial
+        // and linear in the unknowns.
+        let mut dden = PolyK::one();
+        for ci in &c {
+            dden = PolyK::lcm(&dden, &ci.den);
+        }
+        if dden.is_zero() {
+            continue;
+        }
+        // `C_i(k) = D(k)·c_i(k) ∈ Q(n)[k]` — polynomial by construction of `D`.
+        let ci_polys: Option<Vec<PolyK>> = c
+            .iter()
+            .map(|ci| PolyK::exact_div(&dden.mul(&ci.num), &ci.den))
+            .collect();
+        let Some(ci_polys) = ci_polys else {
+            continue;
+        };
+
+        // Gosper normal form of the shift ratio of `W`, *not* of `p`:
+        // `ρ(k) = W(k+1)/W(k) = p(k)·D(k)/D(k+1) = A(k)·C(k+1) / (B(k)·C(k))`.
+        // Normal-forming `p` alone would drop the `D` bookkeeping and the
+        // resulting equation would have no polynomial solution even for
+        // `F = C(n,k)`.
+        let rho_num = p.num.mul(&dden);
+        let rho_den = p.den.mul(&dden.shift_k(1));
+        let Some((aa, bb, cc)) = gosper_normal_form_qn(rho_num, rho_den) else {
+            continue;
+        };
+        let b_eq = bb.shift_k(-1);
+
+        // Gosper's key equation for the term `N(k)·W(k)`:
+        //     A(k)·X(k+1) − B(k−1)·X(k) = C(k)·N(k),
+        // so the right-hand basis the unknown `a_i` multiply is `C(k)·C_i(k)`.
+        let c_ci: Vec<PolyK> = ci_polys.iter().map(|q| cc.mul(q)).collect();
+
+        for d in 0..=opts.max_degree {
+            let Some((x_coeffs, lam_below)) = try_solve(&aa, &b_eq, &c_ci, order, d) else {
+                continue;
+            };
+
+            let mut lam_full = lam_below;
+            lam_full.push(rn_one()); // a_order = 1
+
+            let x_poly = PolyK::from_coeffs(x_coeffs);
+            // `G(k) = (B(k−1)·X(k) / C(k))·W(k) = R(k)·F(n,k)` with
+            // `R(k) = B(k−1)·X(k) / (C(k)·D(k))`.
+            let r_pre = RatK {
+                num: b_eq.mul(&x_poly),
+                den: cc.mul(&dden),
+            }
+            .normalize();
+
+            let a_int: Vec<RatUniPoly> = clear_denominators(&lam_full);
+            if a_int.iter().all(|p| p.is_zero()) {
+                continue;
+            }
+            let scale = rn_poly(a_int[order].clone());
+            if rn_is_zero(&scale) {
+                continue;
+            }
+            let r_final = RatK {
+                num: r_pre.num.scale(&scale),
+                den: r_pre.den.clone(),
+            }
+            .normalize();
+
+            // Exact verification: Σ_i a_i(n)·c_i(n,k) ?= R(n,k+1)·p(n,k) − R(n,k).
+            let mut lhs = RatK::zero();
+            for (i, ci) in c.iter().enumerate() {
+                let ai = RatK::from_rn(rn_poly(a_int[i].clone()));
+                lhs = lhs.add(&ai.mul(ci));
+            }
+            let rhs_check = r_final.shift_k(1).mul(&p).sub(&r_final);
+            if !lhs.sub(&rhs_check).is_zero() {
+                // Refuse silently and keep searching: never return an
+                // unverified certificate.
+                continue;
+            }
+
+            let coeffs_expr: Vec<ExprId> =
+                a_int.iter().map(|p| ratuni_to_expr(pool, n, p)).collect();
+            let certificate_expr = ratk_to_expr(pool, n, k, &r_final);
+
+            let mut log = DerivationLog::new();
+            log.push(RewriteStep::simple(
+                "zeilberger_certificate",
+                term,
+                certificate_expr,
+            ));
+
+            return Ok(DerivedExpr::with_log(
+                ZeilbergerResult {
+                    order,
+                    coeffs: coeffs_expr,
+                    certificate: certificate_expr,
+                },
+                log,
+            ));
+        }
+    }
+
+    Err(HolonomicError::SearchExhausted(format!(
+        "no verified P-recursive relation of order <= {} with certificate degree <= {} \
+         in k was found for {}",
+        opts.max_order,
+        opts.max_degree,
+        pool.display(term)
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn nk(pool: &ExprPool) -> (ExprId, ExprId) {
+        (
+            pool.symbol("n", Domain::Real),
+            pool.symbol("k", Domain::Real),
+        )
+    }
+
+    fn binom(pool: &ExprPool, top: ExprId, bot: ExprId) -> ExprId {
+        let g1 = pool.func("gamma", vec![pool.add(vec![top, pool.integer(1_i32)])]);
+        let g2 = pool.func("gamma", vec![pool.add(vec![bot, pool.integer(1_i32)])]);
+        let g3 = pool.func(
+            "gamma",
+            vec![pool.add(vec![
+                top,
+                pool.mul(vec![bot, pool.integer(-1_i32)]),
+                pool.integer(1_i32),
+            ])],
+        );
+        pool.mul(vec![
+            g1,
+            pool.pow(g2, pool.integer(-1_i32)),
+            pool.pow(g3, pool.integer(-1_i32)),
+        ])
+    }
+
+    /// Σ_k C(n,k) = 2^n : Zeilberger should find the order-1 recurrence
+    /// a_1(n)·F(n+1,k) + a_0(n)·F(n,k) = ΔG with a_1 = 1, a_0 = -2 (up to a
+    /// common integer scale).
+    #[test]
+    fn binomial_row_sum_order_one() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let f = binom(&pool, n, k);
+        let opts = ZeilbergerOpts::default();
+        let result = zeilberger(f, n, k, &pool, &opts).expect("Zeilberger must find a certificate");
+        let r = &result.value;
+        assert_eq!(r.order, 1, "expected order-1 recurrence for Σ_k C(n,k)");
+        assert_eq!(r.coeffs.len(), 2);
+        // The recurrence must be S(n+1) − 2·S(n) = 0 up to an overall scale:
+        // a_0(n) + 2·a_1(n) ≡ 0. Checked numerically at several n, which is
+        // enough to pin a ratio of low-degree polynomials.
+        for ni in [3.0_f64, 7.0, 11.5] {
+            let env = std::collections::HashMap::from([(n, ni)]);
+            let a0 = crate::eval_f64(r.coeffs[0], &pool, &env).expect("a_0(n) evaluates");
+            let a1 = crate::eval_f64(r.coeffs[1], &pool, &env).expect("a_1(n) evaluates");
+            assert!(a1.abs() > 1e-12, "leading coefficient must not vanish");
+            assert!(
+                (a0 / a1 + 2.0).abs() < 1e-9,
+                "expected a_0/a_1 = -2 (S(n+1) = 2·S(n)), got {}",
+                a0 / a1
+            );
+        }
+    }
+
+    /// Refuses non-hypergeometric input rather than guessing.
+    #[test]
+    fn refuses_non_hypergeometric_input() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let bad = pool.func("sin", vec![pool.mul(vec![n, k])]);
+        let opts = ZeilbergerOpts::default();
+        let err = zeilberger(bad, n, k, &pool, &opts).expect_err("sin(nk) is not hypergeometric");
+        assert!(matches!(err, HolonomicError::NotProperHypergeometric(_)));
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-HOLO-001");
+    }
+
+    /// n == k is refused as invalid input, not silently misinterpreted.
+    #[test]
+    fn refuses_coincident_indices() {
+        let pool = ExprPool::new();
+        let n = pool.symbol("n", Domain::Real);
+        let opts = ZeilbergerOpts::default();
+        let err = zeilberger(n, n, n, &pool, &opts).expect_err("n == k must be refused");
+        assert!(matches!(err, HolonomicError::InvalidInput(_)));
+    }
+
+    /// Every returned certificate — not just the happy-path example above —
+    /// satisfies the exact Q(n)(k) identity it claims to.
+    #[test]
+    fn certificate_reverifies_exactly() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let f = binom(&pool, n, k);
+        let opts = ZeilbergerOpts::default();
+        let result = zeilberger(f, n, k, &pool, &opts).expect("certificate");
+        let r = &result.value;
+
+        let term = ProperTerm::parse(f, n, k, &pool).expect("parse");
+        let c: Vec<RatK> = (0..=r.order as i64)
+            .map(|i| term.ratio_n(i).expect("ratio_n"))
+            .collect();
+        let p = term.ratio_k().expect("ratio_k");
+
+        // Re-derive the algebraic coefficients from the returned expressions
+        // via the same parser used for hypergeometric prefactors, and check
+        // the identity independently of the internal search state.
+        let a: Vec<RatK> = r
+            .coeffs
+            .iter()
+            .map(|&e| {
+                let ratk = super::super::hyperterm::as_ratk(e, n, k, &pool, 0)
+                    .expect("coeff must be a function of n alone");
+                assert_eq!(ratk.num.degree().max(0), 0, "coeff must not depend on k");
+                assert_eq!(ratk.den.degree(), 0, "coeff must not depend on k");
+                ratk
+            })
+            .collect();
+        let r_ratk = super::super::hyperterm::as_ratk(r.certificate, n, k, &pool, 0)
+            .expect("certificate must parse back into Q(n)(k)");
+
+        let mut lhs = RatK::zero();
+        for (i, ci) in c.iter().enumerate() {
+            lhs = lhs.add(&a[i].mul(ci));
+        }
+        let rhs = r_ratk.shift_k(1).mul(&p).sub(&r_ratk);
+        assert!(
+            lhs.sub(&rhs).is_zero(),
+            "returned certificate must satisfy the exact identity"
+        );
+    }
+}

--- a/alkahest-core/src/holonomic/zeilberger.rs
+++ b/alkahest-core/src/holonomic/zeilberger.rs
@@ -29,7 +29,7 @@
 //!    *polynomial*, linear in the unknowns. Decompose the shift ratio of `W`,
 //!    `ρ(k) = p(k)·D(k)/D(k+1)`, into Gosper normal form
 //!    `ρ = A(k)·C(k+1) / (B(k)·C(k))` over `Q(n)[k]` — the same shifted-gcd
-//!    construction as [`crate::sum::gosper::gosper_normal_form`], lifted to
+//!    construction as `sum::gosper::gosper_normal_form` (private), lifted to
 //!    the field `Q(n)`. (Normal-forming `p` itself instead of `ρ` loses the
 //!    `D` bookkeeping and the equation below has no polynomial solution even
 //!    for `F = C(n,k)`.)
@@ -62,7 +62,7 @@ use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
 use crate::kernel::{ExprId, ExprPool};
 use crate::matrix::normal_form::RatUniPoly;
 
-/// Search bounds for [`zeilberger`].
+/// Search bounds for [`zeilberger()`].
 #[derive(Debug, Clone, Copy)]
 pub struct ZeilbergerOpts {
     /// Largest recurrence order `J` to try (searched from 1 upward).
@@ -100,7 +100,7 @@ fn k_mono(j: usize) -> PolyK {
     PolyK::from_coeffs(coeffs)
 }
 
-/// Generalization of [`crate::sum::gosper::gosper_normal_form`] from `Q` to
+/// Generalization of `sum::gosper::gosper_normal_form` from `Q` to
 /// the field `Q(n)`: writes `p/q = Z·A(k)·C(k+1) / (B(k)·C(k))` with
 /// `gcd(A(k), B(k+h))` a unit for every `h ≥ 0`, `Z` folded into `A`.
 fn gosper_normal_form_qn(mut p: PolyK, mut q: PolyK) -> Option<(PolyK, PolyK, PolyK)> {

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -17,6 +17,8 @@ pub mod errors;
 pub mod eval;
 pub mod flint;
 pub mod horner;
+// P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+pub mod holonomic;
 pub mod hybrid;
 pub mod integrate;
 pub mod jit;

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -156,6 +156,11 @@ use alkahest_core::transform::{
     FourierError as CoreFourierError, LaplaceError as CoreLaplaceError,
     ZTransformError as CoreZTransformError,
 };
+// P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+use alkahest_core::holonomic::{
+    zeilberger as core_zeilberger, HolonomicError as CoreHolonomicError,
+    ZeilbergerOpts as CoreZeilbergerOpts,
+};
 // V3-1 — Integer number theory
 use alkahest_core::number_theory::{
     discrete_log as nt_discrete_log, factorint as nt_factorint, isprime as nt_isprime,
@@ -288,6 +293,8 @@ pyo3::create_exception!(alkahest, PyRsolveError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyDiophantineError, PyAlkahestError);
 // P1 search plumbing item 4 — budgets, cancellation, determinism
 pyo3::create_exception!(alkahest, PyBudgetExceededError, PyAlkahestError);
+// P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+pyo3::create_exception!(alkahest, PyHolonomicError, PyAlkahestError);
 
 /// Build a structured exception with `.code`, `.remediation`, `.span` attributes.
 fn make_structured_err<E: AlkahestErrorTrait>(
@@ -4182,6 +4189,136 @@ fn py_verify_wz_pair(
     let pool = f.pool.borrow(py);
     let pair = WzPair { f: f.id, g: g.id };
     Ok(core_verify_wz_pair(&pair, n.id, k.id, &pool.inner))
+}
+
+// ---------------------------------------------------------------------------
+// P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+// ---------------------------------------------------------------------------
+
+fn holonomic_error_to_py(e: CoreHolonomicError) -> PyErr {
+    Python::with_gil(|py| {
+        let exc_type = py.get_type_bound::<PyHolonomicError>();
+        make_structured_err(py, &exc_type, &e)
+    })
+}
+
+/// A **verified** Zeilberger certificate, returned by :func:`alkahest.zeilberger`.
+///
+/// Carries the recurrence coefficients ``a_0(n), …, a_J(n)`` and the rational
+/// certificate ``R(n, k)`` satisfying, as an exact identity in ``Q(n)(k)``,
+///
+/// ``Σ_i a_i(n)·F(n+i, k) = G(n, k+1) − G(n, k)``  with  ``G = R·F``.
+///
+/// Summing over ``k`` telescopes the right-hand side, so ``S(n) = Σ_k F(n,k)``
+/// satisfies ``Σ_i a_i(n)·S(n+i) = 0``.  The identity is re-checked exactly
+/// before this object is constructed — a returned certificate is a proof, not a
+/// numerical match.
+#[pyclass(name = "ZeilbergerCertificate")]
+struct PyZeilbergerCertificate {
+    order: usize,
+    coeff_ids: Vec<ExprId>,
+    certificate_id: ExprId,
+    pool: Py<PyExprPool>,
+    derivation: String,
+}
+
+#[pymethods]
+impl PyZeilbergerCertificate {
+    /// Recurrence order ``J``; ``len(coeffs) == order + 1``.
+    #[getter]
+    fn order(&self) -> usize {
+        self.order
+    }
+
+    /// ``[a_0(n), …, a_J(n)]`` — polynomial coefficients of the recurrence.
+    #[getter]
+    fn coeffs(&self, py: Python<'_>) -> Vec<PyExpr> {
+        self.coeff_ids
+            .iter()
+            .map(|&id| PyExpr {
+                id,
+                pool: self.pool.clone_ref(py),
+            })
+            .collect()
+    }
+
+    /// ``R(n, k)`` — the rational certificate, with ``G(n,k) = R(n,k)·F(n,k)``.
+    #[getter]
+    fn certificate(&self, py: Python<'_>) -> PyExpr {
+        let _ = py;
+        PyExpr {
+            id: self.certificate_id,
+            pool: self.pool.clone_ref(py),
+        }
+    }
+
+    /// Human-readable derivation log for the search that produced this.
+    #[getter]
+    fn derivation(&self) -> String {
+        self.derivation.clone()
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let pool = self.pool.borrow(py);
+        let coeffs: Vec<String> = self
+            .coeff_ids
+            .iter()
+            .map(|&id| pool.inner.display(id).to_string())
+            .collect();
+        format!(
+            "ZeilbergerCertificate(order={}, coeffs=[{}], certificate={})",
+            self.order,
+            coeffs.join(", "),
+            pool.inner.display(self.certificate_id)
+        )
+    }
+}
+
+/// `alkahest.zeilberger(term, n, k, *, max_order=4, max_degree=16) -> ZeilbergerCertificate`
+///
+/// Zeilberger's algorithm (creative telescoping) for a proper hypergeometric
+/// term ``F(n, k)``.  Returns a **verified** certificate: the recurrence
+/// ``Σ_i a_i(n)·F(n+i,k) = ΔG`` with ``G = R·F`` is re-checked as an exact
+/// identity in ``Q(n)(k)`` before it is returned.
+///
+/// Raises :exc:`alkahest.HolonomicError` rather than guessing when ``term`` is
+/// outside the proper hypergeometric class (``E-HOLO-001``) or when the bounded
+/// search is exhausted (``E-HOLO-002``).
+#[pyfunction]
+#[pyo3(name = "zeilberger", signature = (term, n, k, *, max_order = 4, max_degree = 16))]
+fn py_zeilberger(
+    py: Python<'_>,
+    term: PyRef<PyExpr>,
+    n: PyRef<PyExpr>,
+    k: PyRef<PyExpr>,
+    max_order: usize,
+    max_degree: usize,
+) -> PyResult<PyZeilbergerCertificate> {
+    let pool_py = term.pool.clone_ref(py);
+    let opts = CoreZeilbergerOpts {
+        max_order,
+        max_degree,
+    };
+    let (order, coeff_ids, certificate_id, derivation) = {
+        let pool = pool_py.borrow(py);
+        let derived = core_zeilberger(term.id, n.id, k.id, &pool.inner, &opts)
+            .map_err(holonomic_error_to_py)?;
+        let derivation = derived.log.display_with(&pool.inner).to_string();
+        let value = derived.value;
+        (
+            value.order,
+            value.coeffs.clone(),
+            value.certificate,
+            derivation,
+        )
+    };
+    Ok(PyZeilbergerCertificate {
+        order,
+        coeff_ids,
+        certificate_id,
+        pool: pool_py,
+        derivation,
+    })
 }
 
 /// `alkahest.match_pattern(pattern_expr, expr) -> list[dict[str, Expr]]`
@@ -9810,6 +9947,9 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_solve_linear_recurrence_homogeneous, m)?)?;
     m.add_function(wrap_pyfunction!(py_rsolve, m)?)?;
     m.add_function(wrap_pyfunction!(py_verify_wz_pair, m)?)?;
+    // P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    m.add_class::<PyZeilbergerCertificate>()?;
+    m.add_function(wrap_pyfunction!(py_zeilberger, m)?)?;
     m.add_function(wrap_pyfunction!(match_pattern, m)?)?;
     m.add_function(wrap_pyfunction!(make_rule, m)?)?;
     m.add_function(wrap_pyfunction!(py_subs, m)?)?;
@@ -10071,6 +10211,11 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("CadError", m.py().get_type_bound::<PyCadError>())?;
     m.add("SumError", m.py().get_type_bound::<PySumError>())?;
     m.add("ProductError", m.py().get_type_bound::<PyProductError>())?;
+    // P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    m.add(
+        "HolonomicError",
+        m.py().get_type_bound::<PyHolonomicError>(),
+    )?;
     m.add(
         "NumberTheoryError",
         m.py().get_type_bound::<PyNumberTheoryError>(),

--- a/docs/features.md
+++ b/docs/features.md
@@ -65,6 +65,7 @@ Current stable feature surface.
 - Linear recurrence solving (`solve_linear_recurrence_homogeneous`)
 - Difference equations / `rsolve`: constant-coefficient recurrences with polynomial RHS
 - Symbolic products: definite and indefinite via Γ-ratio telescoping (`product_definite`, `product_indefinite`, `Product`)
+- Creative telescoping / Zeilberger's algorithm (`zeilberger`): P-recursive recurrence for a proper hypergeometric term plus a rational certificate, re-checked as an exact `Q(n)(k)` identity before it is returned; refuses (`E-HOLO-*`) rather than guessing outside the class or beyond the search bounds
 
 ## Number theory
 

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -25,4 +25,5 @@
 - [Autoresearch / agent loops](./search-plumbing.md)
   - [Budgets, cancellation, and determinism](./budgets.md)
   - [Batch and streaming evaluation](./batch.md)
+  - [Creative telescoping (Zeilberger)](./telescoping.md)
 - [Stability policy](./stability.md)

--- a/docs/mdbook/src/telescoping.md
+++ b/docs/mdbook/src/telescoping.md
@@ -1,0 +1,130 @@
+# Creative telescoping (Zeilberger's algorithm)
+
+`zeilberger` decides combinatorial identities over a well-defined class and
+hands back a **certificate** you can re-check independently. That combination —
+a decision procedure whose output is a short, verifiable algebraic object — is
+why it matters for an autoresearch loop: it turns "this identity survived a
+numeric sweep" into "this identity is proved", without a human in the loop.
+
+```python
+import alkahest as ak
+
+pool = ak.ExprPool()
+n, k = pool.symbol("n"), pool.symbol("k")
+one = pool.integer(1)
+
+# F(n, k) = C(n, k), written as the ratio of gammas the engine recognises.
+F = ak.gamma(n + one) / (ak.gamma(k + one) * ak.gamma(n - k + one))
+
+cert = ak.zeilberger(F, n, k)
+cert.order          # 1
+cert.coeffs         # [a_0(n), a_1(n)] — here proportional to [-2, 1]
+cert.certificate    # R(n, k)
+```
+
+The result says: with `S(n) = Σ_k F(n,k)`,
+
+```text
+Σ_i a_i(n)·S(n+i) = 0
+```
+
+Here that reads `S(n+1) − 2·S(n) = 0`, which together with `S(0) = 1` gives
+`Σ_k C(n,k) = 2^n`.
+
+## What the certificate asserts
+
+The returned `certificate` is a rational function `R(n, k)` such that, with
+`G(n,k) = R(n,k)·F(n,k)`,
+
+```text
+Σ_i a_i(n)·F(n+i, k) = G(n, k+1) − G(n, k)
+```
+
+holds **identically**. Summing over `k` telescopes the right-hand side to zero
+(over a range where the boundary terms vanish), which is what licenses the
+recurrence for `S(n)`. Because the identity is a rational-function identity, a
+reader — or a referee, or another CAS — can verify it by clearing denominators
+and expanding, with no reference to how it was found.
+
+## Verification is not optional
+
+Every certificate is re-checked as an exact identity in `Q(n)(k)` before it is
+returned. A candidate that fails verification is discarded and the search
+continues; it is never returned with a caveat. This is the same
+withhold-rather-than-lie discipline as the Lean certificate exporter: in a loop,
+one unverified certificate becomes a false lemma that every downstream
+derivation inherits.
+
+Verification runs in exact rational arithmetic — no floating point is involved
+at any stage of the algorithm.
+
+## The class it decides, and where it refuses
+
+The supported class is **proper hypergeometric terms**:
+
+```text
+F(n, k) = R(n, k) · z^k · w^n · ∏_j Γ(a_j·n + b_j·k + c_j)^(e_j)
+```
+
+with `R` a rational function, `z, w` nonzero rationals, `a_j, b_j` integers and
+`c_j` rational. Factorials, binomials and Pochhammer symbols are recognised and
+normalised into this form.
+
+Everything else is refused, with a structured error rather than a guess:
+
+| Code | Meaning | What a loop should do |
+|---|---|---|
+| `E-HOLO-001` | Not a proper hypergeometric term | Close this branch — Zeilberger does not apply |
+| `E-HOLO-002` | Search bounds exhausted | Retry with larger `max_order` / `max_degree`, or deprioritise |
+| `E-HOLO-003` | A candidate failed exact verification | Report as a bug with the term |
+| `E-HOLO-004` | Malformed call (`n` and `k` not distinct, non-positive bounds) | Fix the call |
+
+`E-HOLO-002` is worth dwelling on. It does **not** mean "no recurrence exists" —
+it means none was found within the bounds you set. The distinction matters: an
+agent can raise the bounds and retry, whereas `E-HOLO-001` is a permanent answer
+about the input and the branch can be closed for good.
+
+## Cost and bounds
+
+`max_order` (default 4) and `max_degree` (default 16) bound the search. The
+algorithm tries order `J = 1, 2, …` and, for each, certificate degrees
+`d = 0, 1, …`, solving a linear system over `Q(n)` at every `(J, d)` pair. Cost
+grows quickly in both, and a term with no recurrence within the bounds pays the
+full search before refusing. Set the bounds to what you can afford:
+
+```python
+cert = ak.zeilberger(F, n, k, max_order=2, max_degree=6)
+```
+
+## Method
+
+The implementation is the standard Gosper-style reduction (Petkovšek–Wilf–
+Zeilberger, *A=B*, ch. 6; Koepf, *Hypergeometric Summation*, ch. 7), carried out
+over the field `Q(n)` rather than `Q`:
+
+1. Compute the exact shift quotients `p(k) = F(n,k+1)/F(n,k)` and
+   `c_i(k) = F(n+i,k)/F(n,k)` — both rational functions, which is precisely the
+   property that defines the proper hypergeometric class.
+2. Take `D(k)`, a common denominator of the `c_i`, and work with
+   `W(n,k) = F(n,k)/D(k)`, so that `Σ_i a_i·F(n+i,k) = N(k)·W(n,k)` with
+   `N(k) = Σ_i a_i·D(k)·c_i(k)` polynomial and linear in the unknowns.
+3. Decompose the shift ratio of `W`, `ρ(k) = p(k)·D(k)/D(k+1)`, into Gosper
+   normal form `ρ = A(k)·C(k+1)/(B(k)·C(k))`.
+4. Gosper's key equation is then the polynomial identity
+   `A(k)·X(k+1) − B(k−1)·X(k) = C(k)·N(k)`. Comparing coefficients of each power
+   of `k` gives a linear system over `Q(n)`; solving it yields both the `a_i` and
+   the certificate `R = B(k−1)·X(k) / (C(k)·D(k))`.
+5. The solved pair is substituted back and checked exactly. Only then is it
+   returned.
+
+## Scope of this release
+
+Shipped: Zeilberger's algorithm with exact certificate verification, the
+`Q(n)` / `Q(n)(k)` arithmetic tower it rests on, and proper-hypergeometric
+recognition.
+
+Not yet shipped, and tracked as follow-up work: Ore-operator closure properties
+for D-finite functions (sums and products of holonomic objects) and the guessing
+front-end (fitting a P-recursive recurrence or a linear ODE to finite data).
+`sum_indefinite` (Gosper) and `verify_wz_pair` remain the neighbouring tools for
+the indefinite and WZ-pair cases respectively.

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -134,6 +134,8 @@ from .alkahest import (  # noqa: F401
     UniPolyFactorization,
     # V2-7: Polynomial factorization
     UniPolyFactorModP,
+    # P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    ZeilbergerCertificate,
     _build_features,
     _derived_result_context_simplify,
     abs,  # symbolic abs — use alkahest.abs(expr); shadows Python builtin within this module
@@ -263,6 +265,8 @@ from .alkahest import (  # noqa: F401
     verify_wz_pair,
     version,
     voltage_source,
+    # P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    zeilberger,
 )
 from .alkahest import (
     # Phase 15: Symbolic matrices
@@ -322,6 +326,7 @@ from .exceptions import (
     DomainError,
     EigenError,
     FactorError,
+    HolonomicError,
     IntegrationError,
     IoError,
     JitError,
@@ -358,6 +363,7 @@ _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "DomainError",
     "EigenError",
     "FactorError",
+    "HolonomicError",
     "IntegrationError",
     "IoError",
     "JitError",
@@ -1722,6 +1728,8 @@ __all__ = [
     "GbPoly",
     "GradTracedFn",
     "GroebnerBasis",
+    # P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    "HolonomicError",
     "HybridODE",
     "IntegrationError",
     # V1-16: IoError
@@ -1774,6 +1782,8 @@ __all__ = [
     "UniPoly",
     "UniPolyFactorModP",
     "UniPolyFactorization",
+    # P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    "ZeilbergerCertificate",
     "__version__",
     "abs",
     "acos",
@@ -1973,6 +1983,8 @@ __all__ = [
     "verify_wz_pair",
     "version",
     "voltage_source",
+    # P1 item 7 — creative telescoping / holonomic (D-finite) machinery
+    "zeilberger",
 ]
 
 # Drop import-machinery leaks from ``dir(alkahest)`` / autocomplete. Lazy

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -39,6 +39,7 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
     E-DOMAIN-*                 DomainError  (reserved; Python-only pending Rust impl)
     E-CERT-001                 CertificateUnavailableError  (Python-only; certificate ledger)
     E-BUDGET-001 … E-BUDGET-003 BudgetExceededError (P1 search plumbing item 4)
+    E-HOLO-001 … E-HOLO-004    HolonomicError (P1 item 7 — creative telescoping)
     E-BATCH-001                 (Python-only; alkahest._batch fallback for a
                                  batch_map/batch_map_iter item whose exception carried no
                                  .code of its own — see docs/mdbook/src/batch.md)
@@ -191,6 +192,26 @@ class SumError(AlkahestError):
         span: tuple[int, int] | None = None,
     ):
         super().__init__(message, code="E-SUM-001", remediation=remediation, span=span)
+
+
+class HolonomicError(AlkahestError):
+    """Creative telescoping refused: input outside the proper hypergeometric
+    class (``E-HOLO-001``), bounded search exhausted (``E-HOLO-002``), a
+    candidate certificate failed exact verification (``E-HOLO-003``), or the
+    call was malformed (``E-HOLO-004``).
+
+    A refusal here is informative, not a failure: it says the term is not one
+    Zeilberger's algorithm decides at the requested bounds, so a loop can close
+    that branch instead of re-attempting it.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code="E-HOLO-001", remediation=remediation, span=span)
 
 
 class ProductError(AlkahestError):

--- a/tests/test_holonomic.py
+++ b/tests/test_holonomic.py
@@ -1,0 +1,193 @@
+"""P1 item 7 — creative telescoping / holonomic (D-finite) machinery.
+
+Zeilberger's algorithm is a *decision procedure that emits a certificate*: for a
+proper hypergeometric term ``F(n, k)`` it either returns a recurrence together
+with a rational certificate that has been re-checked as an exact identity, or it
+refuses.  These tests cover both halves — the classical identities it must
+decide, and the boundaries at which it must refuse rather than guess.
+"""
+
+import math
+
+import alkahest as ak
+import pytest
+
+
+def _binomial(pool, top, bot):
+    """``C(top, bot)`` as a ratio of gammas — the proper hypergeometric form."""
+    one = pool.integer(1)
+    return ak.gamma(top + one) / (ak.gamma(bot + one) * ak.gamma(top - bot + one))
+
+
+def _num(expr, env):
+    """Float value of ``expr`` under ``env``."""
+    return float(ak.evaluate(expr, env).value)
+
+
+def _eval_coeffs(cert, n, value):
+    """Numeric ``[a_0(n), …, a_J(n)]`` at ``n = value``."""
+    return [_num(c, {n: float(value)}) for c in cert.coeffs]
+
+
+# ---------------------------------------------------------------------------
+# Identities the algorithm must decide
+# ---------------------------------------------------------------------------
+
+
+def test_binomial_row_sum_gives_order_one_recurrence():
+    """``Σ_k C(n,k) = 2^n`` — the textbook order-1 case.
+
+    The certificate says ``S(n+1) − 2·S(n) = 0``, so ``a_0/a_1 == -2``.
+    """
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+
+    cert = ak.zeilberger(_binomial(pool, n, k), n, k)
+
+    assert cert.order == 1
+    assert len(cert.coeffs) == 2
+    for ni in (3.0, 7.0, 11.5):
+        a0, a1 = _eval_coeffs(cert, n, ni)
+        assert a1 != 0.0
+        assert a0 / a1 == pytest.approx(-2.0, rel=1e-12)
+
+
+def test_recurrence_is_satisfied_by_the_actual_sum():
+    """The returned recurrence must hold for the sum it claims to describe.
+
+    This is the end-to-end check that matters: it does not inspect the
+    certificate at all, it just evaluates ``S(n) = Σ_k C(n,k)`` numerically and
+    asserts ``Σ_i a_i(n)·S(n+i) = 0``.
+    """
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+
+    cert = ak.zeilberger(_binomial(pool, n, k), n, k)
+
+    def s(m):
+        return sum(math.comb(m, j) for j in range(m + 1))
+
+    for ni in range(2, 9):
+        a = _eval_coeffs(cert, n, ni)
+        total = sum(a[i] * s(ni + i) for i in range(len(a)))
+        assert total == pytest.approx(0.0, abs=1e-6 * max(1.0, abs(s(ni + len(a) - 1))))
+
+
+def test_certificate_is_returned_and_nontrivial():
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+
+    cert = ak.zeilberger(_binomial(pool, n, k), n, k)
+
+    assert cert.certificate is not None
+    assert str(cert.certificate) != "0"
+    # The derivation log is what makes the result auditable downstream.
+    assert cert.derivation
+    assert "ZeilbergerCertificate(" in repr(cert)
+
+
+def test_certificate_telescopes_the_summand_numerically():
+    """``Σ_i a_i(n)·F(n+i,k) = G(n,k+1) − G(n,k)`` with ``G = R·F``.
+
+    Verified pointwise at integer ``(n, k)`` away from the poles of ``R``.  The
+    identity is checked exactly in ``Q(n)(k)`` inside the engine; this is an
+    independent numeric spot-check of the same claim.
+    """
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+    f = _binomial(pool, n, k)
+
+    cert = ak.zeilberger(f, n, k)
+    order = cert.order
+
+    def big_f(ni, ki):
+        if ki < 0 or ki > ni:
+            return 0.0
+        return float(math.comb(int(ni), int(ki)))
+
+    def g(ni, ki):
+        """``G(n,k) = R(n,k)·F(n,k)``."""
+        r = _num(cert.certificate, {n: float(ni), k: float(ki)})
+        return r * big_f(ni, ki)
+
+    for ni in (5, 6, 7):
+        a = _eval_coeffs(cert, n, ni)
+        for ki in (1, 2, 3):
+            lhs = sum(a[i] * big_f(ni + i, ki) for i in range(order + 1))
+            rhs = g(ni, ki + 1) - g(ni, ki)
+            assert lhs == pytest.approx(rhs, rel=1e-9, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Refusals — a refusal is an informative answer, not a failure
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_non_hypergeometric_input():
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+
+    with pytest.raises(ak.HolonomicError) as excinfo:
+        ak.zeilberger(ak.sin(n * k), n, k)
+
+    assert excinfo.value.code == "E-HOLO-001"
+    assert excinfo.value.remediation
+
+
+def test_refuses_coincident_indices():
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+
+    with pytest.raises(ak.HolonomicError) as excinfo:
+        ak.zeilberger(n, n, n)
+
+    assert excinfo.value.code == "E-HOLO-004"
+
+
+def test_refuses_when_search_bounds_are_exhausted():
+    """No recurrence within the bounds: refuse, do not return a guess.
+
+    ``Σ_k 1/(k² + n)`` is a proper hypergeometric term — both shift quotients
+    are rational — but has no low-order P-recursive relation, so the bounded
+    search must come back empty rather than returning something unverified.
+    """
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+    term = pool.integer(1) / (k * k + n)
+
+    with pytest.raises(ak.HolonomicError) as excinfo:
+        ak.zeilberger(term, n, k, max_order=1, max_degree=2)
+
+    assert excinfo.value.code == "E-HOLO-002"
+    # E-HOLO-002 says "not found within these bounds", not "does not exist" —
+    # the remediation has to tell an agent it can retry wider.
+    assert "max_order" in excinfo.value.remediation
+
+
+def test_rejects_nonsense_bounds():
+    pool = ak.ExprPool()
+    n = pool.symbol("n")
+    k = pool.symbol("k")
+
+    with pytest.raises(ak.HolonomicError) as excinfo:
+        ak.zeilberger(_binomial(pool, n, k), n, k, max_order=0)
+
+    assert excinfo.value.code == "E-HOLO-004"
+
+
+# ---------------------------------------------------------------------------
+# Surface
+# ---------------------------------------------------------------------------
+
+
+def test_exported_surface():
+    assert "zeilberger" in ak.__all__
+    assert "ZeilbergerCertificate" in ak.__all__
+    assert "HolonomicError" in ak.__all__
+    assert issubclass(ak.HolonomicError, ak.AlkahestError)


### PR DESCRIPTION
Implements **P1 mathematics item 7** — "Creative telescoping / holonomic (D-finite) machinery" — from `temp-alkahest/planning/autoresearch.md`.

The note ranks this above the other mathematical coverage gaps for a specific reason: it is a **decision procedure that emits a certificate**, over a class broad enough to contain a large fraction of the identities an autoresearch loop will conjecture. It turns stage 3 → stage 4 (discovery → proof) from heuristic into automatic.

## What is now decided

`zeilberger(F, n, k)` takes a proper hypergeometric term and returns the recurrence

```text
Σ_i a_i(n)·F(n+i, k) = G(n, k+1) − G(n, k),    G = R·F
```

so `S(n) = Σ_k F(n,k)` satisfies `Σ_i a_i(n)·S(n+i) = 0`. For `F = C(n,k)` that is `S(n+1) − 2·S(n) = 0` with certificate `R = −k/(n+1−k)` — i.e. `Σ_k C(n,k) = 2^n`, proved rather than sampled.

Supported class: `F(n,k) = R(n,k)·z^k·w^n·∏_j Γ(a_j·n + b_j·k + c_j)^(e_j)` with rational `R`, integer `a_j, b_j`. `gamma`, `factorial`, `binomial` and `pochhammer` heads are recognised and normalised into it.

## Soundness

Every certificate is **re-checked as an exact `Q(n)(k)` identity** before it is returned. A candidate that fails verification is discarded and the search continues — it is never returned with a caveat. No floating point is involved at any stage of the algorithm.

Refusals carry stable codes and are informative rather than failures:

| Code | Meaning |
|---|---|
| `E-HOLO-001` | Not a proper hypergeometric term — a loop can close the branch permanently |
| `E-HOLO-002` | Search bounds exhausted — **not** "no recurrence exists"; retrying wider is meaningful |
| `E-HOLO-003` | A candidate failed exact verification (should not happen; refused rather than returned) |
| `E-HOLO-004` | Malformed call |

## Two defects found and fixed while wiring this up

The module arrived with the `Q(n)` towers and term recognition in place but a search that returned non-minimal answers or none at all:

1. **The Gosper normal form must be taken for the shift ratio of `F/D`**, where `D` is the common denominator of the shift quotients — not for `p = F(n,k+1)/F(n,k)`. Without the `D` bookkeeping the key equation has no polynomial solution even for `F = C(n,k)`.
2. **The normal form's shifted-gcd loop started at `h = 1`**, leaving a plain common factor (`h = 0`) in both `A` and `B`. That violates the normal-form invariant, so the linear system at the true minimal order is unsolvable and the search runs on to a larger order. Fixing it takes the binomial row sum from a **63s order-2** answer to a **0.18s order-1** one.

## Tests

Rust in-module tests plus `tests/test_holonomic.py` (9 tests). Beyond the certificate's own exact re-verification, the Python suite checks the claim two independent ways: it evaluates `S(n) = Σ_k C(n,k)` numerically and asserts the returned recurrence annihilates it, and it spot-checks the telescoping identity pointwise. Refusal cases cover all four codes, including exhaustion on `Σ_k 1/(k²+n)` — a proper hypergeometric term with no low-order P-recursive relation.

## Gates (all green locally)

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --all`, `ruff check`, `ruff format --check`, `ty check` (42 diagnostics, identical to an untouched worktree — no new ones), certificate ledger drift check, silent-error gate (149 passed), full `pytest` (1607 passed, 27 skipped).

## Scope

Shipped: Zeilberger with exact certificate verification, the `Q(n)`/`Q(n)(k)` arithmetic, proper-hypergeometric recognition. **Not** shipped, and documented as follow-up in `docs/mdbook/src/telescoping.md`: Ore-operator closure properties for D-finite functions, and the guessing front-end (fitting a P-recursive recurrence or linear ODE to finite data).

Docs: new [`docs/mdbook/src/telescoping.md`](docs/mdbook/src/telescoping.md) chapter linked from `SUMMARY.md` under Autoresearch, plus `docs/features.md` and `CHANGELOG.md` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creative telescoping with Zeilberger’s algorithm for supported hypergeometric terms.
  * Added verified recurrence and rational certificate results through the Python API.
  * Added structured holonomic errors with stable diagnostic codes.
* **Documentation**
  * Documented the new algorithm, supported inputs, verification guarantees, and search limits.
* **Bug Fixes**
  * Added clear handling for unsupported terms, invalid bounds, failed verification, and exhausted searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->