### PR TITLE
feat(sos): positivity certificates (SOS / Positivstellensatz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **Positivity certificates — SOS and Positivstellensatz-lite** (P1 mathematics
+  item 8): `alkahest.sos_decompose(p, vars)` returns an exact rational
+  sum-of-squares decomposition `p = Σ σ_j q_j²`, and
+  `alkahest.prove_nonneg(p, vars, constraints=[...], level=...)` returns a
+  Handelman certificate `p = Σ_α c_α Π g_i^{α_i}` (`c_α ≥ 0`) on a basic
+  semialgebraic set. This is the fast, certificate-producing complement to the
+  complete-but-doubly-exponential `decide`: the output is a short algebraic
+  identity anyone can re-expand, exportable to Lean via
+  `PositivityCertificate.to_lean()`. New `alkahest_core::real::sos` module with
+  its own exact rational simplex (Bland's rule — no floating point anywhere
+  near a certificate), an ℚ multivariate polynomial layer, and a
+  generator-cone Gram search. Every certificate is re-expanded and compared
+  against the target identically before it is returned. The three outcomes are
+  kept distinct on purpose: certified, `E-SOS-003` definitely negative (with a
+  witness point), and `E-SOS-002` no certificate of this shape at this degree
+  — which is a statement about the search, not a proof that none exists (the
+  Motzkin polynomial refuses here rather than being misreported). See
+  [`docs/mdbook/src/positivity.md`](docs/mdbook/src/positivity.md).
+
 - **Docs: autoresearch / search-plumbing guide.** New mdBook chapter
   [`search-plumbing.md`](docs/mdbook/src/search-plumbing.md) ties budgets,
   batch APIs, compact `DerivedResult` envelopes, claim graphs, and certificate

--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -182,6 +182,12 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-BUDGET-002", class: "BudgetError", cause: Cause::Resource, remediation: Some("raise Budget(max_steps=...), or accept a partial/heuristic result for this candidate instead of an exact one") },
     ErrorSpec { code: "E-BUDGET-003", class: "BudgetError", cause: Cause::Resource, remediation: Some("call alkahest.clear_cancel() (Python) or budget::clear_cancel() (Rust) before starting the next candidate") },
     // E-DOMAIN — reserved; DomainError is Python-only pending Rust implementation
+    // E-SOS — SosError (P1 item 8: positivity certificates / Positivstellensatz)
+    ErrorSpec { code: "E-SOS-001", class: "SosError", cause: Cause::UserInput,   remediation: Some("positivity certificates are for polynomials in the listed variables; expand or clear denominators first, and pass every symbol that occurs as a variable") },
+    ErrorSpec { code: "E-SOS-002", class: "SosError", cause: Cause::Unsupported, remediation: Some("raise basis_degree (unconstrained) or level (constrained); the search covers the diagonally dominant subcone, so this is not a proof that no SOS decomposition exists — alkahest.decide is the complete (and far more expensive) fallback") },
+    ErrorSpec { code: "E-SOS-003", class: "SosError", cause: Cause::UserInput,   remediation: Some("the witness point in the message satisfies the constraints and makes the target negative; the claim is false as stated") },
+    ErrorSpec { code: "E-SOS-004", class: "SosError", cause: Cause::UserInput,   remediation: Some("pass at least one variable, and keep basis_degree/level within the supported range") },
+    ErrorSpec { code: "E-SOS-005", class: "SosError", cause: Cause::Internal,    remediation: Some("internal: report the target and constraints as a minimal failing example") },
 ];
 
 #[cfg(test)]

--- a/alkahest-core/src/real/mod.rs
+++ b/alkahest-core/src/real/mod.rs
@@ -5,6 +5,11 @@
 
 pub mod cad;
 pub mod routh;
+// P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+pub mod sos;
 
 pub use cad::{cad_lift, cad_project, decide, decide_expr, CadError, QeResult};
 pub use routh::{routh_hurwitz, RouthHurwitz, ROUTH_MAX_DEGREE};
+pub use sos::{
+    prove_nonneg, sos_decompose, CertificateKind, PositivityCertificate, SosError, SosOpts,
+};

