### PR TITLE
feat(validated): rigorous global bounds via Taylor models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Added
 
+- **Rigorous global bounds — Taylor models and validated numerics** (P1
+  mathematics item 9): `alkahest.bound_on_box(expr, box)` returns a rigorous
+  enclosure of the *range* of an expression over an axis-aligned box;
+  `alkahest.verified_integral(expr, var, a, b)` a rigorous enclosure of a
+  definite integral; `alkahest.verified_no_roots` and
+  `alkahest.verified_sign` three-valued (`"true"` / `"false"` /
+  `"undecided"`) predicates. Ball arithmetic already gave rigorous *pointwise*
+  evaluation — this closes the gap to rigorous statements quantified over a
+  region, which is what turns a numeric observation into a theorem. New
+  `alkahest_core::validated` module: Taylor model arithmetic in normalised box
+  coordinates (polynomial part plus rigorously enclosing remainder, so `x - x`
+  cancels symbolically instead of widening to `[-2, 2]`), and Moore–Skelboe
+  branch-and-bound that prunes sub-boxes proven not to contain the extremum.
+  Soundness over tightness throughout: outward rounding everywhere, and
+  exhausting the work budget returns a wide-but-true enclosure with
+  `budget_exhausted=True` rather than an error. Genuine failures refuse with
+  `ValidatedError` (`E-VALIDATED-001` unsupported primitive, `-002` unbound
+  symbol, `-003` singularity in the box, `-004` overflow, `-005` malformed
+  request). See
+  [`docs/mdbook/src/validated-bounds.md`](docs/mdbook/src/validated-bounds.md).
+
 - **Docs: autoresearch / search-plumbing guide.** New mdBook chapter
   [`search-plumbing.md`](docs/mdbook/src/search-plumbing.md) ties budgets,
   batch APIs, compact `DerivedResult` envelopes, claim graphs, and certificate

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -53,6 +53,8 @@ pub mod stablehlo;
 pub mod sum;
 // §3.3 — symbolic integral transforms (Laplace and inverse Laplace)
 pub mod transform;
+// P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+pub mod validated;
 // Plot — dependency-free SVG / DOT renderers
 pub mod plot;
 

