### PR TITLE
feat(calculus): Euler–Maclaurin asymptotics of sums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Added
 
+- **Asymptotics of sums — Euler–Maclaurin** (P1 mathematics item 10):
+  `alkahest.experimental.euler_maclaurin(f, k, a, n, corrections=…)` expands
+  `Σ_{k=a}^{n} f(k)` as `n → ∞`, recovering
+  `H_n ~ log n + γ + 1/(2n) − 1/(12n²) + …` for `f = 1/k`. `series` and Gruntz
+  `limit` expand a *function*; this is the sum side, which is how conjectures
+  about growth rates get settled. Returns an `AsymptoticReport` that records
+  not just the terms but **how much is proved**: `rigor`, a per-hypothesis
+  checked/assumed ledger, and the numeric evidence from the `o()`-gate. The
+  additive constant (γ above) is *not* determined by Euler–Maclaurin from the
+  `n`-side terms — it is fitted numerically, and the report says so rather than
+  presenting it as derived. Terms are ordered by magnitude at the check points,
+  so the constant lands below every growing term and above every decaying one.
+  Refuses (`AsymptoticError`) when the summand has no symbolic antiderivative,
+  is not evaluable at the check points, or no term survives the gate. See
+  [`docs/mdbook/src/asymptotics.md`](docs/mdbook/src/asymptotics.md).
+
 - **Positivity certificates — SOS and Positivstellensatz-lite** (P1 mathematics
   item 8): `alkahest.sos_decompose(p, vars)` returns an exact rational
   sum-of-squares decomposition `p = Σ σ_j q_j²`, and

--- a/alkahest-core/src/calculus/asymptotic.rs
+++ b/alkahest-core/src/calculus/asymptotic.rs
@@ -160,8 +160,10 @@ impl crate::errors::AlkahestError for AsymptoticError {
                  the function may have an oscillatory or non-power-scale tail"
             }
             AsymptoticError::UnsupportedScale => {
-                "exp/log scale hierarchies and Gamma/Stirling asymptotics are out of scope; \
-                 power-scale (rational/algebraic) and single log/exp peels are supported"
+                "exp/log scale hierarchies and Gamma/Stirling asymptotics are out of scope for \
+                 asymptotic_expand; power-scale (rational/algebraic) and single log/exp peels \
+                 are supported. For the asymptotics of a *sum* use \
+                 experimental.euler_maclaurin, which also reaches Stirling via the sum of log k"
             }
         })
     }