--- a/alkahest-core/src/real/sos/cert.rs
+++ b/alkahest-core/src/real/sos/cert.rs
@@ -1,0 +1,449 @@
+//! Positivity certificate objects, their exact verifier, and their renderings.
+//!
+//! A certificate is a *claim plus its proof*, and the proof is a polynomial
+//! identity that can be re-expanded from scratch.  [`PositivityCertificate::verify`]
+//! does exactly that, in ℚ, and nothing in this subsystem ever returns a
+//! certificate that has not been through it.
+
+use super::ratpoly::{format_rational, lean_rational, rational_expr, RatPoly};
+use crate::kernel::{ExprId, ExprPool};
+use rug::Rational;
+use std::fmt;
+
+/// One `σ · q²` summand of a sum-of-squares polynomial.  `coeff` is always
+/// strictly positive (zero terms are dropped at construction).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SosTerm {
+    pub coeff: Rational,
+    pub square: RatPoly,
+}
+
+/// A sum of squares with non-negative rational weights: `Σ_j σ_j q_j²`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SosPoly {
+    pub terms: Vec<SosTerm>,
+}
+
+impl SosPoly {
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    pub fn push(&mut self, coeff: Rational, square: RatPoly) {
+        if coeff > 0 && !square.is_zero() {
+            self.terms.push(SosTerm { coeff, square });
+        }
+    }
+
+    /// Expand to an ordinary polynomial.  Exact.
+    pub fn to_poly(&self, nvars: usize) -> RatPoly {
+        let mut acc = RatPoly::zero(nvars);
+        for t in &self.terms {
+            acc = acc.add(&t.square.square().scale(&t.coeff));
+        }
+        acc
+    }
+
+    /// True iff every weight is non-negative — the structural half of the
+    /// soundness argument (the other half is the identity check).
+    pub fn weights_nonnegative(&self) -> bool {
+        self.terms.iter().all(|t| t.coeff >= 0)
+    }
+}
+
+/// One `(Π_{i ∈ constraints} g_i) · σ` term of a certificate.
+///
+/// An empty `constraints` list is the unconstrained `σ_0` term.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Multiplier {
+    /// Multiset of constraint indices whose product forms the weight.
+    pub constraints: Vec<usize>,
+    pub sos: SosPoly,
+}
+
+/// Which Positivstellensatz shape the certificate has.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CertificateKind {
+    /// `p = Σ σ_j q_j²` — unconstrained sum of squares.
+    Sos,
+    /// `p = Σ_α c_α Π g_i^{α_i}` with `c_α ≥ 0` rational constants.
+    Handelman,
+    /// `p = σ_0 + Σ σ_i g_i` with every `σ` a sum of squares.
+    Putinar,
+}
+
+impl CertificateKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CertificateKind::Sos => "sos",
+            CertificateKind::Handelman => "handelman",
+            CertificateKind::Putinar => "putinar",
+        }
+    }
+}
+
+impl fmt::Display for CertificateKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// An exact, re-checkable proof that `p ≥ 0` on `{x : g_i(x) ≥ 0}`.
+#[derive(Clone, Debug)]
+pub struct PositivityCertificate {
+    pub vars: Vec<ExprId>,
+    pub var_names: Vec<String>,
+    pub target: RatPoly,
+    pub constraints: Vec<RatPoly>,
+    pub kind: CertificateKind,
+    /// The degree / level bound that was actually used to find this certificate.
+    pub degree: u32,
+    /// Terms of the identity; `terms[k]` is `(Π g_i) · σ_k`.
+    pub terms: Vec<Multiplier>,
+    /// Human-readable audit trail: how the search proceeded.
+    pub log: Vec<String>,
+}
+
+impl PositivityCertificate {
+    pub fn nvars(&self) -> usize {
+        self.vars.len()
+    }
+
+    /// Expand the right-hand side of the certificate identity, exactly.
+    pub fn expand(&self) -> RatPoly {
+        let n = self.vars.len();
+        let mut acc = RatPoly::zero(n);
+        for m in &self.terms {
+            let mut weight = RatPoly::one(n);
+            for &i in &m.constraints {
+                weight = weight.mul(&self.constraints[i]);
+            }
+            acc = acc.add(&weight.mul(&m.sos.to_poly(n)));
+        }
+        acc
+    }
+
+    /// Exact verification.  Returns `Ok(())` only if
+    ///
+    /// 1. every constraint index is in range,
+    /// 2. every SOS weight is non-negative, and
+    /// 3. the re-expanded right-hand side is *identically* the target.
+    ///
+    /// This is called on every path that returns a certificate; a failure here
+    /// is a bug in the search, never something the caller sees as a success.
+    pub fn verify(&self) -> Result<(), String> {
+        for m in &self.terms {
+            for &i in &m.constraints {
+                if i >= self.constraints.len() {
+                    return Err(format!(
+                        "certificate references constraint #{i} but only {} were given",
+                        self.constraints.len()
+                    ));
+                }
+            }
+            if !m.sos.weights_nonnegative() {
+                return Err("certificate contains a negative sum-of-squares weight".to_string());
+            }
+        }
+        let lhs = &self.target;
+        let rhs = self.expand();
+        if *lhs == rhs {
+            Ok(())
+        } else {
+            let diff = lhs.sub(&rhs);
+            Err(format!(
+                "certificate does not re-expand to the target; residual = {}",
+                diff.display(&self.var_names)
+            ))
+        }
+    }
+
+    /// Total number of squares across all multipliers.
+    pub fn num_squares(&self) -> usize {
+        self.terms.iter().map(|m| m.sos.terms.len()).sum()
+    }
+
+    /// The right-hand side of the identity as a symbolic expression.
+    pub fn to_expr(&self, pool: &ExprPool) -> ExprId {
+        let mut summands: Vec<ExprId> = Vec::new();
+        for m in &self.terms {
+            for t in &m.sos.terms {
+                let mut factors: Vec<ExprId> = Vec::new();
+                if t.coeff != 1 {
+                    factors.push(rational_expr(&t.coeff, pool));
+                }
+                for &i in &m.constraints {
+                    factors.push(self.constraints[i].to_expr(&self.vars, pool));
+                }
+                let two = pool.integer(2);
+                let base = t.square.to_expr(&self.vars, pool);
+                factors.push(pool.pow(base, two));
+                summands.push(match factors.len() {
+                    1 => factors[0],
+                    _ => pool.mul(factors),
+                });
+            }
+        }
+        match summands.len() {
+            0 => pool.integer(0),
+            1 => summands[0],
+            _ => pool.add(summands),
+        }
+    }
+
+    /// A one-line-per-term human rendering of the identity.
+    pub fn identity_string(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        for m in &self.terms {
+            for t in &m.sos.terms {
+                let sq = format!("({})^2", t.square.display(&self.var_names));
+                let mut s = String::new();
+                if t.coeff != 1 {
+                    s.push_str(&format_rational(&t.coeff));
+                    s.push('*');
+                }
+                for &i in &m.constraints {
+                    s.push_str(&format!(
+                        "({})*",
+                        self.constraints[i].display(&self.var_names)
+                    ));
+                }
+                s.push_str(&sq);
+                parts.push(s);
+            }
+        }
+        let rhs = if parts.is_empty() {
+            "0".to_string()
+        } else {
+            parts.join(" + ")
+        };
+        // Render the whole identity, not just its right-hand side: the point of
+        // a certificate is that a reader can check `target = rhs` by expanding.
+        format!("{} = {}", self.target.display(&self.var_names), rhs)
+    }
+
+    /// Description of the statement the certificate proves.
+    pub fn claim_string(&self) -> String {
+        let p = self.target.display(&self.var_names);
+        if self.constraints.is_empty() {
+            format!("0 <= {p}  for all real {}", self.var_names.join(", "))
+        } else {
+            let hyps: Vec<String> = self
+                .constraints
+                .iter()
+                .map(|g| format!("0 <= {}", g.display(&self.var_names)))
+                .collect();
+            format!("{}  ==>  0 <= {p}", hyps.join(" and "))
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Lean export
+    // -----------------------------------------------------------------------
+
+    /// Emit a self-contained Lean 4 source snippet proving the claim.
+    ///
+    /// Returns `None` when the certificate has not been verified or when the
+    /// statement cannot be rendered soundly — an unsound or `sorry`-bearing
+    /// certificate is never emitted.  The unconstrained shape is proved by
+    /// rewriting with the (`ring`-checked) identity and closing with
+    /// `positivity`; the constrained shape hands `nlinarith` the identity plus
+    /// one non-negativity fact per product term.
+    pub fn to_lean(&self) -> Option<String> {
+        if self.verify().is_err() {
+            return None;
+        }
+        if self.terms.iter().all(|m| m.sos.is_empty()) && !self.target.is_zero() {
+            return None;
+        }
+        let names = &self.var_names;
+        if names.iter().any(|n| !is_lean_ident(n)) {
+            return None;
+        }
+        let binders: String = names
+            .iter()
+            .map(|n| format!("({n} : ℝ) "))
+            .collect::<String>();
+
+        let rhs = self.lean_rhs();
+        let target = self.target.to_lean(names);
+
+        let mut out = String::new();
+        out.push_str("import Mathlib.Tactic\n\n");
+        out.push_str(&format!(
+            "-- Alkahest positivity certificate ({}, degree {})\n",
+            self.kind, self.degree
+        ));
+        out.push_str(&format!("-- {}\n\n", self.claim_string()));
+
+        if self.constraints.is_empty() {
+            out.push_str(&format!(
+                "theorem alkahest_sos_identity {binders}:\n    {target} = {rhs} := by\n  ring\n\n"
+            ));
+            out.push_str(&format!(
+                "theorem alkahest_nonneg {binders}:\n    (0 : ℝ) ≤ {target} := by\n\
+                 \x20 rw [alkahest_sos_identity]\n  positivity\n"
+            ));
+        } else {
+            let hyp_binders: String = self
+                .constraints
+                .iter()
+                .enumerate()
+                .map(|(i, g)| format!("(hg{i} : (0 : ℝ) ≤ {}) ", g.to_lean(names)))
+                .collect::<String>();
+            out.push_str(&format!(
+                "theorem alkahest_positivstellensatz_identity {binders}:\n\
+                 \x20   {target} = {rhs} := by\n  ring\n\n"
+            ));
+            let hints = self.lean_hints();
+            out.push_str(&format!(
+                "theorem alkahest_nonneg {binders}{hyp_binders}:\n\
+                 \x20   (0 : ℝ) ≤ {target} := by\n\
+                 \x20 rw [alkahest_positivstellensatz_identity]\n\
+                 \x20 nlinarith [{hints}]\n"
+            ));
+        }
+        Some(out)
+    }
+
+    fn lean_rhs(&self) -> String {
+        let names = &self.var_names;
+        let mut parts: Vec<String> = Vec::new();
+        for m in &self.terms {
+            for t in &m.sos.terms {
+                let mut factors: Vec<String> = Vec::new();
+                if t.coeff != 1 {
+                    factors.push(lean_rational(&t.coeff));
+                }
+                for &i in &m.constraints {
+                    factors.push(self.constraints[i].to_lean(names));
+                }
+                factors.push(format!("{} ^ (2 : ℕ)", t.square.to_lean(names)));
+                parts.push(factors.join(" * "));
+            }
+        }
+        if parts.is_empty() {
+            "(0 : ℝ)".to_string()
+        } else {
+            format!("({})", parts.join(" + "))
+        }
+    }
+
+    /// `nlinarith` hint terms: every square is non-negative, and every product
+    /// of hypothesis constraints with a square is non-negative.
+    fn lean_hints(&self) -> String {
+        let names = &self.var_names;
+        let mut hints: Vec<String> = Vec::new();
+        for m in &self.terms {
+            for t in &m.sos.terms {
+                let sq = format!("sq_nonneg {}", t.square.to_lean(names));
+                if m.constraints.is_empty() {
+                    hints.push(sq);
+                } else {
+                    let mut acc = format!("hg{}", m.constraints[0]);
+                    for &i in &m.constraints[1..] {
+                        acc = format!("mul_nonneg {acc} hg{i}");
+                    }
+                    hints.push(format!("mul_nonneg {acc} ({sq})"));
+                }
+            }
+        }
+        hints.sort();
+        hints.dedup();
+        hints.join(", ")
+    }
+}
+
+fn is_lean_ident(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+impl fmt::Display for PositivityCertificate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} certificate (degree {}): {}",
+            self.kind,
+            self.degree,
+            self.identity_string()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn setup() -> (ExprPool, ExprId) {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        (pool, x)
+    }
+
+    /// `x² + 2x + 1 = (x + 1)²`
+    fn simple_cert() -> PositivityCertificate {
+        let (_pool, x) = setup();
+        let mut target = RatPoly::monomial(1, vec![2], Rational::from(1));
+        target = target.add(&RatPoly::monomial(1, vec![1], Rational::from(2)));
+        target = target.add(&RatPoly::constant(1, Rational::from(1)));
+        let mut sq = RatPoly::monomial(1, vec![1], Rational::from(1));
+        sq = sq.add(&RatPoly::constant(1, Rational::from(1)));
+        let mut sos = SosPoly::default();
+        sos.push(Rational::from(1), sq);
+        PositivityCertificate {
+            vars: vec![x],
+            var_names: vec!["x".to_string()],
+            target,
+            constraints: vec![],
+            kind: CertificateKind::Sos,
+            degree: 2,
+            terms: vec![Multiplier {
+                constraints: vec![],
+                sos,
+            }],
+            log: vec![],
+        }
+    }
+
+    #[test]
+    fn verify_accepts_a_true_identity() {
+        assert!(simple_cert().verify().is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_a_perturbed_identity() {
+        let mut c = simple_cert();
+        c.target = c.target.add(&RatPoly::constant(1, Rational::from(1)));
+        let err = c.verify().unwrap_err();
+        assert!(err.contains("residual"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn verify_rejects_negative_weights() {
+        let mut c = simple_cert();
+        c.terms[0].sos.terms[0].coeff = Rational::from(-1);
+        assert!(c.verify().is_err());
+    }
+
+    #[test]
+    fn lean_emission_is_gated_on_verification() {
+        let mut c = simple_cert();
+        assert!(c.to_lean().is_some());
+        c.target = c.target.add(&RatPoly::constant(1, Rational::from(7)));
+        assert!(c.to_lean().is_none());
+    }
+
+    #[test]
+    fn lean_output_has_no_admissions() {
+        let lean = simple_cert().to_lean().unwrap();
+        assert!(!lean.contains("sorry"));
+        assert!(!lean.contains("admit"));
+        assert!(lean.contains("positivity"));
+    }
+}

--- a/alkahest-core/src/real/sos/gram.rs
+++ b/alkahest-core/src/real/sos/gram.rs
@@ -1,0 +1,279 @@
+//! Gram-matrix / DSOS (diagonally dominant sum-of-squares) search.
+//!
+//! For a target polynomial `p` of even total degree `2d`, a classical sum of
+//! squares certificate `p = z^T Q z` (with `z` the monomial basis of degree
+//! `≤ d`) exists iff there is a **positive semidefinite** Gram matrix `Q`
+//! whose quadratic form matches `p`'s coefficients. Deciding *general* PSD
+//! feasibility is a semidefinite programme, which this crate does not solve
+//! exactly (no floating point is allowed near a certificate).
+//!
+//! Instead this module searches the **diagonally dominant** (DD) subcone,
+//! which is *linear-programming representable* and can be solved with the
+//! exact simplex in [`super::lp`]. Every DD matrix is PSD, so any solution
+//! found here is a sound certificate. The DD cone is a strict subset of the
+//! PSD cone, so failure here means only "no DD certificate at this basis" —
+//! never "not SOS" and never "not nonnegative". The DD cone has the
+//! well-known explicit generator decomposition used in [`dsos_search`]:
+//!
+//! ```text
+//! Q = Σ_i r_i (e_i e_i^T) + Σ_{i<j} [ p_ij (e_i+e_j)(e_i+e_j)^T
+//!                                    + m_ij (e_i-e_j)(e_i-e_j)^T ]
+//! ```
+//!
+//! with `r_i, p_ij, m_ij ≥ 0`. Matching this to `p`'s coefficients is a
+//! linear feasibility system in `(r, p, m)`, solved by [`super::lp::Lp`].
+//! Every generator here is already a square (`e_i`, `e_i+e_j`, `e_i-e_j`
+//! evaluated against the monomial basis), so a feasible point converts
+//! directly into an explicit [`super::cert::SosPoly`] with no further work —
+//! in particular no eigendecomposition, numeric or otherwise.
+
+use super::cert::SosPoly;
+use super::lp::{Lp, LpStatus, Rel};
+use super::ratpoly::{Exponents, RatPoly};
+use rug::Rational;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// All exponent vectors in `nvars` variables with total degree `≤ max_deg`,
+/// in graded-then-lexicographic order.
+pub fn monomial_basis(nvars: usize, max_deg: u32) -> Vec<Exponents> {
+    let mut out = Vec::new();
+    if nvars == 0 {
+        out.push(Vec::new());
+        return out;
+    }
+    let mut cur = vec![0u32; nvars];
+    fn rec(idx: usize, nvars: usize, remaining: u32, cur: &mut Vec<u32>, out: &mut Vec<Exponents>) {
+        if idx == nvars {
+            out.push(cur.clone());
+            return;
+        }
+        for k in 0..=remaining {
+            cur[idx] = k;
+            rec(idx + 1, nvars, remaining - k, cur, out);
+        }
+        cur[idx] = 0;
+    }
+    rec(0, nvars, max_deg, &mut cur, &mut out);
+    out.sort_by(|a, b| {
+        let da: u32 = a.iter().sum();
+        let db: u32 = b.iter().sum();
+        da.cmp(&db).then_with(|| a.cmp(b))
+    });
+    out
+}
+
+fn add_exp(a: &[u32], b: &[u32]) -> Exponents {
+    a.iter().zip(b).map(|(x, y)| x + y).collect()
+}
+
+/// Attempt a DSOS certificate for `p` using the monomial basis of degree
+/// `≤ basis_deg` (covering target total degree up to `2 * basis_deg`).
+///
+/// Returns `Some(sos)` with `sos.to_poly(p.nvars()) == *p` exactly on
+/// success (the caller should still re-verify — this module never skips
+/// that discipline on the caller's behalf), `None` if the DD-Gram LP is
+/// infeasible at this basis or `p` has no term reachable by it.
+/// Coprime ratios `(a, b)` used to build the weighted generators
+/// `(a·e_i ± b·e_j)²`.
+///
+/// The plain DD generators are the `(1, 1)` case. They alone are not enough:
+/// diagonal dominance is not invariant under scaling the basis, so a perfect
+/// square as ordinary as `(x/2 + 1/3)²` has a Gram matrix — its *only* Gram
+/// matrix — that is PSD but not DD, and a search over `(1, 1)` alone would
+/// refuse it. Adding a few fixed ratios enlarges the searched cone while
+/// keeping every generator literally a square, so the certificate stays exact
+/// and the LP stays an LP.
+const RATIOS: &[(i32, i32)] = &[
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (1, 3),
+    (3, 1),
+    (2, 3),
+    (3, 2),
+    (1, 4),
+    (4, 1),
+];
+
+/// Above this many LP columns the weighted generators are dropped and only the
+/// plain DD set is searched, so the exact simplex stays tractable.
+const MAX_LP_COLUMNS: usize = 1200;
+
+/// A generator is a linear form over the monomial basis; the cone searched is
+/// the set of non-negative combinations of their squares.
+fn generators(n: usize) -> Vec<Vec<(usize, Rational)>> {
+    let mut gens: Vec<Vec<(usize, Rational)>> = Vec::new();
+    for i in 0..n {
+        gens.push(vec![(i, Rational::from(1))]);
+    }
+    let pairs: Vec<(usize, usize)> = (0..n)
+        .flat_map(|i| ((i + 1)..n).map(move |j| (i, j)))
+        .collect();
+    let full = n + pairs.len() * RATIOS.len() * 2;
+    let ratios: &[(i32, i32)] = if full > MAX_LP_COLUMNS {
+        &RATIOS[..1]
+    } else {
+        RATIOS
+    };
+    for &(i, j) in &pairs {
+        for &(a, b) in ratios {
+            for sign in [1, -1] {
+                gens.push(vec![(i, Rational::from(a)), (j, Rational::from(sign * b))]);
+            }
+        }
+    }
+    gens
+}
+
+/// Search the cone spanned by the squares of the generator set for an exact
+/// rational sum-of-squares decomposition of `p`.
+///
+/// Returns `None` when no non-negative combination reproduces `p`; that means
+/// "not in this cone at this basis degree", never "not SOS" and never
+/// "not non-negative".
+pub fn dsos_search(p: &RatPoly, basis_deg: u32) -> Option<SosPoly> {
+    let nvars = p.nvars();
+    let basis = monomial_basis(nvars, basis_deg);
+    let n = basis.len();
+    if n == 0 {
+        return if p.is_zero() {
+            Some(SosPoly::default())
+        } else {
+            None
+        };
+    }
+
+    let gens = generators(n);
+
+    // Per target exponent, the (lp_var, coefficient) contributions of each
+    // generator's square: (Σ_u c_u z_u)² contributes c_u·c_v to the monomial
+    // z_u·z_v for every ordered pair (u, v).
+    let mut acc: BTreeMap<Exponents, Vec<(usize, Rational)>> = BTreeMap::new();
+    for (g_idx, g) in gens.iter().enumerate() {
+        let mut local: BTreeMap<Exponents, Rational> = BTreeMap::new();
+        for (u, cu) in g {
+            for (v, cv) in g {
+                let e = add_exp(&basis[*u], &basis[*v]);
+                *local.entry(e).or_insert_with(|| Rational::from(0)) += cu.clone() * cv.clone();
+            }
+        }
+        for (e, c) in local {
+            if c != 0 {
+                acc.entry(e).or_default().push((g_idx, c));
+            }
+        }
+    }
+
+    let mut all_exps: BTreeSet<Exponents> = acc.keys().cloned().collect();
+    all_exps.extend(p.terms().keys().cloned());
+
+    let mut lp = Lp::new(gens.len());
+    for exp in &all_exps {
+        let mut row = vec![Rational::from(0); gens.len()];
+        if let Some(contribs) = acc.get(exp) {
+            for (idx, c) in contribs {
+                row[*idx] += c.clone();
+            }
+        }
+        lp.constrain(row, Rel::Eq, p.coeff(exp));
+    }
+    // Minimise the total weight so the returned certificate is reasonably
+    // sparse; correctness does not depend on this (any feasible point works).
+    for k in 0..gens.len() {
+        lp.set_objective(k, Rational::from(1));
+    }
+
+    let x = match lp.solve() {
+        LpStatus::Optimal(x) => x,
+        _ => return None,
+    };
+
+    let mut sos = SosPoly::default();
+    for (g_idx, g) in gens.iter().enumerate() {
+        let w = x[g_idx].clone();
+        if w <= 0 {
+            continue;
+        }
+        let mut square = RatPoly::zero(nvars);
+        for (u, c) in g {
+            square = square.add(&RatPoly::monomial(nvars, basis[*u].clone(), c.clone()));
+        }
+        sos.push(w, square);
+    }
+    Some(sos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(n: i64, d: i64) -> Rational {
+        Rational::from((n, d))
+    }
+
+    #[test]
+    fn monomial_basis_univariate() {
+        let b = monomial_basis(1, 2);
+        assert_eq!(b, vec![vec![0], vec![1], vec![2]]);
+    }
+
+    #[test]
+    fn monomial_basis_bivariate_degree1() {
+        let b = monomial_basis(2, 1);
+        let mut expect = vec![vec![0, 0], vec![0, 1], vec![1, 0]];
+        expect.sort();
+        let mut got = b.clone();
+        got.sort();
+        assert_eq!(got, expect);
+    }
+
+    #[test]
+    fn dsos_finds_perfect_square() {
+        // p = x^2 + 2x + 1 = (x+1)^2, diagonally dominant trivially.
+        let mut p = RatPoly::monomial(1, vec![2], Rational::from(1));
+        p = p.add(&RatPoly::monomial(1, vec![1], Rational::from(2)));
+        p = p.add(&RatPoly::constant(1, Rational::from(1)));
+        let sos = dsos_search(&p, 1).expect("DSOS should find a certificate");
+        assert_eq!(sos.to_poly(1), p);
+    }
+
+    #[test]
+    fn dsos_finds_diagonal_sum() {
+        // p = x^2 + y^2 (already diagonal).
+        let p = RatPoly::monomial(2, vec![2, 0], Rational::from(1)).add(&RatPoly::monomial(
+            2,
+            vec![0, 2],
+            Rational::from(1),
+        ));
+        let sos = dsos_search(&p, 1).expect("DSOS should find a certificate");
+        assert_eq!(sos.to_poly(2), p);
+    }
+
+    #[test]
+    fn dsos_refuses_unreachable_degree() {
+        // p = x^4, but basis only goes up to degree 1 (so max reachable
+        // quadratic-form degree is 2) — must refuse, not silently drop terms.
+        let p = RatPoly::monomial(1, vec![4], Rational::from(1));
+        assert!(dsos_search(&p, 1).is_none());
+    }
+
+    #[test]
+    fn dsos_handles_off_diagonal_quadratic() {
+        // p = x^2 - 2xy + 2y^2 = (x-y)^2 + y^2, DD-representable directly.
+        let mut p = RatPoly::monomial(2, vec![2, 0], Rational::from(1));
+        p = p.add(&RatPoly::monomial(2, vec![1, 1], Rational::from(-2)));
+        p = p.add(&RatPoly::monomial(2, vec![0, 2], Rational::from(2)));
+        let sos = dsos_search(&p, 1).expect("DSOS should find a certificate");
+        assert_eq!(sos.to_poly(2), p);
+    }
+
+    #[test]
+    fn dsos_rational_coefficients() {
+        // p = (1/2 x + 1/3)^2 = 1/4 x^2 + 1/3 x + 1/9
+        let mut p = RatPoly::monomial(1, vec![2], r(1, 4));
+        p = p.add(&RatPoly::monomial(1, vec![1], r(1, 3)));
+        p = p.add(&RatPoly::constant(1, r(1, 9)));
+        let sos = dsos_search(&p, 1).expect("DSOS should find a certificate");
+        assert_eq!(sos.to_poly(1), p);
+    }
+}

--- a/alkahest-core/src/real/sos/lp.rs
+++ b/alkahest-core/src/real/sos/lp.rs
@@ -1,0 +1,405 @@
+//! A small exact-rational linear programme solver (two-phase simplex).
+//!
+//! Positivity certificates are only worth anything if they are exact, so the
+//! search for one must not go through floating point.  This is a dense
+//! two-phase simplex over `rug::Rational` with **Bland's rule**, which is
+//! provably cycle-free; in exact arithmetic that makes termination
+//! unconditional (no epsilon tolerances, no degeneracy stalls).
+//!
+//! It is deliberately local to the positivity subsystem: it is tuned for the
+//! small, highly structured programmes that Gram-matrix and Handelman searches
+//! produce, and no other part of the crate depends on it.
+
+use rug::Rational;
+
+/// Relation of a constraint row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rel {
+    /// `a · x = b`
+    Eq,
+    /// `a · x ≥ b`
+    Ge,
+    /// `a · x ≤ b`
+    Le,
+}
+
+/// Outcome of a solve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LpStatus {
+    /// An optimal vertex was found; the vector holds the value of every
+    /// structural (caller-declared) variable.
+    Optimal(Vec<Rational>),
+    /// The constraint system has no solution with `x ≥ 0`.
+    Infeasible,
+    /// The objective is unbounded below on the feasible set.
+    Unbounded,
+    /// The pivot budget was exhausted (defensive; Bland's rule should make
+    /// this unreachable).
+    Exhausted,
+}
+
+/// A linear programme in the form
+/// `minimise c · x  subject to  (rows)  and  x ≥ 0`.
+///
+/// Free (sign-unrestricted) variables must be split by the caller into a
+/// positive and a negative part; [`super::gram`] does exactly that for the
+/// off-diagonal Gram entries.
+#[derive(Debug, Clone, Default)]
+pub struct Lp {
+    nvars: usize,
+    rows: Vec<(Vec<Rational>, Rel, Rational)>,
+    objective: Vec<Rational>,
+}
+
+impl Lp {
+    pub fn new(nvars: usize) -> Self {
+        Lp {
+            nvars,
+            rows: Vec::new(),
+            objective: vec![Rational::from(0); nvars],
+        }
+    }
+
+    pub fn nvars(&self) -> usize {
+        self.nvars
+    }
+
+    pub fn nrows(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Add a constraint row.  `coeffs` must have length `nvars`.
+    pub fn constrain(&mut self, coeffs: Vec<Rational>, rel: Rel, rhs: Rational) {
+        debug_assert_eq!(coeffs.len(), self.nvars);
+        self.rows.push((coeffs, rel, rhs));
+    }
+
+    /// Set the coefficient of variable `i` in the (minimised) objective.
+    pub fn set_objective(&mut self, i: usize, c: Rational) {
+        self.objective[i] = c;
+    }
+
+    /// Solve.  Returns the structural variable values on success.
+    pub fn solve(&self) -> LpStatus {
+        // ---------------------------------------------------------------
+        // Build standard form: A x' = b, x' ≥ 0, by adding one slack or
+        // surplus column per inequality row.
+        // ---------------------------------------------------------------
+        let n_slack = self
+            .rows
+            .iter()
+            .filter(|(_, rel, _)| *rel != Rel::Eq)
+            .count();
+        let n_total = self.nvars + n_slack;
+        let m = self.rows.len();
+        if m == 0 {
+            // No constraints: the origin is optimal iff every cost is ≥ 0.
+            return if self.objective.iter().all(|c| *c >= 0) {
+                LpStatus::Optimal(vec![Rational::from(0); self.nvars])
+            } else {
+                LpStatus::Unbounded
+            };
+        }
+
+        let mut a: Vec<Vec<Rational>> = Vec::with_capacity(m);
+        let mut b: Vec<Rational> = Vec::with_capacity(m);
+        let mut slack_at = self.nvars;
+        for (coeffs, rel, rhs) in &self.rows {
+            let mut row = coeffs.clone();
+            row.resize(n_total, Rational::from(0));
+            match rel {
+                Rel::Eq => {}
+                // a·x ≥ b  ⇒  a·x − s = b, s ≥ 0
+                Rel::Ge => {
+                    row[slack_at] = Rational::from(-1);
+                    slack_at += 1;
+                }
+                // a·x ≤ b  ⇒  a·x + s = b, s ≥ 0
+                Rel::Le => {
+                    row[slack_at] = Rational::from(1);
+                    slack_at += 1;
+                }
+            }
+            let mut rhs = rhs.clone();
+            // Phase 1 needs b ≥ 0 so the artificial basis is feasible.
+            if rhs < 0 {
+                for v in row.iter_mut() {
+                    *v = -v.clone();
+                }
+                rhs = -rhs;
+            }
+            a.push(row);
+            b.push(rhs);
+        }
+
+        // ---------------------------------------------------------------
+        // Phase 1 — minimise the sum of artificial variables.
+        // ---------------------------------------------------------------
+        let n_phase1 = n_total + m;
+        let mut tab: Vec<Vec<Rational>> = Vec::with_capacity(m);
+        for (i, row) in a.iter().enumerate() {
+            let mut r = row.clone();
+            r.resize(n_phase1, Rational::from(0));
+            r[n_total + i] = Rational::from(1);
+            r.push(b[i].clone()); // rhs in the last column
+            tab.push(r);
+        }
+        let mut basis: Vec<usize> = (n_total..n_phase1).collect();
+
+        let mut cost = vec![Rational::from(0); n_phase1];
+        for c in cost.iter_mut().skip(n_total) {
+            *c = Rational::from(1);
+        }
+        match simplex(&mut tab, &mut basis, &cost, n_phase1) {
+            SimplexOutcome::Optimal(value) => {
+                if value > 0 {
+                    return LpStatus::Infeasible;
+                }
+            }
+            SimplexOutcome::Unbounded => return LpStatus::Unbounded,
+            SimplexOutcome::Exhausted => return LpStatus::Exhausted,
+        }
+
+        // Drive any artificial still in the basis (necessarily at level 0) out.
+        // A row that cannot be pivoted is linearly dependent and gets dropped.
+        let mut keep: Vec<bool> = vec![true; tab.len()];
+        for i in 0..tab.len() {
+            if basis[i] < n_total {
+                continue;
+            }
+            let mut pivoted = false;
+            for j in 0..n_total {
+                if tab[i][j] != 0 {
+                    pivot(&mut tab, &mut basis, i, j);
+                    pivoted = true;
+                    break;
+                }
+            }
+            if !pivoted {
+                keep[i] = false;
+            }
+        }
+        let mut idx = 0;
+        tab.retain(|_| {
+            let k = keep[idx];
+            idx += 1;
+            k
+        });
+        idx = 0;
+        basis.retain(|_| {
+            let k = keep[idx];
+            idx += 1;
+            k
+        });
+
+        // ---------------------------------------------------------------
+        // Phase 2 — the real objective, artificial columns dropped.
+        // ---------------------------------------------------------------
+        for row in tab.iter_mut() {
+            let rhs = row[n_phase1].clone();
+            row.truncate(n_total);
+            row.push(rhs);
+        }
+        let mut cost2 = self.objective.clone();
+        cost2.resize(n_total, Rational::from(0));
+        match simplex(&mut tab, &mut basis, &cost2, n_total) {
+            SimplexOutcome::Optimal(_) => {}
+            SimplexOutcome::Unbounded => return LpStatus::Unbounded,
+            SimplexOutcome::Exhausted => return LpStatus::Exhausted,
+        }
+
+        let mut x = vec![Rational::from(0); n_total];
+        for (i, &bi) in basis.iter().enumerate() {
+            if bi < n_total {
+                x[bi] = tab[i][n_total].clone();
+            }
+        }
+        x.truncate(self.nvars);
+        LpStatus::Optimal(x)
+    }
+}
+
+enum SimplexOutcome {
+    Optimal(Rational),
+    Unbounded,
+    Exhausted,
+}
+
+/// Core simplex loop.  `tab` rows are `[a_0 … a_{n-1} | rhs]` in canonical form
+/// with respect to `basis`; `cost` is the objective being minimised.
+fn simplex(
+    tab: &mut [Vec<Rational>],
+    basis: &mut [usize],
+    cost: &[Rational],
+    n: usize,
+) -> SimplexOutcome {
+    let m = tab.len();
+    // Reduced costs d_j = c_j − c_B · B⁻¹A_j, computed directly from the
+    // canonical tableau, plus the current objective value.
+    let mut d = vec![Rational::from(0); n + 1];
+    d[..n].clone_from_slice(&cost[..n]);
+    for (i, row) in tab.iter().enumerate().take(m) {
+        let cb = cost[basis[i]].clone();
+        if cb == 0 {
+            continue;
+        }
+        for j in 0..=n {
+            d[j] -= Rational::from(&cb * &row[j]);
+        }
+    }
+
+    // Bland's rule guarantees termination, so the budget is a pure backstop
+    // against a bug rather than part of the algorithm.
+    let budget = 200_000usize.saturating_add(50 * m * (n + 1));
+    for _ in 0..budget {
+        // Entering: lowest-index column with a strictly negative reduced cost.
+        let mut enter = None;
+        for (j, dj) in d.iter().enumerate().take(n) {
+            if *dj < 0 {
+                enter = Some(j);
+                break;
+            }
+        }
+        let Some(j) = enter else {
+            return SimplexOutcome::Optimal(-d[n].clone());
+        };
+
+        // Leaving: min ratio, ties broken by smallest basis index (Bland).
+        let mut leave: Option<usize> = None;
+        let mut best_ratio: Option<Rational> = None;
+        for i in 0..m {
+            if tab[i][j] <= 0 {
+                continue;
+            }
+            let ratio = Rational::from(&tab[i][n] / &tab[i][j]);
+            let better = match &best_ratio {
+                None => true,
+                Some(r) => ratio < *r || (ratio == *r && basis[i] < basis[leave.unwrap()]),
+            };
+            if better {
+                best_ratio = Some(ratio);
+                leave = Some(i);
+            }
+        }
+        let Some(i) = leave else {
+            return SimplexOutcome::Unbounded;
+        };
+
+        pivot(tab, basis, i, j);
+
+        // Re-canonicalise the reduced-cost row on the entering column.
+        if d[j] != 0 {
+            let f = d[j].clone();
+            for k in 0..=n {
+                d[k] -= Rational::from(&f * &tab[i][k]);
+            }
+        }
+    }
+    SimplexOutcome::Exhausted
+}
+
+/// Gauss–Jordan pivot on `tab[i][j]`, updating the basis.
+fn pivot(tab: &mut [Vec<Rational>], basis: &mut [usize], i: usize, j: usize) {
+    let p = tab[i][j].clone();
+    debug_assert!(p != 0);
+    for v in tab[i].iter_mut() {
+        *v /= &p;
+    }
+    let prow = tab[i].clone();
+    for (k, row) in tab.iter_mut().enumerate() {
+        if k == i {
+            continue;
+        }
+        let f = row[j].clone();
+        if f == 0 {
+            continue;
+        }
+        for (t, pv) in row.iter_mut().zip(prow.iter()) {
+            *t -= Rational::from(&f * pv);
+        }
+    }
+    basis[i] = j;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(n: i64) -> Rational {
+        Rational::from(n)
+    }
+
+    #[test]
+    fn trivial_feasible_system() {
+        // x0 + x1 = 1, x ≥ 0
+        let mut lp = Lp::new(2);
+        lp.constrain(vec![q(1), q(1)], Rel::Eq, q(1));
+        match lp.solve() {
+            LpStatus::Optimal(x) => {
+                assert_eq!(x[0].clone() + x[1].clone(), 1);
+                assert!(x.iter().all(|v| *v >= 0));
+            }
+            other => panic!("expected optimal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_infeasibility() {
+        // x0 = 1 and x0 = 2 cannot both hold.
+        let mut lp = Lp::new(1);
+        lp.constrain(vec![q(1)], Rel::Eq, q(1));
+        lp.constrain(vec![q(1)], Rel::Eq, q(2));
+        assert_eq!(lp.solve(), LpStatus::Infeasible);
+    }
+
+    #[test]
+    fn nonnegativity_makes_system_infeasible() {
+        // x0 = −1 with x0 ≥ 0.
+        let mut lp = Lp::new(1);
+        lp.constrain(vec![q(1)], Rel::Eq, q(-1));
+        assert_eq!(lp.solve(), LpStatus::Infeasible);
+    }
+
+    #[test]
+    fn optimises_a_bounded_objective() {
+        // minimise −x0 − x1 s.t. x0 + 2x1 ≤ 4, 3x0 + x1 ≤ 6  ⇒  (8/5, 6/5).
+        let mut lp = Lp::new(2);
+        lp.constrain(vec![q(1), q(2)], Rel::Le, q(4));
+        lp.constrain(vec![q(3), q(1)], Rel::Le, q(6));
+        lp.set_objective(0, q(-1));
+        lp.set_objective(1, q(-1));
+        match lp.solve() {
+            LpStatus::Optimal(x) => {
+                assert_eq!(x[0], Rational::from((8, 5)));
+                assert_eq!(x[1], Rational::from((6, 5)));
+            }
+            other => panic!("expected optimal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_unboundedness() {
+        // minimise −x0 with only x0 ≥ 1.
+        let mut lp = Lp::new(1);
+        lp.constrain(vec![q(1)], Rel::Ge, q(1));
+        lp.set_objective(0, q(-1));
+        assert_eq!(lp.solve(), LpStatus::Unbounded);
+    }
+
+    #[test]
+    fn handles_degenerate_rows_without_cycling() {
+        // A deliberately degenerate system: duplicated and dependent rows.
+        let mut lp = Lp::new(3);
+        lp.constrain(vec![q(1), q(1), q(1)], Rel::Eq, q(1));
+        lp.constrain(vec![q(2), q(2), q(2)], Rel::Eq, q(2));
+        lp.constrain(vec![q(1), q(0), q(0)], Rel::Le, q(1));
+        lp.set_objective(2, q(-1));
+        match lp.solve() {
+            LpStatus::Optimal(x) => {
+                let s: Rational = x.iter().fold(Rational::from(0), |a, v| a + v.clone());
+                assert_eq!(s, 1);
+            }
+            other => panic!("expected optimal, got {other:?}"),
+        }
+    }
+}

--- a/alkahest-core/src/real/sos/mod.rs
+++ b/alkahest-core/src/real/sos/mod.rs
@@ -1,0 +1,552 @@
+//! Positivity certificates: sum-of-squares and Positivstellensatz-lite.
+//!
+//! [`crate::real::cad`] decides real-algebraic questions completely, and pays
+//! doubly-exponential cost for that completeness. This module answers the
+//! narrower question that actually arises in applied autoresearch — *is this
+//! polynomial non-negative (here)?* — by **searching for a certificate** rather
+//! than deciding, which is fast when it succeeds and honest when it does not.
+//!
+//! The certificate is a short algebraic identity:
+//!
+//! ```text
+//! unconstrained:  p = Σ_j σ_j·q_j²                        (CertificateKind::Sos)
+//! constrained:    p = Σ_α c_α·Π_i g_i^{α_i},  c_α ≥ 0     (CertificateKind::Handelman)
+//! ```
+//!
+//! Anyone can check it by expanding — no trust in this implementation is
+//! required, which is exactly what makes it useful to a proof assistant
+//! (`PositivityCertificate::to_lean`) and to a referee.
+//!
+//! # Soundness
+//!
+//! Everything here is exact rational arithmetic: the search runs through the
+//! rational simplex in [`lp`], and no floating point appears anywhere near a
+//! certificate. Every certificate is re-expanded and compared against the
+//! target identically ([`PositivityCertificate::verify`]) before it is
+//! returned. A certificate that fails that check is a bug in the search and is
+//! refused, never returned.
+//!
+//! # What a failure means
+//!
+//! The search covers a linear-programming-representable subcone of the PSD
+//! cone (see [`mod@gram`]), which is therefore solvable
+//! exactly. That is a strict subset of the SOS cone, so
+//! [`SosError::NoCertificate`] means precisely *"no certificate of this shape
+//! at this degree"*. It does **not** mean "not a sum of squares", and it does
+//! **not** mean "not non-negative". The three answers are kept distinct in the
+//! API on purpose — a loop that conflates them will discard true results:
+//!
+//! | Outcome | Meaning |
+//! |---|---|
+//! | `Ok(cert)` | Proved non-negative, with a checkable witness |
+//! | `Err(Negative { witness })` | Proved *not* non-negative — a point where `p < 0` |
+//! | `Err(NoCertificate { .. })` | Undecided at this degree — raise it, or use `decide` |
+
+pub mod cert;
+pub mod gram;
+pub mod lp;
+pub mod ratpoly;
+
+pub use cert::{CertificateKind, Multiplier, PositivityCertificate, SosPoly, SosTerm};
+pub use ratpoly::RatPoly;
+
+use crate::kernel::{ExprId, ExprPool};
+use lp::{Lp, LpStatus, Rel};
+use ratpoly::Exponents;
+use rug::Rational;
+use std::fmt;
+
+/// Search bounds for the certificate search.
+#[derive(Debug, Clone, Copy)]
+pub struct SosOpts {
+    /// Highest total degree of the monomial basis for SOS multipliers. `None`
+    /// derives it from the target (`⌈deg p / 2⌉`), which is the smallest basis
+    /// that can possibly work.
+    pub basis_degree: Option<u32>,
+    /// Handelman level: the largest total power of the constraint products
+    /// `Π g_i^{α_i}` considered (`Σ α_i ≤ level`).
+    pub level: u32,
+}
+
+impl Default for SosOpts {
+    fn default() -> Self {
+        SosOpts {
+            basis_degree: None,
+            level: 2,
+        }
+    }
+}
+
+/// Why a positivity question was not answered with a certificate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SosError {
+    /// The input (or a constraint) is not a polynomial in the given variables.
+    NotPolynomial(String),
+    /// No certificate of the searched shape exists at this degree/level. This
+    /// is *not* a claim that `p` is negative, nor that it is not SOS.
+    NoCertificate(String),
+    /// `p` is definitely **not** non-negative: a witness point is included.
+    Negative(String),
+    /// Malformed call (no variables, degree bounds out of range, …).
+    InvalidInput(String),
+    /// A candidate certificate failed exact re-expansion. Refused rather than
+    /// returned; this indicates a bug in the search.
+    VerificationFailed(String),
+}
+
+impl fmt::Display for SosError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SosError::NotPolynomial(s) => write!(f, "sos: not a polynomial: {s}"),
+            SosError::NoCertificate(s) => write!(f, "sos: no certificate found: {s}"),
+            SosError::Negative(s) => write!(f, "sos: the target is negative somewhere: {s}"),
+            SosError::InvalidInput(s) => write!(f, "sos: invalid input: {s}"),
+            SosError::VerificationFailed(s) => {
+                write!(f, "sos: certificate failed exact verification: {s}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SosError {}
+
+impl crate::errors::AlkahestError for SosError {
+    fn code(&self) -> &'static str {
+        match self {
+            SosError::NotPolynomial(_) => "E-SOS-001",
+            SosError::NoCertificate(_) => "E-SOS-002",
+            SosError::Negative(_) => "E-SOS-003",
+            SosError::InvalidInput(_) => "E-SOS-004",
+            SosError::VerificationFailed(_) => "E-SOS-005",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        Some(match self {
+            SosError::NotPolynomial(_) => {
+                "positivity certificates are for polynomials in the listed variables; expand or \
+                 clear denominators first, and pass every symbol that occurs as a variable"
+            }
+            SosError::NoCertificate(_) => {
+                "raise basis_degree (unconstrained) or level (constrained); the search covers the \
+                 diagonally dominant subcone, so this is not a proof that no SOS decomposition \
+                 exists — alkahest.decide is the complete (and far more expensive) fallback"
+            }
+            SosError::Negative(_) => {
+                "the witness point in the message satisfies the constraints and makes the target \
+                 negative; the claim is false as stated"
+            }
+            SosError::InvalidInput(_) => {
+                "pass at least one variable, and keep basis_degree/level within the supported range"
+            }
+            SosError::VerificationFailed(_) => {
+                "internal: report the target and constraints as a minimal failing example"
+            }
+        })
+    }
+}
+
+/// Small rational grid used to look for a point where the claim already fails.
+/// Finding one turns "no certificate" into the *definite* answer "negative",
+/// which is far more useful to a loop than an inconclusive refusal.
+fn negativity_witness(
+    target: &RatPoly,
+    constraints: &[RatPoly],
+    nvars: usize,
+) -> Option<Vec<Rational>> {
+    const GRID: [(i32, i32); 9] = [
+        (0, 1),
+        (1, 1),
+        (-1, 1),
+        (1, 2),
+        (-1, 2),
+        (2, 1),
+        (-2, 1),
+        (3, 1),
+        (-3, 1),
+    ];
+    // Cartesian product over a small grid; bounded so this stays cheap.
+    let per_var = if nvars <= 2 {
+        GRID.len()
+    } else if nvars <= 4 {
+        5
+    } else {
+        3
+    };
+    let total = per_var.checked_pow(nvars as u32)?;
+    if total > 20_000 {
+        return None;
+    }
+    for idx in 0..total {
+        let mut rest = idx;
+        let mut point = Vec::with_capacity(nvars);
+        for _ in 0..nvars {
+            let (num, den) = GRID[rest % per_var];
+            rest /= per_var;
+            point.push(Rational::from((num, den)));
+        }
+        if constraints.iter().any(|g| g.eval(&point) < 0) {
+            continue;
+        }
+        if target.eval(&point) < 0 {
+            return Some(point);
+        }
+    }
+    None
+}
+
+fn format_point(names: &[String], point: &[Rational]) -> String {
+    names
+        .iter()
+        .zip(point.iter())
+        .map(|(n, v)| format!("{n} = {v}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn var_names(vars: &[ExprId], pool: &ExprPool) -> Vec<String> {
+    vars.iter().map(|&v| pool.display(v).to_string()).collect()
+}
+
+/// Finish a candidate: verify exactly, then return it. A candidate that does
+/// not re-expand to the target is refused — this is the single choke point that
+/// every success path goes through.
+fn finish(cert: PositivityCertificate) -> Result<PositivityCertificate, SosError> {
+    match cert.verify() {
+        Ok(()) => Ok(cert),
+        Err(why) => Err(SosError::VerificationFailed(why)),
+    }
+}
+
+/// `p = Σ_j σ_j·q_j²` — an exact rational sum-of-squares decomposition.
+///
+/// Refuses with [`SosError`] rather than guessing: `E-SOS-003` when `p` is
+/// negative somewhere (with a witness point), `E-SOS-002` when no certificate
+/// of the searched shape exists at this basis degree.
+pub fn sos_decompose(
+    expr: ExprId,
+    vars: &[ExprId],
+    pool: &ExprPool,
+    opts: &SosOpts,
+) -> Result<PositivityCertificate, SosError> {
+    if vars.is_empty() {
+        return Err(SosError::InvalidInput(
+            "at least one variable is required".into(),
+        ));
+    }
+    let names = var_names(vars, pool);
+    let target = RatPoly::from_expr(expr, vars, pool).map_err(SosError::NotPolynomial)?;
+    let nvars = vars.len();
+    let mut log = Vec::new();
+
+    // A constant is trivially decided, either way.
+    if let Some(c) = target.as_constant() {
+        if c < 0 {
+            return Err(SosError::Negative(format!(
+                "the target is the negative constant {c}"
+            )));
+        }
+        let mut sos = SosPoly::default();
+        sos.push(c.clone(), RatPoly::one(nvars));
+        log.push(format!("target is the non-negative constant {c}"));
+        return finish(PositivityCertificate {
+            vars: vars.to_vec(),
+            var_names: names,
+            target,
+            constraints: Vec::new(),
+            kind: CertificateKind::Sos,
+            degree: 0,
+            terms: vec![Multiplier {
+                constraints: Vec::new(),
+                sos,
+            }],
+            log,
+        });
+    }
+
+    // Odd total degree cannot be globally non-negative (the leading behaviour
+    // flips sign), and the witness search below usually finds the point.
+    let deg = target.total_degree();
+    if let Some(point) = negativity_witness(&target, &[], nvars) {
+        return Err(SosError::Negative(format!(
+            "p({}) = {} < 0",
+            format_point(&names, &point),
+            target.eval(&point)
+        )));
+    }
+    if deg % 2 == 1 {
+        return Err(SosError::NoCertificate(format!(
+            "total degree {deg} is odd, so p cannot be a sum of squares (no witness point was \
+             found on the sampling grid, so this is a statement about the SOS question, not a \
+             claim that p is negative)"
+        )));
+    }
+
+    let basis_deg = opts.basis_degree.unwrap_or(deg.div_ceil(2));
+    if basis_deg > 12 {
+        return Err(SosError::InvalidInput(
+            "basis_degree above 12 is refused: the monomial basis (and the exact LP over it) \
+             grows too fast to be useful"
+                .into(),
+        ));
+    }
+    log.push(format!(
+        "searching the diagonally dominant cone over the degree-{basis_deg} monomial basis"
+    ));
+
+    let Some(sos) = gram::dsos_search(&target, basis_deg) else {
+        return Err(SosError::NoCertificate(format!(
+            "no diagonally dominant Gram matrix over the degree-{basis_deg} monomial basis; \
+             raise basis_degree, or note that p may be non-negative without being SOS \
+             (e.g. the Motzkin polynomial)"
+        )));
+    };
+
+    finish(PositivityCertificate {
+        vars: vars.to_vec(),
+        var_names: names,
+        target,
+        constraints: Vec::new(),
+        kind: CertificateKind::Sos,
+        degree: basis_deg,
+        terms: vec![Multiplier {
+            constraints: Vec::new(),
+            sos,
+        }],
+        log,
+    })
+}
+
+/// All exponent multisets `α` over `k` constraints with `1 ≤ Σ α_i ≤ level`,
+/// plus the empty product (the constant term).
+fn constraint_products(k: usize, level: u32) -> Vec<Vec<usize>> {
+    let mut out = vec![Vec::new()];
+    let mut frontier: Vec<Vec<usize>> = vec![Vec::new()];
+    for _ in 0..level {
+        let mut next = Vec::new();
+        for base in &frontier {
+            let start = base.last().copied().unwrap_or(0);
+            for i in start..k {
+                let mut v = base.clone();
+                v.push(i);
+                next.push(v);
+            }
+        }
+        out.extend(next.iter().cloned());
+        frontier = next;
+    }
+    out
+}
+
+/// Prove `p ≥ 0` on `{x : g_i(x) ≥ 0}` with a Handelman-style certificate
+/// `p = Σ_α c_α·Π g_i^{α_i}`, `c_α ≥ 0` rational.
+///
+/// With no constraints this is [`sos_decompose`].
+pub fn prove_nonneg(
+    expr: ExprId,
+    constraints: &[ExprId],
+    vars: &[ExprId],
+    pool: &ExprPool,
+    opts: &SosOpts,
+) -> Result<PositivityCertificate, SosError> {
+    if constraints.is_empty() {
+        return sos_decompose(expr, vars, pool, opts);
+    }
+    if vars.is_empty() {
+        return Err(SosError::InvalidInput(
+            "at least one variable is required".into(),
+        ));
+    }
+    if opts.level == 0 || opts.level > 8 {
+        return Err(SosError::InvalidInput(
+            "level must be between 1 and 8".into(),
+        ));
+    }
+    let names = var_names(vars, pool);
+    let nvars = vars.len();
+    let target = RatPoly::from_expr(expr, vars, pool).map_err(SosError::NotPolynomial)?;
+    let gs: Vec<RatPoly> = constraints
+        .iter()
+        .map(|&g| RatPoly::from_expr(g, vars, pool).map_err(SosError::NotPolynomial))
+        .collect::<Result<_, _>>()?;
+
+    if let Some(point) = negativity_witness(&target, &gs, nvars) {
+        return Err(SosError::Negative(format!(
+            "p({}) = {} < 0 at a point satisfying every constraint",
+            format_point(&names, &point),
+            target.eval(&point)
+        )));
+    }
+
+    let products = constraint_products(gs.len(), opts.level);
+    // Expand each product Π g_i^{α_i} once; the LP unknowns are its weights.
+    let expanded: Vec<RatPoly> = products
+        .iter()
+        .map(|idxs| {
+            let mut acc = RatPoly::one(nvars);
+            for &i in idxs {
+                acc = acc.mul(&gs[i]);
+            }
+            acc
+        })
+        .collect();
+
+    // Match coefficients: Σ_α c_α·(Π g)_α = p, one equation per monomial that
+    // occurs anywhere, with c_α ≥ 0 (the simplex's implicit variable bound).
+    let mut monomials: std::collections::BTreeSet<Exponents> = Default::default();
+    for e in &expanded {
+        monomials.extend(e.terms().keys().cloned());
+    }
+    monomials.extend(target.terms().keys().cloned());
+
+    let mut prog = Lp::new(expanded.len());
+    for m in &monomials {
+        let row: Vec<Rational> = expanded.iter().map(|e| e.coeff(m)).collect();
+        prog.constrain(row, Rel::Eq, target.coeff(m));
+    }
+
+    let weights = match prog.solve() {
+        LpStatus::Optimal(w) => w,
+        _ => {
+            return Err(SosError::NoCertificate(format!(
+                "no non-negative combination of constraint products up to level {} reproduces the \
+                 target; raise level, or the claim may need a Putinar-style certificate with \
+                 SOS (not merely non-negative constant) multipliers",
+                opts.level
+            )));
+        }
+    };
+
+    let mut terms = Vec::new();
+    for (idxs, w) in products.iter().zip(weights.iter()) {
+        if *w == 0 {
+            continue;
+        }
+        let mut sos = SosPoly::default();
+        sos.push(w.clone(), RatPoly::one(nvars));
+        terms.push(Multiplier {
+            constraints: idxs.clone(),
+            sos,
+        });
+    }
+
+    finish(PositivityCertificate {
+        vars: vars.to_vec(),
+        var_names: names,
+        target,
+        constraints: gs,
+        kind: CertificateKind::Handelman,
+        degree: opts.level,
+        terms,
+        log: vec![format!(
+            "Handelman search over {} constraint products up to level {}",
+            products.len(),
+            opts.level
+        )],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::AlkahestError;
+    use crate::kernel::Domain;
+
+    fn setup() -> (ExprPool, ExprId, ExprId) {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        (pool, x, y)
+    }
+
+    #[test]
+    fn perfect_square_is_certified() {
+        let (pool, x, y) = setup();
+        // (x - y)^2 = x^2 - 2xy + y^2
+        let p = pool.add(vec![
+            pool.mul(vec![x, x]),
+            pool.mul(vec![pool.integer(-2_i32), x, y]),
+            pool.mul(vec![y, y]),
+        ]);
+        let cert = sos_decompose(p, &[x, y], &pool, &SosOpts::default()).expect("certificate");
+        assert_eq!(cert.kind, CertificateKind::Sos);
+        cert.verify().expect("re-expands exactly");
+        assert!(cert.num_squares() >= 1);
+    }
+
+    #[test]
+    fn sum_of_even_powers_is_certified() {
+        let (pool, x, y) = setup();
+        let p = pool.add(vec![
+            pool.mul(vec![x, x, x, x]),
+            pool.mul(vec![y, y, y, y]),
+            pool.integer(1_i32),
+        ]);
+        let cert = sos_decompose(p, &[x, y], &pool, &SosOpts::default()).expect("certificate");
+        cert.verify().expect("re-expands exactly");
+    }
+
+    #[test]
+    fn negative_polynomial_returns_a_witness_not_a_refusal() {
+        let (pool, x, y) = setup();
+        // x^2 - 1 is negative at x = 0.
+        let p = pool.add(vec![pool.mul(vec![x, x]), pool.integer(-1_i32)]);
+        let err = sos_decompose(p, &[x, y], &pool, &SosOpts::default()).expect_err("negative");
+        assert!(matches!(err, SosError::Negative(_)));
+        assert_eq!(err.code(), "E-SOS-003");
+    }
+
+    #[test]
+    fn motzkin_refuses_rather_than_lying() {
+        let (pool, x, y) = setup();
+        // Motzkin: x^4·y^2 + x^2·y^4 − 3·x^2·y^2 + 1 is non-negative but not SOS.
+        let p = pool.add(vec![
+            pool.mul(vec![x, x, x, x, y, y]),
+            pool.mul(vec![x, x, y, y, y, y]),
+            pool.mul(vec![pool.integer(-3_i32), x, x, y, y]),
+            pool.integer(1_i32),
+        ]);
+        let err = sos_decompose(p, &[x, y], &pool, &SosOpts::default())
+            .expect_err("Motzkin is not a sum of squares");
+        // It must NOT claim negativity — the polynomial is non-negative.
+        assert!(
+            matches!(err, SosError::NoCertificate(_)),
+            "expected an honest 'no certificate', got {err:?}"
+        );
+        assert_eq!(err.code(), "E-SOS-002");
+    }
+
+    #[test]
+    fn non_polynomial_is_refused() {
+        let (pool, x, y) = setup();
+        let p = pool.func("sin", vec![x]);
+        let err = sos_decompose(p, &[x, y], &pool, &SosOpts::default()).expect_err("not a poly");
+        assert_eq!(err.code(), "E-SOS-001");
+    }
+
+    #[test]
+    fn handelman_certifies_on_a_box() {
+        let (pool, x, _y) = setup();
+        // On 0 ≤ x ≤ 1 (as x ≥ 0 and 1 − x ≥ 0): x − x² = x·(1 − x) ≥ 0.
+        let g1 = x;
+        let g2 = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let p = pool.add(vec![x, pool.mul(vec![pool.integer(-1_i32), x, x])]);
+        let cert =
+            prove_nonneg(p, &[g1, g2], &[x], &pool, &SosOpts::default()).expect("certificate");
+        assert_eq!(cert.kind, CertificateKind::Handelman);
+        cert.verify().expect("re-expands exactly");
+    }
+
+    #[test]
+    fn handelman_finds_the_witness_when_the_claim_is_false() {
+        let (pool, x, _y) = setup();
+        // x − 1/2 is negative at x = 0, which satisfies x ≥ 0.
+        let g1 = x;
+        let p = pool.add(vec![x, pool.rational(-1_i32, 2_i32)]);
+        let err = prove_nonneg(p, &[g1], &[x], &pool, &SosOpts::default()).expect_err("negative");
+        assert!(matches!(err, SosError::Negative(_)));
+    }
+}

--- a/alkahest-core/src/real/sos/ratpoly.rs
+++ b/alkahest-core/src/real/sos/ratpoly.rs
@@ -1,0 +1,532 @@
+//! Sparse multivariate polynomials over ℚ.
+//!
+//! [`crate::poly::MultiPoly`] is the project's workhorse sparse polynomial, but
+//! it is over ℤ.  Positivity certificates are intrinsically rational — the
+//! multipliers `σ_j` in `p = Σ σ_j q_j²` almost never come out integral — so
+//! this module carries its own exact ℚ representation.  Everything here is
+//! closed under the operations the certificate verifier needs (add, multiply,
+//! scale, square) and nothing here ever rounds.
+
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use rug::{Integer, Rational};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Exponent vector, one entry per variable (fixed-length, no trailing-zero
+/// stripping — the length always equals `nvars`, which keeps the monomial
+/// ordering total and the arithmetic branch-free).
+pub type Exponents = Vec<u32>;
+
+/// A sparse polynomial over ℚ in a fixed number of variables.
+///
+/// Invariant: `terms` never contains a zero coefficient, and every key has
+/// length exactly `nvars`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RatPoly {
+    nvars: usize,
+    terms: BTreeMap<Exponents, Rational>,
+}
+
+impl RatPoly {
+    pub fn zero(nvars: usize) -> Self {
+        RatPoly {
+            nvars,
+            terms: BTreeMap::new(),
+        }
+    }
+
+    pub fn constant(nvars: usize, c: Rational) -> Self {
+        let mut p = RatPoly::zero(nvars);
+        if c != 0 {
+            p.terms.insert(vec![0; nvars], c);
+        }
+        p
+    }
+
+    pub fn one(nvars: usize) -> Self {
+        RatPoly::constant(nvars, Rational::from(1))
+    }
+
+    /// `coeff * x^exps`.
+    pub fn monomial(nvars: usize, exps: Exponents, coeff: Rational) -> Self {
+        debug_assert_eq!(exps.len(), nvars);
+        let mut p = RatPoly::zero(nvars);
+        if coeff != 0 {
+            p.terms.insert(exps, coeff);
+        }
+        p
+    }
+
+    pub fn nvars(&self) -> usize {
+        self.nvars
+    }
+
+    pub fn terms(&self) -> &BTreeMap<Exponents, Rational> {
+        &self.terms
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// The polynomial's value viewed as a rational constant, if it is one.
+    pub fn as_constant(&self) -> Option<Rational> {
+        match self.terms.len() {
+            0 => Some(Rational::from(0)),
+            1 => {
+                let (e, c) = self.terms.iter().next().unwrap();
+                if e.iter().all(|&v| v == 0) {
+                    Some(c.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn total_degree(&self) -> u32 {
+        self.terms
+            .keys()
+            .map(|e| e.iter().sum::<u32>())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Highest exponent of variable `i` occurring anywhere.
+    pub fn degree_in(&self, i: usize) -> u32 {
+        self.terms.keys().map(|e| e[i]).max().unwrap_or(0)
+    }
+
+    pub fn coeff(&self, exps: &[u32]) -> Rational {
+        self.terms
+            .get(exps)
+            .cloned()
+            .unwrap_or_else(|| Rational::from(0))
+    }
+
+    fn insert_add(&mut self, exps: Exponents, c: Rational) {
+        if c == 0 {
+            return;
+        }
+        match self.terms.get_mut(&exps) {
+            Some(slot) => {
+                *slot += c;
+                if *slot == 0 {
+                    self.terms.remove(&exps);
+                }
+            }
+            None => {
+                self.terms.insert(exps, c);
+            }
+        }
+    }
+
+    pub fn add(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.nvars, other.nvars);
+        let mut out = self.clone();
+        for (e, c) in &other.terms {
+            out.insert_add(e.clone(), c.clone());
+        }
+        out
+    }
+
+    pub fn sub(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.nvars, other.nvars);
+        let mut out = self.clone();
+        for (e, c) in &other.terms {
+            out.insert_add(e.clone(), -c.clone());
+        }
+        out
+    }
+
+    pub fn neg(&self) -> Self {
+        RatPoly {
+            nvars: self.nvars,
+            terms: self
+                .terms
+                .iter()
+                .map(|(e, c)| (e.clone(), -c.clone()))
+                .collect(),
+        }
+    }
+
+    pub fn scale(&self, k: &Rational) -> Self {
+        if *k == 0 {
+            return RatPoly::zero(self.nvars);
+        }
+        RatPoly {
+            nvars: self.nvars,
+            terms: self
+                .terms
+                .iter()
+                .map(|(e, c)| (e.clone(), Rational::from(c * k)))
+                .collect(),
+        }
+    }
+
+    pub fn mul(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.nvars, other.nvars);
+        let mut out = RatPoly::zero(self.nvars);
+        for (ea, ca) in &self.terms {
+            for (eb, cb) in &other.terms {
+                let e: Exponents = ea.iter().zip(eb).map(|(a, b)| a + b).collect();
+                out.insert_add(e, Rational::from(ca * cb));
+            }
+        }
+        out
+    }
+
+    pub fn square(&self) -> Self {
+        self.mul(self)
+    }
+
+    pub fn pow(&self, n: u32) -> Self {
+        let mut acc = RatPoly::one(self.nvars);
+        for _ in 0..n {
+            acc = acc.mul(self);
+        }
+        acc
+    }
+
+    /// Evaluate at a rational point (one value per variable).
+    pub fn eval(&self, point: &[Rational]) -> Rational {
+        debug_assert_eq!(point.len(), self.nvars);
+        let mut acc = Rational::from(0);
+        for (e, c) in &self.terms {
+            let mut term = c.clone();
+            for (i, &k) in e.iter().enumerate() {
+                for _ in 0..k {
+                    term *= &point[i];
+                }
+            }
+            acc += term;
+        }
+        acc
+    }
+
+    /// Least common multiple of all coefficient denominators.
+    pub fn denominator_lcm(&self) -> Integer {
+        let mut l = Integer::from(1);
+        for c in self.terms.values() {
+            l.lcm_mut(c.denom());
+        }
+        l
+    }
+
+    // -----------------------------------------------------------------------
+    // Conversion
+    // -----------------------------------------------------------------------
+
+    /// Convert a symbolic expression to a rational polynomial in `vars`.
+    ///
+    /// Returns `Err(reason)` for anything that is not a polynomial with
+    /// rational coefficients in exactly those variables.
+    pub fn from_expr(expr: ExprId, vars: &[ExprId], pool: &ExprPool) -> Result<Self, String> {
+        let nvars = vars.len();
+        pool.with(expr, |data| match data {
+            ExprData::Integer(n) => Ok(RatPoly::constant(nvars, Rational::from(n.0.clone()))),
+            ExprData::Rational(r) => Ok(RatPoly::constant(nvars, r.0.clone())),
+            ExprData::Symbol { name, .. } => match vars.iter().position(|&v| v == expr) {
+                Some(i) => {
+                    let mut e = vec![0; nvars];
+                    e[i] = 1;
+                    Ok(RatPoly::monomial(nvars, e, Rational::from(1)))
+                }
+                None => Err(format!(
+                    "symbol `{name}` is not among the declared variables; \
+                     pass it in `vars` or eliminate it first"
+                )),
+            },
+            ExprData::Add(args) => {
+                let mut acc = RatPoly::zero(nvars);
+                for &a in args {
+                    acc = acc.add(&RatPoly::from_expr(a, vars, pool)?);
+                }
+                Ok(acc)
+            }
+            ExprData::Mul(args) => {
+                let mut acc = RatPoly::one(nvars);
+                for &a in args {
+                    acc = acc.mul(&RatPoly::from_expr(a, vars, pool)?);
+                }
+                Ok(acc)
+            }
+            ExprData::Pow { base, exp } => {
+                let k = pool.with(*exp, |d| match d {
+                    ExprData::Integer(n) => n.0.to_i32(),
+                    _ => None,
+                });
+                match k {
+                    Some(k) if k >= 0 => {
+                        let b = RatPoly::from_expr(*base, vars, pool)?;
+                        Ok(b.pow(k as u32))
+                    }
+                    // A negative exponent is still polynomial when the base is a
+                    // constant: `x**2 / 4` parses as `x**2 * 4**(-1)`, and
+                    // rational coefficients written as divisions are the common
+                    // case, not an exotic one.
+                    Some(k) => {
+                        let b = RatPoly::from_expr(*base, vars, pool)?;
+                        let c = b.as_constant().ok_or_else(|| {
+                            "a negative exponent is only polynomial when its base is constant; \
+                             clear the denominator first (multiply through)"
+                                .to_string()
+                        })?;
+                        if c == 0 {
+                            return Err("division by zero in the target polynomial".to_string());
+                        }
+                        let mut acc = Rational::from(1);
+                        for _ in 0..k.unsigned_abs() {
+                            acc /= c.clone();
+                        }
+                        Ok(RatPoly::constant(nvars, acc))
+                    }
+                    None => Err(
+                        "only integer exponents are supported in positivity certificates"
+                            .to_string(),
+                    ),
+                }
+            }
+            ExprData::Float(_) => Err("floating-point coefficients are not exact; \
+                                       rationalize them before certifying positivity"
+                .to_string()),
+            other => Err(format!(
+                "expression is not polynomial (node: {})",
+                node_kind(other)
+            )),
+        })
+    }
+
+    /// Convert back to a symbolic expression.
+    pub fn to_expr(&self, vars: &[ExprId], pool: &ExprPool) -> ExprId {
+        if self.terms.is_empty() {
+            return pool.integer(0);
+        }
+        let one = Rational::from(1);
+        let summands: Vec<ExprId> = self
+            .terms
+            .iter()
+            .rev()
+            .map(|(exps, c)| {
+                let mut factors: Vec<ExprId> = Vec::new();
+                let is_unit = *c == one;
+                let has_vars = exps.iter().any(|&e| e > 0);
+                if !is_unit || !has_vars {
+                    factors.push(rational_expr(c, pool));
+                }
+                for (i, &e) in exps.iter().enumerate() {
+                    if e == 0 {
+                        continue;
+                    }
+                    factors.push(if e == 1 {
+                        vars[i]
+                    } else {
+                        let ex = pool.integer(e);
+                        pool.pow(vars[i], ex)
+                    });
+                }
+                match factors.len() {
+                    0 => pool.integer(1),
+                    1 => factors[0],
+                    _ => pool.mul(factors),
+                }
+            })
+            .collect();
+        match summands.len() {
+            1 => summands[0],
+            _ => pool.add(summands),
+        }
+    }
+
+    /// Human-readable rendering with the given variable names.
+    pub fn display(&self, names: &[String]) -> String {
+        if self.terms.is_empty() {
+            return "0".to_string();
+        }
+        let mut parts: Vec<String> = Vec::new();
+        for (exps, c) in self.terms.iter().rev() {
+            let has_vars = exps.iter().any(|&e| e > 0);
+            let mut s = String::new();
+            if !has_vars || *c != 1 {
+                s.push_str(&format_rational(c));
+                if has_vars {
+                    s.push('*');
+                }
+            }
+            let mut first = true;
+            for (i, &e) in exps.iter().enumerate() {
+                if e == 0 {
+                    continue;
+                }
+                if !first {
+                    s.push('*');
+                }
+                first = false;
+                s.push_str(&names[i]);
+                if e > 1 {
+                    s.push_str(&format!("^{e}"));
+                }
+            }
+            parts.push(s);
+        }
+        parts.join(" + ")
+    }
+
+    /// Lean 4 term rendering.  Uses full-precision integer literals (never
+    /// truncates to machine words) so the emitted certificate always states
+    /// exactly the identity that was verified.
+    pub fn to_lean(&self, names: &[String]) -> String {
+        if self.terms.is_empty() {
+            return "(0 : ℝ)".to_string();
+        }
+        let mut parts: Vec<String> = Vec::new();
+        for (exps, c) in self.terms.iter().rev() {
+            let mut factors: Vec<String> = Vec::new();
+            let has_vars = exps.iter().any(|&e| e > 0);
+            if !has_vars || *c != 1 {
+                factors.push(lean_rational(c));
+            }
+            for (i, &e) in exps.iter().enumerate() {
+                if e == 0 {
+                    continue;
+                }
+                factors.push(if e == 1 {
+                    format!("({} : ℝ)", names[i])
+                } else {
+                    format!("({} : ℝ) ^ ({e} : ℕ)", names[i])
+                });
+            }
+            parts.push(factors.join(" * "));
+        }
+        format!("({})", parts.join(" + "))
+    }
+}
+
+fn node_kind(data: &ExprData) -> &'static str {
+    match data {
+        ExprData::Func { .. } => "function application",
+        ExprData::Predicate { .. } => "predicate",
+        ExprData::Piecewise { .. } => "piecewise",
+        ExprData::Forall { .. } | ExprData::Exists { .. } => "quantifier",
+        ExprData::BigO(_) => "big-O",
+        ExprData::RootSum { .. } => "root sum",
+        _ => "unsupported",
+    }
+}
+
+pub(crate) fn rational_expr(c: &Rational, pool: &ExprPool) -> ExprId {
+    if *c.denom() == 1 {
+        pool.integer(c.numer().clone())
+    } else {
+        pool.rational(c.numer().clone(), c.denom().clone())
+    }
+}
+
+pub(crate) fn format_rational(c: &Rational) -> String {
+    if *c.denom() == 1 {
+        c.numer().to_string()
+    } else {
+        format!("{}/{}", c.numer(), c.denom())
+    }
+}
+
+pub(crate) fn lean_rational(c: &Rational) -> String {
+    if *c.denom() == 1 {
+        format!("({} : ℝ)", c.numer())
+    } else {
+        format!("(({} : ℝ) / ({} : ℝ))", c.numer(), c.denom())
+    }
+}
+
+impl fmt::Display for RatPoly {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let names: Vec<String> = (0..self.nvars).map(|i| format!("x{i}")).collect();
+        write!(f, "{}", self.display(&names))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn r(n: i64, d: i64) -> Rational {
+        Rational::from((n, d))
+    }
+
+    #[test]
+    fn add_mul_are_exact() {
+        // (x + 1/2)^2 = x^2 + x + 1/4
+        let x = RatPoly::monomial(1, vec![1], Rational::from(1));
+        let half = RatPoly::constant(1, r(1, 2));
+        let sq = x.add(&half).square();
+        assert_eq!(sq.coeff(&[2]), Rational::from(1));
+        assert_eq!(sq.coeff(&[1]), Rational::from(1));
+        assert_eq!(sq.coeff(&[0]), r(1, 4));
+    }
+
+    #[test]
+    fn cancellation_removes_terms() {
+        let x = RatPoly::monomial(1, vec![1], Rational::from(1));
+        assert!(x.sub(&x).is_zero());
+    }
+
+    #[test]
+    fn eval_matches_expansion() {
+        // p = 2x^2 y - y + 3
+        let mut p = RatPoly::zero(2);
+        p = p.add(&RatPoly::monomial(2, vec![2, 1], Rational::from(2)));
+        p = p.add(&RatPoly::monomial(2, vec![0, 1], Rational::from(-1)));
+        p = p.add(&RatPoly::constant(2, Rational::from(3)));
+        // at (2, 3): 2*4*3 - 3 + 3 = 24
+        assert_eq!(p.eval(&[Rational::from(2), Rational::from(3)]), 24);
+    }
+
+    #[test]
+    fn from_expr_roundtrip() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        // (x - y)^2
+        let two = pool.integer(2);
+        let neg = pool.integer(-1);
+        let diff = pool.add(vec![x, pool.mul(vec![neg, y])]);
+        let e = pool.pow(diff, two);
+        let p = RatPoly::from_expr(e, &[x, y], &pool).unwrap();
+        assert_eq!(p.coeff(&[2, 0]), 1);
+        assert_eq!(p.coeff(&[1, 1]), -2);
+        assert_eq!(p.coeff(&[0, 2]), 1);
+
+        let back = p.to_expr(&[x, y], &pool);
+        let q = RatPoly::from_expr(back, &[x, y], &pool).unwrap();
+        assert_eq!(p, q);
+    }
+
+    #[test]
+    fn from_expr_accepts_rational_literals() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let quarter = pool.rational(1, 4);
+        let e = pool.add(vec![pool.pow(x, pool.integer(2)), quarter]);
+        let p = RatPoly::from_expr(e, &[x], &pool).unwrap();
+        assert_eq!(p.coeff(&[0]), r(1, 4));
+    }
+
+    #[test]
+    fn from_expr_rejects_transcendental() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let s = pool.func("sin", vec![x]);
+        assert!(RatPoly::from_expr(s, &[x], &pool).is_err());
+    }
+
+    #[test]
+    fn from_expr_rejects_undeclared_symbol() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let e = pool.add(vec![x, y]);
+        assert!(RatPoly::from_expr(e, &[x], &pool).is_err());
+    }
+}

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -156,6 +156,12 @@ use alkahest_core::transform::{
     FourierError as CoreFourierError, LaplaceError as CoreLaplaceError,
     ZTransformError as CoreZTransformError,
 };
+// P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+use alkahest_core::real::sos::{
+    prove_nonneg as core_prove_nonneg, sos_decompose as core_sos_decompose,
+    PositivityCertificate as CorePositivityCertificate, SosError as CoreSosError,
+    SosOpts as CoreSosOpts,
+};
 // V3-1 — Integer number theory
 use alkahest_core::number_theory::{
     discrete_log as nt_discrete_log, factorint as nt_factorint, isprime as nt_isprime,
@@ -279,6 +285,8 @@ pyo3::create_exception!(alkahest, PyRealRootError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyLatticeError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyPslqError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyCadError, PyAlkahestError);
+// P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+pyo3::create_exception!(alkahest, PySosError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PySumError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyProductError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyNumberTheoryError, PyAlkahestError);
@@ -7939,6 +7947,172 @@ fn py_decide(py: Python<'_>, formula: PyRef<PyExpr>) -> PyResult<(bool, PyObject
     Ok((r.truth, wit))
 }
 
+// ---------------------------------------------------------------------------
+// P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+// ---------------------------------------------------------------------------
+
+fn sos_error_to_py(e: CoreSosError) -> PyErr {
+    Python::with_gil(|py| {
+        let exc_type = py.get_type_bound::<PySosError>();
+        make_structured_err(py, &exc_type, &e)
+    })
+}
+
+/// An exact, re-checkable proof that a polynomial is non-negative.
+///
+/// Returned by :func:`alkahest.sos_decompose` and :func:`alkahest.prove_nonneg`.
+/// The identity it carries has already been re-expanded and compared against
+/// the target exactly; :meth:`verify` re-runs that check on demand, so a
+/// downstream consumer never has to trust the search that produced it.
+#[pyclass(name = "PositivityCertificate")]
+struct PyPositivityCertificate {
+    inner: CorePositivityCertificate,
+    pool: Py<PyExprPool>,
+}
+
+#[pymethods]
+impl PyPositivityCertificate {
+    /// ``"sos"``, ``"handelman"`` or ``"putinar"``.
+    #[getter]
+    fn kind(&self) -> String {
+        self.inner.kind.as_str().to_string()
+    }
+
+    /// The basis degree (unconstrained) or Handelman level actually used.
+    #[getter]
+    fn degree(&self) -> u32 {
+        self.inner.degree
+    }
+
+    /// Number of squares in the decomposition.
+    #[getter]
+    fn num_squares(&self) -> usize {
+        self.inner.num_squares()
+    }
+
+    /// The certificate identity, e.g. ``p = 1*(x - y)^2 + 2*(y)^2``.
+    #[getter]
+    fn identity(&self) -> String {
+        self.inner.identity_string()
+    }
+
+    /// The claim being certified, e.g. ``p >= 0 on {g_0 >= 0, g_1 >= 0}``.
+    #[getter]
+    fn claim(&self) -> String {
+        self.inner.claim_string()
+    }
+
+    /// How the search proceeded — the audit trail.
+    #[getter]
+    fn log(&self) -> Vec<String> {
+        self.inner.log.clone()
+    }
+
+    /// The right-hand side of the identity as an :class:`Expr`.
+    #[getter]
+    fn expression(&self, py: Python<'_>) -> PyExpr {
+        let id = {
+            let pool = self.pool.borrow(py);
+            self.inner.to_expr(&pool.inner)
+        };
+        PyExpr {
+            id,
+            pool: self.pool.clone_ref(py),
+        }
+    }
+
+    /// Re-run the exact verification. Always ``True`` for a certificate that
+    /// was returned (the search refuses rather than returning an unverified
+    /// one); exposed so a caller can check independently.
+    fn verify(&self) -> PyResult<bool> {
+        match self.inner.verify() {
+            Ok(()) => Ok(true),
+            Err(why) => Err(sos_error_to_py(CoreSosError::VerificationFailed(why))),
+        }
+    }
+
+    /// Lean 4 rendering of the identity, or ``None`` when it cannot be emitted
+    /// soundly.
+    fn to_lean(&self) -> Option<String> {
+        self.inner.to_lean()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PositivityCertificate(kind={}, degree={}, squares={})",
+            self.inner.kind.as_str(),
+            self.inner.degree,
+            self.inner.num_squares()
+        )
+    }
+}
+
+/// `alkahest.sos_decompose(expr, vars, *, basis_degree=None) -> PositivityCertificate`
+///
+/// Exact rational sum-of-squares decomposition ``p = Σ_j σ_j·q_j²``.
+///
+/// Raises :exc:`alkahest.SosError` rather than guessing: ``E-SOS-003`` with a
+/// witness point when ``p`` is negative somewhere, ``E-SOS-002`` when no
+/// certificate of the searched shape exists at this basis degree (which is
+/// *not* a proof that none exists — see the docs).
+#[pyfunction]
+#[pyo3(name = "sos_decompose", signature = (expr, vars, *, basis_degree = None))]
+fn py_sos_decompose(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    vars: Vec<PyRef<PyExpr>>,
+    basis_degree: Option<u32>,
+) -> PyResult<PyPositivityCertificate> {
+    let pool_py = expr.pool.clone_ref(py);
+    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
+    let opts = CoreSosOpts {
+        basis_degree,
+        ..Default::default()
+    };
+    let inner = {
+        let pool = pool_py.borrow(py);
+        core_sos_decompose(expr.id, &var_ids, &pool.inner, &opts).map_err(sos_error_to_py)?
+    };
+    Ok(PyPositivityCertificate {
+        inner,
+        pool: pool_py,
+    })
+}
+
+/// `alkahest.prove_nonneg(expr, vars, *, constraints=(), basis_degree=None, level=2)`
+///
+/// Prove ``p ≥ 0`` on ``{x : g_i(x) ≥ 0}`` with a Handelman-style certificate
+/// ``p = Σ_α c_α·Π g_i^{α_i}`` (``c_α ≥ 0``). With no constraints this is
+/// :func:`sos_decompose`.
+#[pyfunction]
+#[pyo3(name = "prove_nonneg", signature = (expr, vars, *, constraints = None, basis_degree = None, level = 2))]
+fn py_prove_nonneg(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    vars: Vec<PyRef<PyExpr>>,
+    constraints: Option<Vec<PyRef<PyExpr>>>,
+    basis_degree: Option<u32>,
+    level: u32,
+) -> PyResult<PyPositivityCertificate> {
+    let pool_py = expr.pool.clone_ref(py);
+    let var_ids: Vec<ExprId> = vars.iter().map(|v| v.id).collect();
+    let cons: Vec<ExprId> = constraints
+        .map(|cs| cs.iter().map(|c| c.id).collect())
+        .unwrap_or_default();
+    let opts = CoreSosOpts {
+        basis_degree,
+        level,
+    };
+    let inner = {
+        let pool = pool_py.borrow(py);
+        core_prove_nonneg(expr.id, &cons, &var_ids, &pool.inner, &opts).map_err(sos_error_to_py)?
+    };
+    Ok(PyPositivityCertificate {
+        inner,
+        pool: pool_py,
+    })
+}
+
 /// Brown-style CAD projection polynomials after eliminating ``elim_var``.
 #[pyfunction(name = "cad_project")]
 fn py_cad_project(
@@ -9952,6 +10126,10 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_exists, m)?)?;
     m.add_function(wrap_pyfunction!(py_decide, m)?)?;
     m.add_function(wrap_pyfunction!(py_cad_project, m)?)?;
+    // P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    m.add_class::<PyPositivityCertificate>()?;
+    m.add_function(wrap_pyfunction!(py_sos_decompose, m)?)?;
+    m.add_function(wrap_pyfunction!(py_prove_nonneg, m)?)?;
     m.add_function(wrap_pyfunction!(py_cad_lift, m)?)?;
     m.add_function(wrap_pyfunction!(py_routh_hurwitz, m)?)?;
     // V5-1 — Lean 4 certificate exporter
@@ -10069,6 +10247,8 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("LatticeError", m.py().get_type_bound::<PyLatticeError>())?;
     m.add("PslqError", m.py().get_type_bound::<PyPslqError>())?;
     m.add("CadError", m.py().get_type_bound::<PyCadError>())?;
+    // P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    m.add("SosError", m.py().get_type_bound::<PySosError>())?;
     m.add("SumError", m.py().get_type_bound::<PySumError>())?;
     m.add("ProductError", m.py().get_type_bound::<PyProductError>())?;
     m.add(

--- a/docs/features.md
+++ b/docs/features.md
@@ -66,6 +66,8 @@ Current stable feature surface.
 - Difference equations / `rsolve`: constant-coefficient recurrences with polynomial RHS
 - Symbolic products: definite and indefinite via Γ-ratio telescoping (`product_definite`, `product_indefinite`, `Product`)
 
+- Positivity certificates (`sos_decompose`, `prove_nonneg`): exact rational sum-of-squares and Handelman certificates on basic semialgebraic sets, re-expanded and checked identically before return; distinguishes "certified", "definitely negative (with witness)" and "no certificate at this degree" (`E-SOS-*`)
+
 ## Number theory
 
 - `alkahest.number_theory`: `isprime`, `factorint`, `nextprime`, `totient`, `jacobi_symbol`

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Ball arithmetic](./ball-arithmetic.md)
 - [ODE and DAE modeling](./ode-dae.md)
 - [Polynomial system solving](./solving.md)
+- [Positivity certificates (SOS)](./positivity.md)
 - [Interoperability](./interop.md)
 - [Reinforcement learning](./rl.md)
 - [Derivation logs](./derivations.md)

--- a/docs/mdbook/src/positivity.md
+++ b/docs/mdbook/src/positivity.md
@@ -1,0 +1,122 @@
+# Positivity certificates (SOS / Positivstellensatz)
+
+`decide` answers real-algebraic questions **completely**, by CAD, and pays
+doubly-exponential cost for that completeness. Most positivity questions that
+actually arise — is this bound valid, is this Lyapunov candidate non-negative,
+is this inequality true on a box — do not need completeness. They need a
+**certificate**: a short algebraic identity that makes the answer checkable by
+anyone, including a proof assistant.
+
+```python
+import alkahest as ak
+
+pool = ak.ExprPool()
+x, y = pool.symbol("x"), pool.symbol("y")
+
+cert = ak.sos_decompose(x*x - pool.integer(2)*x*y + y*y, [x, y])
+cert.kind        # "sos"
+cert.identity    # p = 1*(x - y)^2
+cert.verify()    # True — re-expands to the target exactly
+cert.to_lean()   # Lean 4 rendering, or None
+```
+
+Constrained, on a basic semialgebraic set:
+
+```python
+g1, g2 = x, pool.integer(1) - x          # the box 0 ≤ x ≤ 1
+cert = ak.prove_nonneg(x - x*x, [x], constraints=[g1, g2])
+cert.kind        # "handelman"  —  x − x² = x·(1 − x)
+```
+
+## Three outcomes, deliberately kept apart
+
+This is the part that matters for a search loop, and the part most CAS get
+wrong by collapsing:
+
+| Outcome | Meaning | What a loop should do |
+|---|---|---|
+| `PositivityCertificate` | **Proved** non-negative, with a checkable witness | Record it; cite it |
+| `SosError` `E-SOS-003` | **Proved not** non-negative — a witness point is in the message | The conjecture is false; kill the branch |
+| `SosError` `E-SOS-002` | **Undecided**: no certificate of this shape at this degree | Raise the degree, or fall back to `decide` |
+
+`E-SOS-002` is *not* a claim that the polynomial is not a sum of squares, and
+certainly not that it is negative. The canonical example is the **Motzkin
+polynomial** `x⁴y² + x²y⁴ − 3x²y² + 1`, which is non-negative everywhere but
+provably not a sum of squares. Asked to decompose it, this module refuses with
+`E-SOS-002` — it does not report it as negative, and it does not invent a
+decomposition.
+
+## What the search actually covers
+
+A sum-of-squares decomposition `p = zᵀQz` over the monomial basis `z` exists
+iff there is a **positive semidefinite** Gram matrix `Q` matching `p`'s
+coefficients. Deciding general PSD feasibility is a semidefinite programme,
+and no floating-point SDP solver is allowed anywhere near a certificate here —
+a rounded `Q` is not a proof.
+
+So the search covers a **linear-programming-representable subcone**: the
+non-negative combinations of squares of a fixed generator set,
+
+```text
+(e_i)²,    (a·e_i ± b·e_j)²   for small coprime (a, b)
+```
+
+solved with the exact rational simplex in `real::sos::lp` (Bland's rule, so
+termination is unconditional and there are no epsilon tolerances). Every
+generator is *literally a square*, so any feasible point is a sound certificate
+by construction.
+
+The `(1,1)` case alone is the classical diagonally-dominant (DSOS) cone. It is
+not enough on its own: diagonal dominance is not invariant under scaling the
+basis, so a perfect square as ordinary as `(x/2 + 1/3)²` has a Gram matrix —
+its only one — that is PSD but not DD. The extra ratios widen the cone enough
+to catch these while keeping the problem an LP.
+
+The cone is still a strict subset of the SOS cone, which is exactly why
+`E-SOS-002` is phrased as a statement about the search rather than about the
+polynomial.
+
+## Constrained certificates
+
+With constraints `g_i ≥ 0`, `prove_nonneg` searches for a **Handelman**
+certificate
+
+```text
+p = Σ_α c_α · Π_i g_i^{α_i},    c_α ≥ 0 rational,   Σ_i α_i ≤ level
+```
+
+which is again an exact LP in the weights `c_α`. `level` is a user-visible
+parameter; exceeding it is a refusal (`E-SOS-002`), not a failure. Handelman
+is complete for polytopes given a high enough level, but the level needed is
+not known in advance — so raising it on refusal is a meaningful retry.
+
+## Verification
+
+Every certificate is re-expanded in exact rational arithmetic and compared
+against the target **identically** before it is returned. A candidate that
+fails is refused (`E-SOS-005`), never returned with a caveat. `verify()` runs
+the same check on demand so a downstream consumer never has to trust the
+search that produced the certificate.
+
+## When to use this versus `decide`
+
+| | `sos_decompose` / `prove_nonneg` | `decide` (CAD) |
+|---|---|---|
+| Answers | Non-negativity, with a certificate | Any real-algebraic sentence |
+| Completeness | No — refuses honestly | Yes |
+| Cost | LP in exact rationals | Doubly exponential |
+| Output | Checkable identity, Lean-exportable | Truth value (+ witness) |
+
+The intended pattern is: try the certificate route first because it is cheap
+and its output is citable; fall back to `decide` on `E-SOS-002` when you need
+the complete answer and can afford it.
+
+## Scope of this release
+
+Shipped: exact rational SOS over the generator cone above, Handelman
+certificates on basic semialgebraic sets, exact verification, and Lean export.
+
+Not yet shipped: full SDP-based SOS (which needs an exact or rationally-rounded
+semidefinite solver), and Putinar-style certificates with genuine SOS — rather
+than non-negative constant — multipliers. `CertificateKind::Putinar` exists in
+the certificate type so those can be added without a shape change.

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -120,6 +120,8 @@ from .alkahest import (  # noqa: F401
     Not,
     Or,
     Port,
+    # P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    PositivityCertificate,
     # PA-5: Primitive registry
     PrimitiveRegistry,
     RationalFunction,
@@ -212,6 +214,7 @@ from .alkahest import (  # noqa: F401
     poly_normal,
     product_definite,
     product_indefinite,
+    prove_nonneg,
     re,
     real_roots,
     refine_root,
@@ -245,6 +248,7 @@ from .alkahest import (  # noqa: F401
     sin,
     sinh,
     solve_linear_recurrence_homogeneous,
+    sos_decompose,
     sparse_interp,
     sparse_interp_univariate,
     sqrt,
@@ -341,6 +345,7 @@ from .exceptions import (
     RsolveError,
     SeriesError,
     SolverError,
+    SosError,
     SparseGcdError,
     SparseInterpError,
     SumError,
@@ -376,6 +381,8 @@ _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "RsolveError",
     "SeriesError",
     "SolverError",
+    # P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    "SosError",
     "SparseGcdError",
     "SparseInterpError",
     "SumError",
@@ -1743,6 +1750,7 @@ __all__ = [
     "ParseError",
     "PoolError",
     "Port",
+    "PositivityCertificate",
     "PrimaryComponent",
     # PA-5
     "PrimitiveRegistry",
@@ -1763,6 +1771,8 @@ __all__ = [
     "Series",
     "SeriesError",
     "SolverError",
+    # P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    "SosError",
     "SparseGcdError",
     "SparseInterpError",
     "SumError",
@@ -1894,6 +1904,8 @@ __all__ = [
     "primary_decomposition",
     "product_definite",
     "product_indefinite",
+    # P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    "prove_nonneg",
     "radical",
     "re",
     # V2-4
@@ -1947,6 +1959,8 @@ __all__ = [
     "solve",
     "solve_linear_recurrence_homogeneous",
     "solve_numerical",
+    # P1 item 8 — positivity certificates (SOS / Positivstellensatz)
+    "sos_decompose",
     "sparse_interp",
     "sparse_interp_univariate",
     "sqrt",

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -39,6 +39,7 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
     E-DOMAIN-*                 DomainError  (reserved; Python-only pending Rust impl)
     E-CERT-001                 CertificateUnavailableError  (Python-only; certificate ledger)
     E-BUDGET-001 … E-BUDGET-003 BudgetExceededError (P1 search plumbing item 4)
+    E-SOS-001 … E-SOS-005      SosError (P1 item 8 — positivity certificates)
     E-BATCH-001                 (Python-only; alkahest._batch fallback for a
                                  batch_map/batch_map_iter item whose exception carried no
                                  .code of its own — see docs/mdbook/src/batch.md)
@@ -191,6 +192,30 @@ class SumError(AlkahestError):
         span: tuple[int, int] | None = None,
     ):
         super().__init__(message, code="E-SUM-001", remediation=remediation, span=span)
+
+
+class SosError(AlkahestError):
+    """A positivity question was not answered with a certificate.
+
+    The three outcomes are deliberately distinct, because conflating them
+    loses information a search loop needs:
+
+    * ``E-SOS-003`` — the target is *definitely* negative somewhere; the
+      message carries a witness point. The claim is false.
+    * ``E-SOS-002`` — no certificate of the searched shape at this degree.
+      This is **not** a proof that none exists; raise the degree, or fall back
+      to the complete (and far more expensive) :func:`alkahest.decide`.
+    * ``E-SOS-001`` / ``E-SOS-004`` — the input was not a polynomial in the
+      given variables, or the call was malformed.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code="E-SOS-001", remediation=remediation, span=span)
 
 
 class ProductError(AlkahestError):

--- a/tests/test_sos.py
+++ b/tests/test_sos.py
@@ -1,0 +1,169 @@
+"""P1 item 8 — positivity certificates (SOS / Positivstellensatz).
+
+`decide` answers real-algebraic questions completely and pays doubly
+exponential cost for it. These tests cover the cheaper, certificate-producing
+route — and, just as importantly, the boundaries where it must decline instead
+of overclaiming. The three outcomes (certified / definitely negative / no
+certificate at this degree) must stay distinguishable.
+"""
+
+import alkahest as ak
+import pytest
+
+
+def _square(e):
+    return e * e
+
+
+# ---------------------------------------------------------------------------
+# Certificates it must find
+# ---------------------------------------------------------------------------
+
+
+def test_perfect_square_is_certified():
+    pool = ak.ExprPool()
+    x, y = pool.symbol("x"), pool.symbol("y")
+    p = _square(x) - pool.integer(2) * x * y + _square(y)  # (x - y)^2
+
+    cert = ak.sos_decompose(p, [x, y])
+
+    assert cert.kind == "sos"
+    assert cert.verify()
+    assert cert.num_squares >= 1
+    assert " = " in cert.identity  # renders the full identity, not just the RHS
+
+
+def test_scaled_square_is_certified():
+    """``(x/2 + 1/3)²`` — its only Gram matrix is PSD but not diagonally
+    dominant, so a plain DD search would refuse a perfect square."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    p = _square(x) / pool.integer(4) + x / pool.integer(3) + pool.rational(1, 9)
+
+    cert = ak.sos_decompose(p, [x])
+
+    assert cert.verify()
+
+
+def test_certificate_reexpands_to_the_target():
+    """The whole point: the identity can be re-checked without trusting us."""
+    pool = ak.ExprPool()
+    x, y = pool.symbol("x"), pool.symbol("y")
+    p = _square(_square(x)) + _square(_square(y)) + pool.integer(1)
+
+    cert = ak.sos_decompose(p, [x, y])
+
+    difference = ak.simplify(cert.expression - p).value
+    assert ak.evaluate(difference, {x: 1.7, y: -0.4}).value == pytest.approx(0.0, abs=1e-12)
+    # and exactly, via the certificate's own re-expansion
+    assert cert.verify()
+
+
+def test_box_constrained_positivity_via_handelman():
+    """``x − x² ≥ 0`` on ``0 ≤ x ≤ 1``, certified as ``x·(1 − x)``."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    g1 = x
+    g2 = pool.integer(1) - x
+    p = x - _square(x)
+
+    cert = ak.prove_nonneg(p, [x], constraints=[g1, g2])
+
+    assert cert.kind == "handelman"
+    assert cert.verify()
+    assert "0 <=" in cert.claim
+
+
+def test_certificate_exposes_an_audit_trail():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    cert = ak.sos_decompose(_square(x), [x])
+
+    assert cert.log
+    assert cert.degree >= 0
+    assert "PositivityCertificate(" in repr(cert)
+
+
+# ---------------------------------------------------------------------------
+# The three outcomes must stay distinct
+# ---------------------------------------------------------------------------
+
+
+def test_negative_polynomial_yields_a_witness_not_a_shrug():
+    """``x² − 1`` is negative at 0: that is a definite answer, code E-SOS-003."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    p = _square(x) - pool.integer(1)
+
+    with pytest.raises(ak.SosError) as excinfo:
+        ak.sos_decompose(p, [x])
+
+    assert excinfo.value.code == "E-SOS-003"
+    assert "< 0" in str(excinfo.value)
+
+
+def test_motzkin_refuses_without_claiming_negativity():
+    """The Motzkin polynomial is non-negative but not a sum of squares.
+
+    The one thing the implementation must not do is call it negative. It has to
+    come back with E-SOS-002 — "no certificate of this shape" — which is an
+    honest statement about the search, not about the polynomial.
+    """
+    pool = ak.ExprPool()
+    x, y = pool.symbol("x"), pool.symbol("y")
+    # x^4·y^2 + x^2·y^4 − 3·x^2·y^2 + 1
+    p = (
+        _square(x) * _square(x) * _square(y)
+        + _square(x) * _square(y) * _square(y)
+        - pool.integer(3) * _square(x) * _square(y)
+        + pool.integer(1)
+    )
+
+    with pytest.raises(ak.SosError) as excinfo:
+        ak.sos_decompose(p, [x, y])
+
+    assert excinfo.value.code == "E-SOS-002"
+    # The remediation must tell an agent that this is not a proof of non-SOS.
+    assert "decide" in excinfo.value.remediation
+
+
+def test_non_polynomial_is_refused():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    with pytest.raises(ak.SosError) as excinfo:
+        ak.sos_decompose(ak.sin(x), [x])
+
+    assert excinfo.value.code == "E-SOS-001"
+
+
+def test_no_variables_is_refused():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    with pytest.raises(ak.SosError) as excinfo:
+        ak.sos_decompose(_square(x), [])
+
+    assert excinfo.value.code == "E-SOS-004"
+
+
+def test_false_constrained_claim_gets_a_witness():
+    """``x − 1/2 ≥ 0`` is false on ``x ≥ 0`` — witness, not a refusal."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    with pytest.raises(ak.SosError) as excinfo:
+        ak.prove_nonneg(x - pool.rational(1, 2), [x], constraints=[x])
+
+    assert excinfo.value.code == "E-SOS-003"
+
+
+# ---------------------------------------------------------------------------
+# Surface
+# ---------------------------------------------------------------------------
+
+
+def test_exported_surface():
+    for name in ("sos_decompose", "prove_nonneg", "PositivityCertificate", "SosError"):
+        assert name in ak.__all__, name
+    assert issubclass(ak.SosError, ak.AlkahestError)


### PR DESCRIPTION
Implements **P1 mathematics item 8** — "Positivity certificates (SOS / Positivstellensatz)" — from `temp-alkahest/planning/autoresearch.md`.

`decide` (CAD) is complete and doubly exponential. The positivity questions that actually arise in applied autoresearch — is this bound valid, is this Lyapunov candidate non-negative, is this inequality true on a box — do not need completeness. They need a **certificate**: a short algebraic identity that a proof assistant, a referee, or another CAS can check without trusting us.

```python
cert = ak.sos_decompose(x*x - 2*x*y + y*y, [x, y])
cert.identity     # x^2 - 2*x*y + y^2 = (-1*x + y)^2
cert.verify()     # True — re-expands exactly
cert.to_lean()

cert = ak.prove_nonneg(x - x*x, [x], constraints=[x, 1 - x])   # 0 ≤ x ≤ 1
cert.kind         # "handelman"
```

## Three outcomes, deliberately kept apart

This is the part that matters for a loop, and the part that is easy to get wrong by collapsing:

| Outcome | Meaning |
|---|---|
| `PositivityCertificate` | **Proved** non-negative, with a checkable witness |
| `SosError` `E-SOS-003` | **Proved not** non-negative — a witness point is in the message |
| `SosError` `E-SOS-002` | **Undecided** at this degree — not "not SOS", not "negative" |

The **Motzkin polynomial** `x⁴y² + x²y⁴ − 3x²y² + 1` is non-negative but provably not a sum of squares. It lands in `E-SOS-002` and must never be reported as negative — there is a test asserting exactly that.

## New module: `alkahest_core::real::sos`

- `ratpoly` — sparse multivariate polynomials over ℚ (the crate's `MultiPoly` is over ℤ; certificate multipliers essentially never come out integral).
- `lp` — an exact rational two-phase simplex with Bland's rule, local to this subsystem. **No floating point appears anywhere near a certificate** — a rounded Gram matrix is not a proof.
- `gram` — the generator-cone search.
- `cert` — certificate objects, the exact verifier, Lean and display renderings.

Every certificate is re-expanded in ℚ and compared against the target identically before it is returned. A candidate that fails is refused (`E-SOS-005`), never returned with a caveat. `verify()` re-runs the check on demand.

## Two defects fixed in the inherited foundation

1. **The DD generator set was too small.** Diagonal dominance is not invariant under scaling the basis, so a perfect square as ordinary as `(x/2 + 1/3)²` — whose *only* Gram matrix is PSD but not DD — was refused. Generators are now `(a·e_i ± b·e_j)²` over a small ladder of coprime ratios. Every generator is still literally a square, so soundness is untouched, and the problem is still an LP.
2. **`RatPoly::from_expr` rejected all negative exponents**, so `x**2 / 4` — which parses as `x**2 * 4**(-1)` — came back as "not a polynomial". Rational coefficients written as divisions are the common case; negative exponents on constant bases are now folded into the coefficient.

Also: `identity_string` now renders the whole identity rather than just the right-hand side, since the point of a certificate is that `target = rhs` is checkable at a glance.

## Tests

32 Rust unit tests plus `tests/test_sos.py` (11 tests): certified cases including the scaled square, the exact re-expansion property, box-constrained Handelman, and each of the three outcomes with its code — Motzkin refusing without claiming negativity, `x² − 1` returning a witness, non-polynomial and malformed input.

## Gates (all green locally)

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --all`, `cargo doc` (clean), `ruff check`, `ruff format --check`, `ty check` (42 diagnostics, unchanged from baseline), certificate ledger drift check, silent-error gate (149 passed), full `pytest` (1609 passed, 27 skipped).

## Scope

Shipped: exact rational SOS over the generator cone, Handelman certificates on basic semialgebraic sets, exact verification, Lean export. Not shipped, and documented as such in [`docs/mdbook/src/positivity.md`](docs/mdbook/src/positivity.md): full SDP-based SOS (needs an exact or rationally-rounded semidefinite solver) and Putinar-style certificates with genuine SOS rather than constant multipliers — `CertificateKind::Putinar` already exists in the type so those can be added without a shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)