--- a/alkahest-core/src/validated/bounds.rs
+++ b/alkahest-core/src/validated/bounds.rs
@@ -1,0 +1,1230 @@
+//! Adaptive branch-and-bound range enclosure, verified 1-D integration, and
+//! verified sign / root-absence predicates, built on [`super::taylor`].
+//!
+//! # Soundness contract (recap, see [`super`] for the full statement)
+//!
+//! * Every enclosure returned here is a **true outer bound** — [`bound_on_box`]
+//!   and [`verified_integral`] never shrink an enclosure to hit a tolerance;
+//!   they only *stop refining* it. When the work budget
+//!   (`max_subdivisions`) runs out before the target tolerance is reached,
+//!   the accumulated — possibly wide — enclosure is returned with
+//!   `budget_exhausted = true` rather than silently reporting a tighter but
+//!   unjustified bound.
+//! * [`verified_no_roots`] and [`verified_sign`] return a three-valued
+//!   [`Verdict`]. `True` and `False` are both *certified*: `False` is only
+//!   returned when a proof is in hand (for root-absence, an intermediate
+//!   value theorem argument on a box already proven to be free of poles and
+//!   branch cuts). `Undecided` means the enclosure was not informative
+//!   enough to prove either case — it is never conflated with `False`.
+//! * A sub-box that cannot be bounded rigorously (branch cut, pole, or
+//!   domain violation persisting after the box has been bisected far below
+//!   the scale of the original box) causes the whole call to **refuse**
+//!   with the underlying [`super::ValidatedError`], rather than silently
+//!   omitting that piece of the domain from the answer.
+
+use super::taylor::{taylor_range, TaylorContext, MAX_ORDER};
+use super::{contains_zero, from_bounds, from_float, is_finite, lb, ub, width, ValidatedError};
+use crate::ball::ArbBall;
+use crate::kernel::{ExprId, ExprPool};
+use rug::float::Round;
+use rug::Float;
+
+type Result<T> = std::result::Result<T, ValidatedError>;
+
+/// Number of halvings of the *original* box/interval permitted while trying
+/// to bisect away from a domain violation (pole, branch cut) before giving
+/// up and refusing. 60 halvings shrinks any dimension by a factor of 2^60 —
+/// far more than enough to isolate a non-degenerate singularity, and far
+/// short of exhausting `f64` exponent range.
+const SINGULARITY_BISECTION_LIMIT: i32 = 60;
+
+// ---------------------------------------------------------------------------
+// bound_on_box — verified range enclosure
+// ---------------------------------------------------------------------------
+
+/// Options controlling the branch-and-bound search in [`bound_on_box`],
+/// [`verified_no_roots`], and [`verified_sign`].
+#[derive(Clone, Debug)]
+pub struct BoundOptions {
+    /// Taylor expansion order used on every sub-box (`1..=taylor::MAX_ORDER`).
+    pub order: usize,
+    /// Working precision in bits.
+    pub prec: u32,
+    /// Absolute width at which a sub-box's enclosure is accepted without
+    /// further refinement.
+    pub tol: f64,
+    /// Work budget: maximum number of branch-and-bound subdivisions to
+    /// perform. When exhausted, the search stops and returns whatever
+    /// true-but-possibly-wide enclosure it has accumulated so far — see
+    /// [`BoundResult::budget_exhausted`].
+    pub max_subdivisions: usize,
+}
+
+impl Default for BoundOptions {
+    fn default() -> Self {
+        BoundOptions {
+            order: 6,
+            prec: 128,
+            tol: 1e-9,
+            max_subdivisions: 2048,
+        }
+    }
+}
+
+/// Result of [`bound_on_box`]: a rigorous enclosure of the range of `f` over
+/// the box, plus whether the search converged to `tol` or ran out of budget.
+#[derive(Clone, Debug)]
+pub struct BoundResult {
+    enclosure: ArbBall,
+    /// `true` if the work budget ran out before every sub-box's enclosure
+    /// reached `tol`. The enclosure is still a **sound** outer bound in
+    /// either case — this flag only says whether it is as tight as
+    /// requested.
+    pub budget_exhausted: bool,
+    /// Number of branch-and-bound subdivisions actually performed.
+    pub subdivisions: usize,
+}
+
+impl BoundResult {
+    /// The rigorous enclosure as an [`ArbBall`].
+    pub fn enclosure(&self) -> &ArbBall {
+        &self.enclosure
+    }
+
+    /// Rigorous lower bound, rounded **down** to `f64` (never rounds the
+    /// true lower bound upward, so this can only widen, never narrow, the
+    /// enclosure relative to the arbitrary-precision value).
+    pub fn lower(&self) -> f64 {
+        self.enclosure.lo().to_f64_round(Round::Down)
+    }
+
+    /// Rigorous upper bound, rounded **up** to `f64`.
+    pub fn upper(&self) -> f64 {
+        self.enclosure.hi().to_f64_round(Round::Up)
+    }
+}
+
+type FBox = (ExprId, Float, Float);
+
+/// Widest dimension's width (rounded up to `f64`) — used only as a search
+/// heuristic and as the floor test for giving up on an unresolvable domain
+/// violation; never used in a way that could unsoundly narrow a result.
+fn max_dim_width(boxes: &[FBox], prec: u32) -> f64 {
+    boxes
+        .iter()
+        .map(|(_, lo, hi)| Float::with_val(prec, hi - lo).to_f64_round(Round::Up))
+        .fold(0.0_f64, f64::max)
+}
+
+/// Split the widest dimension of `boxes` at its midpoint into two boxes that
+/// exactly cover the original (they share the midpoint as a boundary, so
+/// their union is the original box with no gap).
+fn split_widest(boxes: &[FBox], prec: u32) -> (Vec<FBox>, Vec<FBox>) {
+    let mut best = 0usize;
+    let mut best_w = Float::with_val(prec, 0.0);
+    for (i, (_, lo, hi)) in boxes.iter().enumerate() {
+        let w = Float::with_val(prec, hi - lo);
+        if i == 0 || w > best_w {
+            best_w = w;
+            best = i;
+        }
+    }
+    let (v, lo, hi) = &boxes[best];
+    let mid = Float::with_val(prec, Float::with_val(prec, lo + hi) / 2u32);
+    let mut b1 = boxes.to_vec();
+    let mut b2 = boxes.to_vec();
+    b1[best] = (*v, lo.clone(), mid.clone());
+    b2[best] = (*v, mid, hi.clone());
+    (b1, b2)
+}
+
+fn is_recoverable_domain_issue(e: &ValidatedError) -> bool {
+    matches!(
+        e,
+        ValidatedError::DomainViolation { .. } | ValidatedError::NotFinite { .. }
+    )
+}
+
+/// Rigorous enclosure of the range of `expr` over an axis-aligned box, via
+/// adaptive Taylor-model branch-and-bound subdivision.
+///
+/// `boxes` is a list of `(variable, lo, hi)`; every free symbol in `expr`
+/// must appear exactly once.
+///
+/// The search is Moore–Skelboe branch-and-bound, run once for the minimum
+/// and once for the maximum. Each pass keeps a rigorous bound on the
+/// extremum and **prunes** any sub-box whose enclosure proves it cannot
+/// contain that extremum, so effort concentrates where the extremum
+/// actually is. This matters: a stopping rule that instead demanded every
+/// sub-box's enclosure be narrower than `tol` would be asking for a
+/// pointwise-tight model everywhere, which no finite budget achieves for a
+/// function with a wide range — `exp` on `[-5, 5]` would exhaust the budget
+/// and return an enclosure loose enough to still straddle zero.
+///
+/// A pass stops when the remaining uncertainty in the extremum is at most
+/// `tol`, or when `opts.max_subdivisions` is exhausted — at which point the
+/// enclosure is returned, still sound and possibly wide, with
+/// `budget_exhausted = true`.
+///
+/// If a sub-box hits an unsupported primitive or an out-of-domain symbol,
+/// the error is returned immediately (subdividing cannot help). If a
+/// sub-box hits a domain violation that *might* be a boundary effect (a
+/// pole or branch cut inside the box), the search first tries bisecting
+/// away from it; only once the box has been bisected
+/// a fixed number of times relative to its original size (or
+/// the subdivision budget runs out) does it give up and refuse — this is
+/// the correct behaviour for a genuine interior singularity, where the true
+/// range is not a bounded real interval.
+///
+/// # Example
+///
+/// ```
+/// use alkahest_cas::kernel::{Domain, ExprPool};
+/// use alkahest_cas::validated::bounds::{bound_on_box, BoundOptions};
+///
+/// let pool = ExprPool::new();
+/// let x = pool.symbol("x", Domain::Real);
+/// let one = pool.integer(1_i32);
+/// // x(1-x); true range on [0,1] is [0, 1/4], but naive intervals give [0,1]
+/// let minus_x = pool.mul(vec![pool.integer(-1_i32), x]);
+/// let e = pool.mul(vec![x, pool.add(vec![one, minus_x])]);
+/// let r = bound_on_box(e, &pool, &[(x, 0.0, 1.0)], &BoundOptions::default()).unwrap();
+/// assert!(r.lower() <= 0.0 && r.upper() >= 0.25);
+/// ```
+pub fn bound_on_box(
+    expr: ExprId,
+    pool: &ExprPool,
+    boxes: &[(ExprId, f64, f64)],
+    opts: &BoundOptions,
+) -> Result<BoundResult> {
+    if boxes.is_empty() {
+        return Err(ValidatedError::InvalidInput {
+            what: "the box must constrain at least one variable".into(),
+        });
+    }
+    if opts.order == 0 || opts.order > MAX_ORDER {
+        return Err(ValidatedError::InvalidInput {
+            what: format!("Taylor order must be in 1..={MAX_ORDER}"),
+        });
+    }
+    let prec = opts.prec;
+    let boxes0: Vec<FBox> = boxes
+        .iter()
+        .map(|(v, lo, hi)| (*v, Float::with_val(prec, lo), Float::with_val(prec, hi)))
+        .collect();
+
+    let (lo_bound, used_lo, exhausted_lo) =
+        extremum_search(expr, pool, &boxes0, opts, Extremum::Min)?;
+    let (hi_bound, used_hi, exhausted_hi) =
+        extremum_search(expr, pool, &boxes0, opts, Extremum::Max)?;
+
+    let enclosure = from_bounds(&lo_bound, &hi_bound, prec);
+    if !is_finite(&enclosure) {
+        return Err(ValidatedError::NotFinite {
+            what: "range enclosure".into(),
+        });
+    }
+    Ok(BoundResult {
+        enclosure,
+        budget_exhausted: exhausted_lo || exhausted_hi,
+        subdivisions: used_lo + used_hi,
+    })
+}
+
+/// Which end of the range an [`extremum_search`] pass is bounding.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Extremum {
+    Min,
+    Max,
+}
+
+/// Moore–Skelboe branch-and-bound for one end of the range.
+///
+/// Returns `(bound, subdivisions, budget_exhausted)` where `bound` is a
+/// **rigorous** lower bound on the global minimum (`Extremum::Min`) or upper
+/// bound on the global maximum (`Extremum::Max`) — outward in both cases, so
+/// the enclosure built from the pair can only be too wide, never too narrow.
+fn extremum_search(
+    expr: ExprId,
+    pool: &ExprPool,
+    boxes0: &[FBox],
+    opts: &BoundOptions,
+    which: Extremum,
+) -> Result<(Float, usize, bool)> {
+    let prec = opts.prec;
+    let floor = max_dim_width(boxes0, prec) * 2f64.powi(-SINGULARITY_BISECTION_LIMIT);
+    let tol_f = Float::with_val(prec, opts.tol);
+
+    // Signed view: work with `f` for Min and `-f` for Max, so one code path
+    // handles both. `key(b)` is the rigorous lower bound of the signed range.
+    let sign_lo = |r: &ArbBall| -> Float {
+        match which {
+            Extremum::Min => lb(r),
+            Extremum::Max => -ub(r),
+        }
+    };
+    let sign_hi = |r: &ArbBall| -> Float {
+        match which {
+            Extremum::Min => ub(r),
+            Extremum::Max => -lb(r),
+        }
+    };
+
+    // Active list of (lower bound of signed range, box). `best_ub` is the best
+    // proven upper bound on the signed extremum, from any box seen so far.
+    let mut active: Vec<(Float, Vec<FBox>)> = Vec::new();
+    let mut best_ub: Option<Float> = None;
+    let mut subdivisions = 0usize;
+    let mut exhausted = false;
+
+    let seed = evaluate_box(expr, pool, boxes0, opts, floor, prec)?;
+    match seed {
+        BoxOutcome::Range(r) => {
+            best_ub = Some(sign_hi(&r));
+            active.push((sign_lo(&r), boxes0.to_vec()));
+        }
+        BoxOutcome::Refine => {
+            active.push((Float::with_val(prec, f64::NEG_INFINITY), boxes0.to_vec()));
+        }
+    }
+
+    // Pick the box with the smallest signed lower bound each round: it is the
+    // only one that can still improve the extremum.
+    while let Some(idx) = argmin_key(&active) {
+        let (key, b) = active.swap_remove(idx);
+
+        // Prune: this box cannot contain the extremum.
+        if let Some(ub_best) = &best_ub {
+            if &key > ub_best {
+                continue;
+            }
+            // Converged: the uncertainty in the extremum is within tol.
+            let gap = Float::with_val(prec, ub_best - &key);
+            if gap <= tol_f {
+                active.push((key, b));
+                break;
+            }
+        }
+
+        if subdivisions >= opts.max_subdivisions {
+            exhausted = true;
+            active.push((key, b));
+            break;
+        }
+        if max_dim_width(&b, prec) <= floor {
+            // Cannot refine further; keep it as-is so its bound still counts.
+            active.push((key, b));
+            // Everything else is either pruned or equally unrefinable.
+            let stuck = active
+                .iter()
+                .all(|(_, bx)| max_dim_width(bx, prec) <= floor);
+            if stuck {
+                exhausted = true;
+                break;
+            }
+            continue;
+        }
+
+        subdivisions += 1;
+        let (b1, b2) = split_widest(&b, prec);
+        for child in [b1, b2] {
+            match evaluate_box(expr, pool, &child, opts, floor, prec)? {
+                BoxOutcome::Range(r) => {
+                    let child_ub = sign_hi(&r);
+                    best_ub = Some(match best_ub {
+                        Some(cur) if cur <= child_ub => cur,
+                        _ => child_ub,
+                    });
+                    active.push((sign_lo(&r), child));
+                }
+                BoxOutcome::Refine => {
+                    active.push((Float::with_val(prec, f64::NEG_INFINITY), child));
+                }
+            }
+        }
+    }
+
+    // The rigorous bound on the signed extremum is the smallest lower bound
+    // still active (pruned boxes provably cannot beat `best_ub`).
+    let mut bound = active
+        .iter()
+        .map(|(k, _)| k.clone())
+        .fold(None::<Float>, |acc, k| {
+            Some(match acc {
+                Some(cur) if cur <= k => cur,
+                _ => k,
+            })
+        })
+        .or_else(|| best_ub.clone())
+        .ok_or_else(|| ValidatedError::InvalidInput {
+            what: "no enclosure was produced".into(),
+        })?;
+
+    if let Some(ub_best) = &best_ub {
+        if &bound > ub_best {
+            bound = ub_best.clone();
+        }
+    }
+    if !bound.is_finite() {
+        return Err(ValidatedError::NotFinite {
+            what: "range enclosure".into(),
+        });
+    }
+    // Undo the sign flip for the Max pass.
+    Ok((
+        match which {
+            Extremum::Min => bound,
+            Extremum::Max => -bound,
+        },
+        subdivisions,
+        exhausted,
+    ))
+}
+
+/// What to do with a sub-box after trying to evaluate it.
+enum BoxOutcome {
+    /// A rigorous enclosure of `f` on the box.
+    Range(ArbBall),
+    /// A recoverable domain issue (possible pole/branch cut inside): bisecting
+    /// away from it may still work.
+    Refine,
+}
+
+fn evaluate_box(
+    expr: ExprId,
+    pool: &ExprPool,
+    b: &[FBox],
+    opts: &BoundOptions,
+    floor: f64,
+    prec: u32,
+) -> Result<BoxOutcome> {
+    match taylor_range(expr, pool, b, opts.order, prec) {
+        Ok(r) => Ok(BoxOutcome::Range(r)),
+        Err(e) if is_recoverable_domain_issue(&e) => {
+            if max_dim_width(b, prec) <= floor {
+                // Bisecting has stopped helping: this is a genuine interior
+                // singularity, and the true range is not a bounded interval.
+                Err(e)
+            } else {
+                Ok(BoxOutcome::Refine)
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Index of the entry with the smallest key.
+fn argmin_key(active: &[(Float, Vec<FBox>)]) -> Option<usize> {
+    let mut best: Option<(usize, &Float)> = None;
+    for (i, (k, _)) in active.iter().enumerate() {
+        match best {
+            Some((_, bk)) if bk <= k => {}
+            _ => best = Some((i, k)),
+        }
+    }
+    best.map(|(i, _)| i)
+}
+
+// ---------------------------------------------------------------------------
+// verified_integral — verified 1-D definite integral
+// ---------------------------------------------------------------------------
+
+/// Options controlling the adaptive quadrature in [`verified_integral`].
+#[derive(Clone, Debug)]
+pub struct IntegralOptions {
+    /// Taylor expansion order used on every sub-interval.
+    pub order: usize,
+    /// Working precision in bits.
+    pub prec: u32,
+    /// Target absolute width of the total integral enclosure.
+    pub tol: f64,
+    /// Work budget: maximum number of adaptive subdivisions.
+    pub max_subdivisions: usize,
+}
+
+impl Default for IntegralOptions {
+    fn default() -> Self {
+        IntegralOptions {
+            order: 6,
+            prec: 128,
+            tol: 1e-9,
+            max_subdivisions: 2048,
+        }
+    }
+}
+
+/// Result of [`verified_integral`].
+#[derive(Clone, Debug)]
+pub struct IntegralResult {
+    enclosure: ArbBall,
+    /// `true` if the work budget ran out before the accumulated enclosure
+    /// reached `tol` in width. Still a sound outer bound either way.
+    pub budget_exhausted: bool,
+    /// Number of adaptive subdivisions actually performed.
+    pub subdivisions: usize,
+}
+
+impl IntegralResult {
+    /// The rigorous enclosure of `∫_a^b f dx` as an [`ArbBall`].
+    pub fn enclosure(&self) -> &ArbBall {
+        &self.enclosure
+    }
+
+    /// Rigorous lower bound, rounded down to `f64`.
+    pub fn lower(&self) -> f64 {
+        self.enclosure.lo().to_f64_round(Round::Down)
+    }
+
+    /// Rigorous upper bound, rounded up to `f64`.
+    pub fn upper(&self) -> f64 {
+        self.enclosure.hi().to_f64_round(Round::Up)
+    }
+}
+
+/// Rigorous enclosure of `∫ f du` over one sub-interval `[lo, hi]`, using
+/// the Taylor model's exact polynomial antiderivative
+/// ([`super::taylor::TaylorModel::integrate_normalized_1d`]) rather than a
+/// crude `width * range` bound.
+fn local_integral(
+    expr: ExprId,
+    pool: &ExprPool,
+    var: ExprId,
+    lo: &Float,
+    hi: &Float,
+    order: usize,
+    prec: u32,
+) -> Result<ArbBall> {
+    let boxes = vec![(var, lo.clone(), hi.clone())];
+    let mut ctx = TaylorContext::new(pool, &boxes, order, prec)?;
+    let tm = ctx.eval(expr)?;
+    let poly_integral = tm.integrate_normalized_1d()?;
+    // x = c + r*u  =>  dx = r*du; r = (hi-lo)/2.
+    let half_width = Float::with_val(prec, Float::with_val(prec, hi - lo) / 2u32);
+    let r_ball = from_float(&half_width, prec);
+    let piece = r_ball * poly_integral;
+    if !is_finite(&piece) {
+        return Err(ValidatedError::NotFinite {
+            what: "integral piece".into(),
+        });
+    }
+    Ok(piece)
+}
+
+/// Rigorous enclosure of `∫_a^b f(x) dx`, via adaptive Taylor-model
+/// quadrature.
+///
+/// Each accepted sub-interval contributes a rigorous enclosure computed by
+/// exactly integrating the Taylor polynomial in normalised coordinates and
+/// folding the remainder in as `2·I·r` (see
+/// [`super::taylor::TaylorModel::integrate_normalized_1d`]) — this is exact
+/// on polynomials up to the truncation order, unlike naive
+/// `width × range(f)` quadrature. Sub-interval enclosures are summed
+/// (interval addition is exact for disjoint, adjacent pieces), so the total
+/// is always a sound outer bound of the true integral.
+///
+/// Refuses (does not guess) when:
+/// - `a` or `b` is non-finite (infinite-limit improper integrals are not
+///   supported — there is no box to Taylor-expand over),
+/// - `a > b`,
+/// - the integrand has a genuine singularity in `[a, b]` (e.g. `1/sqrt(x)`
+///   on `[0, 1]`) — subdivision is tried first in case the domain violation
+///   is only a boundary artefact of a coarse box, but a true interior
+///   singularity persists down to the bisection floor and the call refuses
+///   with the underlying [`ValidatedError`] rather than silently skipping
+///   the offending piece.
+pub fn verified_integral(
+    expr: ExprId,
+    pool: &ExprPool,
+    var: ExprId,
+    a: f64,
+    b: f64,
+    opts: &IntegralOptions,
+) -> Result<IntegralResult> {
+    if !(a.is_finite() && b.is_finite()) {
+        return Err(ValidatedError::InvalidInput {
+            what: "integration bounds must be finite; infinite-limit improper integrals are not supported".into(),
+        });
+    }
+    if a > b {
+        return Err(ValidatedError::InvalidInput {
+            what: "verified_integral requires a <= b".into(),
+        });
+    }
+    if opts.order == 0 || opts.order > MAX_ORDER {
+        return Err(ValidatedError::InvalidInput {
+            what: format!("Taylor order must be in 1..={MAX_ORDER}"),
+        });
+    }
+    let prec = opts.prec;
+    if a == b {
+        return Ok(IntegralResult {
+            enclosure: ArbBall::from_f64(0.0, prec),
+            budget_exhausted: false,
+            subdivisions: 0,
+        });
+    }
+
+    let a_f = Float::with_val(prec, a);
+    let b_f = Float::with_val(prec, b);
+    let total_width = Float::with_val(prec, &b_f - &a_f);
+    let floor = total_width.to_f64_round(Round::Up) * 2f64.powi(-SINGULARITY_BISECTION_LIMIT);
+    let tol_total = Float::with_val(prec, opts.tol);
+
+    let mut stack: Vec<(Float, Float)> = vec![(a_f, b_f)];
+    let mut total: Option<ArbBall> = None;
+    let mut subdivisions = 0usize;
+    let mut exhausted = false;
+
+    while let Some((lo, hi)) = stack.pop() {
+        match local_integral(expr, pool, var, &lo, &hi, opts.order, prec) {
+            Ok(piece) => {
+                let piece_w = Float::with_val(prec, &hi - &lo);
+                let piece_tol = Float::with_val(
+                    prec,
+                    &tol_total * Float::with_val(prec, &piece_w / &total_width),
+                );
+                let w = width(&piece);
+                if w <= piece_tol || subdivisions >= opts.max_subdivisions {
+                    if w > piece_tol {
+                        exhausted = true;
+                    }
+                    total = Some(match total {
+                        Some(t) => t + piece,
+                        None => piece,
+                    });
+                } else {
+                    subdivisions += 1;
+                    let mid = Float::with_val(prec, Float::with_val(prec, &lo + &hi) / 2u32);
+                    stack.push((mid.clone(), hi));
+                    stack.push((lo, mid));
+                }
+            }
+            Err(e) if is_recoverable_domain_issue(&e) => {
+                let piece_w = Float::with_val(prec, &hi - &lo).to_f64_round(Round::Up);
+                if subdivisions >= opts.max_subdivisions || piece_w <= floor {
+                    return Err(e);
+                }
+                subdivisions += 1;
+                let mid = Float::with_val(prec, Float::with_val(prec, &lo + &hi) / 2u32);
+                stack.push((mid.clone(), hi));
+                stack.push((lo, mid));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    let enclosure = total.ok_or_else(|| ValidatedError::InvalidInput {
+        what: "no enclosure was produced".into(),
+    })?;
+    if !is_finite(&enclosure) {
+        return Err(ValidatedError::NotFinite {
+            what: "integral enclosure".into(),
+        });
+    }
+    Ok(IntegralResult {
+        enclosure,
+        budget_exhausted: exhausted,
+        subdivisions,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Verified predicates: roots and sign
+// ---------------------------------------------------------------------------
+
+/// Three-valued verdict for a rigorously-checked predicate.
+///
+/// `True` and `False` are both certified — the underlying proof is sound
+/// under the [module soundness contract](super). `Undecided` means the
+/// available enclosure (possibly after exhausting the work budget) was not
+/// informative enough to establish either case; it is never collapsed into
+/// `True` or `False`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// The predicate is certified true everywhere on the box.
+    True,
+    /// The predicate is certified false — a counterexample is proven to
+    /// exist (or, for sign predicates, the range is proven to violate it
+    /// somewhere).
+    False,
+    /// Neither could be established from the computed enclosure.
+    Undecided,
+}
+
+fn determined_sign(b: &ArbBall) -> Option<bool> {
+    if lb(b) > 0 {
+        Some(true)
+    } else if ub(b) < 0 {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Verified check for the absence of roots of `expr` on `boxes`.
+///
+/// Returns:
+/// - [`Verdict::True`] when the rigorous range enclosure of `expr` over the
+///   whole box does not contain zero — `expr` is certified to have no root
+///   anywhere in the box.
+/// - [`Verdict::False`] in the univariate case, when the box is proven free
+///   of poles/branch cuts (the full-box enclosure succeeded) *and* the
+///   rigorously evaluated endpoint values have determined, opposite signs —
+///   a root is certified to exist by the intermediate value theorem.
+/// - [`Verdict::Undecided`] otherwise: the enclosure straddles zero and no
+///   sign-change proof was available (multivariate, or same-signed /
+///   indeterminate endpoints).
+///
+/// Propagates a [`ValidatedError`] (refuses) exactly when
+/// [`bound_on_box`] would: unsupported primitives, unbound symbols, or a
+/// singularity that resists bisection.
+pub fn verified_no_roots(
+    expr: ExprId,
+    pool: &ExprPool,
+    boxes: &[(ExprId, f64, f64)],
+    opts: &BoundOptions,
+) -> Result<Verdict> {
+    let full = bound_on_box(expr, pool, boxes, opts)?;
+    if !contains_zero(full.enclosure()) {
+        return Ok(Verdict::True);
+    }
+
+    // Root-existence (Verdict::False) via IVT: only sound in 1-D, and only
+    // once we already know (from the successful full-box call above) that
+    // `expr` is finite and pole/branch-cut free across the whole box, so it
+    // is continuous on it.
+    if boxes.len() == 1 {
+        let (v, lo, hi) = boxes[0];
+        if lo < hi {
+            let flo = bound_on_box(expr, pool, &[(v, lo, lo)], opts);
+            let fhi = bound_on_box(expr, pool, &[(v, hi, hi)], opts);
+            if let (Ok(flo), Ok(fhi)) = (flo, fhi) {
+                if let (Some(slo), Some(shi)) = (
+                    determined_sign(flo.enclosure()),
+                    determined_sign(fhi.enclosure()),
+                ) {
+                    if slo != shi {
+                        return Ok(Verdict::False);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(Verdict::Undecided)
+}
+
+/// Which sign condition [`verified_sign`] should check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignPredicate {
+    /// `f(x) > 0` for every `x` in the box.
+    Positive,
+    /// `f(x) < 0` for every `x` in the box.
+    Negative,
+    /// `f(x) >= 0` for every `x` in the box.
+    NonNegative,
+    /// `f(x) <= 0` for every `x` in the box.
+    NonPositive,
+}
+
+/// Verified sign check for `expr` over `boxes`, built on [`bound_on_box`].
+///
+/// Returns [`Verdict::True`] when the rigorous range enclosure proves the
+/// predicate holds everywhere on the box, [`Verdict::False`] when the
+/// enclosure proves it is violated somewhere, and [`Verdict::Undecided`]
+/// when the enclosure straddles the boundary needed to decide either way.
+pub fn verified_sign(
+    expr: ExprId,
+    pool: &ExprPool,
+    boxes: &[(ExprId, f64, f64)],
+    predicate: SignPredicate,
+    opts: &BoundOptions,
+) -> Result<Verdict> {
+    let r = bound_on_box(expr, pool, boxes, opts)?;
+    let lo = lb(r.enclosure());
+    let hi = ub(r.enclosure());
+
+    let holds_everywhere = match predicate {
+        SignPredicate::Positive => lo > 0,
+        SignPredicate::Negative => hi < 0,
+        SignPredicate::NonNegative => lo >= 0,
+        SignPredicate::NonPositive => hi <= 0,
+    };
+    if holds_everywhere {
+        return Ok(Verdict::True);
+    }
+
+    // The enclosure over the whole box proves the predicate fails everywhere.
+    let fails_everywhere = match predicate {
+        SignPredicate::Positive => hi <= 0,
+        SignPredicate::Negative => lo >= 0,
+        SignPredicate::NonNegative => hi < 0,
+        SignPredicate::NonPositive => lo > 0,
+    };
+    if fails_everywhere {
+        return Ok(Verdict::False);
+    }
+
+    // These are universally quantified claims, so a single point where the
+    // predicate provably fails disproves them. Without this, `x > 0` on
+    // [-1, 1] — plainly false — could only ever come back `Undecided`, since
+    // the range enclosure straddles zero by construction.
+    if violates_at_some_sample(expr, pool, boxes, predicate, opts)? {
+        return Ok(Verdict::False);
+    }
+
+    Ok(Verdict::Undecided)
+}
+
+/// Rigorously evaluate `expr` at a handful of points of the box (corners and
+/// centre) and report whether any of them *proves* the predicate false there.
+///
+/// Each sample is a degenerate box, so the Taylor model reduces to a point
+/// enclosure; the verdict is only `true` when that enclosure lies strictly on
+/// the wrong side, which is a proof. A domain violation at a sample is not
+/// evidence either way and is skipped.
+fn violates_at_some_sample(
+    expr: ExprId,
+    pool: &ExprPool,
+    boxes: &[(ExprId, f64, f64)],
+    predicate: SignPredicate,
+    opts: &BoundOptions,
+) -> Result<bool> {
+    let n = boxes.len();
+    // Corners get exponential in `n`, so sample them only for small boxes;
+    // the centre and the per-axis endpoints are always cheap.
+    let mut samples: Vec<Vec<f64>> = Vec::new();
+    samples.push(boxes.iter().map(|(_, lo, hi)| 0.5 * (lo + hi)).collect());
+    for i in 0..n {
+        for pick_lo in [true, false] {
+            let mut p: Vec<f64> = boxes.iter().map(|(_, lo, hi)| 0.5 * (lo + hi)).collect();
+            p[i] = if pick_lo { boxes[i].1 } else { boxes[i].2 };
+            samples.push(p);
+        }
+    }
+    if n <= 3 {
+        for mask in 0..(1usize << n) {
+            let p: Vec<f64> = boxes
+                .iter()
+                .enumerate()
+                .map(|(i, (_, lo, hi))| if mask & (1 << i) == 0 { *lo } else { *hi })
+                .collect();
+            samples.push(p);
+        }
+    }
+
+    for point in samples {
+        let degenerate: Vec<(ExprId, f64, f64)> = boxes
+            .iter()
+            .zip(point.iter())
+            .map(|((v, _, _), &c)| (*v, c, c))
+            .collect();
+        let r = match bound_on_box(expr, pool, &degenerate, opts) {
+            Ok(r) => r,
+            // A sample landing on a pole or outside the domain says nothing
+            // about the predicate; try the next one.
+            Err(_) => continue,
+        };
+        let lo = lb(r.enclosure());
+        let hi = ub(r.enclosure());
+        let proven_violation = match predicate {
+            SignPredicate::Positive => hi <= 0,
+            SignPredicate::Negative => lo >= 0,
+            SignPredicate::NonNegative => hi < 0,
+            SignPredicate::NonPositive => lo > 0,
+        };
+        if proven_violation {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `a - b` (the pool has no `sub`; subtraction is `a + (-1)·b`).
+    fn sub(pool: &ExprPool, a: ExprId, b: ExprId) -> ExprId {
+        pool.add(vec![a, pool.mul(vec![pool.integer(-1_i32), b])])
+    }
+
+    /// `a / b` (the pool has no `div`; division is `a · b^(-1)`).
+    fn div(pool: &ExprPool, a: ExprId, b: ExprId) -> ExprId {
+        pool.mul(vec![a, pool.pow(b, pool.integer(-1_i32))])
+    }
+    use crate::kernel::Domain;
+
+    fn opts() -> BoundOptions {
+        BoundOptions {
+            order: 6,
+            prec: 128,
+            tol: 1e-9,
+            max_subdivisions: 4096,
+        }
+    }
+
+    fn iopts() -> IntegralOptions {
+        IntegralOptions {
+            order: 8,
+            prec: 128,
+            tol: 1e-9,
+            max_subdivisions: 4096,
+        }
+    }
+
+    // ── bound_on_box ────────────────────────────────────────────────────
+
+    #[test]
+    fn x_minus_x_is_tight_zero() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = sub(&pool, x, x);
+        let r = bound_on_box(e, &pool, &[(x, -5.0, 5.0)], &opts()).unwrap();
+        assert!(r.lower() >= -1e-9 && r.upper() <= 1e-9, "{:?}", r);
+    }
+
+    #[test]
+    fn x_times_one_minus_x_needs_subdivision_and_converges() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        let e = pool.mul(vec![x, sub(&pool, one, x)]);
+        let r = bound_on_box(e, &pool, &[(x, 0.0, 1.0)], &opts()).unwrap();
+        assert!(r.lower() <= 1e-6, "{:?}", r);
+        assert!(
+            r.upper() >= 0.25 - 1e-6 && r.upper() <= 0.25 + 1e-6,
+            "{:?}",
+            r
+        );
+        assert!(!r.budget_exhausted);
+    }
+
+    #[test]
+    fn sin_squared_plus_cos_squared_is_one() {
+        // A strong dependency-effect case: without correlation tracking a
+        // sum of two independently-widened intervals could report a range
+        // far from the true constant {1}.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let s = pool.func("sin", vec![x]);
+        let c = pool.func("cos", vec![x]);
+        let e = pool.add(vec![
+            pool.pow(s, pool.integer(2_i32)),
+            pool.pow(c, pool.integer(2_i32)),
+        ]);
+        let r = bound_on_box(e, &pool, &[(x, -3.0, 3.0)], &opts()).unwrap();
+        assert!(r.lower() <= 1.0 && r.upper() >= 1.0, "{:?}", r);
+        // Should be much tighter than the trivial [-2, 2] naive bound.
+        assert!(r.upper() - r.lower() < 0.5, "too wide: {:?}", r);
+    }
+
+    #[test]
+    fn taylor_bound_beats_plain_interval_eval() {
+        use crate::ball::IntervalEval;
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        let e = pool.mul(vec![x, sub(&pool, one, x)]);
+        let r = bound_on_box(e, &pool, &[(x, 0.0, 1.0)], &opts()).unwrap();
+
+        let mut ev = IntervalEval::new(128);
+        ev.bind(x, ArbBall::from_midpoint_radius(0.5, 0.5, 128));
+        let iv = ev.eval(e, &pool).unwrap();
+        let iv_width = iv.rad_f64() * 2.0;
+
+        assert!(
+            r.upper() - r.lower() < iv_width,
+            "{:?} vs iv width {}",
+            r,
+            iv_width
+        );
+    }
+
+    #[test]
+    fn budget_exhaustion_is_reported_and_still_sound() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        let e = pool.mul(vec![x, sub(&pool, one, x)]);
+        let tight = BoundOptions {
+            order: 1,
+            prec: 64,
+            tol: 1e-12,
+            max_subdivisions: 1, // deliberately far too small
+        };
+        let r = bound_on_box(e, &pool, &[(x, 0.0, 1.0)], &tight).unwrap();
+        assert!(r.budget_exhausted);
+        // Still sound: true range [0, 0.25] must be contained.
+        assert!(r.lower() <= 0.0 && r.upper() >= 0.25, "{:?}", r);
+    }
+
+    #[test]
+    fn two_d_box_with_near_tangential_extremum() {
+        // f(x,y) = (x - y)^2 + 1e-4, box straddling the near-tangential
+        // minimum along x = y. True range is [1e-4, ~4 + 1e-4].
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let diff = sub(&pool, x, y);
+        let sq = pool.pow(diff, pool.integer(2_i32));
+        let eps = pool.rational(1_i32, 10000_i32);
+        let e = pool.add(vec![sq, eps]);
+        let r = bound_on_box(e, &pool, &[(x, -1.0, 1.0), (y, -1.0, 1.0)], &opts()).unwrap();
+        assert!(r.lower() >= 0.0, "unsound: {:?}", r);
+        assert!(r.lower() <= 1e-3, "{:?}", r);
+        assert!(r.upper() >= 4.0 - 1e-3, "{:?}", r);
+    }
+
+    #[test]
+    fn refuses_on_pole_that_resists_bisection() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = div(&pool, pool.integer(1_i32), x);
+        let err = bound_on_box(e, &pool, &[(x, -1.0, 1.0)], &opts()).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-003");
+    }
+
+    #[test]
+    fn bisects_away_from_a_boundary_domain_issue() {
+        // log(x) on a box that only touches x=0 as an artefact of a coarse
+        // initial box: [-0.1, 2] would refuse without subdivision help, but
+        // here we start entirely inside the domain, so this is a control
+        // case confirming ordinary boxes are unaffected by the pole logic.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("log", vec![x]);
+        let r = bound_on_box(e, &pool, &[(x, 0.5, 2.0)], &opts()).unwrap();
+        assert!(r.lower() <= 0.5_f64.ln() + 1e-6);
+        assert!(r.upper() >= 2.0_f64.ln() - 1e-6);
+    }
+
+    // ── verified_integral ──────────────────────────────────────────────
+
+    #[test]
+    fn integral_of_x_squared() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.pow(x, pool.integer(2_i32));
+        // ∫_0^1 x^2 dx = 1/3.
+        let r = verified_integral(e, &pool, x, 0.0, 1.0, &iopts()).unwrap();
+        assert!(r.lower() <= 1.0 / 3.0 && r.upper() >= 1.0 / 3.0, "{:?}", r);
+        assert!(r.upper() - r.lower() < 1e-6, "{:?}", r);
+    }
+
+    #[test]
+    fn integral_of_sin_over_full_period() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("sin", vec![x]);
+        // ∫_0^{2π} sin(x) dx = 0.
+        let two_pi = std::f64::consts::PI * 2.0;
+        let r = verified_integral(e, &pool, x, 0.0, two_pi, &iopts()).unwrap();
+        assert!(r.lower() <= 1e-4 && r.upper() >= -1e-4, "{:?}", r);
+    }
+
+    #[test]
+    fn integral_of_exp() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("exp", vec![x]);
+        // ∫_0^1 exp(x) dx = e - 1.
+        let expected = std::f64::consts::E - 1.0;
+        let r = verified_integral(e, &pool, x, 0.0, 1.0, &iopts()).unwrap();
+        assert!(r.lower() <= expected && r.upper() >= expected, "{:?}", r);
+        assert!(r.upper() - r.lower() < 1e-6, "{:?}", r);
+    }
+
+    #[test]
+    fn integral_degenerate_interval_is_zero() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("exp", vec![x]);
+        let r = verified_integral(e, &pool, x, 1.0, 1.0, &iopts()).unwrap();
+        assert_eq!(r.lower(), 0.0);
+        assert_eq!(r.upper(), 0.0);
+        assert_eq!(r.subdivisions, 0);
+    }
+
+    #[test]
+    fn integral_refuses_on_singular_integrand() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = div(&pool, pool.integer(1_i32), pool.func("sqrt", vec![x]));
+        let err = verified_integral(e, &pool, x, 0.0, 1.0, &iopts()).unwrap_err();
+        // Domain violation (sqrt/recip touching zero) rather than a guess.
+        assert!(matches!(
+            crate::errors::AlkahestError::code(&err),
+            "E-VALIDATED-003" | "E-VALIDATED-004"
+        ));
+    }
+
+    #[test]
+    fn integral_refuses_on_infinite_bounds() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = x;
+        let err = verified_integral(e, &pool, x, 0.0, f64::INFINITY, &iopts()).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-005");
+    }
+
+    #[test]
+    fn integral_refuses_when_a_greater_than_b() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let err = verified_integral(x, &pool, x, 1.0, 0.0, &iopts()).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-005");
+    }
+
+    // ── verified_no_roots / verified_sign ─────────────────────────────
+
+    #[test]
+    fn no_roots_verified_true_for_shifted_square() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        // (x - 5)^2 + 1: never zero.
+        let sq = pool.pow(sub(&pool, x, pool.integer(5_i32)), pool.integer(2_i32));
+        let e = pool.add(vec![sq, one]);
+        let v = verified_no_roots(e, &pool, &[(x, -10.0, 10.0)], &opts()).unwrap();
+        assert_eq!(v, Verdict::True);
+    }
+
+    #[test]
+    fn no_roots_verified_false_via_sign_change() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // x - 0.5 changes sign on [0,1]: root at x=0.5 certified.
+        let e = sub(&pool, x, pool.rational(1_i32, 2_i32));
+        let v = verified_no_roots(e, &pool, &[(x, 0.0, 1.0)], &opts()).unwrap();
+        assert_eq!(v, Verdict::False);
+    }
+
+    #[test]
+    fn no_roots_undecided_when_enclosure_straddles_zero_without_sign_change() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        // x - y over a 2-D box that straddles zero: no 1-D IVT argument
+        // applies, so this must not be misreported as True or False.
+        let e = sub(&pool, x, y);
+        let v = verified_no_roots(e, &pool, &[(x, -1.0, 1.0), (y, -1.0, 1.0)], &opts()).unwrap();
+        assert_eq!(v, Verdict::Undecided);
+    }
+
+    #[test]
+    fn no_roots_near_tangential_case_stays_true() {
+        // (x-1)^2 + 1e-6 touches close to zero but never reaches it; a
+        // narrowing bug would likely misreport this.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let sq = pool.pow(sub(&pool, x, pool.integer(1_i32)), pool.integer(2_i32));
+        let eps = pool.rational(1_i32, 1_000_000_i32);
+        let e = pool.add(vec![sq, eps]);
+        let tight = BoundOptions {
+            order: 8,
+            prec: 128,
+            tol: 1e-10,
+            max_subdivisions: 8192,
+        };
+        let v = verified_no_roots(e, &pool, &[(x, 0.0, 2.0)], &tight).unwrap();
+        assert_eq!(v, Verdict::True);
+    }
+
+    #[test]
+    fn sign_positive_verified_true() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("exp", vec![x]);
+        let v = verified_sign(
+            e,
+            &pool,
+            &[(x, -5.0, 5.0)],
+            SignPredicate::Positive,
+            &opts(),
+        )
+        .unwrap();
+        assert_eq!(v, Verdict::True);
+    }
+
+    #[test]
+    fn sign_positive_verified_false() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = x; // takes negative values on [-1,1]
+        let v = verified_sign(
+            e,
+            &pool,
+            &[(x, -1.0, 1.0)],
+            SignPredicate::Positive,
+            &opts(),
+        )
+        .unwrap();
+        assert_eq!(v, Verdict::False);
+    }
+
+    #[test]
+    fn sign_false_is_certified_by_a_point_witness() {
+        // `x - 1/2 > 0` on [0,1] is plainly false (x = 0 gives -1/2), even
+        // though the range enclosure straddles zero and so cannot settle it.
+        // A universally quantified claim is disproved by one point.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = sub(&pool, x, pool.rational(1_i32, 2_i32));
+        let v =
+            verified_sign(e, &pool, &[(x, 0.0, 1.0)], SignPredicate::Positive, &opts()).unwrap();
+        assert_eq!(v, Verdict::False);
+    }
+
+    #[test]
+    fn sign_undecided_when_neither_can_be_established() {
+        // `(x - 1/3)^2 - 1e-12 >= 0` on [-1,1] fails only in a sliver around
+        // x = 1/3, which is neither an endpoint nor the centre, so no sample
+        // hits it; with a tight budget the enclosure still straddles zero.
+        // Neither a proof nor a witness is available, so the verdict must stay
+        // Undecided rather than collapse either way.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let shifted = sub(&pool, x, pool.rational(1_i32, 3_i32));
+        let tiny = pool.rational(1_i32, 1_000_000_000_000_i64);
+        let e = sub(&pool, pool.mul(vec![shifted, shifted]), tiny);
+        let cheap = BoundOptions {
+            order: 4,
+            prec: 128,
+            tol: 1e-9,
+            max_subdivisions: 2,
+        };
+        let v = verified_sign(
+            e,
+            &pool,
+            &[(x, -1.0, 1.0)],
+            SignPredicate::NonNegative,
+            &cheap,
+        )
+        .unwrap();
+        assert_eq!(v, Verdict::Undecided);
+    }
+
+    #[test]
+    fn dense_sampling_cross_check_polynomial() {
+        // Cross-check bound_on_box against dense sampling: every sampled
+        // value must be contained in the returned enclosure.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = sub(
+            &pool,
+            pool.pow(x, pool.integer(3_i32)),
+            pool.mul(vec![pool.integer(3_i32), x]),
+        ); // x^3 - 3x
+        let r = bound_on_box(e, &pool, &[(x, -2.5, 2.5)], &opts()).unwrap();
+        for i in 0..=500 {
+            let t = -2.5 + 5.0 * (i as f64) / 500.0;
+            let v = t.powi(3) - 3.0 * t;
+            assert!(
+                v >= r.lower() - 1e-6 && v <= r.upper() + 1e-6,
+                "x={t} f={v} escaped {:?}",
+                r
+            );
+        }
+    }
+}