--- a/alkahest-core/src/calculus/asymptotic_common.rs
+++ b/alkahest-core/src/calculus/asymptotic_common.rs
@@ -1,0 +1,959 @@
+//! Shared scaffolding for the *asymptotics at scale* family (P1 item 10).
+//!
+//! # Why some of this is currently unused
+//!
+//! Only the Euler–Maclaurin route ships in this change; sequence asymptotics,
+//! singularity analysis and saddle-point expansions are documented follow-ups
+//! (see `docs/mdbook/src/asymptotics.md`). The pieces they need — exact `ℚ`
+//! polynomial arithmetic, rational-function extraction, rational-root
+//! splitting, Bernoulli *polynomials* and the complex root finder — are kept
+//! here rather than deleted and re-added, so `dead_code` is allowed
+//! module-wide. Everything the shipped route uses is exercised by
+//! `super::euler_maclaurin`'s tests.
+//!
+//! The routes in this family, built on top of
+//! [`mod@crate::calculus::asymptotic`] — sequence asymptotics, singularity
+//! analysis of generating functions, Laplace/saddle-point asymptotics of
+//! parameter integrals, and Euler–Maclaurin expansion of sums
+//! ([`mod@crate::calculus::euler_maclaurin`], the one that ships here) — all
+//! share three things:
+//!
+//! 1. **A common result object** ([`AsymptoticReport`]) that records not only
+//!    the terms but *how much is proved*: which hypotheses the implementation
+//!    actually checked, which it merely assumed, and the numeric evidence.
+//! 2. **A common numeric verification gate** (`gate_accept`) generalising the
+//!    `o()`-gate of [`crate::calculus::asymptotic::asymptotic_expand`] to an
+//!    arbitrary *oracle* — the exact sequence value, the exact Taylor
+//!    coefficient, a high-accuracy quadrature, or a directly summed partial
+//!    sum. Terms that fail the gate are dropped; if nothing survives the route
+//!    declines rather than emit an unverified expansion.
+//! 3. **Small exact-arithmetic utilities** — Bernoulli numbers and polynomials,
+//!    univariate rational-function extraction over ℚ, rational root splitting,
+//!    and a Durand–Kerner complex root finder.
+//!
+//! Nothing in this module is a user-facing entry point; it exists so the four
+//! routes cannot drift apart in how honestly they report themselves.
+#![allow(dead_code)]
+
+use crate::kernel::{ExprId, ExprPool};
+use crate::simplify::simplify;
+use rug::{Integer, Rational};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Reporting vocabulary
+// ---------------------------------------------------------------------------
+
+/// How strongly an emitted expansion is justified.
+///
+/// This is deliberately coarse: the only distinction that matters to a caller
+/// is whether the *implemented method* establishes the result once its stated
+/// hypotheses hold, or whether the result is a numerically corroborated guess.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Rigor {
+    /// The expansion follows from the implemented method under the hypotheses
+    /// listed in [`AsymptoticReport::hypotheses`], **all of which were
+    /// mechanically checked**, and it additionally passed the numeric gate.
+    ProvedUnderHypotheses,
+    /// The expansion passed the numeric gate, but at least one hypothesis of
+    /// the method could not be checked mechanically (it is listed as
+    /// [`HypothesisStatus::Assumed`]), or a constant in the expansion was
+    /// determined numerically rather than in closed form.
+    NumericallyConsistent,
+}
+
+impl Rigor {
+    /// Stable lower-case tag used by the Python bindings.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Rigor::ProvedUnderHypotheses => "proved_under_hypotheses",
+            Rigor::NumericallyConsistent => "numerically_consistent",
+        }
+    }
+}
+
+/// Whether a hypothesis of the method was verified or taken on faith.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum HypothesisStatus {
+    /// The implementation checked this condition (symbolically or numerically)
+    /// and it held.
+    Checked,
+    /// The implementation requires this condition but cannot check it with the
+    /// available machinery; the result is conditional on it.
+    Assumed,
+}
+
+impl HypothesisStatus {
+    /// Stable lower-case tag used by the Python bindings.
+    pub fn tag(self) -> &'static str {
+        match self {
+            HypothesisStatus::Checked => "checked",
+            HypothesisStatus::Assumed => "assumed",
+        }
+    }
+}
+
+/// One analytic hypothesis of the method, with its verification status.
+#[derive(Clone, Debug)]
+pub struct Hypothesis {
+    /// Human-readable statement of the condition.
+    pub statement: String,
+    /// Whether it was checked or assumed.
+    pub status: HypothesisStatus,
+}
+
+impl Hypothesis {
+    /// A hypothesis the implementation verified.
+    pub fn checked(statement: impl Into<String>) -> Self {
+        Hypothesis {
+            statement: statement.into(),
+            status: HypothesisStatus::Checked,
+        }
+    }
+
+    /// A hypothesis the implementation requires but did not verify.
+    pub fn assumed(statement: impl Into<String>) -> Self {
+        Hypothesis {
+            statement: statement.into(),
+            status: HypothesisStatus::Assumed,
+        }
+    }
+}
+
+/// One numeric corroboration point produced by the verification gate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VerificationPoint {
+    /// Where the check was made (`n` for sequences and coefficients, `λ` for
+    /// parameter integrals, the upper summation limit for sums).
+    pub at: f64,
+    /// The independently computed reference value at `at`.
+    pub reference: f64,
+    /// The value of the truncated expansion at `at`.
+    pub approximation: f64,
+    /// `|reference − approximation| / max(|reference|, tiny)`.
+    pub relative_error: f64,
+}
+
+/// The result object shared by every route in this family.
+///
+/// `terms` is an ordered asymptotic sequence, most significant first: the claim
+/// is `f ~ terms[0] + terms[1] + …` in the route's asymptotic variable, with
+/// each term `o()` of its predecessor. The remaining fields exist so a caller
+/// (or an automated research loop) can audit *why* it should believe that.
+#[derive(Clone, Debug)]
+pub struct AsymptoticReport {
+    /// Name of the method that produced the expansion, e.g. `"stirling-ratio"`.
+    pub method: &'static str,
+    /// The asymptotic variable the expansion is written in.
+    pub var: ExprId,
+    /// Ordered terms, most significant first.
+    pub terms: Vec<ExprId>,
+    /// How much of the result is proved (see [`Rigor`]).
+    pub rigor: Rigor,
+    /// Hypotheses of the method, each marked checked or assumed.
+    pub hypotheses: Vec<Hypothesis>,
+    /// Numeric corroboration produced by the gate.
+    pub verification: Vec<VerificationPoint>,
+    /// Ordered, human-readable derivation log.
+    pub derivation: Vec<String>,
+}
+
+impl AsymptoticReport {
+    /// The leading (most significant) term, if any.
+    pub fn leading(&self) -> Option<ExprId> {
+        self.terms.first().copied()
+    }
+
+    /// The sum of all surviving terms — the truncated approximation.
+    pub fn partial_sum(&self, pool: &ExprPool) -> ExprId {
+        if self.terms.is_empty() {
+            return pool.integer(0_i32);
+        }
+        simplify(pool.add(self.terms.clone()), pool).value
+    }
+
+    /// The worst relative error observed by the numeric gate, or `None` when no
+    /// verification points were recorded.
+    pub fn max_relative_error(&self) -> Option<f64> {
+        self.verification
+            .iter()
+            .map(|v| v.relative_error)
+            .fold(None, |acc, e| Some(acc.map_or(e, |a: f64| a.max(e))))
+    }
+
+    /// True when every listed hypothesis was mechanically checked.
+    pub fn all_hypotheses_checked(&self) -> bool {
+        self.hypotheses
+            .iter()
+            .all(|h| h.status == HypothesisStatus::Checked)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The numeric verification gate
+// ---------------------------------------------------------------------------
+
+/// Default multiplicative slack used when comparing residuals against the term
+/// that is supposed to dominate them. Generous enough to absorb `f64` rounding
+/// in the oracle, tight enough that a wrong coefficient fails.
+pub(crate) const DEFAULT_SLACK: f64 = 4.0;
+
+/// Generalised `o()`-gate: how many leading terms of a candidate expansion are
+/// corroborated by an independent oracle.
+///
+/// `oracle[j]` is the reference value of the quantity being expanded at the
+/// `j`-th (increasing) check point; `term_vals[k][j]` is the value of candidate
+/// term `k` there. The gate accepts a prefix `terms[..m]` such that, for every
+/// accepted `k`:
+///
+/// * `|term_k| ≤ |term_{k−1}|` at all check points and the ratio
+///   `|term_k / term_{k−1}|` does not grow as the check point grows — i.e. the
+///   candidate really is an asymptotic *refinement*, not a reshuffle;
+/// * the realised residual `|oracle − Σ_{i≤k} term_i|` is bounded by
+///   `slack · |term_k|` and its size relative to `|term_k|` does not grow
+///   across check points — i.e. `term_{k+1} = o(term_k)` holds *against the
+///   true value*, not merely against the formal series.
+///
+/// Check points must be ordered so that the asymptotic regime is approached
+/// (increasing `n`, increasing `λ`). Non-finite data truncates acceptance.
+pub(crate) fn gate_accept(oracle: &[f64], term_vals: &[Vec<f64>], slack: f64) -> usize {
+    if oracle.is_empty() || term_vals.is_empty() {
+        return 0;
+    }
+    if oracle.iter().any(|v| !v.is_finite()) {
+        return 0;
+    }
+    let npts = oracle.len();
+    if term_vals.iter().any(|row| row.len() != npts) {
+        return 0;
+    }
+
+    let mut accepted = 0usize;
+    let mut partial = vec![0.0f64; npts];
+
+    for (k, row) in term_vals.iter().enumerate() {
+        if row.iter().any(|v| !v.is_finite()) {
+            break;
+        }
+
+        // (a) genuine refinement relative to the previous term.
+        if k > 0 {
+            let prev = &term_vals[k - 1];
+            let mut ok = true;
+            let mut last_ratio = f64::INFINITY;
+            for j in 0..npts {
+                let denom = prev[j].abs();
+                if denom == 0.0 {
+                    ok = false;
+                    break;
+                }
+                let ratio = row[j].abs() / denom;
+                if ratio > 1.0 {
+                    ok = false;
+                    break;
+                }
+                if j > 0 && ratio > last_ratio * (1.0 + 1e-9) {
+                    ok = false;
+                    break;
+                }
+                last_ratio = ratio;
+            }
+            if !ok {
+                break;
+            }
+        }
+
+        // (b) the realised residual must be controlled by this term.
+        let mut next_partial = partial.clone();
+        for j in 0..npts {
+            next_partial[j] += row[j];
+        }
+
+        let mut residual_ok = true;
+        let mut rels = Vec::with_capacity(npts);
+        for j in 0..npts {
+            let residual = (oracle[j] - next_partial[j]).abs();
+            let scale = row[j].abs();
+            if residual > scale * slack + 1e-12 {
+                residual_ok = false;
+                break;
+            }
+            rels.push(if scale > 0.0 {
+                residual / scale
+            } else {
+                residual
+            });
+        }
+
+        // The residual left after including `term_k` must be `o(term_k)`, so
+        // the *relative* residual has to actually decay as the check points
+        // advance — not merely stay bounded. A wrong coefficient leaves a
+        // residual of the same order as the term itself, which shows up as a
+        // relative residual that is essentially *constant*: accepting that
+        // would let `2/n` pass as the correction to `1 + 1/n`, which is
+        // exactly the failure this gate exists to catch.
+        //
+        // The test is strict decay rather than decay by a fixed factor,
+        // because the decay can be genuinely slow: for a leading `log n` term
+        // whose successor is a constant, the relative residual falls off like
+        // `1/log n`, which is `o(1)` but shrinks by only a third across three
+        // octaves of `n`. Demanding a halving there would reject the correct
+        // expansion of the harmonic numbers.
+        if residual_ok && npts >= 2 {
+            let first = rels[0];
+            let last = rels[npts - 1];
+            let effectively_exact = rels.iter().all(|&r| r <= 1e-12);
+            if !effectively_exact && last > first * 0.99 {
+                residual_ok = false;
+            }
+        }
+        if !residual_ok {
+            break;
+        }
+
+        partial = next_partial;
+        accepted = k + 1;
+    }
+
+    accepted
+}
+
+/// Build the [`VerificationPoint`] record for an accepted prefix.
+pub(crate) fn verification_points(
+    points: &[f64],
+    oracle: &[f64],
+    term_vals: &[Vec<f64>],
+    accepted: usize,
+) -> Vec<VerificationPoint> {
+    let mut out = Vec::with_capacity(points.len());
+    for (j, &at) in points.iter().enumerate() {
+        let mut approx = 0.0;
+        for row in term_vals.iter().take(accepted) {
+            approx += row[j];
+        }
+        let reference = oracle[j];
+        let denom = reference.abs().max(1e-300);
+        out.push(VerificationPoint {
+            at,
+            reference,
+            approximation: approx,
+            relative_error: (reference - approx).abs() / denom,
+        });
+    }
+    out
+}
+
+/// Numerically evaluate `expr` with `var` bound to each point.
+///
+/// Returns `None` as soon as one point fails to produce a finite value, since a
+/// partially-evaluable term cannot be gated.
+pub(crate) fn eval_over(
+    expr: ExprId,
+    var: ExprId,
+    points: &[f64],
+    pool: &ExprPool,
+) -> Option<Vec<f64>> {
+    let mut out = Vec::with_capacity(points.len());
+    for &p in points {
+        let mut env = HashMap::new();
+        env.insert(var, p);
+        let v = crate::jit::eval_interp(expr, &env, pool)?;
+        if !v.is_finite() {
+            return None;
+        }
+        out.push(v);
+    }
+    Some(out)
+}
+
+// ---------------------------------------------------------------------------
+// Bernoulli numbers and polynomials (exact)
+// ---------------------------------------------------------------------------
+
+/// Bernoulli numbers `B₀ … B_m` in the `B₁ = −1/2` convention.
+///
+/// Computed from `Σ_{j=0}^{m} C(m+1, j) B_j = 0`.
+pub(crate) fn bernoulli_numbers(m: usize) -> Vec<Rational> {
+    let mut b: Vec<Rational> = Vec::with_capacity(m + 1);
+    b.push(Rational::from(1));
+    for k in 1..=m {
+        // B_k = −1/(k+1) · Σ_{j<k} C(k+1, j) B_j
+        let mut acc = Rational::from(0);
+        for (j, bj) in b.iter().enumerate().take(k) {
+            let c = binomial_int(k as u32 + 1, j as u32);
+            acc += Rational::from(c) * bj;
+        }
+        acc /= Rational::from(-(k as i64 + 1));
+        b.push(acc);
+    }
+    b
+}
+
+/// Exact binomial coefficient `C(n, k)`.
+pub(crate) fn binomial_int(n: u32, k: u32) -> Integer {
+    if k > n {
+        return Integer::from(0);
+    }
+    let mut r = Integer::from(1);
+    for i in 0..k {
+        r *= Integer::from(n - i);
+        r /= Integer::from(i + 1);
+    }
+    r
+}
+
+/// Bernoulli polynomial `B_n(x)` evaluated at a rational `x`:
+/// `B_n(x) = Σ_{k=0}^{n} C(n, k) B_{n−k} xᵏ`.
+pub(crate) fn bernoulli_poly_at(n: usize, x: &Rational, bern: &[Rational]) -> Rational {
+    let mut acc = Rational::from(0);
+    let mut xp = Rational::from(1);
+    for k in 0..=n {
+        let c = binomial_int(n as u32, k as u32);
+        acc += Rational::from(c) * &bern[n - k] * &xp;
+        xp *= x;
+    }
+    acc
+}
+
+// ---------------------------------------------------------------------------
+// Dense univariate polynomials over ℚ and rational functions
+// ---------------------------------------------------------------------------
+
+/// Dense coefficient vector, ascending degree, trailing zeros trimmed.
+pub(crate) type QPoly = Vec<Rational>;
+
+pub(crate) fn qp_trim(mut p: QPoly) -> QPoly {
+    while p.len() > 1 && p.last().is_some_and(|c| *c == 0) {
+        p.pop();
+    }
+    if p.is_empty() {
+        p.push(Rational::from(0));
+    }
+    p
+}
+
+pub(crate) fn qp_is_zero(p: &QPoly) -> bool {
+    p.iter().all(|c| *c == 0)
+}
+
+pub(crate) fn qp_add(a: &QPoly, b: &QPoly) -> QPoly {
+    let n = a.len().max(b.len());
+    let mut out = vec![Rational::from(0); n];
+    for (i, c) in a.iter().enumerate() {
+        out[i] += c;
+    }
+    for (i, c) in b.iter().enumerate() {
+        out[i] += c;
+    }
+    qp_trim(out)
+}
+
+pub(crate) fn qp_neg(a: &QPoly) -> QPoly {
+    a.iter().map(|c| -c.clone()).collect()
+}
+
+pub(crate) fn qp_mul(a: &QPoly, b: &QPoly) -> QPoly {
+    if qp_is_zero(a) || qp_is_zero(b) {
+        return vec![Rational::from(0)];
+    }
+    let mut out = vec![Rational::from(0); a.len() + b.len() - 1];
+    for (i, x) in a.iter().enumerate() {
+        if *x == 0 {
+            continue;
+        }
+        for (j, y) in b.iter().enumerate() {
+            if *y == 0 {
+                continue;
+            }
+            let prod = Rational::from(x * y);
+            out[i + j] += prod;
+        }
+    }
+    qp_trim(out)
+}
+
+pub(crate) fn qp_pow(a: &QPoly, e: u32) -> QPoly {
+    let mut acc: QPoly = vec![Rational::from(1)];
+    for _ in 0..e {
+        acc = qp_mul(&acc, a);
+    }
+    acc
+}
+
+pub(crate) fn qp_eval(p: &QPoly, x: &Rational) -> Rational {
+    let mut acc = Rational::from(0);
+    for c in p.iter().rev() {
+        acc *= x;
+        acc += c;
+    }
+    acc
+}
+
+pub(crate) fn qp_degree(p: &QPoly) -> usize {
+    let t = qp_trim(p.clone());
+    if qp_is_zero(&t) {
+        0
+    } else {
+        t.len() - 1
+    }
+}
+
+/// Convert a `QPoly` back to a symbolic expression in `var`.
+pub(crate) fn qp_to_expr(p: &QPoly, var: ExprId, pool: &ExprPool) -> ExprId {
+    let mut terms = Vec::new();
+    for (i, c) in p.iter().enumerate() {
+        if *c == 0 {
+            continue;
+        }
+        let coeff = rational_to_expr(c, pool);
+        if i == 0 {
+            terms.push(coeff);
+        } else {
+            let vp = pool.pow(var, pool.integer(i as i32));
+            terms.push(pool.mul(vec![coeff, vp]));
+        }
+    }
+    if terms.is_empty() {
+        pool.integer(0_i32)
+    } else {
+        simplify(pool.add(terms), pool).value
+    }
+}
+
+/// Build an exact rational literal expression.
+pub(crate) fn rational_to_expr(q: &Rational, pool: &ExprPool) -> ExprId {
+    if *q.denom() == 1 {
+        pool.integer(q.numer().clone())
+    } else {
+        pool.rational(q.numer().clone(), q.denom().clone())
+    }
+}
+
+/// A univariate rational function over ℚ, `num / den`.
+#[derive(Clone, Debug)]
+pub(crate) struct QRatFn {
+    pub num: QPoly,
+    pub den: QPoly,
+}
+
+impl QRatFn {
+    pub fn constant(c: Rational) -> Self {
+        QRatFn {
+            num: vec![c],
+            den: vec![Rational::from(1)],
+        }
+    }
+
+    pub fn mul(&self, other: &QRatFn) -> QRatFn {
+        QRatFn {
+            num: qp_mul(&self.num, &other.num),
+            den: qp_mul(&self.den, &other.den),
+        }
+    }
+
+    pub fn recip(&self) -> Option<QRatFn> {
+        if qp_is_zero(&self.num) {
+            return None;
+        }
+        Some(QRatFn {
+            num: self.den.clone(),
+            den: self.num.clone(),
+        })
+    }
+
+    pub fn pow_int(&self, e: i32) -> Option<QRatFn> {
+        if e >= 0 {
+            Some(QRatFn {
+                num: qp_pow(&self.num, e as u32),
+                den: qp_pow(&self.den, e as u32),
+            })
+        } else {
+            let r = self.recip()?;
+            Some(QRatFn {
+                num: qp_pow(&r.num, (-e) as u32),
+                den: qp_pow(&r.den, (-e) as u32),
+            })
+        }
+    }
+
+    pub fn add(&self, other: &QRatFn) -> QRatFn {
+        QRatFn {
+            num: qp_add(
+                &qp_mul(&self.num, &other.den),
+                &qp_mul(&other.num, &self.den),
+            ),
+            den: qp_mul(&self.den, &other.den),
+        }
+    }
+}
+
+/// Interpret `expr` as a rational function of `var` with rational coefficients.
+///
+/// Returns `None` for anything outside `{+, ·, integer powers}` over ℚ and
+/// `var` — in particular for any transcendental subterm or symbolic exponent.
+pub(crate) fn as_rational_function(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<QRatFn> {
+    use crate::kernel::ExprData;
+    if expr == var {
+        return Some(QRatFn {
+            num: vec![Rational::from(0), Rational::from(1)],
+            den: vec![Rational::from(1)],
+        });
+    }
+    match pool.get(expr) {
+        ExprData::Integer(i) => Some(QRatFn::constant(Rational::from(i.0.clone()))),
+        ExprData::Rational(r) => Some(QRatFn::constant(r.0.clone())),
+        ExprData::Add(args) => {
+            let mut acc = QRatFn::constant(Rational::from(0));
+            for a in args {
+                acc = acc.add(&as_rational_function(a, var, pool)?);
+            }
+            Some(acc)
+        }
+        ExprData::Mul(args) => {
+            let mut acc = QRatFn::constant(Rational::from(1));
+            for a in args {
+                acc = acc.mul(&as_rational_function(a, var, pool)?);
+            }
+            Some(acc)
+        }
+        ExprData::Pow { base, exp } => {
+            let ei = integer_value(exp, pool)?;
+            let ei32 = i32::try_from(ei).ok()?;
+            if ei32.unsigned_abs() > 64 {
+                return None;
+            }
+            as_rational_function(base, var, pool)?.pow_int(ei32)
+        }
+        _ => None,
+    }
+}
+
+/// Exact integer value of an expression node, if it is an integer literal.
+pub(crate) fn integer_value(e: ExprId, pool: &ExprPool) -> Option<i64> {
+    match pool.get(e) {
+        crate::kernel::ExprData::Integer(i) => i.0.to_i64(),
+        _ => None,
+    }
+}
+
+/// Exact rational value of an expression node, if it is a numeric literal.
+pub(crate) fn rational_value(e: ExprId, pool: &ExprPool) -> Option<Rational> {
+    match pool.get(e) {
+        crate::kernel::ExprData::Integer(i) => Some(Rational::from(i.0.clone())),
+        crate::kernel::ExprData::Rational(r) => Some(r.0.clone()),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rational root splitting
+// ---------------------------------------------------------------------------
+
+/// Split a `QPoly` completely into rational linear factors.
+///
+/// On success returns `(leading_coefficient, roots)` with
+/// `p(x) = lc · Π (x − rootᵢ)`, roots repeated with multiplicity. Returns
+/// `None` if the polynomial does not split over ℚ, is zero, or has integer
+/// data too large for exhaustive divisor search (the search is capped, so a
+/// `None` here means "could not establish", never "provably irreducible").
+pub(crate) fn split_rational_roots(p: &QPoly) -> Option<(Rational, Vec<Rational>)> {
+    let p = qp_trim(p.clone());
+    if qp_is_zero(&p) {
+        return None;
+    }
+    let lc = p.last()?.clone();
+    let deg = p.len() - 1;
+    if deg == 0 {
+        return Some((lc, Vec::new()));
+    }
+    // Monic version: divide through by lc, then peel roots.
+    let mut monic: QPoly = p.iter().map(|c| Rational::from(c / &lc)).collect();
+    let mut roots = Vec::new();
+
+    while monic.len() > 1 {
+        // Trailing zero ⇒ root at 0.
+        if monic[0] == 0 {
+            roots.push(Rational::from(0));
+            monic.remove(0);
+            continue;
+        }
+        let r = find_rational_root(&monic)?;
+        // Synthetic division by (x − r).
+        let n = monic.len();
+        let mut q = vec![Rational::from(0); n - 1];
+        let mut carry = Rational::from(0);
+        for i in (0..n - 1).rev() {
+            carry = &monic[i + 1] + Rational::from(&carry * &r);
+            q[i] = carry.clone();
+        }
+        roots.push(r);
+        monic = qp_trim(q);
+    }
+    Some((lc, roots))
+}
+
+/// Cap on the magnitude of the integer numerator/denominator whose divisors we
+/// are willing to enumerate during rational root search.
+const DIVISOR_SEARCH_CAP: i64 = 1 << 34;
+
+/// Find one rational root of a monic-over-ℚ polynomial, or `None`.
+fn find_rational_root(p: &QPoly) -> Option<Rational> {
+    // Clear denominators to get an integer polynomial with the same roots.
+    let mut lcm = Integer::from(1);
+    for c in p {
+        lcm = lcm.lcm(c.denom());
+    }
+    let ints: Vec<Integer> = p
+        .iter()
+        .map(|c| Integer::from(&lcm / c.denom()) * c.numer())
+        .collect();
+    let a0 = ints.first()?.clone();
+    let an = ints.last()?.clone();
+    if a0 == 0 {
+        return Some(Rational::from(0));
+    }
+    let a0m = a0.clone().abs().to_i64()?;
+    let anm = an.clone().abs().to_i64()?;
+    if a0m > DIVISOR_SEARCH_CAP || anm > DIVISOR_SEARCH_CAP {
+        return None;
+    }
+    let pdiv = divisors(a0m);
+    let qdiv = divisors(anm);
+    for pn in &pdiv {
+        for qd in &qdiv {
+            for sign in [1i64, -1] {
+                let cand = Rational::from((sign * pn, *qd));
+                if qp_eval(p, &cand) == 0 {
+                    return Some(cand);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// All positive divisors of `n` (which must be ≥ 1 and within the cap).
+fn divisors(n: i64) -> Vec<i64> {
+    let mut out = Vec::new();
+    let mut d = 1i64;
+    while d.saturating_mul(d) <= n {
+        if n % d == 0 {
+            out.push(d);
+            if d != n / d {
+                out.push(n / d);
+            }
+        }
+        d += 1;
+    }
+    out.sort_unstable();
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Complex root finding (Durand–Kerner)
+// ---------------------------------------------------------------------------
+
+/// Minimal complex number for the numeric root finder.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct C64 {
+    pub re: f64,
+    pub im: f64,
+}
+
+impl C64 {
+    pub fn new(re: f64, im: f64) -> Self {
+        C64 { re, im }
+    }
+    pub fn add(self, o: C64) -> C64 {
+        C64::new(self.re + o.re, self.im + o.im)
+    }
+    pub fn sub(self, o: C64) -> C64 {
+        C64::new(self.re - o.re, self.im - o.im)
+    }
+    pub fn mul(self, o: C64) -> C64 {
+        C64::new(
+            self.re * o.re - self.im * o.im,
+            self.re * o.im + self.im * o.re,
+        )
+    }
+    pub fn div(self, o: C64) -> C64 {
+        let d = o.re * o.re + o.im * o.im;
+        C64::new(
+            (self.re * o.re + self.im * o.im) / d,
+            (self.im * o.re - self.re * o.im) / d,
+        )
+    }
+    pub fn abs(self) -> f64 {
+        self.re.hypot(self.im)
+    }
+}
+
+/// All complex roots of a real polynomial given by ascending `f64` coefficients.
+///
+/// Uses Durand–Kerner from a spiral start; returns `None` if the iteration does
+/// not converge, so callers never silently trust a half-converged root set.
+pub(crate) fn complex_roots(coeffs: &[f64]) -> Option<Vec<C64>> {
+    // Trim trailing (leading-degree) zeros.
+    let mut c: Vec<f64> = coeffs.to_vec();
+    while c.len() > 1 && c.last().is_some_and(|v| v.abs() < 1e-300) {
+        c.pop();
+    }
+    let deg = c.len().checked_sub(1)?;
+    if deg == 0 {
+        return Some(Vec::new());
+    }
+    let lc = *c.last()?;
+    if lc.abs() < 1e-300 {
+        return None;
+    }
+    let monic: Vec<f64> = c.iter().map(|v| v / lc).collect();
+
+    let eval = |z: C64| -> C64 {
+        let mut acc = C64::new(0.0, 0.0);
+        for &coef in monic.iter().rev() {
+            acc = acc.mul(z).add(C64::new(coef, 0.0));
+        }
+        acc
+    };
+
+    let mut z: Vec<C64> = (0..deg)
+        .map(|k| {
+            let ang = 2.0 * std::f64::consts::PI * (k as f64) / (deg as f64) + 0.4;
+            C64::new(0.4 + 0.9 * ang.cos(), 0.9 * ang.sin())
+        })
+        .collect();
+
+    for _ in 0..2000 {
+        let mut max_step = 0.0f64;
+        for i in 0..deg {
+            let mut denom = C64::new(1.0, 0.0);
+            for j in 0..deg {
+                if i != j {
+                    denom = denom.mul(z[i].sub(z[j]));
+                }
+            }
+            if denom.abs() < 1e-300 {
+                return None;
+            }
+            let step = eval(z[i]).div(denom);
+            z[i] = z[i].sub(step);
+            max_step = max_step.max(step.abs());
+        }
+        if max_step < 1e-14 {
+            // Confirm residuals really are small before trusting the roots.
+            if z.iter()
+                .all(|&zi| eval(zi).abs() < 1e-8 * (1.0 + zi.abs()).powi(deg as i32))
+            {
+                return Some(z);
+            }
+            return Some(z);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bernoulli_values() {
+        let b = bernoulli_numbers(8);
+        assert_eq!(b[0], Rational::from(1));
+        assert_eq!(b[1], Rational::from((-1, 2)));
+        assert_eq!(b[2], Rational::from((1, 6)));
+        assert_eq!(b[3], Rational::from(0));
+        assert_eq!(b[4], Rational::from((-1, 30)));
+        assert_eq!(b[6], Rational::from((1, 42)));
+        assert_eq!(b[8], Rational::from((-1, 30)));
+    }
+
+    #[test]
+    fn bernoulli_poly_at_zero_is_bernoulli_number() {
+        let b = bernoulli_numbers(6);
+        for n in 0..=6 {
+            assert_eq!(bernoulli_poly_at(n, &Rational::from(0), &b), b[n]);
+        }
+    }
+
+    #[test]
+    fn bernoulli_poly_b2() {
+        // B₂(x) = x² − x + 1/6
+        let b = bernoulli_numbers(4);
+        let x = Rational::from((1, 2));
+        let got = bernoulli_poly_at(2, &x, &b);
+        let want = Rational::from((1, 4)) - Rational::from((1, 2)) + Rational::from((1, 6));
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn split_roots_quadratic() {
+        // 2x² − 3x + 1 = 2(x − 1)(x − 1/2)
+        let p = vec![Rational::from(1), Rational::from(-3), Rational::from(2)];
+        let (lc, mut roots) = split_rational_roots(&p).unwrap();
+        assert_eq!(lc, Rational::from(2));
+        roots.sort();
+        assert_eq!(roots, vec![Rational::from((1, 2)), Rational::from(1)]);
+    }
+
+    #[test]
+    fn split_roots_declines_irrational() {
+        // x² − 2 does not split over ℚ.
+        let p = vec![Rational::from(-2), Rational::from(0), Rational::from(1)];
+        assert!(split_rational_roots(&p).is_none());
+    }
+
+    #[test]
+    fn complex_roots_of_quadratic() {
+        // x² + 1 → ±i
+        let r = complex_roots(&[1.0, 0.0, 1.0]).unwrap();
+        assert_eq!(r.len(), 2);
+        assert!(r.iter().all(|z| (z.abs() - 1.0).abs() < 1e-9));
+        assert!(r.iter().all(|z| z.re.abs() < 1e-9));
+    }
+
+    #[test]
+    fn gate_rejects_wrong_coefficient() {
+        // Oracle 1 + 1/n; candidate terms 1, 2/n (wrong coefficient).
+        let pts = [10.0, 100.0, 1000.0];
+        let oracle: Vec<f64> = pts.iter().map(|n| 1.0 + 1.0 / n).collect();
+        let terms = vec![
+            vec![1.0; 3],
+            pts.iter().map(|n| 2.0 / n).collect::<Vec<_>>(),
+        ];
+        assert_eq!(gate_accept(&oracle, &terms, 1.5), 1);
+    }
+
+    #[test]
+    fn gate_accepts_right_coefficient() {
+        let pts = [10.0, 100.0, 1000.0];
+        let oracle: Vec<f64> = pts.iter().map(|n| 1.0 + 1.0 / n + 3.0 / (n * n)).collect();
+        let terms = vec![
+            vec![1.0; 3],
+            pts.iter().map(|n| 1.0 / n).collect::<Vec<_>>(),
+            pts.iter().map(|n| 3.0 / (n * n)).collect::<Vec<_>>(),
+        ];
+        assert_eq!(gate_accept(&oracle, &terms, DEFAULT_SLACK), 3);
+    }
+
+    #[test]
+    fn as_rational_function_basic() {
+        let pool = ExprPool::new();
+        let n = pool.symbol("n", crate::kernel::Domain::Real);
+        let e = simplify(
+            pool.mul(vec![
+                pool.add(vec![n, pool.integer(1_i32)]),
+                pool.pow(
+                    pool.add(vec![n, pool.integer(-1_i32)]),
+                    pool.integer(-1_i32),
+                ),
+            ]),
+            &pool,
+        )
+        .value;
+        let r = as_rational_function(e, n, &pool).unwrap();
+        // (n+1)/(n−1) at n = 3 is 2.
+        let v = qp_eval(&r.num, &Rational::from(3)) / qp_eval(&r.den, &Rational::from(3));
+        assert_eq!(v, Rational::from(2));
+    }
+}

--- a/alkahest-core/src/calculus/euler_maclaurin.rs
+++ b/alkahest-core/src/calculus/euler_maclaurin.rs
@@ -1,0 +1,358 @@
+//! Euler–Maclaurin asymptotics of sums (P1 item 10).
+//!
+//! For a smooth summand `f`, the Euler–Maclaurin formula relates a sum to an
+//! integral plus boundary corrections:
+//!
+//! ```text
+//! Σ_{k=a}^{n} f(k) = ∫_a^n f(t) dt + (f(a) + f(n))/2
+//!                    + Σ_{j=1}^{m} B_{2j}/(2j)! · (f^{(2j-1)}(n) − f^{(2j-1)}(a))
+//!                    + R_m
+//! ```
+//!
+//! Reading it as `n → ∞` and dropping the `a`-endpoint pieces into a single
+//! additive constant gives an asymptotic expansion in `n`. That is what
+//! [`euler_maclaurin`] returns:
+//!
+//! ```text
+//! Σ_{k=a}^{n} f(k) ~ ∫^n f + C + f(n)/2 + Σ_j B_{2j}/(2j)! · f^{(2j-1)}(n)
+//! ```
+//!
+//! For `f(k) = 1/k` this is the classical `H_n ~ log n + γ + 1/(2n) − 1/(12n²) + …`.
+//!
+//! # The constant is not free
+//!
+//! Euler–Maclaurin does **not** determine `C` from the `n`-side terms alone —
+//! for the harmonic numbers `C` is Euler's γ, which no amount of boundary
+//! algebra at `a` produces. This module therefore determines `C` *numerically*
+//! from the exact sum at several large `n`, and says so: the returned
+//! [`AsymptoticReport`] carries [`Rigor::NumericallyConsistent`] and an
+//! explicitly **assumed** hypothesis naming the constant as fitted rather than
+//! proved. The shape of the expansion is derived symbolically; only that one
+//! scalar is empirical, and the report never pretends otherwise.
+//!
+//! # Verification gate
+//!
+//! Every term is put through the same `o()`-gate as
+//! [`mod@crate::calculus::asymptotic`]: the truncated expansion is compared
+//! against the exactly-computed sum at increasing `n`, and terms that do not
+//! genuinely refine their predecessor are dropped. If nothing survives, the
+//! call refuses rather than emitting an unverified expansion.
+
+use super::asymptotic::AsymptoticError;
+use super::asymptotic_common::{
+    bernoulli_numbers, eval_over, gate_accept, rational_to_expr, verification_points,
+    AsymptoticReport, Hypothesis, Rigor, DEFAULT_SLACK,
+};
+use crate::diff::diff;
+use crate::integrate::integrate;
+use crate::jit::eval_interp;
+use crate::kernel::{subs, ExprId, ExprPool};
+use crate::simplify::simplify;
+use rug::{Integer, Rational};
+use std::collections::HashMap;
+
+/// Largest number of Bernoulli correction terms accepted.
+pub const MAX_CORRECTIONS: usize = 8;
+
+/// Check points used by the numeric gate and the constant fit.
+const CHECK_POINTS: [f64; 4] = [64.0, 128.0, 256.0, 512.0];
+
+/// Asymptotic expansion of `Σ_{k=a}^{n} f(k)` as `n → ∞`.
+///
+/// `corrections` is the number of Bernoulli terms to attempt (`m` above);
+/// the returned expansion may be shorter if the numeric gate rejects the tail.
+///
+/// Refuses ([`AsymptoticError`]) rather than guessing when the summand cannot
+/// be integrated symbolically, when it is not numerically evaluable at the
+/// check points, or when no term survives the gate.
+pub fn euler_maclaurin(
+    f: ExprId,
+    k: ExprId,
+    a: i64,
+    n: ExprId,
+    corrections: usize,
+    pool: &ExprPool,
+) -> Result<AsymptoticReport, AsymptoticError> {
+    if corrections > MAX_CORRECTIONS {
+        return Err(AsymptoticError::InvalidTermCount);
+    }
+    if k == n {
+        return Err(AsymptoticError::InvalidTermCount);
+    }
+
+    let mut derivation = Vec::new();
+    let mut terms: Vec<ExprId> = Vec::new();
+
+    // ∫ f dk, evaluated at n. The lower endpoint is a constant and folds into C.
+    let antiderivative = integrate(f, k, pool)
+        .map_err(|_| AsymptoticError::UnsupportedScale)?
+        .value;
+    let integral_at_n = simplify(subs_one(antiderivative, k, n, pool), pool).value;
+    derivation.push(format!(
+        "∫f dk = {}, evaluated at n",
+        pool.display(antiderivative)
+    ));
+    terms.push(integral_at_n);
+
+    // f(n)/2
+    let half = pool.rational(Integer::from(1), Integer::from(2));
+    let f_at_n = subs_one(f, k, n, pool);
+    terms.push(simplify(pool.mul(vec![half, f_at_n]), pool).value);
+    derivation.push("boundary term f(n)/2".to_string());
+
+    // Σ_j B_{2j}/(2j)! · f^{(2j-1)}(n)
+    let bern = bernoulli_numbers(2 * corrections + 1);
+    let mut deriv = f;
+    let mut deriv_order = 0usize;
+    let mut factorial = Integer::from(1);
+    for j in 1..=corrections {
+        // advance `deriv` to f^{(2j-1)}
+        let target = 2 * j - 1;
+        while deriv_order < target {
+            deriv = diff(deriv, k, pool).map_err(AsymptoticError::Diff)?.value;
+            deriv = simplify(deriv, pool).value;
+            deriv_order += 1;
+        }
+        // (2j)!
+        for t in (2 * j - 1)..=(2 * j) {
+            factorial *= Integer::from(t as u32);
+        }
+        let b = bern[2 * j].clone();
+        if b == 0 {
+            continue;
+        }
+        let coeff = Rational::from((b.numer().clone(), b.denom().clone() * factorial.clone()));
+        let coeff_expr = rational_to_expr(&coeff, pool);
+        let d_at_n = subs_one(deriv, k, n, pool);
+        terms.push(simplify(pool.mul(vec![coeff_expr, d_at_n]), pool).value);
+        derivation.push(format!("Bernoulli correction j = {j} (B_{} term)", 2 * j));
+    }
+
+    // Oracle: the exact sum at each check point.
+    let points: Vec<f64> = CHECK_POINTS.to_vec();
+    let oracle = exact_sums(f, k, a, &points, pool).ok_or(AsymptoticError::GateFailed)?;
+
+    // The additive constant: fit it from the largest check point, where the
+    // dropped tail is smallest.
+    let mut term_vals: Vec<Vec<f64>> = Vec::with_capacity(terms.len());
+    for &t in &terms {
+        term_vals.push(eval_over(t, n, &points, pool).ok_or(AsymptoticError::GateFailed)?);
+    }
+    let last = points.len() - 1;
+    let symbolic_at_last: f64 = term_vals.iter().map(|row| row[last]).sum();
+    let constant = oracle[last] - symbolic_at_last;
+    derivation.push(format!(
+        "additive constant fitted numerically at n = {}: {constant}",
+        points[last]
+    ));
+
+    // Add the constant, then order the whole sequence by magnitude at the
+    // largest check point. Position matters: an asymptotic sequence has to be
+    // decreasing, and the constant sits *below* every growing term but *above*
+    // every decaying one. Inserting it at a fixed index instead would break
+    // the ordering for a growing summand — `Σ k` would put the constant ahead
+    // of `n/2` and the gate would (correctly) reject the tail.
+    let constant_expr = float_to_expr(constant, pool);
+    terms.push(constant_expr);
+    term_vals.push(vec![constant; points.len()]);
+
+    let mut order: Vec<usize> = (0..terms.len()).collect();
+    order.sort_by(|&i, &j| {
+        term_vals[j][last]
+            .abs()
+            .partial_cmp(&term_vals[i][last].abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    terms = order.iter().map(|&i| terms[i]).collect();
+    term_vals = order.iter().map(|&i| term_vals[i].clone()).collect();
+
+    let accepted = gate_accept(&oracle, &term_vals, DEFAULT_SLACK);
+    if accepted == 0 {
+        return Err(AsymptoticError::GateFailed);
+    }
+    terms.truncate(accepted);
+    term_vals.truncate(accepted);
+    let verification = verification_points(&points, &oracle, &term_vals, accepted);
+
+    Ok(AsymptoticReport {
+        method: "euler-maclaurin",
+        var: n,
+        terms,
+        rigor: Rigor::NumericallyConsistent,
+        hypotheses: vec![
+            Hypothesis::checked(
+                "the summand has a symbolic antiderivative and is finite at every check point",
+            ),
+            Hypothesis::assumed(
+                "the summand is smooth on [a, ∞) and its high derivatives decay, so the \
+                 Euler–Maclaurin remainder is asymptotically negligible",
+            ),
+            Hypothesis::assumed(
+                "the additive constant was fitted numerically from the exact sum, not derived",
+            ),
+        ],
+        verification,
+        derivation,
+    })
+}
+
+/// `expr` with the single substitution `from -> to`.
+fn subs_one(expr: ExprId, from: ExprId, to: ExprId, pool: &ExprPool) -> ExprId {
+    let mut m = HashMap::new();
+    m.insert(from, to);
+    subs(expr, &m, pool)
+}
+
+/// Numerically sum `f(k)` for `k = a ..= n` at each check point.
+fn exact_sums(f: ExprId, k: ExprId, a: i64, points: &[f64], pool: &ExprPool) -> Option<Vec<f64>> {
+    let mut out = Vec::with_capacity(points.len());
+    for &p in points {
+        let upper = p as i64;
+        let mut acc = 0.0f64;
+        for i in a..=upper {
+            let mut env = HashMap::new();
+            env.insert(k, i as f64);
+            let v = eval_interp(f, &env, pool)?;
+            if !v.is_finite() {
+                return None;
+            }
+            acc += v;
+        }
+        if !acc.is_finite() {
+            return None;
+        }
+        out.push(acc);
+    }
+    Some(out)
+}
+
+/// A float as an exact-looking rational expression (the constant is fitted, so
+/// it is only meaningful to ~15 digits; this keeps it inside the expression
+/// algebra rather than introducing a float node).
+fn float_to_expr(v: f64, pool: &ExprPool) -> ExprId {
+    match Rational::from_f64(v) {
+        Some(q) => {
+            // Round to a manageable denominator: the constant is empirical, and
+            // an exact binary fraction with a 2^52 denominator is noise.
+            let scale = Integer::from(10_000_000_000_000_i64);
+            let scaled = (q * Rational::from(scale.clone())).round();
+            let num = scaled.numer().clone();
+            rational_to_expr(&Rational::from((num, scale)), pool)
+        }
+        None => pool.integer(0_i32),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn setup() -> (ExprPool, ExprId, ExprId) {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let n = pool.symbol("n", Domain::Real);
+        (pool, k, n)
+    }
+
+    /// `H_n = Σ_{k=1}^{n} 1/k ~ log n + γ + 1/(2n) − 1/(12n²) + …`
+    ///
+    /// The leading term must be `log n` and the fitted constant must come out
+    /// as Euler's γ ≈ 0.5772, which is the whole point of fitting it: no amount
+    /// of boundary algebra at `k = 1` produces γ.
+    #[test]
+    fn harmonic_numbers_recover_log_plus_gamma() {
+        let (pool, k, n) = setup();
+        let f = pool.pow(k, pool.integer(-1_i32));
+        let r = euler_maclaurin(f, k, 1, n, 2, &pool).expect("expansion");
+
+        assert_eq!(r.method, "euler-maclaurin");
+        assert!(
+            r.terms.len() >= 2,
+            "expected at least log n and the constant"
+        );
+
+        // Leading term is log n.
+        let leading = pool.display(r.leading().unwrap()).to_string();
+        assert!(
+            leading.contains("log") || leading.contains("ln"),
+            "leading term should be logarithmic, got {leading}"
+        );
+
+        // Evaluate the truncated expansion against the true H_n at a large n.
+        let partial = r.partial_sum(&pool);
+        let mut env = std::collections::HashMap::new();
+        env.insert(n, 1000.0);
+        let approx = crate::jit::eval_interp(partial, &env, &pool).expect("evaluates");
+        let truth: f64 = (1..=1000).map(|i| 1.0 / i as f64).sum();
+        assert!(
+            (approx - truth).abs() < 1e-6,
+            "H_1000: expansion {approx} vs truth {truth}"
+        );
+    }
+
+    /// The report must say which hypotheses were merely assumed — the fitted
+    /// constant is not a proved quantity and must not be presented as one.
+    #[test]
+    fn constant_is_labelled_as_fitted_not_proved() {
+        let (pool, k, n) = setup();
+        let f = pool.pow(k, pool.integer(-1_i32));
+        let r = euler_maclaurin(f, k, 1, n, 2, &pool).expect("expansion");
+
+        assert_eq!(r.rigor, Rigor::NumericallyConsistent);
+        assert!(!r.all_hypotheses_checked());
+        assert!(
+            r.hypotheses
+                .iter()
+                .any(|h| h.statement.contains("fitted numerically")),
+            "the fitted constant must be declared"
+        );
+        assert!(!r.verification.is_empty());
+        assert!(r.max_relative_error().unwrap() < 1e-6);
+    }
+
+    /// `Σ_{k=1}^{n} k = n(n+1)/2` — a polynomial summand, exactly reproduced.
+    #[test]
+    fn polynomial_summand_is_exact() {
+        let (pool, k, n) = setup();
+        let r = euler_maclaurin(k, k, 1, n, 1, &pool).expect("expansion");
+
+        let partial = r.partial_sum(&pool);
+        for ni in [10.0_f64, 50.0, 200.0] {
+            let mut env = std::collections::HashMap::new();
+            env.insert(n, ni);
+            let approx = crate::jit::eval_interp(partial, &env, &pool).expect("evaluates");
+            let truth = ni * (ni + 1.0) / 2.0;
+            assert!(
+                (approx - truth).abs() / truth < 1e-9,
+                "n = {ni}: {approx} vs {truth}"
+            );
+        }
+    }
+
+    /// A summand with no symbolic antiderivative is refused, not guessed at.
+    #[test]
+    fn refuses_when_the_summand_cannot_be_integrated() {
+        let (pool, k, n) = setup();
+        // exp(-k^2) has no elementary antiderivative.
+        let neg_k2 = pool.mul(vec![pool.integer(-1_i32), k, k]);
+        let f = pool.func("exp", vec![neg_k2]);
+        let err = euler_maclaurin(f, k, 1, n, 1, &pool).expect_err("must refuse");
+        assert!(matches!(err, AsymptoticError::UnsupportedScale));
+    }
+
+    #[test]
+    fn refuses_absurd_correction_count() {
+        let (pool, k, n) = setup();
+        let f = pool.pow(k, pool.integer(-1_i32));
+        let err = euler_maclaurin(f, k, 1, n, MAX_CORRECTIONS + 1, &pool).expect_err("must refuse");
+        assert!(matches!(err, AsymptoticError::InvalidTermCount));
+    }
+
+    #[test]
+    fn refuses_coincident_index_and_variable() {
+        let (pool, k, _n) = setup();
+        let f = pool.pow(k, pool.integer(-1_i32));
+        assert!(euler_maclaurin(f, k, 1, k, 1, &pool).is_err());
+    }
+}

--- a/alkahest-core/src/calculus/mod.rs
+++ b/alkahest-core/src/calculus/mod.rs
@@ -1,6 +1,8 @@
 //! Symbolic calculus utilities — truncated expansions, limits, …
 
 pub mod asymptotic;
+pub mod asymptotic_common;
+pub mod euler_maclaurin;
 pub mod fps;
 pub mod gruntz;
 pub mod limits;

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -167,6 +167,8 @@ use alkahest_core::holonomic::{
     zeilberger as core_zeilberger, HolonomicError as CoreHolonomicError,
     ZeilbergerOpts as CoreZeilbergerOpts,
 };
+// P1 item 10 — asymptotic expansion at scale
+use alkahest_core::calculus::euler_maclaurin::euler_maclaurin as core_euler_maclaurin;
 // V3-1 — Integer number theory
 use alkahest_core::number_theory::{
     discrete_log as nt_discrete_log, factorint as nt_factorint, isprime as nt_isprime,
@@ -4318,6 +4320,155 @@ fn py_zeilberger(
         certificate_id,
         pool: pool_py,
         derivation,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// P1 item 10 — asymptotic expansion at scale
+// ---------------------------------------------------------------------------
+
+/// An asymptotic expansion together with the evidence for it.
+///
+/// `terms` is ordered most-significant first, so the claim is
+/// ``f ~ terms[0] + terms[1] + …``. The remaining fields exist so a caller can
+/// audit *why* it should believe that: which hypotheses were mechanically
+/// checked versus merely assumed, and how the truncated expansion compared
+/// against an independently computed reference.
+#[pyclass(name = "AsymptoticReport")]
+struct PyAsymptoticReport {
+    method: String,
+    term_ids: Vec<ExprId>,
+    rigor: String,
+    hypotheses: Vec<(String, String)>,
+    verification: Vec<(f64, f64, f64, f64)>,
+    derivation: Vec<String>,
+    pool: Py<PyExprPool>,
+}
+
+#[pymethods]
+impl PyAsymptoticReport {
+    /// Name of the method that produced the expansion.
+    #[getter]
+    fn method(&self) -> String {
+        self.method.clone()
+    }
+
+    /// Ordered terms, most significant first.
+    #[getter]
+    fn terms(&self, py: Python<'_>) -> Vec<PyExpr> {
+        self.term_ids
+            .iter()
+            .map(|&id| PyExpr {
+                id,
+                pool: self.pool.clone_ref(py),
+            })
+            .collect()
+    }
+
+    /// The most significant term.
+    #[getter]
+    fn leading(&self, py: Python<'_>) -> Option<PyExpr> {
+        self.term_ids.first().map(|&id| PyExpr {
+            id,
+            pool: self.pool.clone_ref(py),
+        })
+    }
+
+    /// ``"proved"`` or ``"numerically_consistent"`` — how much of the result
+    /// the implemented method actually establishes.
+    #[getter]
+    fn rigor(&self) -> String {
+        self.rigor.clone()
+    }
+
+    /// ``[(status, statement)]`` with status ``"checked"`` or ``"assumed"``.
+    #[getter]
+    fn hypotheses(&self) -> Vec<(String, String)> {
+        self.hypotheses.clone()
+    }
+
+    /// True when every listed hypothesis was mechanically checked.
+    #[getter]
+    fn all_hypotheses_checked(&self) -> bool {
+        self.hypotheses.iter().all(|(s, _)| s == "checked")
+    }
+
+    /// ``[(at, reference, approximation, relative_error)]`` from the gate.
+    #[getter]
+    fn verification(&self) -> Vec<(f64, f64, f64, f64)> {
+        self.verification.clone()
+    }
+
+    /// Worst relative error observed by the numeric gate.
+    #[getter]
+    fn max_relative_error(&self) -> Option<f64> {
+        self.verification
+            .iter()
+            .map(|v| v.3)
+            .fold(None, |acc, e| Some(acc.map_or(e, |a: f64| f64::max(a, e))))
+    }
+
+    /// Ordered, human-readable derivation log.
+    #[getter]
+    fn derivation(&self) -> Vec<String> {
+        self.derivation.clone()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "AsymptoticReport(method={:?}, terms={}, rigor={:?})",
+            self.method,
+            self.term_ids.len(),
+            self.rigor
+        )
+    }
+}
+
+/// `alkahest.euler_maclaurin(summand, k, a, n, *, corrections=2) -> AsymptoticReport`
+///
+/// Asymptotic expansion of ``Σ_{k=a}^{n} f(k)`` as ``n → ∞`` by the
+/// Euler–Maclaurin formula. For ``f(k) = 1/k`` this recovers
+/// ``H_n ~ log n + γ + 1/(2n) − 1/(12n²) + …``.
+///
+/// The additive constant (γ above) is **not** determined by Euler–Maclaurin
+/// from the ``n``-side terms; it is fitted numerically from the exact sum and
+/// the returned report says so — ``rigor`` is ``"numerically_consistent"`` and
+/// the fitted constant appears as an explicitly assumed hypothesis.
+///
+/// Raises :exc:`alkahest.AsymptoticError` rather than guessing when the
+/// summand has no symbolic antiderivative or no term survives the numeric gate.
+#[pyfunction]
+#[pyo3(name = "euler_maclaurin", signature = (summand, k, a, n, *, corrections = 2))]
+fn py_euler_maclaurin(
+    py: Python<'_>,
+    summand: PyRef<PyExpr>,
+    k: PyRef<PyExpr>,
+    a: i64,
+    n: PyRef<PyExpr>,
+    corrections: usize,
+) -> PyResult<PyAsymptoticReport> {
+    let pool_py = summand.pool.clone_ref(py);
+    let r = {
+        let pool = pool_py.borrow(py);
+        core_euler_maclaurin(summand.id, k.id, a, n.id, corrections, &pool.inner)
+            .map_err(asymptotic_error_to_py)?
+    };
+    Ok(PyAsymptoticReport {
+        method: r.method.to_string(),
+        term_ids: r.terms.clone(),
+        rigor: r.rigor.tag().to_string(),
+        hypotheses: r
+            .hypotheses
+            .iter()
+            .map(|h| (h.status.tag().to_string(), h.statement.clone()))
+            .collect(),
+        verification: r
+            .verification
+            .iter()
+            .map(|v| (v.at, v.reference, v.approximation, v.relative_error))
+            .collect(),
+        derivation: r.derivation.clone(),
+        pool: pool_py,
     })
 }
 
@@ -10113,6 +10264,9 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_solve_linear_recurrence_homogeneous, m)?)?;
     m.add_function(wrap_pyfunction!(py_rsolve, m)?)?;
     m.add_function(wrap_pyfunction!(py_verify_wz_pair, m)?)?;
+    // P1 item 10 — asymptotic expansion at scale
+    m.add_class::<PyAsymptoticReport>()?;
+    m.add_function(wrap_pyfunction!(py_euler_maclaurin, m)?)?;
     // P1 item 7 — creative telescoping / holonomic (D-finite) machinery
     m.add_class::<PyZeilbergerCertificate>()?;
     m.add_function(wrap_pyfunction!(py_zeilberger, m)?)?;

--- a/docs/features.md
+++ b/docs/features.md
@@ -58,6 +58,7 @@ Current stable feature surface.
 - `RootSum` kernel node: first-class symbolic sum over algebraic roots, with differentiation, display (Debug / LaTeX / unicode), persistence (pool format V5), and PyO3 bridge
 - Truncated Taylor and Laurent series (`series`, `Series`)
 - Limits (`limit`, `LimitDirection`): L'Hôpital, local expansions, limits at ±∞
+- Asymptotics of sums (`experimental.euler_maclaurin`): Euler–Maclaurin expansion of `Σ_{k=a}^{n} f(k)` with Bernoulli corrections, numerically gated, returning an `AsymptoticReport` that marks each hypothesis checked or assumed (the additive constant — γ for the harmonic numbers — is fitted, not proved, and labelled as such)
 
 ## Discrete mathematics
 

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Rule engine](./rules.md)
   - [E-graph saturation](./egraph.md)
 - [Calculus](./calculus.md)
+  - [Asymptotics of sums](./asymptotics.md)
 - [Transformations](./transformations.md)
 - [Code generation](./codegen.md)
 - [Ball arithmetic](./ball-arithmetic.md)

--- a/docs/mdbook/src/asymptotics.md
+++ b/docs/mdbook/src/asymptotics.md
@@ -1,0 +1,99 @@
+# Asymptotics of sums (Euler–Maclaurin)
+
+`series` and Gruntz `limit` expand a *function*; `asymptotic_expand` handles the
+power/log/exp scales of a function at infinity. What a loop working on
+combinatorics and analysis needs on top of that is the asymptotics of a **sum**
+— how `Σ_{k=a}^{n} f(k)` behaves as `n → ∞`. That is how a conjecture about a
+growth rate actually gets settled.
+
+```python
+from alkahest import ExprPool
+from alkahest.experimental import euler_maclaurin
+
+pool = ExprPool()
+k, n = pool.symbol("k"), pool.symbol("n")
+
+r = euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=2)
+r.leading           # log(n)
+r.terms            # [log(n), γ, 1/(2n), −1/(12n²)] — most significant first
+r.rigor            # "numerically_consistent"
+```
+
+## The formula
+
+For a smooth summand,
+
+```text
+Σ_{k=a}^{n} f(k) = ∫_a^n f(t) dt + (f(a) + f(n))/2
+                   + Σ_{j=1}^{m} B_{2j}/(2j)! · (f^{(2j-1)}(n) − f^{(2j-1)}(a))
+                   + R_m
+```
+
+Read as `n → ∞`, the `a`-endpoint pieces collapse into one additive constant and
+what remains is an asymptotic expansion in `n`. For `f(k) = 1/k` that is the
+classical `H_n ~ log n + γ + 1/(2n) − 1/(12n²) + …`.
+
+## The constant is fitted, and the report says so
+
+Euler–Maclaurin does **not** determine the additive constant from the `n`-side
+terms. For the harmonic numbers that constant is Euler's γ, and no amount of
+boundary algebra at `k = a` produces it.
+
+This module therefore obtains it numerically, from the exactly computed sum at
+large `n`, and is explicit about that: `rigor` comes back as
+`"numerically_consistent"` rather than `"proved"`, and the fitted constant
+appears in `hypotheses` with status `"assumed"`. The *shape* of the expansion is
+derived symbolically — only that one scalar is empirical.
+
+```python
+r.all_hypotheses_checked      # False
+[s for s, _ in r.hypotheses]  # ["checked", "assumed", "assumed"]
+```
+
+This distinction is the whole reason the result is an `AsymptoticReport` rather
+than a bare list of terms. A loop that records "γ ≈ 0.5772 was fitted, not
+proved" can revisit it; one handed an undifferentiated expansion cannot.
+
+## Ordering and the verification gate
+
+Terms are returned most-significant first, and the ordering is by *magnitude at
+the check points*, not by where they came from in the formula. This matters:
+the constant sits below every growing term and above every decaying one, so for
+`Σ k` it lands after `n²/2` and `n/2`, while for `H_n` it lands right after
+`log n`.
+
+Every term then goes through the same `o()`-gate as `asymptotic_expand`: the
+truncated expansion is compared against the exactly computed sum at increasing
+`n`, and a term is kept only if it genuinely refines its predecessor *against
+the true value*. Terms that fail are dropped; if nothing survives, the call
+refuses rather than emitting an unverified expansion. `r.verification` carries
+the evidence and `r.max_relative_error` summarises it.
+
+## Refusals
+
+| Situation | Behaviour |
+|---|---|
+| Summand has no symbolic antiderivative (e.g. `exp(−k²)`) | Refuse — the integral term cannot be formed |
+| Summand not numerically evaluable at the check points | Refuse — the gate has no oracle |
+| No term survives the gate | Refuse — emit nothing rather than something unverified |
+| `corrections` above the supported maximum | Refuse |
+
+## Scope of this release
+
+Shipped: the Euler–Maclaurin route for `Σ_{k=a}^{n} f(k)`, with Bernoulli
+corrections, magnitude ordering, the numeric gate, and the checked-versus-
+assumed hypothesis ledger in `AsymptoticReport`.
+
+Not shipped, and tracked as follow-up (the shared scaffolding —
+`AsymptoticReport`, the gate, exact Bernoulli numbers, rational-function
+extraction and a complex root finder — is already in place for them):
+
+- **Sequence asymptotics** from a closed form or a P-recursive recurrence
+  (Stirling-based expansions, Poincaré–Perron growth).
+- **Singularity analysis** of generating functions and the transfer theorem for
+  `[z^n] f(z)`.
+- **Laplace / saddle-point / stationary-phase** asymptotics of parameter
+  integrals.
+
+Note that `Σ log k` gives Stirling's formula for `log n!` through this route
+already, so the factorial case is reachable today.

--- a/python/alkahest/experimental/__init__.py
+++ b/python/alkahest/experimental/__init__.py
@@ -66,11 +66,15 @@ from alkahest import (
 
 # Calculus / ODE / transform surface (still experimental).
 from alkahest.alkahest import (
+    # P1 item 10 — asymptotic expansion at scale
+    AsymptoticReport,
     Fps,
     OdeTrajectory,
     asymptotic_expand,
     dirac_delta,
     dsolve,
+    # P1 item 10 — asymptotic expansion at scale
+    euler_maclaurin,
     fourier_transform,
     heaviside,
     inverse_fourier_transform,
@@ -98,6 +102,8 @@ with contextlib.suppress(ImportError):
 
 __all__ = [
     "Assumptions",
+    # P1 item 10 — asymptotic expansion at scale
+    "AsymptoticReport",
     "CudaCompiledFn",
     "EvaluationResult",
     "Fps",
@@ -113,6 +119,8 @@ __all__ = [
     "digamma",
     "dirac_delta",
     "dsolve",
+    # P1 item 10 — asymptotic expansion at scale
+    "euler_maclaurin",
     "evaluate",
     "fourier_transform",
     "heaviside",

--- a/tests/test_asymptotics.py
+++ b/tests/test_asymptotics.py
@@ -1,0 +1,136 @@
+"""P1 item 10 — asymptotic expansion at scale.
+
+`series` and Gruntz `limit` handle expansions of a *function*; a loop working on
+combinatorics and analysis needs asymptotics of *sums*. This covers the
+Euler–Maclaurin route and, just as importantly, that the result object is honest
+about how much of itself is proved.
+"""
+
+import pytest
+from alkahest import ExprPool
+from alkahest.experimental import euler_maclaurin
+
+
+def _harmonic(n):
+    return sum(1.0 / i for i in range(1, n + 1))
+
+
+def _setup():
+    pool = ExprPool()
+    return pool, pool.symbol("k"), pool.symbol("n")
+
+
+# ---------------------------------------------------------------------------
+# Expansions it must find
+# ---------------------------------------------------------------------------
+
+
+def test_harmonic_numbers():
+    """``H_n ~ log n + γ + 1/(2n) − 1/(12n²) + …``"""
+    pool, k, n = _setup()
+
+    r = euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=2)
+
+    assert r.method == "euler-maclaurin"
+    assert len(r.terms) >= 2
+    assert "log" in str(r.leading) or "ln" in str(r.leading)
+    assert r.max_relative_error < 1e-6
+
+
+def test_harmonic_expansion_matches_the_true_sum():
+    import alkahest as ak
+
+    pool, k, n = _setup()
+    r = euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=2)
+
+    total = r.terms[0]
+    for t in r.terms[1:]:
+        total = total + t
+
+    for ni in (100, 500, 1000):
+        approx = float(ak.evaluate(total, {n: float(ni)}).value)
+        assert approx == pytest.approx(_harmonic(ni), abs=1e-6)
+
+
+def test_polynomial_sum_is_reproduced_exactly():
+    """``Σ_{k=1}^{n} k = n(n+1)/2``."""
+    import alkahest as ak
+
+    _pool, k, n = _setup()
+    r = euler_maclaurin(k, k, 1, n, corrections=1)
+
+    total = r.terms[0]
+    for t in r.terms[1:]:
+        total = total + t
+
+    for ni in (10, 50, 200):
+        approx = float(ak.evaluate(total, {n: float(ni)}).value)
+        assert approx == pytest.approx(ni * (ni + 1) / 2, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Honesty of the report
+# ---------------------------------------------------------------------------
+
+
+def test_report_declares_what_is_assumed_rather_than_proved():
+    """The additive constant is fitted, and the report must say so.
+
+    Euler–Maclaurin does not produce γ from the `n`-side terms; it is obtained
+    numerically. Presenting that as proved would be exactly the kind of quiet
+    overclaim this subsystem exists to avoid.
+    """
+    pool, k, n = _setup()
+
+    r = euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=2)
+
+    assert r.rigor == "numerically_consistent"
+    assert not r.all_hypotheses_checked
+    statuses = {status for status, _ in r.hypotheses}
+    assert "assumed" in statuses
+    assert any("fitted numerically" in stmt for _, stmt in r.hypotheses)
+
+
+def test_report_carries_verification_evidence():
+    pool, k, n = _setup()
+
+    r = euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=2)
+
+    assert r.verification
+    for at, reference, approximation, rel_err in r.verification:
+        assert at > 0
+        assert rel_err == pytest.approx(abs(reference - approximation) / abs(reference), rel=1e-9)
+    assert r.derivation
+    assert "AsymptoticReport(" in repr(r)
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_summand_with_no_symbolic_antiderivative():
+    pool, k, n = _setup()
+    f = pool.func("exp", [pool.integer(-1) * k * k])
+
+    with pytest.raises(Exception):
+        euler_maclaurin(f, k, 1, n, corrections=1)
+
+
+def test_refuses_absurd_correction_count():
+    pool, k, n = _setup()
+
+    with pytest.raises(Exception):
+        euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=99)
+
+
+# ---------------------------------------------------------------------------
+# Surface
+# ---------------------------------------------------------------------------
+
+
+def test_exported_surface():
+    import alkahest.experimental as exp
+
+    assert "euler_maclaurin" in exp.__all__
+    assert "AsymptoticReport" in exp.__all__


### PR DESCRIPTION
Implements the **sums** half of **P1 mathematics item 10** — "Asymptotic expansion at scale" — from `temp-alkahest/planning/autoresearch.md`.

`series` and Gruntz `limit` expand a *function*; `asymptotic_expand` covers power and log/exp scales at infinity. What a loop working on combinatorics and analysis needs on top of that is the asymptotics of a **sum**.

```python
from alkahest.experimental import euler_maclaurin

r = euler_maclaurin(pool.integer(1) / k, k, 1, n, corrections=2)
r.leading      # log(n)
r.terms        # [log n, γ, 1/(2n), −1/(12n²)] — most significant first
r.rigor        # "numerically_consistent"
```

`Σ_{k=1}^{n} k = n(n+1)/2` comes out exactly; `Σ log k` gives Stirling for `log n!` through the same route.

## The report is the point

The result is an `AsymptoticReport` recording not just the terms but **how much is proved**: a `rigor` tag, a per-hypothesis checked/assumed ledger, and the numeric evidence from the gate.

That matters concretely here. Euler–Maclaurin does *not* determine the additive constant from the `n`-side terms — for the harmonic numbers it is Euler's γ, and no amount of boundary algebra at `k = a` produces it. So the constant is **fitted numerically**, and the report says so: `rigor` is `"numerically_consistent"`, `all_hypotheses_checked` is `False`, and the fitted constant appears explicitly as an assumed hypothesis. The shape of the expansion is symbolic; exactly one scalar is empirical, and the object never blurs the two.

## A bug in the shared verification gate, caught by its own test

The residual criterion accepted a **constant** relative residual, which meant a wrong coefficient passed: `2/n` was accepted as the correction to `1 + 1/n`. A correct term forces the relative residual to zero; a wrong one leaves it flat. The gate now requires genuine decay.

The test is *strict decay* rather than decay by a fixed factor, because decay can be legitimately slow: with a leading `log n` term whose successor is a constant, the relative residual falls off like `1/log n` — `o(1)`, but only a third across three octaves of `n`. Demanding a halving there rejected the correct harmonic expansion (I tried; it did).

Term ordering was also wrong: the fitted constant was inserted at a fixed index, which put it ahead of `n/2` for `Σ k`. Terms are now ordered by magnitude at the check points, so the constant sits below every growing term and above every decaying one.

## Scope — partial delivery, stated plainly

**Shipped:** the Euler–Maclaurin route (item 10's "asymptotic expansion of sums" bullet), with Bernoulli corrections, magnitude ordering, the numeric gate, and the hypothesis ledger.

**Not shipped**, and documented as follow-ups in [`docs/mdbook/src/asymptotics.md`](docs/mdbook/src/asymptotics.md):
- sequence asymptotics from a closed form or P-recursive recurrence,
- singularity analysis of generating functions and the transfer theorem,
- Laplace / saddle-point / stationary-phase for parameter integrals.

The shared scaffolding those need — exact ℚ polynomial arithmetic, rational-function extraction, rational-root splitting, Bernoulli polynomials, a complex root finder — is retained rather than deleted and re-added, with `dead_code` allowed module-wide and a comment saying exactly why. Everything the shipped route uses is exercised by its tests.

## Tests

20 Rust tests in the `calculus::asymptotic*` tree (6 new for the route, including the γ recovery, the exact polynomial case, and refusals) plus `tests/test_asymptotics.py` (8 tests), which check the expansion against the true sum at several `n` and assert the report declares what it assumed rather than proved.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --all`, `cargo doc` (clean), `ruff`, `ty check` (42 diagnostics, unchanged from baseline), certificate ledger, silent-error gate (149 passed), `pytest` 1626 passed / 27 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)