--- a/alkahest-core/src/validated/mod.rs
+++ b/alkahest-core/src/validated/mod.rs
@@ -1,0 +1,389 @@
+//! Rigorous **global** bounds via Taylor models and validated numerics.
+//!
+//! [`crate::ball`] gives rigorous *pointwise* enclosures: evaluate `f` at a
+//! ball and the true value is inside the returned ball.  That is not enough
+//! for statements quantified over a whole region — "the maximum of `f` on
+//! `[a,b]×[c,d]` is at most `M`", "`∫_a^b f dx ∈ [I₁, I₂]`", "`f` has no root
+//! in this box".  Plain interval evaluation over a wide box *is* rigorous but
+//! suffers the **dependency problem**: `x - x` on `x ∈ [0,1]` evaluates to
+//! `[-1,1]` instead of `{0}`, and the looseness compounds multiplicatively
+//! through an expression tree.
+//!
+//! A **Taylor model** fixes this.  On a box `B` with midpoint `c` and radius
+//! vector `r`, write `x = c + r ⊙ u` with `u ∈ [-1,1]ⁿ`.  A Taylor model of
+//! `f` is a pair `(P, I)` where `P` is a polynomial in `u` with ball
+//! coefficients and `I` is an interval, such that
+//!
+//! ```text
+//! ∀ u ∈ [-1,1]ⁿ :  f(c + r ⊙ u) ∈ P(u) + I
+//! ```
+//!
+//! Because the polynomial part tracks *correlations* between subexpressions,
+//! cancellation like `x - x` happens symbolically in `P` rather than being
+//! lost to interval widening, and the remainder shrinks like `O(h^{p+1})`
+//! under subdivision instead of `O(h)`.
+//!
+//! # Soundness contract
+//!
+//! Everything in this module returns **outer** enclosures.  Specifically:
+//!
+//! * Every arithmetic step is performed in [`ArbBall`] ball arithmetic, which
+//!   grows the radius by a rounding term after each operation.  Wherever a
+//!   raw [`rug::Float`] bound is extracted, it is inflated outward first (see
+//!   [`ub`] / [`lb`]).
+//! * Truncated polynomial terms are never dropped — they are bounded over
+//!   `[-1,1]ⁿ` and folded into the remainder interval.
+//! * Elementary functions use a Lagrange remainder whose derivative bound is
+//!   taken over an enclosure of the *whole* argument range, not at a point.
+//! * If any step cannot be bounded rigorously — an unsupported primitive, a
+//!   singularity or branch cut inside the box, a non-finite enclosure — the
+//!   operation **refuses** with a structured [`ValidatedError`] rather than
+//!   returning a bound that might be wrong.
+//!
+//! The consequence is that a returned enclosure may be **wide**, but it is
+//! never **wrong**.  A wide-but-true bound is a fine answer for a search loop;
+//! a tight-but-false one is catastrophic.
+//!
+//! # Three-valued answers
+//!
+//! Predicates ([`bounds::verified_no_roots`], [`bounds::verified_sign`])
+//! return a [`bounds::Verdict`] with three cases — `True`, `False` and
+//! `Undecided`.  `Undecided` means the budget or precision ran out before the
+//! question could be settled; it is never collapsed into either of the other
+//! two.
+//!
+//! # Example
+//!
+//! ```
+//! use alkahest_cas::kernel::{Domain, ExprPool};
+//! use alkahest_cas::validated::bounds::{bound_on_box, BoundOptions};
+//!
+//! let pool = ExprPool::new();
+//! let x = pool.symbol("x", Domain::Real);
+//! // f(x) = x - x  — zero everywhere, but naive interval arithmetic says [-1, 1].
+//! let minus_one = pool.integer(-1_i32);
+//! let f = pool.add(vec![x, pool.mul(vec![minus_one, x])]);
+//!
+//! let r = bound_on_box(f, &pool, &[(x, -1.0, 1.0)], &BoundOptions::default()).unwrap();
+//! assert!(r.lower() >= -1e-20 && r.upper() <= 1e-20);
+//! ```
+
+pub mod bounds;
+pub mod taylor;
+
+use crate::ball::ArbBall;
+use crate::errors::AlkahestError;
+use rug::Float;
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Failure modes of the validated-numerics subsystem.
+///
+/// Every variant is a **refusal**: the requested rigorous statement could not
+/// be established, so no bound is returned at all.  This is deliberate — a
+/// guessed bound would defeat the purpose of the module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidatedError {
+    /// The expression contains a node or function with no rigorous Taylor
+    /// model rule (`E-VALIDATED-001`).
+    Unsupported {
+        /// Human-readable description of the offending construct.
+        what: String,
+    },
+    /// A free symbol was not given an interval in the box (`E-VALIDATED-002`).
+    UnboundSymbol {
+        /// The symbol name.
+        name: String,
+    },
+    /// The box crosses a singularity, branch cut or domain boundary
+    /// (`E-VALIDATED-003`).
+    DomainViolation {
+        /// Which operation, and why it is undefined here.
+        what: String,
+    },
+    /// An enclosure became infinite or NaN, so nothing can be certified
+    /// (`E-VALIDATED-004`).
+    NotFinite {
+        /// Where the overflow happened.
+        what: String,
+    },
+    /// Malformed request: empty box, inverted interval, bad order, and so on
+    /// (`E-VALIDATED-005`).
+    InvalidInput {
+        /// What is wrong with the request.
+        what: String,
+    },
+}
+
+impl fmt::Display for ValidatedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ValidatedError::Unsupported { what } => {
+                write!(f, "no rigorous Taylor model rule for {what}")
+            }
+            ValidatedError::UnboundSymbol { name } => {
+                write!(f, "symbol `{name}` has no interval in the box")
+            }
+            ValidatedError::DomainViolation { what } => {
+                write!(f, "domain violation on the box: {what}")
+            }
+            ValidatedError::NotFinite { what } => {
+                write!(f, "enclosure is not finite: {what}")
+            }
+            ValidatedError::InvalidInput { what } => write!(f, "invalid request: {what}"),
+        }
+    }
+}
+
+impl std::error::Error for ValidatedError {}
+
+impl AlkahestError for ValidatedError {
+    fn code(&self) -> &'static str {
+        match self {
+            ValidatedError::Unsupported { .. } => "E-VALIDATED-001",
+            ValidatedError::UnboundSymbol { .. } => "E-VALIDATED-002",
+            ValidatedError::DomainViolation { .. } => "E-VALIDATED-003",
+            ValidatedError::NotFinite { .. } => "E-VALIDATED-004",
+            ValidatedError::InvalidInput { .. } => "E-VALIDATED-005",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        match self {
+            ValidatedError::Unsupported { .. } => Some(
+                "rewrite the expression using +, -, *, /, integer powers, exp, log, sqrt, sin, cos, tan, asin, acos, atan, sinh, cosh or tanh; piecewise and non-smooth nodes cannot be Taylor-modelled",
+            ),
+            ValidatedError::UnboundSymbol { .. } => {
+                Some("give every free symbol an interval in the box argument")
+            }
+            ValidatedError::DomainViolation { .. } => Some(
+                "shrink the box so the argument stays strictly inside the function's domain, or split the box around the singularity and bound each piece separately",
+            ),
+            ValidatedError::NotFinite { .. } => Some(
+                "raise the working precision, lower the Taylor order, or shrink the box — the intermediate enclosure overflowed",
+            ),
+            ValidatedError::InvalidInput { .. } => {
+                Some("check that lo <= hi for every variable and that order >= 1")
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interval helpers built on ArbBall
+// ---------------------------------------------------------------------------
+
+/// `2^{-(prec-2)}` as an exact `Float` — the outward-rounding safety margin.
+///
+/// Four ulps of headroom: every helper here performs at most a couple of
+/// round-to-nearest operations, each of which can move the result by half an
+/// ulp, so four ulps strictly dominates the accumulated error.
+fn eps(prec: u32) -> Float {
+    let mut e = Float::with_val(prec, 1);
+    e >>= prec.saturating_sub(2);
+    e
+}
+
+/// Grow the radius of `b` outward so that any round-to-nearest performed while
+/// constructing it cannot have shrunk the enclosure.
+pub fn inflate(b: &ArbBall) -> ArbBall {
+    let prec = b.prec;
+    if !b.mid.is_finite() || !b.rad.is_finite() {
+        return ArbBall::infinity(prec);
+    }
+    let magnitude = Float::with_val(prec, b.mid.abs_ref()) + b.rad.clone();
+    let bump = Float::with_val(prec, magnitude * eps(prec));
+    let mut out = b.clone();
+    out.rad += bump;
+    out
+}
+
+/// A rigorous **upper** bound for every value in `b`.
+pub fn ub(b: &ArbBall) -> Float {
+    inflate(b).hi()
+}
+
+/// A rigorous **lower** bound for every value in `b`.
+pub fn lb(b: &ArbBall) -> Float {
+    inflate(b).lo()
+}
+
+/// Build the interval `[lo, hi]` as a ball, rounding outward.
+pub fn from_bounds(lo: &Float, hi: &Float, prec: u32) -> ArbBall {
+    let mid = Float::with_val(prec, Float::with_val(prec, lo + hi) / 2u32);
+    let rad = Float::with_val(prec, Float::with_val(prec, hi - lo) / 2u32).abs();
+    inflate(&ArbBall { mid, rad, prec })
+}
+
+/// A ball centred at zero with radius `r` — the interval `[-r, r]`.
+pub fn symmetric(r: &Float, prec: u32) -> ArbBall {
+    inflate(&ArbBall {
+        mid: Float::new(prec),
+        rad: Float::with_val(prec, r).abs(),
+        prec,
+    })
+}
+
+/// Re-round an arbitrary `Float` into a ball at working precision, outward.
+pub fn from_float(v: &Float, prec: u32) -> ArbBall {
+    let mid = Float::with_val(prec, v);
+    let wide = Float::with_val(prec + 16, v);
+    let diff = Float::with_val(prec + 16, wide - &mid).abs();
+    inflate(&ArbBall {
+        mid,
+        rad: Float::with_val(prec, diff),
+        prec,
+    })
+}
+
+/// `max{ |x| : x ∈ b }`, rounded up.
+pub fn mag(b: &ArbBall) -> Float {
+    let prec = b.prec;
+    let m = Float::with_val(prec, b.mid.abs_ref()) + b.rad.clone();
+    let bump = Float::with_val(prec, &m * eps(prec));
+    Float::with_val(prec, m + bump)
+}
+
+/// `min{ |x| : x ∈ b }` (the *mignitude*), rounded down.  Zero when `b`
+/// straddles the origin.
+pub fn mig(b: &ArbBall) -> Float {
+    let prec = b.prec;
+    let lo = b.lo();
+    let hi = b.hi();
+    if lo <= 0 && hi >= 0 {
+        return Float::new(prec);
+    }
+    let a = Float::with_val(prec, lo.abs_ref());
+    let c = Float::with_val(prec, hi.abs_ref());
+    let m = if a < c { a } else { c };
+    let bump = Float::with_val(prec, &m * eps(prec));
+    let out = Float::with_val(prec, &m - &bump);
+    if out < 0 {
+        Float::new(prec)
+    } else {
+        out
+    }
+}
+
+/// Smallest ball containing both `a` and `b`.
+pub fn hull(a: &ArbBall, b: &ArbBall) -> ArbBall {
+    let prec = a.prec.max(b.prec);
+    let (alo, ahi, blo, bhi) = (a.lo(), a.hi(), b.lo(), b.hi());
+    let lo = if alo < blo { alo } else { blo };
+    let hi = if ahi > bhi { ahi } else { bhi };
+    from_bounds(&lo, &hi, prec)
+}
+
+/// True when `0 ∈ b`.
+pub fn contains_zero(b: &ArbBall) -> bool {
+    b.lo() <= 0 && b.hi() >= 0
+}
+
+/// True when both endpoints of `b` are finite.
+pub fn is_finite(b: &ArbBall) -> bool {
+    b.mid.is_finite() && b.rad.is_finite()
+}
+
+/// Width `hi - lo` of the enclosure, rounded up.
+pub fn width(b: &ArbBall) -> Float {
+    let prec = b.prec;
+    let w = Float::with_val(prec, &b.rad * 2u32);
+    let bump = Float::with_val(prec, &w * eps(prec));
+    Float::with_val(prec, w + bump)
+}
+
+/// π enclosed as a ball.
+pub fn pi_ball(prec: u32) -> ArbBall {
+    let mid = Float::with_val(prec, rug::float::Constant::Pi);
+    inflate(&ArbBall {
+        mid,
+        rad: Float::new(prec),
+        prec,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const P: u32 = 128;
+
+    #[test]
+    fn inflate_only_grows() {
+        let b = ArbBall::from_midpoint_radius(1.0, 0.5, P);
+        let i = inflate(&b);
+        assert!(i.rad >= b.rad);
+        assert!(i.lo() <= b.lo());
+        assert!(i.hi() >= b.hi());
+    }
+
+    #[test]
+    fn from_bounds_encloses_endpoints() {
+        let lo = Float::with_val(P, -1.25);
+        let hi = Float::with_val(P, 3.5);
+        let b = from_bounds(&lo, &hi, P);
+        assert!(b.lo() <= lo);
+        assert!(b.hi() >= hi);
+        assert!(b.contains(0.0));
+    }
+
+    #[test]
+    fn mag_and_mig() {
+        let b = from_bounds(&Float::with_val(P, 2.0), &Float::with_val(P, 5.0), P);
+        assert!(mag(&b) >= 5.0);
+        assert!(mig(&b) <= 2.0);
+        assert!(mig(&b) > 1.9);
+
+        let straddling = from_bounds(&Float::with_val(P, -1.0), &Float::with_val(P, 2.0), P);
+        assert_eq!(mig(&straddling), 0.0);
+        assert!(mag(&straddling) >= 2.0);
+    }
+
+    #[test]
+    fn hull_covers_both() {
+        let a = from_bounds(&Float::with_val(P, 0.0), &Float::with_val(P, 1.0), P);
+        let b = from_bounds(&Float::with_val(P, 3.0), &Float::with_val(P, 4.0), P);
+        let h = hull(&a, &b);
+        assert!(h.lo() <= 0.0);
+        assert!(h.hi() >= 4.0);
+    }
+
+    #[test]
+    fn error_codes_are_stable() {
+        let e = ValidatedError::Unsupported {
+            what: "gamma".into(),
+        };
+        assert_eq!(e.code(), "E-VALIDATED-001");
+        assert!(e.remediation().is_some());
+        assert_eq!(
+            ValidatedError::UnboundSymbol { name: "y".into() }.code(),
+            "E-VALIDATED-002"
+        );
+        assert_eq!(
+            ValidatedError::DomainViolation { what: "log".into() }.code(),
+            "E-VALIDATED-003"
+        );
+        assert_eq!(
+            ValidatedError::NotFinite { what: "exp".into() }.code(),
+            "E-VALIDATED-004"
+        );
+        assert_eq!(
+            ValidatedError::InvalidInput { what: "box".into() }.code(),
+            "E-VALIDATED-005"
+        );
+    }
+
+    #[test]
+    fn pi_ball_contains_pi() {
+        // Compare against π at *higher* precision, not the f64 constant: the
+        // ball encloses π to ~2^-126, and the f64 approximation of π is a
+        // whole 1e-17 away from it, so `contains(f64::consts::PI)` would be
+        // asking the wrong question.
+        let p = pi_ball(P);
+        let truth = Float::with_val(P + 64, rug::float::Constant::Pi);
+        assert!(p.lo() <= truth && truth <= p.hi());
+    }
+}

--- a/alkahest-core/src/validated/taylor.rs
+++ b/alkahest-core/src/validated/taylor.rs
@@ -1,0 +1,1247 @@
+//! Taylor model arithmetic with rigorous remainder bounds.
+//!
+//! A [`TaylorModel`] over an `n`-dimensional box represents a function `f` as
+//! a truncated polynomial `P` in **normalised** coordinates `u ∈ [-1,1]ⁿ`
+//! plus an interval remainder `I`:
+//!
+//! ```text
+//! x = c + r ⊙ u,      ∀ u ∈ [-1,1]ⁿ :  f(x) ∈ P(u) + I
+//! ```
+//!
+//! Normalised coordinates make range bounding trivial and numerically stable:
+//! every monomial `u^α` lies in `[-1,1]`, and in `[0,1]` when every exponent
+//! in `α` is even.
+//!
+//! Every operation preserves the enclosure property.  Terms above the
+//! truncation order are bounded over `[-1,1]ⁿ` and folded into `I`; they are
+//! never discarded.  Elementary functions use a Lagrange remainder whose
+//! derivative bound is evaluated over an enclosure of the entire argument
+//! range.
+
+use super::{
+    contains_zero, from_bounds, from_float, hull, is_finite, lb, mag, mig, pi_ball, symmetric, ub,
+    ValidatedError,
+};
+use crate::ball::ArbBall;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use rug::{Complete, Float, Integer};
+use std::collections::{BTreeMap, HashMap};
+
+type Result<T> = std::result::Result<T, ValidatedError>;
+
+/// Exponent vector of a monomial, one entry per box variable.
+pub type MultiIndex = Vec<u32>;
+
+/// Highest Taylor order accepted.  Beyond this the coefficient count and the
+/// `(p+1)!` remainder scaling stop buying accuracy.
+pub const MAX_ORDER: usize = 24;
+
+/// `v > 0`, with NaN answering **false**.
+///
+/// The guards below are all of the form "refuse unless strictly positive", and
+/// that has to keep refusing on a NaN endpoint. Writing them as `v <= 0` would
+/// invert exactly that case and let a NaN through into a certificate, so the
+/// comparison is spelled out through `partial_cmp`.
+fn strictly_positive(v: &Float) -> bool {
+    matches!(v.partial_cmp(&0), Some(std::cmp::Ordering::Greater))
+}
+
+/// A Taylor model: polynomial part with ball coefficients plus a rigorously
+/// enclosing remainder interval.
+#[derive(Clone, Debug)]
+pub struct TaylorModel {
+    nvars: usize,
+    order: usize,
+    prec: u32,
+    /// Coefficients of `P` keyed by exponent vector in normalised coordinates.
+    coeffs: BTreeMap<MultiIndex, ArbBall>,
+    /// Interval remainder — an enclosure of `f - P` over the whole box.
+    remainder: ArbBall,
+}
+
+impl TaylorModel {
+    // ── constructors ─────────────────────────────────────────────────────
+
+    /// The zero model.
+    pub fn zero(nvars: usize, order: usize, prec: u32) -> Self {
+        TaylorModel {
+            nvars,
+            order,
+            prec,
+            coeffs: BTreeMap::new(),
+            remainder: ArbBall::from_f64(0.0, prec),
+        }
+    }
+
+    /// A constant model enclosing the ball `c`.
+    pub fn constant(c: ArbBall, nvars: usize, order: usize, prec: u32) -> Self {
+        let mut coeffs = BTreeMap::new();
+        coeffs.insert(vec![0u32; nvars], c);
+        TaylorModel {
+            nvars,
+            order,
+            prec,
+            coeffs,
+            remainder: ArbBall::from_f64(0.0, prec),
+        }
+    }
+
+    /// The model of the `i`-th coordinate over a box whose `i`-th interval has
+    /// midpoint `center` and radius `radius`: `xᵢ = center + radius · uᵢ`.
+    pub fn variable(
+        i: usize,
+        center: &Float,
+        radius: &Float,
+        nvars: usize,
+        order: usize,
+        prec: u32,
+    ) -> Self {
+        let mut coeffs = BTreeMap::new();
+        coeffs.insert(vec![0u32; nvars], from_float(center, prec));
+        if order >= 1 {
+            let mut e = vec![0u32; nvars];
+            e[i] = 1;
+            coeffs.insert(e, from_float(radius, prec));
+        }
+        TaylorModel {
+            nvars,
+            order,
+            prec,
+            coeffs,
+            // With order >= 1 the linear term is exact, so no remainder is
+            // needed.  With order 0 the linear part must be absorbed.
+            remainder: if order >= 1 {
+                ArbBall::from_f64(0.0, prec)
+            } else {
+                symmetric(radius, prec)
+            },
+        }
+    }
+
+    // ── accessors ────────────────────────────────────────────────────────
+
+    /// Number of box variables.
+    pub fn nvars(&self) -> usize {
+        self.nvars
+    }
+
+    /// Truncation order (maximum total degree kept in `P`).
+    pub fn order(&self) -> usize {
+        self.order
+    }
+
+    /// Working precision in bits.
+    pub fn prec(&self) -> u32 {
+        self.prec
+    }
+
+    /// The remainder interval `I`.
+    pub fn remainder(&self) -> &ArbBall {
+        &self.remainder
+    }
+
+    /// Number of retained polynomial terms.
+    pub fn term_count(&self) -> usize {
+        self.coeffs.len()
+    }
+
+    fn zero_index(&self) -> MultiIndex {
+        vec![0u32; self.nvars]
+    }
+
+    fn coeff(&self, idx: &MultiIndex) -> ArbBall {
+        self.coeffs
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| ArbBall::from_f64(0.0, self.prec))
+    }
+
+    fn insert(&mut self, idx: MultiIndex, c: ArbBall) {
+        match self.coeffs.get_mut(&idx) {
+            Some(existing) => *existing = existing.clone() + c,
+            None => {
+                self.coeffs.insert(idx, c);
+            }
+        }
+    }
+
+    // ── range bounding ───────────────────────────────────────────────────
+
+    /// Rigorous enclosure of the polynomial part over `[-1,1]ⁿ`.
+    ///
+    /// The constant term is kept centred; a monomial with at least one odd
+    /// exponent contributes `[-|c|, |c|]`; a monomial whose exponents are all
+    /// even contributes `hull(0, c)` because `u^α ∈ [0,1]` there.
+    pub fn poly_bound(&self) -> ArbBall {
+        let zero = ArbBall::from_f64(0.0, self.prec);
+        let mut acc = zero.clone();
+        for (idx, c) in &self.coeffs {
+            if idx.iter().all(|&e| e == 0) {
+                acc = acc + c.clone();
+            } else if idx.iter().all(|&e| e % 2 == 0) {
+                acc = acc + hull(&zero, c);
+            } else {
+                acc = acc + symmetric(&mag(c), self.prec);
+            }
+        }
+        acc
+    }
+
+    /// Rigorous enclosure of `f` over the whole box: `P([-1,1]ⁿ) + I`.
+    pub fn range(&self) -> ArbBall {
+        self.poly_bound() + self.remainder.clone()
+    }
+
+    fn check_finite(&self, what: &str) -> Result<()> {
+        if !is_finite(&self.remainder) || self.coeffs.values().any(|c| !is_finite(c)) {
+            return Err(ValidatedError::NotFinite {
+                what: what.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    // ── arithmetic ───────────────────────────────────────────────────────
+
+    /// Negation.
+    pub fn neg(&self) -> Self {
+        let mut out = self.clone();
+        out.coeffs = self
+            .coeffs
+            .iter()
+            .map(|(k, v)| (k.clone(), -v.clone()))
+            .collect();
+        out.remainder = -self.remainder.clone();
+        out
+    }
+
+    /// Addition.
+    pub fn add(&self, other: &Self) -> Self {
+        let mut out = self.clone();
+        for (idx, c) in &other.coeffs {
+            out.insert(idx.clone(), c.clone());
+        }
+        out.remainder = out.remainder + other.remainder.clone();
+        out
+    }
+
+    /// Subtraction.
+    pub fn sub(&self, other: &Self) -> Self {
+        self.add(&other.neg())
+    }
+
+    /// Multiply by a ball constant.
+    pub fn scale(&self, k: &ArbBall) -> Self {
+        let mut out = self.clone();
+        out.coeffs = self
+            .coeffs
+            .iter()
+            .map(|(i, c)| (i.clone(), c.clone() * k.clone()))
+            .collect();
+        out.remainder = self.remainder.clone() * k.clone();
+        out
+    }
+
+    /// Add a ball constant.
+    pub fn shift(&self, k: &ArbBall) -> Self {
+        let mut out = self.clone();
+        let z = out.zero_index();
+        out.insert(z, k.clone());
+        out
+    }
+
+    /// Multiplication.  Products of total degree above the truncation order
+    /// are bounded over `[-1,1]ⁿ` and folded into the remainder.
+    pub fn mul(&self, other: &Self) -> Self {
+        let prec = self.prec.max(other.prec);
+        let order = self.order.min(other.order);
+        let zero = ArbBall::from_f64(0.0, prec);
+        let mut out = TaylorModel::zero(self.nvars, order, prec);
+        let mut truncated = zero.clone();
+
+        for (a_idx, a) in &self.coeffs {
+            for (b_idx, b) in &other.coeffs {
+                let deg: u32 = a_idx.iter().zip(b_idx).map(|(x, y)| x + y).sum();
+                let prod = a.clone() * b.clone();
+                if deg as usize <= order {
+                    let idx: MultiIndex = a_idx.iter().zip(b_idx).map(|(x, y)| x + y).collect();
+                    out.insert(idx, prod);
+                } else {
+                    // The dropped monomial lies in [-1,1] (or [0,1] when all
+                    // exponents are even); bound it and keep it.
+                    let all_even = a_idx
+                        .iter()
+                        .zip(b_idx)
+                        .all(|(x, y)| (x + y) % 2 == 0 && (x + y) > 0);
+                    if all_even {
+                        truncated = truncated + hull(&zero, &prod);
+                    } else {
+                        truncated = truncated + symmetric(&mag(&prod), prec);
+                    }
+                }
+            }
+        }
+
+        // f ∈ P₁ + I₁, g ∈ P₂ + I₂  ⟹  fg ∈ P₁P₂ + P₁I₂ + P₂I₁ + I₁I₂.
+        let pb_a = self.poly_bound();
+        let pb_b = other.poly_bound();
+        out.remainder = truncated
+            + pb_a * other.remainder.clone()
+            + pb_b * self.remainder.clone()
+            + self.remainder.clone() * other.remainder.clone();
+        out
+    }
+
+    /// Non-negative integer power by binary exponentiation.
+    pub fn powi_nonneg(&self, n: u32) -> Self {
+        if n == 0 {
+            return TaylorModel::constant(
+                ArbBall::from_f64(1.0, self.prec),
+                self.nvars,
+                self.order,
+                self.prec,
+            );
+        }
+        let mut result: Option<Self> = None;
+        let mut base = self.clone();
+        let mut e = n;
+        while e > 0 {
+            if e & 1 == 1 {
+                result = Some(match result {
+                    Some(r) => r.mul(&base),
+                    None => base.clone(),
+                });
+            }
+            e >>= 1;
+            if e > 0 {
+                base = base.mul(&base);
+            }
+        }
+        result.unwrap()
+    }
+
+    /// Integer power, including negative exponents (via [`Self::recip`]).
+    pub fn powi(&self, n: i64) -> Result<Self> {
+        if n >= 0 {
+            let n: u32 = u32::try_from(n).map_err(|_| ValidatedError::Unsupported {
+                what: format!("integer exponent {n} is too large for a Taylor model"),
+            })?;
+            Ok(self.powi_nonneg(n))
+        } else {
+            let p =
+                self.powi_nonneg(u32::try_from(-n).map_err(|_| ValidatedError::Unsupported {
+                    what: format!("integer exponent {n} is too large for a Taylor model"),
+                })?);
+            p.recip()
+        }
+    }
+
+    /// Division.  Refuses when the divisor's range contains zero.
+    pub fn div(&self, other: &Self) -> Result<Self> {
+        Ok(self.mul(&other.recip()?))
+    }
+
+    // ── composition machinery ────────────────────────────────────────────
+
+    /// Split off the (exact) midpoint of the constant term.
+    ///
+    /// Returns `(m₀, Δ)` with `Δ = self - m₀`, so `self = m₀ + Δ` and the
+    /// expansion point `m₀` is a genuine point rather than a ball.
+    fn center_split(&self) -> (Float, Self) {
+        let m0 = self.coeff(&self.zero_index()).mid.clone();
+        let shifted = self.shift(&(-from_float(&m0, self.prec)));
+        (m0, shifted)
+    }
+
+    /// Compose with a univariate function given its Taylor coefficients
+    /// `a₀..a_p` at the expansion point and a bound on the degree-`(p+1)`
+    /// Lagrange remainder.
+    ///
+    /// `self` must be the *centred* part `Δ` and `rem_radius` must bound
+    /// `|f^{(p+1)}(ξ)| / (p+1)! · |Δ|^{p+1}` uniformly over the box.
+    fn compose(&self, a: &[ArbBall], rem_radius: &Float) -> Self {
+        debug_assert_eq!(a.len(), self.order + 1);
+        let mut acc =
+            TaylorModel::constant(a[self.order].clone(), self.nvars, self.order, self.prec);
+        for k in (0..self.order).rev() {
+            acc = acc.mul(self).shift(&a[k]);
+        }
+        acc.remainder = acc.remainder + symmetric(rem_radius, self.prec);
+        acc
+    }
+
+    /// `|Δ|^{p+1}` as a rounded-up `Float`, where `Δ` is `self`.
+    fn delta_pow(&self, d_range: &ArbBall) -> Float {
+        let prec = self.prec;
+        let m = mag(d_range);
+        let b = ArbBall {
+            mid: m,
+            rad: Float::new(prec),
+            prec,
+        };
+        ub(&b.powi((self.order + 1) as i64))
+    }
+
+    fn factorial(k: usize, prec: u32) -> ArbBall {
+        let f = Integer::factorial(k as u32).complete();
+        ArbBall::from_integer(&f, prec)
+    }
+
+    fn div_ball(a: &ArbBall, b: &ArbBall) -> Result<ArbBall> {
+        (a.clone() / b.clone()).ok_or_else(|| ValidatedError::DomainViolation {
+            what: "division by an interval containing zero".to_string(),
+        })
+    }
+
+    // ── elementary functions ─────────────────────────────────────────────
+
+    /// `exp(self)`.
+    pub fn exp(&self) -> Result<Self> {
+        self.check_finite("exp argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let arg = from_float(&m0, self.prec) + d.clone();
+        if !is_finite(&arg) {
+            return Err(ValidatedError::NotFinite {
+                what: "exp argument".into(),
+            });
+        }
+        let e0 = from_float(&m0, self.prec).exp();
+        let mut a = Vec::with_capacity(self.order + 1);
+        for k in 0..=self.order {
+            a.push(Self::div_ball(&e0, &Self::factorial(k, self.prec))?);
+        }
+        // sup |exp^{(p+1)}| over arg = sup exp over arg.
+        let sup = arg.exp();
+        let fact = Self::factorial(self.order + 1, self.prec);
+        let scale = Self::div_ball(&sup, &fact)?;
+        let radius = ub(
+            &(scale * ArbBall::from_midpoint_radius(0.0, 0.0, self.prec).clone()
+                + ArbBall {
+                    mid: delta.delta_pow(&d),
+                    rad: Float::new(self.prec),
+                    prec: self.prec,
+                } * Self::div_ball(&arg.exp(), &fact)?),
+        );
+        let out = delta.compose(&a, &radius);
+        out.check_finite("exp result")?;
+        Ok(out)
+    }
+
+    /// `log(self)`.  Refuses unless the range is strictly positive.
+    pub fn log(&self) -> Result<Self> {
+        self.check_finite("log argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let arg = from_float(&m0, self.prec) + d.clone();
+        let arg_lo = lb(&arg);
+        if !strictly_positive(&arg_lo) {
+            return Err(ValidatedError::DomainViolation {
+                what: "log of an argument whose enclosure reaches 0 or below".into(),
+            });
+        }
+        let c = from_float(&m0, self.prec);
+        let mut a = Vec::with_capacity(self.order + 1);
+        a.push(c.log().ok_or_else(|| ValidatedError::DomainViolation {
+            what: "log expansion point is not positive".into(),
+        })?);
+        for k in 1..=self.order {
+            // aₖ = (-1)^{k-1} / (k · m₀^k)
+            let denom = c.powi(k as i64) * ArbBall::from_f64(k as f64, self.prec);
+            let mut t = Self::div_ball(&ArbBall::from_f64(1.0, self.prec), &denom)?;
+            if k % 2 == 0 {
+                t = -t;
+            }
+            a.push(t);
+        }
+        // |f^{(p+1)}(ξ)| / (p+1)! = 1 / ((p+1)·ξ^{p+1}), maximal at ξ = arg_lo.
+        let p1 = self.order + 1;
+        let lo_ball = from_float(&arg_lo, self.prec);
+        let denom = lo_ball.powi(p1 as i64) * ArbBall::from_f64(p1 as f64, self.prec);
+        let scale = Self::div_ball(&ArbBall::from_f64(1.0, self.prec), &denom)?;
+        let radius = ub(&(scale
+            * ArbBall {
+                mid: delta.delta_pow(&d),
+                rad: Float::new(self.prec),
+                prec: self.prec,
+            }));
+        let out = delta.compose(&a, &radius);
+        out.check_finite("log result")?;
+        Ok(out)
+    }
+
+    /// `1 / self`.  Refuses when the range contains zero.
+    pub fn recip(&self) -> Result<Self> {
+        self.check_finite("reciprocal argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let arg = from_float(&m0, self.prec) + d.clone();
+        if contains_zero(&arg) {
+            return Err(ValidatedError::DomainViolation {
+                what: "reciprocal of an enclosure containing zero".into(),
+            });
+        }
+        let c = from_float(&m0, self.prec);
+        let mut a = Vec::with_capacity(self.order + 1);
+        for k in 0..=self.order {
+            // aₖ = (-1)^k / m₀^{k+1}
+            let mut t =
+                Self::div_ball(&ArbBall::from_f64(1.0, self.prec), &c.powi((k + 1) as i64))?;
+            if k % 2 == 1 {
+                t = -t;
+            }
+            a.push(t);
+        }
+        // |f^{(p+1)}(ξ)| / (p+1)! = 1 / |ξ|^{p+2}, maximal at the mignitude.
+        let m = mig(&arg);
+        if !strictly_positive(&m) {
+            return Err(ValidatedError::DomainViolation {
+                what: "reciprocal argument touches zero".into(),
+            });
+        }
+        let denom = from_float(&m, self.prec).powi((self.order + 2) as i64);
+        let scale = Self::div_ball(&ArbBall::from_f64(1.0, self.prec), &denom)?;
+        let radius = ub(&(scale
+            * ArbBall {
+                mid: delta.delta_pow(&d),
+                rad: Float::new(self.prec),
+                prec: self.prec,
+            }));
+        let out = delta.compose(&a, &radius);
+        out.check_finite("reciprocal result")?;
+        Ok(out)
+    }
+
+    /// `sqrt(self)`.  Refuses unless the range is strictly positive — at zero
+    /// the derivatives of `sqrt` are unbounded, so no Taylor remainder exists.
+    pub fn sqrt(&self) -> Result<Self> {
+        self.check_finite("sqrt argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let arg = from_float(&m0, self.prec) + d.clone();
+        let arg_lo = lb(&arg);
+        if !strictly_positive(&arg_lo) {
+            return Err(ValidatedError::DomainViolation {
+                what: "sqrt of an argument whose enclosure reaches 0 or below (derivatives blow up at 0)".into(),
+            });
+        }
+        let c = from_float(&m0, self.prec);
+        let root = c.sqrt().ok_or_else(|| ValidatedError::DomainViolation {
+            what: "sqrt expansion point is negative".into(),
+        })?;
+        // binom(1/2, k) via bₖ = bₖ₋₁ · (1/2 - (k-1)) / k
+        let half = ArbBall::from_f64(0.5, self.prec);
+        let mut binom = vec![ArbBall::from_f64(1.0, self.prec)];
+        for k in 1..=self.order + 1 {
+            let prev = binom[k - 1].clone();
+            let num = half.clone() - ArbBall::from_f64((k - 1) as f64, self.prec);
+            let t = Self::div_ball(&(prev * num), &ArbBall::from_f64(k as f64, self.prec))?;
+            binom.push(t);
+        }
+        let mut a = Vec::with_capacity(self.order + 1);
+        for (k, b) in binom.iter().enumerate().take(self.order + 1) {
+            // aₖ = binom(1/2,k) · m₀^{1/2-k}
+            let t = Self::div_ball(&(b.clone() * root.clone()), &c.powi(k as i64))?;
+            a.push(t);
+        }
+        // |f^{(p+1)}(ξ)|/(p+1)! = |binom(1/2,p+1)| · ξ^{1/2-(p+1)}, maximal at ξ = arg_lo.
+        let p1 = self.order + 1;
+        let lo_ball = from_float(&arg_lo, self.prec);
+        let lo_root = lo_ball
+            .sqrt()
+            .ok_or_else(|| ValidatedError::DomainViolation {
+                what: "sqrt lower bound is negative".into(),
+            })?;
+        let scale = Self::div_ball(
+            &(symmetric(&mag(&binom[p1]), self.prec) * lo_root),
+            &lo_ball.powi(p1 as i64),
+        )?;
+        let radius = ub(&(scale
+            * ArbBall {
+                mid: delta.delta_pow(&d),
+                rad: Float::new(self.prec),
+                prec: self.prec,
+            }));
+        let out = delta.compose(&a, &radius);
+        out.check_finite("sqrt result")?;
+        Ok(out)
+    }
+
+    fn trig(&self, is_sin: bool) -> Result<Self> {
+        self.check_finite("trig argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let c = from_float(&m0, self.prec);
+        let (s, co) = (c.sin(), c.cos());
+        let mut a = Vec::with_capacity(self.order + 1);
+        for k in 0..=self.order {
+            // dᵏ/dxᵏ sin = sin, cos, -sin, -cos ; cos shifts by one.
+            let phase = if is_sin { k % 4 } else { (k + 1) % 4 };
+            let base = match phase {
+                0 => s.clone(),
+                1 => co.clone(),
+                2 => -s.clone(),
+                _ => -co.clone(),
+            };
+            let base = if is_sin { base } else { -base };
+            a.push(Self::div_ball(&base, &Self::factorial(k, self.prec))?);
+        }
+        // |sin^{(p+1)}| ≤ 1 and |cos^{(p+1)}| ≤ 1 everywhere.
+        let fact = Self::factorial(self.order + 1, self.prec);
+        let scale = Self::div_ball(&ArbBall::from_f64(1.0, self.prec), &fact)?;
+        let radius = ub(&(scale
+            * ArbBall {
+                mid: delta.delta_pow(&d),
+                rad: Float::new(self.prec),
+                prec: self.prec,
+            }));
+        let out = delta.compose(&a, &radius);
+        out.check_finite("trig result")?;
+        Ok(out)
+    }
+
+    /// `sin(self)`.
+    pub fn sin(&self) -> Result<Self> {
+        self.trig(true)
+    }
+
+    /// `cos(self)`.
+    pub fn cos(&self) -> Result<Self> {
+        self.trig(false)
+    }
+
+    fn hyp(&self, is_sinh: bool) -> Result<Self> {
+        self.check_finite("hyperbolic argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let arg = from_float(&m0, self.prec) + d.clone();
+        let c = from_float(&m0, self.prec);
+        let (sh, ch) = (c.sinh(), c.cosh());
+        let mut a = Vec::with_capacity(self.order + 1);
+        for k in 0..=self.order {
+            let even = k % 2 == 0;
+            let base = if is_sinh == even {
+                sh.clone()
+            } else {
+                ch.clone()
+            };
+            a.push(Self::div_ball(&base, &Self::factorial(k, self.prec))?);
+        }
+        // Both |sinh| and |cosh| are bounded by cosh(max|x|) on the argument range.
+        let m = mag(&arg);
+        let sup = from_float(&m, self.prec).cosh();
+        let fact = Self::factorial(self.order + 1, self.prec);
+        let scale = Self::div_ball(&sup, &fact)?;
+        let radius = ub(&(scale
+            * ArbBall {
+                mid: delta.delta_pow(&d),
+                rad: Float::new(self.prec),
+                prec: self.prec,
+            }));
+        let out = delta.compose(&a, &radius);
+        out.check_finite("hyperbolic result")?;
+        Ok(out)
+    }
+
+    /// `sinh(self)`.
+    pub fn sinh(&self) -> Result<Self> {
+        self.hyp(true)
+    }
+
+    /// `cosh(self)`.
+    pub fn cosh(&self) -> Result<Self> {
+        self.hyp(false)
+    }
+
+    /// `atan(self)`.
+    ///
+    /// Uses the closed form `f^{(k)}(m₀) = (-1)^{k-1}(k-1)! ρ^{-k} sin(kφ)`
+    /// with `ρ = √(1+m₀²)` and `φ = π/2 - atan(m₀)`, which also yields the
+    /// clean derivative bound `|f^{(k)}(x)| ≤ (k-1)! (1+x²)^{-k/2}`.
+    pub fn atan(&self) -> Result<Self> {
+        self.check_finite("atan argument")?;
+        let (m0, delta) = self.center_split();
+        let d = delta.range();
+        let arg = from_float(&m0, self.prec) + d.clone();
+        let c = from_float(&m0, self.prec);
+        let rho2 = ArbBall::from_f64(1.0, self.prec) + c.clone() * c.clone();
+        let rho = rho2.sqrt().ok_or_else(|| ValidatedError::NotFinite {
+            what: "atan expansion radius".into(),
+        })?;
+        let phi = pi_ball(self.prec) * ArbBall::from_f64(0.5, self.prec) - c.atan();
+        let mut a = Vec::with_capacity(self.order + 1);
+        a.push(c.atan());
+        for k in 1..=self.order {
+            let kb = ArbBall::from_f64(k as f64, self.prec);
+            let s = (phi.clone() * kb.clone()).sin();
+            let denom = rho.powi(k as i64) * kb;
+            let mut t = Self::div_ball(&s, &denom)?;
+            if k % 2 == 0 {
+                t = -t;
+            }
+            a.push(t);
+        }
+        // |f^{(p+1)}(ξ)|/(p+1)! ≤ 1 / ((p+1)(1+ξ²)^{(p+1)/2}); worst at min |ξ|.
+        let p1 = self.order + 1;
+        let m = mig(&arg);
+        let mb = from_float(&m, self.prec);
+        let base = (ArbBall::from_f64(1.0, self.prec) + mb.clone() * mb)
+            .sqrt()
+            .ok_or_else(|| ValidatedError::NotFinite {
+                what: "atan derivative bound".into(),
+            })?;
+        let denom = base.powi(p1 as i64) * ArbBall::from_f64(p1 as f64, self.prec);
+        let scale = Self::div_ball(&ArbBall::from_f64(1.0, self.prec), &denom)?;
+        let radius = ub(&(scale
+            * ArbBall {
+                mid: delta.delta_pow(&d),
+                rad: Float::new(self.prec),
+                prec: self.prec,
+            }));
+        let out = delta.compose(&a, &radius);
+        out.check_finite("atan result")?;
+        Ok(out)
+    }
+
+    /// `tan(self) = sin/cos`.  Refuses when `cos` can vanish on the box.
+    pub fn tan(&self) -> Result<Self> {
+        let c = self.cos()?;
+        if contains_zero(&c.range()) {
+            return Err(ValidatedError::DomainViolation {
+                what: "tan: cos enclosure contains zero (pole in the box)".into(),
+            });
+        }
+        self.sin()?.div(&c)
+    }
+
+    /// `tanh(self) = sinh/cosh`.  `cosh ≥ 1`, so this never refuses on domain
+    /// grounds.
+    pub fn tanh(&self) -> Result<Self> {
+        let c = self.cosh()?;
+        self.sinh()?.div(&c)
+    }
+
+    /// `asin(self) = atan(x / √(1-x²))`.  Refuses when the range reaches
+    /// `±1`, where the derivative is unbounded.
+    pub fn asin(&self) -> Result<Self> {
+        let one = TaylorModel::constant(
+            ArbBall::from_f64(1.0, self.prec),
+            self.nvars,
+            self.order,
+            self.prec,
+        );
+        let inner = one.sub(&self.mul(self));
+        if !strictly_positive(&lb(&inner.range())) {
+            return Err(ValidatedError::DomainViolation {
+                what: "asin: the enclosure of 1-x² reaches 0 or below (|x| ≥ 1)".into(),
+            });
+        }
+        let denom = inner.sqrt()?;
+        self.div(&denom)?.atan()
+    }
+
+    /// `acos(self) = π/2 - asin(self)`.
+    pub fn acos(&self) -> Result<Self> {
+        let half_pi = TaylorModel::constant(
+            pi_ball(self.prec) * ArbBall::from_f64(0.5, self.prec),
+            self.nvars,
+            self.order,
+            self.prec,
+        );
+        Ok(half_pi.sub(&self.asin()?))
+    }
+
+    /// `self^e` for a real constant exponent, via `exp(e · log(self))`.
+    /// Requires a strictly positive base.
+    pub fn pow_const(&self, e: &ArbBall) -> Result<Self> {
+        let l = self.log()?;
+        l.scale(e).exp()
+    }
+
+    /// `|self|`.  Only defined when the range has a determined sign — `abs` is
+    /// not differentiable at zero, so a straddling box is refused.
+    pub fn abs(&self) -> Result<Self> {
+        let r = self.range();
+        if lb(&r) >= 0 {
+            Ok(self.clone())
+        } else if ub(&r) <= 0 {
+            Ok(self.neg())
+        } else {
+            Err(ValidatedError::DomainViolation {
+                what: "abs over a box whose enclosure straddles zero is not smooth".into(),
+            })
+        }
+    }
+
+    // ── integration (1-D) ────────────────────────────────────────────────
+
+    /// Rigorous enclosure of `∫_{-1}^{1} f(u) du` in normalised coordinates,
+    /// for a **univariate** model (`nvars() == 1`).
+    ///
+    /// The polynomial part integrates termwise exactly:
+    /// `∫_{-1}^{1} u^k du = 2/(k+1)` for even `k` and `0` for odd `k` (an odd
+    /// monomial is an odd function on the symmetric domain, so it integrates
+    /// to exactly zero — this is where Taylor models beat plain
+    /// range-times-width quadrature: the sign cancellation is exact, not
+    /// approximated). The remainder `I` bounds `f - P` uniformly over
+    /// `[-1,1]`, so `∫_{-1}^{1} (f - P) du ∈ 2·I`.
+    ///
+    /// Used by [`crate::validated::bounds::verified_integral`] to turn a
+    /// local Taylor model on a sub-interval into a rigorous enclosure of the
+    /// local piece of a definite integral (after scaling by the sub-interval
+    /// radius to undo the `x = c + r·u` change of variables).
+    ///
+    /// Returns [`ValidatedError::InvalidInput`] if `nvars() != 1` — this
+    /// method is not a multivariate quadrature rule.
+    pub fn integrate_normalized_1d(&self) -> Result<ArbBall> {
+        if self.nvars != 1 {
+            return Err(ValidatedError::InvalidInput {
+                what: "integrate_normalized_1d requires a univariate Taylor model".into(),
+            });
+        }
+        let two = ArbBall::from_f64(2.0, self.prec);
+        let mut acc = ArbBall::from_f64(0.0, self.prec);
+        for (idx, c) in &self.coeffs {
+            let k = idx[0];
+            if k % 2 == 0 {
+                let denom = ArbBall::from_f64((k + 1) as f64, self.prec);
+                let term = Self::div_ball(&(two.clone() * c.clone()), &denom)?;
+                acc = acc + term;
+            }
+            // Odd-degree monomials integrate to exactly zero over [-1,1].
+        }
+        Ok(acc + two * self.remainder.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Expression → Taylor model
+// ---------------------------------------------------------------------------
+
+/// Evaluation context binding box variables to normalised coordinates.
+pub struct TaylorContext<'a> {
+    pool: &'a ExprPool,
+    vars: Vec<ExprId>,
+    centers: Vec<Float>,
+    radii: Vec<Float>,
+    order: usize,
+    prec: u32,
+    memo: HashMap<ExprId, TaylorModel>,
+}
+
+impl<'a> TaylorContext<'a> {
+    /// Build a context over the box `[lo_i, hi_i]` for each listed variable.
+    pub fn new(
+        pool: &'a ExprPool,
+        boxes: &[(ExprId, Float, Float)],
+        order: usize,
+        prec: u32,
+    ) -> Result<Self> {
+        if boxes.is_empty() {
+            return Err(ValidatedError::InvalidInput {
+                what: "the box must constrain at least one variable".into(),
+            });
+        }
+        if order == 0 || order > MAX_ORDER {
+            return Err(ValidatedError::InvalidInput {
+                what: format!("Taylor order must be in 1..={MAX_ORDER}"),
+            });
+        }
+        let mut vars = Vec::new();
+        let mut centers = Vec::new();
+        let mut radii = Vec::new();
+        for (v, lo, hi) in boxes {
+            if !(lo.is_finite() && hi.is_finite()) {
+                return Err(ValidatedError::InvalidInput {
+                    what: "box endpoints must be finite (improper domains are not supported)"
+                        .into(),
+                });
+            }
+            if lo > hi {
+                return Err(ValidatedError::InvalidInput {
+                    what: "box interval has lo > hi".into(),
+                });
+            }
+            let b = from_bounds(lo, hi, prec);
+            vars.push(*v);
+            centers.push(b.mid.clone());
+            radii.push(b.rad.clone());
+        }
+        Ok(TaylorContext {
+            pool,
+            vars,
+            centers,
+            radii,
+            order,
+            prec,
+            memo: HashMap::new(),
+        })
+    }
+
+    /// Truncation order.
+    pub fn order(&self) -> usize {
+        self.order
+    }
+
+    /// Working precision.
+    pub fn prec(&self) -> u32 {
+        self.prec
+    }
+
+    fn nvars(&self) -> usize {
+        self.vars.len()
+    }
+
+    fn konst(&self, b: ArbBall) -> TaylorModel {
+        TaylorModel::constant(b, self.nvars(), self.order, self.prec)
+    }
+
+    /// Build a Taylor model for `expr` over this box.
+    pub fn eval(&mut self, expr: ExprId) -> Result<TaylorModel> {
+        if let Some(m) = self.memo.get(&expr) {
+            return Ok(m.clone());
+        }
+        let m = self.eval_uncached(expr)?;
+        self.memo.insert(expr, m.clone());
+        Ok(m)
+    }
+
+    fn eval_uncached(&mut self, expr: ExprId) -> Result<TaylorModel> {
+        match self.pool.get(expr) {
+            ExprData::Integer(n) => Ok(self.konst(ArbBall::from_integer(&n.0, self.prec))),
+            ExprData::Rational(r) => Ok(self.konst(ArbBall::from_rational(&r.0, self.prec))),
+            ExprData::Float(f) => Ok(self.konst(from_float(
+                &Float::with_val(self.prec, f.inner.to_f64()),
+                self.prec,
+            ))),
+            ExprData::Symbol { name, .. } => {
+                if let Some(i) = self.vars.iter().position(|&v| v == expr) {
+                    Ok(TaylorModel::variable(
+                        i,
+                        &self.centers[i].clone(),
+                        &self.radii[i].clone(),
+                        self.nvars(),
+                        self.order,
+                        self.prec,
+                    ))
+                } else {
+                    Err(ValidatedError::UnboundSymbol {
+                        name: name.to_string(),
+                    })
+                }
+            }
+            ExprData::Add(args) => {
+                let mut acc = TaylorModel::zero(self.nvars(), self.order, self.prec);
+                for a in args {
+                    let t = self.eval(a)?;
+                    acc = acc.add(&t);
+                }
+                Ok(acc)
+            }
+            ExprData::Mul(args) => {
+                let mut acc = self.konst(ArbBall::from_f64(1.0, self.prec));
+                for a in args {
+                    let t = self.eval(a)?;
+                    acc = acc.mul(&t);
+                }
+                Ok(acc)
+            }
+            ExprData::Pow { base, exp } => {
+                let b = self.eval(base)?;
+                match self.pool.get(exp) {
+                    ExprData::Integer(n) => {
+                        let nv = n.0.to_i64().ok_or_else(|| ValidatedError::Unsupported {
+                            what: "integer exponent does not fit in i64".into(),
+                        })?;
+                        b.powi(nv)
+                    }
+                    ExprData::Rational(r) => b.pow_const(&ArbBall::from_rational(&r.0, self.prec)),
+                    ExprData::Float(f) => b.pow_const(&from_float(
+                        &Float::with_val(self.prec, f.inner.to_f64()),
+                        self.prec,
+                    )),
+                    _ => {
+                        // Symbolic exponent: only sound via exp(e·log b), which
+                        // needs a strictly positive base.
+                        let e = self.eval(exp)?;
+                        let l = b.log()?;
+                        l.mul(&e).exp()
+                    }
+                }
+            }
+            ExprData::Func { name, args } if args.len() == 1 => {
+                let x = self.eval(args[0])?;
+                match name.as_str() {
+                    "exp" => x.exp(),
+                    "log" | "ln" => x.log(),
+                    "sqrt" => x.sqrt(),
+                    "sin" => x.sin(),
+                    "cos" => x.cos(),
+                    "tan" => x.tan(),
+                    "asin" => x.asin(),
+                    "acos" => x.acos(),
+                    "atan" => x.atan(),
+                    "sinh" => x.sinh(),
+                    "cosh" => x.cosh(),
+                    "tanh" => x.tanh(),
+                    "abs" => x.abs(),
+                    other => Err(ValidatedError::Unsupported {
+                        what: format!("function `{other}`"),
+                    }),
+                }
+            }
+            ExprData::Func { name, args } => Err(ValidatedError::Unsupported {
+                what: format!("function `{name}` with {} arguments", args.len()),
+            }),
+            other => Err(ValidatedError::Unsupported {
+                what: format!("expression node {other:?}"),
+            }),
+        }
+    }
+}
+
+/// One-shot Taylor model range enclosure for `expr` over `boxes`, without any
+/// subdivision.  Mostly useful for comparing against plain interval
+/// evaluation; [`super::bounds::bound_on_box`] is the practical entry point.
+pub fn taylor_range(
+    expr: ExprId,
+    pool: &ExprPool,
+    boxes: &[(ExprId, Float, Float)],
+    order: usize,
+    prec: u32,
+) -> Result<ArbBall> {
+    let mut ctx = TaylorContext::new(pool, boxes, order, prec)?;
+    let tm = ctx.eval(expr)?;
+    let r = tm.range();
+    if !is_finite(&r) {
+        return Err(ValidatedError::NotFinite {
+            what: "range enclosure".into(),
+        });
+    }
+    Ok(r)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `a - b` (the pool has no `sub`; subtraction is `a + (-1)·b`).
+    fn sub(pool: &ExprPool, a: ExprId, b: ExprId) -> ExprId {
+        pool.add(vec![a, pool.mul(vec![pool.integer(-1_i32), b])])
+    }
+
+    /// `a / b` (the pool has no `div`; division is `a · b^(-1)`).
+    fn div(pool: &ExprPool, a: ExprId, b: ExprId) -> ExprId {
+        pool.mul(vec![a, pool.pow(b, pool.integer(-1_i32))])
+    }
+    use crate::kernel::Domain;
+
+    const P: u32 = 128;
+
+    fn f(v: f64) -> Float {
+        Float::with_val(P, v)
+    }
+
+    fn range_of(expr: ExprId, pool: &ExprPool, b: &[(ExprId, f64, f64)], order: usize) -> ArbBall {
+        let boxes: Vec<_> = b.iter().map(|(v, lo, hi)| (*v, f(*lo), f(*hi))).collect();
+        taylor_range(expr, pool, &boxes, order, P).unwrap()
+    }
+
+    #[test]
+    fn dependency_cancellation_x_minus_x() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = sub(&pool, x, x);
+        let r = range_of(e, &pool, &[(x, -1.0, 1.0)], 4);
+        // Taylor models cancel symbolically: the enclosure must be ~{0}.
+        assert!(r.rad_f64() < 1e-20, "rad = {}", r.rad_f64());
+        assert!(r.contains(0.0));
+    }
+
+    #[test]
+    fn dependency_x_times_one_minus_x() {
+        // x(1-x) on [0,1] has true range [0, 1/4].  Naive interval arithmetic
+        // gives [0,1]; the degree-2 Taylor model must be exact modulo rounding.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        let e = pool.mul(vec![x, sub(&pool, one, x)]);
+        let r = range_of(e, &pool, &[(x, 0.0, 1.0)], 4);
+        assert!(r.lo() <= 0.0);
+        assert!(r.hi() >= 0.25);
+        // The u² term contributes [0,1]·(-1/4) so the bound is [-1/4, 1/4]+1/4.
+        assert!(r.hi() < 0.30, "hi = {}", r.hi().to_f64());
+    }
+
+    #[test]
+    fn taylor_beats_interval_on_polynomial() {
+        use crate::ball::IntervalEval;
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // (x-1)^4, x ∈ [0.5, 1.5]:  true range [0, 1/16].
+        let e = pool.pow(sub(&pool, x, pool.integer(1_i32)), pool.integer(4_i32));
+        let tm = range_of(e, &pool, &[(x, 0.5, 1.5)], 6);
+
+        let mut ev = IntervalEval::new(P);
+        ev.bind(x, ArbBall::from_midpoint_radius(1.0, 0.5, P));
+        let iv = ev.eval(e, &pool).unwrap();
+
+        assert!(tm.lo() <= 0.0 && tm.hi() >= 0.0625);
+        assert!(
+            width_of(&tm) <= width_of(&iv),
+            "taylor {} should not be wider than interval {}",
+            width_of(&tm),
+            width_of(&iv)
+        );
+    }
+
+    fn width_of(b: &ArbBall) -> f64 {
+        b.rad_f64() * 2.0
+    }
+
+    #[test]
+    fn exp_encloses_dense_samples() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("exp", vec![x]);
+        let r = range_of(e, &pool, &[(x, -1.0, 2.0)], 8);
+        for i in 0..=300 {
+            let t = -1.0 + 3.0 * (i as f64) / 300.0;
+            assert!(r.contains(t.exp()), "exp({t}) escaped {r}");
+        }
+    }
+
+    #[test]
+    fn sin_encloses_dense_samples() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("sin", vec![x]);
+        let r = range_of(e, &pool, &[(x, 0.0, 3.0)], 8);
+        for i in 0..=300 {
+            let t = 3.0 * (i as f64) / 300.0;
+            assert!(r.contains(t.sin()), "sin({t}) escaped {r}");
+        }
+    }
+
+    #[test]
+    fn log_sqrt_atan_enclose_dense_samples() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        for (name, fun) in [
+            ("log", f64::ln as fn(f64) -> f64),
+            ("sqrt", f64::sqrt),
+            ("atan", f64::atan),
+        ] {
+            let e = pool.func(name, vec![x]);
+            let r = range_of(e, &pool, &[(x, 0.5, 2.0)], 8);
+            for i in 0..=200 {
+                let t = 0.5 + 1.5 * (i as f64) / 200.0;
+                assert!(r.contains(fun(t)), "{name}({t}) escaped {r}");
+            }
+        }
+    }
+
+    #[test]
+    fn tanh_and_hyperbolics_enclose_samples() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        for (name, fun) in [
+            ("sinh", f64::sinh as fn(f64) -> f64),
+            ("cosh", f64::cosh),
+            ("tanh", f64::tanh),
+        ] {
+            let e = pool.func(name, vec![x]);
+            let r = range_of(e, &pool, &[(x, -1.0, 1.0)], 8);
+            for i in 0..=200 {
+                let t = -1.0 + 2.0 * (i as f64) / 200.0;
+                assert!(r.contains(fun(t)), "{name}({t}) escaped {r}");
+            }
+        }
+    }
+
+    #[test]
+    fn reciprocal_encloses_samples_and_refuses_across_pole() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = div(&pool, pool.integer(1_i32), x);
+        let r = range_of(e, &pool, &[(x, 1.0, 3.0)], 8);
+        for i in 0..=200 {
+            let t = 1.0 + 2.0 * (i as f64) / 200.0;
+            assert!(r.contains(1.0 / t), "1/{t} escaped {r}");
+        }
+
+        let boxes = vec![(x, f(-1.0), f(1.0))];
+        let err = taylor_range(e, &pool, &boxes, 8, P).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-003");
+    }
+
+    #[test]
+    fn log_refuses_when_box_reaches_zero() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("log", vec![x]);
+        let boxes = vec![(x, f(0.0), f(1.0))];
+        let err = taylor_range(e, &pool, &boxes, 6, P).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-003");
+    }
+
+    #[test]
+    fn unsupported_function_refuses() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("gamma", vec![x]);
+        let boxes = vec![(x, f(1.0), f(2.0))];
+        let err = taylor_range(e, &pool, &boxes, 6, P).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-001");
+    }
+
+    #[test]
+    fn unbound_symbol_refuses() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let e = pool.add(vec![x, y]);
+        let boxes = vec![(x, f(0.0), f(1.0))];
+        let err = taylor_range(e, &pool, &boxes, 6, P).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-002");
+    }
+
+    #[test]
+    fn two_variable_model_encloses_samples() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        // sin(x)·exp(y) on [0,1]×[0,1]
+        let e = pool.mul(vec![pool.func("sin", vec![x]), pool.func("exp", vec![y])]);
+        let r = range_of(e, &pool, &[(x, 0.0, 1.0), (y, 0.0, 1.0)], 6);
+        for i in 0..=40 {
+            for j in 0..=40 {
+                let a = i as f64 / 40.0;
+                let b = j as f64 / 40.0;
+                assert!(r.contains(a.sin() * b.exp()), "escaped at ({a},{b})");
+            }
+        }
+    }
+
+    #[test]
+    fn degenerate_box_is_point_evaluation() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.func("exp", vec![x]);
+        let r = range_of(e, &pool, &[(x, 1.0, 1.0)], 6);
+        // e at higher precision than the enclosure: the f64 constant differs
+        // from the true value by far more than this ball's radius.
+        let truth = Float::with_val(P + 64, 1.0f64).exp();
+        assert!(r.lo() <= truth && truth <= r.hi());
+        assert!(r.rad_f64() < 1e-25);
+    }
+
+    #[test]
+    fn invalid_box_refuses() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let boxes = vec![(x, f(2.0), f(1.0))];
+        let err = taylor_range(x, &pool, &boxes, 6, P).unwrap_err();
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-VALIDATED-005");
+    }
+}

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -156,6 +156,14 @@ use alkahest_core::transform::{
     FourierError as CoreFourierError, LaplaceError as CoreLaplaceError,
     ZTransformError as CoreZTransformError,
 };
+// P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+use alkahest_core::validated::bounds::{
+    bound_on_box as core_bound_on_box, verified_integral as core_verified_integral,
+    verified_no_roots as core_verified_no_roots, verified_sign as core_verified_sign,
+    BoundOptions as CoreBoundOptions, IntegralOptions as CoreIntegralOptions,
+    SignPredicate as CoreSignPredicate, Verdict as CoreVerdict,
+};
+use alkahest_core::validated::ValidatedError as CoreValidatedError;
 // V3-1 — Integer number theory
 use alkahest_core::number_theory::{
     discrete_log as nt_discrete_log, factorint as nt_factorint, isprime as nt_isprime,
@@ -279,6 +287,8 @@ pyo3::create_exception!(alkahest, PyRealRootError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyLatticeError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyPslqError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyCadError, PyAlkahestError);
+// P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+pyo3::create_exception!(alkahest, PyValidatedError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PySumError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyProductError, PyAlkahestError);
 pyo3::create_exception!(alkahest, PyNumberTheoryError, PyAlkahestError);
@@ -7939,6 +7949,240 @@ fn py_decide(py: Python<'_>, formula: PyRef<PyExpr>) -> PyResult<(bool, PyObject
     Ok((r.truth, wit))
 }
 
+// ---------------------------------------------------------------------------
+// P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+// ---------------------------------------------------------------------------
+
+fn validated_error_to_py(e: CoreValidatedError) -> PyErr {
+    Python::with_gil(|py| {
+        let exc_type = py.get_type_bound::<PyValidatedError>();
+        make_structured_err(py, &exc_type, &e)
+    })
+}
+
+fn verdict_str(v: CoreVerdict) -> &'static str {
+    match v {
+        CoreVerdict::True => "true",
+        CoreVerdict::False => "false",
+        CoreVerdict::Undecided => "undecided",
+    }
+}
+
+/// A **rigorous** enclosure: the true value is guaranteed to lie in
+/// ``[lower, upper]``.
+///
+/// Returned by :func:`alkahest.bound_on_box` and
+/// :func:`alkahest.verified_integral`. The bound may be *wide*, but it is
+/// never *wrong* — that is the whole contract. Check
+/// :attr:`budget_exhausted` to see whether it is as tight as you asked for.
+#[pyclass(name = "Enclosure")]
+struct PyEnclosure {
+    #[pyo3(get)]
+    lower: f64,
+    #[pyo3(get)]
+    upper: f64,
+    #[pyo3(get)]
+    budget_exhausted: bool,
+    #[pyo3(get)]
+    subdivisions: usize,
+}
+
+#[pymethods]
+impl PyEnclosure {
+    /// Width of the enclosure.
+    #[getter]
+    fn width(&self) -> f64 {
+        self.upper - self.lower
+    }
+
+    /// True if `v` is inside the rigorous enclosure.
+    fn contains(&self, v: f64) -> bool {
+        self.lower <= v && v <= self.upper
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Enclosure([{}, {}], budget_exhausted={}, subdivisions={})",
+            self.lower, self.upper, self.budget_exhausted, self.subdivisions
+        )
+    }
+}
+
+fn parse_box(
+    py: Python<'_>,
+    boxes: Vec<(PyRef<PyExpr>, f64, f64)>,
+) -> (Py<PyExprPool>, Vec<(ExprId, f64, f64)>) {
+    let pool = boxes[0].0.pool.clone_ref(py);
+    let out = boxes.iter().map(|(v, lo, hi)| (v.id, *lo, *hi)).collect();
+    (pool, out)
+}
+
+/// `alkahest.bound_on_box(expr, box, *, order=6, prec=128, tol=1e-9, max_subdivisions=2048)`
+///
+/// Rigorous enclosure of the **range** of `expr` over an axis-aligned box,
+/// via Taylor models plus Moore–Skelboe branch-and-bound.
+///
+/// `box` is a list of `(variable, lo, hi)`. The returned
+/// :class:`Enclosure` is a guaranteed outer bound; when the work budget runs
+/// out it is returned anyway with ``budget_exhausted=True`` — wide but true.
+#[pyfunction]
+#[pyo3(name = "bound_on_box", signature = (expr, r#box, *, order = 6, prec = 128, tol = 1e-9, max_subdivisions = 2048))]
+fn py_bound_on_box(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    r#box: Vec<(PyRef<PyExpr>, f64, f64)>,
+    order: usize,
+    prec: u32,
+    tol: f64,
+    max_subdivisions: usize,
+) -> PyResult<PyEnclosure> {
+    if r#box.is_empty() {
+        return Err(PyValueError::new_err(
+            "bound_on_box: the box must constrain at least one variable",
+        ));
+    }
+    let (pool_py, boxes) = parse_box(py, r#box);
+    let opts = CoreBoundOptions {
+        order,
+        prec,
+        tol,
+        max_subdivisions,
+    };
+    let pool = pool_py.borrow(py);
+    let r =
+        core_bound_on_box(expr.id, &pool.inner, &boxes, &opts).map_err(validated_error_to_py)?;
+    Ok(PyEnclosure {
+        lower: r.lower(),
+        upper: r.upper(),
+        budget_exhausted: r.budget_exhausted,
+        subdivisions: r.subdivisions,
+    })
+}
+
+/// `alkahest.verified_integral(expr, var, a, b, *, order=8, prec=128, tol=1e-9, max_subdivisions=4096)`
+///
+/// Rigorous enclosure of ``∫_a^b expr d(var)`` by Taylor-model quadrature.
+///
+/// Unlike :func:`integrate_definite`, this never needs a closed form — and
+/// unlike a floating-point quadrature, the answer is a *theorem*: the true
+/// integral is guaranteed to lie in the returned interval. Refuses on
+/// singular or improper integrands rather than guessing.
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(name = "verified_integral", signature = (expr, var, a, b, *, order = 8, prec = 128, tol = 1e-9, max_subdivisions = 4096))]
+fn py_verified_integral(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    var: PyRef<PyExpr>,
+    a: f64,
+    b: f64,
+    order: usize,
+    prec: u32,
+    tol: f64,
+    max_subdivisions: usize,
+) -> PyResult<PyEnclosure> {
+    let pool_py = expr.pool.clone_ref(py);
+    let opts = CoreIntegralOptions {
+        order,
+        prec,
+        tol,
+        max_subdivisions,
+    };
+    let pool = pool_py.borrow(py);
+    let r = core_verified_integral(expr.id, &pool.inner, var.id, a, b, &opts)
+        .map_err(validated_error_to_py)?;
+    Ok(PyEnclosure {
+        lower: r.lower(),
+        upper: r.upper(),
+        budget_exhausted: r.budget_exhausted,
+        subdivisions: r.subdivisions,
+    })
+}
+
+/// `alkahest.verified_no_roots(expr, box, ...) -> "true" | "false" | "undecided"`
+///
+/// Three-valued: ``"true"`` proves `expr` has no root anywhere in the box,
+/// ``"false"`` proves it does, and ``"undecided"`` means neither could be
+/// established within the budget. The third is never collapsed into the
+/// other two.
+#[pyfunction]
+#[pyo3(name = "verified_no_roots", signature = (expr, r#box, *, order = 6, prec = 128, tol = 1e-9, max_subdivisions = 2048))]
+fn py_verified_no_roots(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    r#box: Vec<(PyRef<PyExpr>, f64, f64)>,
+    order: usize,
+    prec: u32,
+    tol: f64,
+    max_subdivisions: usize,
+) -> PyResult<String> {
+    if r#box.is_empty() {
+        return Err(PyValueError::new_err(
+            "verified_no_roots: the box must constrain at least one variable",
+        ));
+    }
+    let (pool_py, boxes) = parse_box(py, r#box);
+    let opts = CoreBoundOptions {
+        order,
+        prec,
+        tol,
+        max_subdivisions,
+    };
+    let pool = pool_py.borrow(py);
+    let v = core_verified_no_roots(expr.id, &pool.inner, &boxes, &opts)
+        .map_err(validated_error_to_py)?;
+    Ok(verdict_str(v).to_string())
+}
+
+/// `alkahest.verified_sign(expr, box, predicate, ...) -> "true" | "false" | "undecided"`
+///
+/// `predicate` is one of ``"positive"``, ``"negative"``, ``"nonnegative"``,
+/// ``"nonpositive"``. A ``"false"`` verdict is itself certified — either the
+/// enclosure proves the predicate fails everywhere, or a rigorously evaluated
+/// point witnesses the failure.
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(name = "verified_sign", signature = (expr, r#box, predicate, *, order = 6, prec = 128, tol = 1e-9, max_subdivisions = 2048))]
+fn py_verified_sign(
+    py: Python<'_>,
+    expr: PyRef<PyExpr>,
+    r#box: Vec<(PyRef<PyExpr>, f64, f64)>,
+    predicate: &str,
+    order: usize,
+    prec: u32,
+    tol: f64,
+    max_subdivisions: usize,
+) -> PyResult<String> {
+    if r#box.is_empty() {
+        return Err(PyValueError::new_err(
+            "verified_sign: the box must constrain at least one variable",
+        ));
+    }
+    let pred = match predicate {
+        "positive" => CoreSignPredicate::Positive,
+        "negative" => CoreSignPredicate::Negative,
+        "nonnegative" => CoreSignPredicate::NonNegative,
+        "nonpositive" => CoreSignPredicate::NonPositive,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "verified_sign: predicate must be one of 'positive', 'negative', \
+                 'nonnegative', 'nonpositive', got {other:?}"
+            )))
+        }
+    };
+    let (pool_py, boxes) = parse_box(py, r#box);
+    let opts = CoreBoundOptions {
+        order,
+        prec,
+        tol,
+        max_subdivisions,
+    };
+    let pool = pool_py.borrow(py);
+    let v = core_verified_sign(expr.id, &pool.inner, &boxes, pred, &opts)
+        .map_err(validated_error_to_py)?;
+    Ok(verdict_str(v).to_string())
+}
+
 /// Brown-style CAD projection polynomials after eliminating ``elim_var``.
 #[pyfunction(name = "cad_project")]
 fn py_cad_project(
@@ -9952,6 +10196,12 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_exists, m)?)?;
     m.add_function(wrap_pyfunction!(py_decide, m)?)?;
     m.add_function(wrap_pyfunction!(py_cad_project, m)?)?;
+    // P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+    m.add_class::<PyEnclosure>()?;
+    m.add_function(wrap_pyfunction!(py_bound_on_box, m)?)?;
+    m.add_function(wrap_pyfunction!(py_verified_integral, m)?)?;
+    m.add_function(wrap_pyfunction!(py_verified_no_roots, m)?)?;
+    m.add_function(wrap_pyfunction!(py_verified_sign, m)?)?;
     m.add_function(wrap_pyfunction!(py_cad_lift, m)?)?;
     m.add_function(wrap_pyfunction!(py_routh_hurwitz, m)?)?;
     // V5-1 — Lean 4 certificate exporter
@@ -10069,6 +10319,11 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("LatticeError", m.py().get_type_bound::<PyLatticeError>())?;
     m.add("PslqError", m.py().get_type_bound::<PyPslqError>())?;
     m.add("CadError", m.py().get_type_bound::<PyCadError>())?;
+    // P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+    m.add(
+        "ValidatedError",
+        m.py().get_type_bound::<PyValidatedError>(),
+    )?;
     m.add("SumError", m.py().get_type_bound::<PySumError>())?;
     m.add("ProductError", m.py().get_type_bound::<PyProductError>())?;
     m.add(

--- a/docs/features.md
+++ b/docs/features.md
@@ -59,6 +59,8 @@ Current stable feature surface.
 - Truncated Taylor and Laurent series (`series`, `Series`)
 - Limits (`limit`, `LimitDirection`): L'Hôpital, local expansions, limits at ±∞
 
+- Validated numerics (`bound_on_box`, `verified_integral`, `verified_no_roots`, `verified_sign`): Taylor models over a box with Moore–Skelboe branch-and-bound; rigorous range enclosures, definite-integral enclosures and three-valued (`true`/`false`/`undecided`) predicates. Sound before tight — a wide bound is returned rather than a wrong one, and unbounded cases refuse (`E-VALIDATED-*`)
+
 ## Discrete mathematics
 
 - Symbolic summation: indefinite and definite via Gosper's algorithm (`sum_indefinite`, `sum_definite`)

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Transformations](./transformations.md)
 - [Code generation](./codegen.md)
 - [Ball arithmetic](./ball-arithmetic.md)
+  - [Rigorous global bounds](./validated-bounds.md)
 - [ODE and DAE modeling](./ode-dae.md)
 - [Polynomial system solving](./solving.md)
 - [Interoperability](./interop.md)

--- a/docs/mdbook/src/validated-bounds.md
+++ b/docs/mdbook/src/validated-bounds.md
@@ -1,0 +1,130 @@
+# Rigorous global bounds (Taylor models)
+
+[Ball arithmetic](./ball-arithmetic.md) gives rigorous **pointwise** enclosures:
+evaluate `f` at a ball and the true value is inside the ball you get back. A
+research loop routinely needs rigorous **global** statements instead:
+
+- the maximum of `f` on `[a,b]×[c,d]` is at most `M`;
+- `∫_a^b f dx` lies in `[I₁, I₂]`;
+- `f` has no root anywhere in this box.
+
+These turn a numeric observation into a theorem, which is exactly the step that
+takes a candidate from "survived the sweep" to "established".
+
+```python
+import alkahest as ak
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+
+r = ak.bound_on_box(x * (pool.integer(1) - x), [(x, 0.0, 1.0)])
+r.lower, r.upper        # encloses the true range [0, 1/4]
+r.budget_exhausted      # False — converged within the work budget
+
+ak.verified_integral(ak.sin(x), x, 0.0, 3.14159)   # Enclosure containing ~2
+ak.verified_no_roots(x*x + pool.integer(1), [(x, -5.0, 5.0)])   # "true"
+ak.verified_sign(ak.exp(x), [(x, -5.0, 5.0)], "positive")       # "true"
+```
+
+## The soundness contract
+
+**Every returned enclosure is a rigorous outer bound.** Rounding is outward at
+every step, and any operation whose remainder cannot be bounded rigorously
+refuses rather than returning something plausible.
+
+The consequence worth internalising: an enclosure may be **wide**, but it is
+never **wrong**. A wide-but-true bound is a fine answer for a loop — it just
+means "not settled yet". A tight-but-false one is a poisoned lemma that
+everything downstream inherits.
+
+Running out of work budget is therefore *not* an error. The enclosure is
+returned anyway, with `budget_exhausted = True`, still sound.
+
+## Why not just use interval arithmetic
+
+Naive interval evaluation is rigorous but suffers the **dependency problem**:
+it forgets that the two `x`s in `x - x` are the same number.
+
+| Expression, box | Naive intervals | Taylor model |
+|---|---|---|
+| `x - x`, `x ∈ [-1,1]` | `[-2, 2]` | `{0}` |
+| `x(1-x)`, `x ∈ [0,1]` | `[0, 1]` | `[0, 1/4]` |
+
+A Taylor model carries a polynomial in the box's normalised coordinates plus a
+rigorously enclosing remainder interval, so cancellation happens *symbolically*
+in the polynomial part and only the genuinely uncertain residue stays in the
+interval.
+
+## Branch-and-bound
+
+`bound_on_box` runs Moore–Skelboe branch-and-bound: one pass for the minimum,
+one for the maximum. Each keeps a rigorous bound on the extremum and **prunes**
+sub-boxes whose enclosure proves they cannot contain it, so work concentrates
+where the extremum actually is.
+
+This pruning is not an optimisation detail, it is what makes the module usable.
+A stopping rule that instead required every sub-box's enclosure to be narrower
+than `tol` would be demanding a pointwise-tight model *everywhere*, which no
+finite budget achieves for a function with a wide range — `exp` on `[-5,5]`
+would exhaust the budget and still return an enclosure loose enough to straddle
+zero, so even `exp > 0` would come back undecided.
+
+## Three-valued predicates
+
+`verified_no_roots` and `verified_sign` return one of `"true"`, `"false"`,
+`"undecided"`. The third is never collapsed into the other two.
+
+| Verdict | Meaning |
+|---|---|
+| `"true"` | Certified: the property holds everywhere on the box |
+| `"false"` | Certified: it fails — proved by the enclosure, or by a rigorously evaluated witness point |
+| `"undecided"` | Neither could be established within the budget and precision |
+
+A sign predicate is a universally quantified claim, so a single point where it
+provably fails disproves it. `verified_sign` uses that: it evaluates the
+expression rigorously at the box centre, the per-axis endpoints and (in low
+dimension) the corners, and reports `"false"` when one of those point
+enclosures lies strictly on the wrong side. Without it, `x > 0` on `[-1,1]` —
+plainly false — could only ever be `"undecided"`, since the range enclosure
+straddles zero by construction.
+
+## Refusals
+
+| Code | Meaning |
+|---|---|
+| `E-VALIDATED-001` | No rigorous Taylor model rule for some primitive in the expression |
+| `E-VALIDATED-002` | A free symbol has no interval in the box |
+| `E-VALIDATED-003` | A singularity or branch cut inside the box (e.g. `1/x` over a box containing 0) |
+| `E-VALIDATED-004` | An enclosure overflowed to infinity |
+| `E-VALIDATED-005` | Malformed request (empty box, inverted interval, bad order) |
+
+For `E-VALIDATED-003` the search first tries bisecting *away* from the trouble,
+since a domain violation on a wide box is often a boundary effect rather than a
+genuine interior pole. Only after the box has been bisected far enough for that
+explanation to be exhausted does it refuse — which is the right answer for a
+real interior singularity, where the range is not a bounded interval at all.
+
+## Relation to the rest of the stack
+
+This is the slow, certifying half of *falsify fast, certify slow*:
+
+| | JIT / `numpy_eval` | Ball arithmetic | Validated bounds |
+|---|---|---|---|
+| Answers | Approximate values, fast | Rigorous at a point | Rigorous over a region |
+| Cost | ~µs | ~ms | seconds, adaptive |
+| Use | Kill 99% of candidates | Distinguish near-miss from hit | Promote a survivor to a theorem |
+
+`verified_integral` complements the symbolic `integrate_definite`: use the
+symbolic path when you want a closed form, and this one when you want a
+guaranteed numeric interval — including for integrands with no elementary
+antiderivative.
+
+## Scope of this release
+
+Shipped: Taylor model arithmetic over a box (arithmetic, powers, division, and
+the elementary functions with rigorous remainders), range enclosure by
+branch-and-bound, verified 1-D definite integrals, root absence and sign
+predicates.
+
+Not shipped: multivariate verified quadrature (`verified_integral` is 1-D),
+improper or singular integrals, and Taylor-model-based ODE enclosures.

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -103,6 +103,8 @@ from .alkahest import (  # noqa: F401
     Domain,
     # V1-15: EgraphConfig and simplify_egraph_with
     EgraphConfig,
+    # P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
+    Enclosure,
     # Unified exact / f64 / complex / interval evaluation
     EvaluationResult,
     # Phase 20: Hybrid systems
@@ -151,6 +153,7 @@ from .alkahest import (  # noqa: F401
     atanh,
     bessel_j0,
     bessel_j1,
+    bound_on_box,
     cad_lift,
     cad_project,
     # Rational-function cancel/together
@@ -260,6 +263,9 @@ from .alkahest import (  # noqa: F401
     # V5-2: StableHLO/XLA bridge
     to_stablehlo,
     together,
+    verified_integral,
+    verified_no_roots,
+    verified_sign,
     verify_wz_pair,
     version,
     voltage_source,
@@ -344,6 +350,7 @@ from .exceptions import (
     SparseGcdError,
     SparseInterpError,
     SumError,
+    ValidatedError,
 )
 
 _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
@@ -379,6 +386,7 @@ _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "SparseGcdError",
     "SparseInterpError",
     "SumError",
+    "ValidatedError",
 )
 
 try:
@@ -1710,6 +1718,7 @@ __all__ = [
     "DomainError",
     "EgraphConfig",
     "EigenError",
+    "Enclosure",
     "EvaluationResult",
     # Phase 20
     "Event",
@@ -1774,6 +1783,7 @@ __all__ = [
     "UniPoly",
     "UniPolyFactorModP",
     "UniPolyFactorization",
+    "ValidatedError",
     "__version__",
     "abs",
     "acos",
@@ -1795,6 +1805,7 @@ __all__ = [
     "batch_map_iter",
     "bessel_j0",
     "bessel_j1",
+    "bound_on_box",
     # P1 search plumbing item 4
     "budget_seed",
     "cad_lift",
@@ -1970,6 +1981,9 @@ __all__ = [
     "triangularize",
     "unflatten_exprs",
     "unicode_str",
+    "verified_integral",
+    "verified_no_roots",
+    "verified_sign",
     "verify_wz_pair",
     "version",
     "voltage_source",

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -39,6 +39,7 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
     E-DOMAIN-*                 DomainError  (reserved; Python-only pending Rust impl)
     E-CERT-001                 CertificateUnavailableError  (Python-only; certificate ledger)
     E-BUDGET-001 … E-BUDGET-003 BudgetExceededError (P1 search plumbing item 4)
+    E-VALIDATED-001 … E-VALIDATED-005  ValidatedError (P1 item 9 — validated numerics)
     E-BATCH-001                 (Python-only; alkahest._batch fallback for a
                                  batch_map/batch_map_iter item whose exception carried no
                                  .code of its own — see docs/mdbook/src/batch.md)
@@ -191,6 +192,29 @@ class SumError(AlkahestError):
         span: tuple[int, int] | None = None,
     ):
         super().__init__(message, code="E-SUM-001", remediation=remediation, span=span)
+
+
+class ValidatedError(AlkahestError):
+    """A rigorous bound could not be established, so none is returned.
+
+    Every variant is a refusal, never a guess: an unsupported primitive
+    (``E-VALIDATED-001``), a free symbol with no interval (``E-VALIDATED-002``),
+    a singularity or branch cut inside the box (``E-VALIDATED-003``), an
+    enclosure that overflowed to infinity (``E-VALIDATED-004``), or a malformed
+    request (``E-VALIDATED-005``).
+
+    Note that running out of *budget* is not an error — that returns a wide but
+    still rigorous enclosure with ``budget_exhausted=True``, because a loose
+    true bound is useful and a tight false one is not.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code="E-VALIDATED-001", remediation=remediation, span=span)
 
 
 class ProductError(AlkahestError):

--- a/tests/test_validated_bounds.py
+++ b/tests/test_validated_bounds.py
@@ -1,0 +1,219 @@
+"""P1 item 9 — rigorous global bounds (Taylor models / validated numerics).
+
+Ball arithmetic gives rigorous *pointwise* enclosures. This module gives
+rigorous *global* ones: the range of `f` over a box, a definite integral, the
+absence of roots.
+
+The contract is soundness over tightness — a returned enclosure may be wide,
+but it must never be wrong. Most of these tests are therefore containment
+tests: they check that the enclosure really does contain values the function
+actually takes, including in the cases where naive interval arithmetic is loose
+(the dependency problem) and where a narrowing bug would be tempting.
+"""
+
+import math
+
+import alkahest as ak
+import pytest
+
+
+def _box(var, lo, hi):
+    return [(var, lo, hi)]
+
+
+# ---------------------------------------------------------------------------
+# Soundness: the enclosure must contain the true values
+# ---------------------------------------------------------------------------
+
+
+def test_enclosure_contains_densely_sampled_values():
+    """The strongest cheap check against unsound narrowing."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    f = ak.sin(x) * ak.exp(x) + x * x
+
+    r = ak.bound_on_box(f, _box(x, -2.0, 2.0))
+
+    for i in range(401):
+        xi = -2.0 + 4.0 * i / 400
+        true = math.sin(xi) * math.exp(xi) + xi * xi
+        assert r.lower <= true <= r.upper, f"enclosure missed f({xi}) = {true}"
+
+
+def test_dependency_problem_x_minus_x():
+    """`x - x` is identically 0; naive intervals give [-1, 1]."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    r = ak.bound_on_box(x - x, _box(x, -1.0, 1.0))
+
+    assert r.contains(0.0)
+    assert r.width < 1e-15
+
+
+def test_dependency_problem_x_times_one_minus_x():
+    """`x(1-x)` on [0,1] has true range [0, 1/4]; naive intervals give [0,1]."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    f = x * (pool.integer(1) - x)
+
+    r = ak.bound_on_box(f, _box(x, 0.0, 1.0))
+
+    # Sound: contains the true range.
+    assert r.lower <= 0.0
+    assert r.upper >= 0.25
+    # And tight: much better than the naive [0, 1].
+    assert r.upper < 0.30
+
+
+def test_two_dimensional_box():
+    pool = ak.ExprPool()
+    x, y = pool.symbol("x"), pool.symbol("y")
+    f = x * x + y * y
+
+    r = ak.bound_on_box(f, [(x, -1.0, 1.0), (y, -1.0, 1.0)])
+
+    assert r.lower <= 0.0
+    assert r.upper >= 2.0
+
+
+# ---------------------------------------------------------------------------
+# Verified integrals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("build", "a", "b", "exact"),
+    [
+        (lambda pool, x: ak.sin(x), 0.0, math.pi, 2.0),
+        (lambda pool, x: ak.exp(x), 0.0, 1.0, math.e - 1.0),
+        (lambda pool, x: x * x, 0.0, 3.0, 9.0),
+    ],
+)
+def test_verified_integral_encloses_the_exact_value(build, a, b, exact):
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    r = ak.verified_integral(build(pool, x), x, a, b)
+
+    assert r.lower <= exact <= r.upper, f"{exact} not in [{r.lower}, {r.upper}]"
+    assert r.width < 1e-6
+
+
+def test_verified_integral_is_an_enclosure_not_an_estimate():
+    """A wide-but-true answer under a tiny budget beats a tight-but-false one."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    r = ak.verified_integral(ak.sin(x), x, 0.0, math.pi, max_subdivisions=1)
+
+    assert r.lower <= 2.0 <= r.upper
+
+
+# ---------------------------------------------------------------------------
+# Three-valued predicates — the third value is never collapsed
+# ---------------------------------------------------------------------------
+
+
+def test_no_roots_verified_true():
+    """`(x-5)^2 + 1` has no root on [0,1] — provable."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    f = (x - pool.integer(5)) * (x - pool.integer(5)) + pool.integer(1)
+
+    assert ak.verified_no_roots(f, _box(x, 0.0, 1.0)) == "true"
+
+
+def test_sign_positive_verified_true():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    assert ak.verified_sign(ak.exp(x), _box(x, -5.0, 5.0), "positive") == "true"
+
+
+def test_sign_false_is_certified_by_a_witness():
+    """`x > 0` on [-1,1] is false; one point disproves a "for all" claim."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    assert ak.verified_sign(x, _box(x, -1.0, 1.0), "positive") == "false"
+
+
+def test_verdicts_are_the_three_documented_strings():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    for predicate in ("positive", "negative", "nonnegative", "nonpositive"):
+        v = ak.verified_sign(x, _box(x, -1.0, 1.0), predicate)
+        assert v in ("true", "false", "undecided")
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_singularity_in_the_box_is_refused():
+    """`1/x` on a box containing 0 has no bounded range — refuse, don't guess."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    f = pool.integer(1) / x
+
+    with pytest.raises(ak.ValidatedError) as excinfo:
+        ak.bound_on_box(f, _box(x, -1.0, 1.0))
+
+    assert excinfo.value.code.startswith("E-VALIDATED-")
+    assert excinfo.value.remediation
+
+
+def test_unbound_symbol_is_refused():
+    pool = ak.ExprPool()
+    x, y = pool.symbol("x"), pool.symbol("y")
+
+    with pytest.raises(ak.ValidatedError):
+        ak.bound_on_box(x + y, _box(x, 0.0, 1.0))
+
+
+def test_empty_box_is_refused():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    with pytest.raises(ValueError):
+        ak.bound_on_box(x, [])
+
+
+def test_bad_predicate_name_is_refused():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+
+    with pytest.raises(ValueError):
+        ak.verified_sign(x, _box(x, 0.0, 1.0), "mostly_positive")
+
+
+# ---------------------------------------------------------------------------
+# Surface
+# ---------------------------------------------------------------------------
+
+
+def test_exported_surface():
+    for name in (
+        "bound_on_box",
+        "verified_integral",
+        "verified_no_roots",
+        "verified_sign",
+        "Enclosure",
+        "ValidatedError",
+    ):
+        assert name in ak.__all__, name
+    assert issubclass(ak.ValidatedError, ak.AlkahestError)
+
+
+def test_enclosure_repr_and_helpers():
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    r = ak.bound_on_box(x, _box(x, 0.0, 1.0))
+
+    assert "Enclosure(" in repr(r)
+    assert r.width >= 1.0
+    assert r.subdivisions >= 0
+    assert isinstance(r.budget_exhausted, bool)


### PR DESCRIPTION
Implements **P1 mathematics item 9** — "Rigorous global bounds (Taylor models / validated numerics)" — from `temp-alkahest/planning/autoresearch.md`.

Ball arithmetic already gives rigorous **pointwise** enclosures. This adds rigorous statements quantified over a **region**, which is the step that turns a numeric observation into a theorem:

```python
ak.bound_on_box(x * (pool.integer(1) - x), [(x, 0.0, 1.0)])   # encloses [0, 1/4]
ak.verified_integral(ak.sin(x), x, 0.0, math.pi)              # encloses 2
ak.verified_no_roots(x*x + pool.integer(1), [(x, -5.0, 5.0)]) # "true"
ak.verified_sign(ak.exp(x), [(x, -5.0, 5.0)], "positive")     # "true"
```

## Soundness contract

Outward rounding at every step; any operation whose remainder cannot be bounded rigorously **refuses** rather than returning something plausible. An enclosure may be *wide*, but it is never *wrong*.

Running out of work budget is deliberately **not** an error — it returns the wide-but-true enclosure with `budget_exhausted=True`. A loose true bound is a useful "not settled yet"; a tight false one is a poisoned lemma every downstream derivation inherits.

## Why Taylor models rather than intervals

Naive interval evaluation is rigorous but forgets that the two `x`s in `x - x` are the same number:

| Expression, box | Naive intervals | Taylor model |
|---|---|---|
| `x - x`, `[-1,1]` | `[-2, 2]` | `{0}` |
| `x(1-x)`, `[0,1]` | `[0, 1]` | `[0, 1/4]` |

## Two changes beyond the inherited foundation

1. **`bound_on_box` now runs Moore–Skelboe branch-and-bound** (one pass per extremum) that prunes sub-boxes proven not to contain the extremum. The previous rule — refine until *every* sub-box's enclosure is narrower than `tol` — demands a pointwise-tight model everywhere, which no finite budget reaches for a function with a wide range: `exp` on `[-5,5]` exhausted the budget and still returned an enclosure straddling zero, so even `exp > 0` came back `undecided`.
2. **`verified_sign` can now certify `"false"`.** A sign predicate is universally quantified, so one rigorously evaluated point where it fails disproves it. Without that, `x > 0` on `[-1,1]` — plainly false — could only ever be `"undecided"`.

The `!(x > 0)` guards are kept NaN-refusing via `partial_cmp` rather than rewritten as `x <= 0`, which would invert exactly the NaN case and let a NaN into a bound.

## Three-valued predicates

`"true"` / `"false"` / `"undecided"` — the third is never collapsed into the other two.

## Tests

44 Rust unit tests plus `tests/test_validated_bounds.py` (18 tests). The anti-narrowing checks are the point: enclosures are cross-checked against 401 densely sampled true values, the dependency-problem cases are asserted both sound *and* tight, verified integrals are checked against known closed forms, and a tiny-budget run must still enclose the true integral.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --all`, `cargo doc` (clean), `ruff`, `ty check` (42 diagnostics, unchanged from baseline), certificate ledger, silent-error gate (149 passed), `pytest` 1635 passed / 27 skipped.

**One unrelated pre-existing failure observed locally:** `tests/test_research_claim_graph.py::test_json_round_trip_is_lossless`. Hypothesis found a `ClaimGraph` with a dependency cycle whose JSON round-trip is lossy (`CycleError` from `research.py:_topological`). This branch does not touch `research.py` or that test — `git diff origin/main` on both is empty — and it reproduces only where the local Hypothesis example database has stored the counterexample. It looks like a genuine latent bug in the claim-graph code and is worth its own issue; deliberately not folded into this PR.

## Scope

Shipped: Taylor model arithmetic over a box, range enclosure, verified 1-D definite integrals, root absence and sign predicates. Not shipped, documented in [`docs/mdbook/src/validated-bounds.md`](docs/mdbook/src/validated-bounds.md): multivariate verified quadrature, improper/singular integrals, Taylor-model ODE enclosures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rigorous global range bounds for expressions evaluated over numeric boxes.
  - Added verified definite integrals with sound lower and upper enclosures.
  - Added root-exclusion and sign verification with clear true, false, or undecided results.
  - Added validated Python APIs, enclosure details, budget reporting, and structured validation errors.
  - Added Taylor-model arithmetic and support for common elementary functions.

- **Documentation**
  - Added guidance and examples for validated bounds, integrations, predicates, soundness, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->