### PR TITLE
fix(interp): make Zippel oracle cost polynomial instead of multiplicative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Sparse interpolation: Zippel oracle cost is now polynomial, not
+  multiplicative.** `sparse_interp` was formulated recursively — interpolate the
+  coefficients of `x₁` as polynomials in the remaining variables, recursively —
+  which makes each level's oracle a batched Vandermonde lift calling the level
+  below `t` times, so black-box evaluations grew as the **product** `∏ tᵢ` down
+  the recursion instead of the sum. Measured on the V2-3 roadmap corpus:
+  70 calls at 2 variables, 1,771 at 3, 139,552 at 4, 15,019,900 at 5 (75 s) —
+  a factor of 25 → 79 → 108 per added variable, extrapolating to ~1e17 at ten,
+  i.e. it never returned. Replaced with Zippel's actual iterative algorithm,
+  which introduces one variable at a time and recovers the coefficients of the
+  *known* skeleton from a transposed Vandermonde system: `O(n·d·T)` calls.
+  The same corpus now takes **34 / 62 / 97 / 139 calls at 2–5 variables and
+  601 for the 10-variable, 15-term roadmap case**, which completes in
+  milliseconds. That acceptance criterion (≥ 95% success over 20 seeds) passes
+  for the first time and its test is un-skipped; a new Rust test asserts the
+  oracle *call count* grows linearly in the variable count, since a functional
+  test alone cannot tell a correct implementation from one that never finishes.
+  `sparse_interp` additionally verifies each candidate against the black box at
+  random points and re-draws its anchors on mismatch, so an unlucky anchor
+  (Zippel's skeleton hypothesis is probabilistic) now produces a refusal rather
+  than a confidently wrong polynomial.
+
 ### Added
 
 - **Asymptotics of sums — Euler–Maclaurin** (P1 mathematics item 10):

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@
 | **1.0.0** | ✅ Complete | Production NVPTX, MLIR dialect, Gröbner solver, semver API, persistent pool (see [CHANGELOG](CHANGELOG.md#100)) |
 | **2.0.0** | ✅ Complete | Full mathematical coverage: summation, series, limits, eigenvalues, number theory, noncommutative algebra, regular chains, primary decomposition, differential algebra, homotopy continuation, Diophantine equations, symbolic products, rsolve, algebraic Risch, LaTeX/Unicode output, string parsing (see [CHANGELOG](CHANGELOG.md#200--2026-05-06)) |
 | **2.0.3** | ✅ Complete | Full Gruntz MRV limits, polyhedral BKK homotopy, Lean Filter.Tendsto certificates, F5 Gröbner, demo playground Lean panel (see [CHANGELOG](CHANGELOG.md#203--2026-05-21)) |
-| **2.0.4** | ✅ Complete | Sparse multivariate interpolation (Ben-Or/Tiwari, Zippel) + sparse modular GCD substrate (see [CHANGELOG](CHANGELOG.md#204--2026-05-22)) |
+| **2.0.4** | ✅ Complete | Sparse multivariate interpolation (Ben-Or/Tiwari, Zippel) + sparse modular GCD substrate (see [CHANGELOG](CHANGELOG.md#204--2026-05-22)). Acceptance criterion (10-variable, 15-term, ≥ 95% success) met once the Zippel lift became iterative — `O(n·d·T)` oracle calls, ~600 for that case. |
 | **Next** | 🚧 In progress | CAD, generalized Pell, full algebraic Risch — see below |
 
 **Test coverage:** ~607 Rust unit/proptest/doctest + 1028 Python tests, zero errors.
@@ -24,21 +24,6 @@ Items in rough priority order. None are committed to a specific release date.
 - **Generalized Pell and higher-degree Diophantine** — `x² - D·y² = N` for arbitrary N; quadratics with cross-term
 - **Higher-degree algebraic Risch** — multiple generators; cbrt and nth-root extensions; full Trager algorithm
 - **Transcendental Risch (Phase 2)** — ✅ **Implemented** (issue #4): polynomial RDE solver, hyperexponential and hyperlogarithmic tower cases, NonElementary certification; remaining gaps: multiple generators, mixed exp+log towers, rational coefficients in RDE (exp(x)/x), full Liouville structure theorem
-
-### Mathematical coverage (regressions / known gaps)
-- **Sparse interpolation: make Zippel oracle cost polynomial, not multiplicative.** The
-  V2-3 acceptance criterion (10-variable, 15-term recovery at ≥ 95% success) is currently
-  **unreachable**. `zippel_helper` / `zippel_helper_multi` recurse so that each level's
-  "oracle" is itself a batched lift calling the level below `t` times, so total oracle
-  calls grow as `∏ tᵢ` down the recursion instead of `Σ`. Measured on the roadmap
-  corpus: 2 vars → 70 calls, 3 → 1,771, 4 → 139,552, 5 → 15,019,900 (75 s); a growth
-  factor of 25 → 79 → 108 per added variable, extrapolating to ~1e17 calls at 10
-  variables. Textbook Zippel is `O(n·t·d)`: each new variable should cost `(d+1)·t`
-  *additional* evaluations by solving for the coefficients of the already-known skeleton
-  via a transposed Vandermonde system, rather than re-deriving them recursively. Until
-  that lands, `tests/test_sparse_interp.py::test_roadmap_10var_15term` is skipped (it
-  consumed the entire 6 h Tier 1b nightly cap and reported nothing) and
-  `test_multivariate_stress_4var` is the regression guard.
 
 ### Infrastructure
 - **Complete Lean certificate coverage** — bring Lean 4 export (rewrite-tagged proof traces and algorithmic witnesses) up to parity with every supported proof-producing operation; track gaps and add regression checks so new algorithms and rules do not land without matching certificate paths or Mathlib theorem hooks.

--- a/alkahest-core/src/poly/interp.rs
+++ b/alkahest-core/src/poly/interp.rs
@@ -837,246 +837,40 @@ fn dense_interpolate(vals: &[u64], prime: u64) -> Vec<(u64, u32)> {
 // Multivariate Zippel (recursive)
 // ---------------------------------------------------------------------------
 
-/// One Vandermonde lift applied coherently across `dim` sibling components.
-fn lifted_eval_union(
-    x_pts: &[u64],
-    joint_exps: &[u32],
-    eval_multi: &dyn Fn(&[u64]) -> Vec<u64>,
-    prime: u64,
-    dim: usize,
-    m_count: usize,
-    x_suffix: &[u64],
-) -> Vec<u64> {
-    let mut new_vec = Vec::with_capacity(dim * m_count);
-    for j in 0..dim {
-        let f_vals: Vec<u64> = x_pts
-            .iter()
-            .map(|&xk| {
-                let mut args = vec![xk];
-                args.extend_from_slice(x_suffix);
-                eval_multi(&args).get(j).copied().unwrap_or(0)
-            })
-            .collect();
-        let coeffs = vandermonde_solve(x_pts, joint_exps, &f_vals, prime)
-            .unwrap_or_else(|| vec![0u64; m_count]);
-        debug_assert_eq!(coeffs.len(), m_count);
-        new_vec.extend(coeffs);
-    }
-    new_vec
-}
-
 /// Batched lifting: recover `dim` sibling coefficient polynomials simultaneously.
 /// Each map entry is `sparse exponents → coeff` in the remaining variables only.
 #[allow(clippy::too_many_arguments)] // recursion driver: shared oracle plus dimension bounds
-fn zippel_helper_multi(
-    eval_multi: &dyn Fn(&[u64]) -> Vec<u64>,
-    n_vars: usize,
-    dim: usize,
-    term_bound: usize,
-    degree_bound: u32,
-    prime: u64,
-    g: u64,
-    rng: &mut Xorshift64,
-) -> Result<Vec<BTreeMap<Vec<u32>, u64>>, SparseInterpError> {
-    if dim == 0 {
-        return Ok(vec![]);
-    }
-
-    if n_vars == 0 {
-        let v = eval_multi(&[]);
-        let mut out = Vec::with_capacity(dim);
-        for j in 0..dim {
-            let mut m = BTreeMap::new();
-            let c = *v.get(j).unwrap_or(&0);
-            if c != 0 {
-                m.insert(vec![], c);
-            }
-            out.push(m);
-        }
-        return Ok(out);
-    }
-
-    if n_vars == 1 {
-        let mut out = Vec::with_capacity(dim);
-        for j in 0..dim {
-            let terms = if degree_bound <= term_bound as u32 {
-                let d = degree_bound as usize + 1;
-                let vals: Vec<u64> = (1..=d as u64)
-                    .map(|x| eval_multi(&[x % prime]).get(j).copied().unwrap_or(0))
-                    .collect();
-                dense_interpolate(&vals, prime)
-            } else {
-                bt_univariate(
-                    &|t| eval_multi(&[t]).get(j).copied().unwrap_or(0),
-                    term_bound,
-                    prime,
-                    g,
-                    rng,
-                )?
-            };
-            let mut m = BTreeMap::new();
-            for (c, e) in terms {
-                if c != 0 {
-                    m.insert(vec![e], c);
-                }
-            }
-            out.push(m);
-        }
-        return Ok(out);
-    }
-
-    let a_rest: Vec<u64> = (0..n_vars - 1).map(|_| rng.nonzero(prime)).collect();
-
-    let mut per_comp_skeletons: Vec<Vec<(u64, u32)>> = Vec::with_capacity(dim);
-    for j in 0..dim {
-        let sk = {
-            let f1 = |t: u64| -> u64 {
-                let mut args = vec![t];
-                args.extend_from_slice(&a_rest);
-                eval_multi(&args).get(j).copied().unwrap_or(0)
-            };
-            if degree_bound <= term_bound as u32 {
-                let d = degree_bound as usize + 1;
-                let v: Vec<u64> = (1..=d as u64).map(|x| f1(x % prime)).collect();
-                dense_interpolate(&v, prime)
-            } else {
-                bt_univariate(&f1, term_bound, prime, g, rng)?
-            }
-        };
-        per_comp_skeletons.push(sk);
-    }
-
-    let mut joint_exps: Vec<u32> = Vec::new();
-    for sk in &per_comp_skeletons {
-        for &(_, e) in sk {
-            joint_exps.push(e);
-        }
-    }
-    joint_exps.sort_unstable();
-    joint_exps.dedup();
-    let m_count = joint_exps.len();
-
-    let empty_maps = || (0..dim).map(|_| BTreeMap::new()).collect::<Vec<_>>();
-
-    if m_count == 0 {
-        return Ok(empty_maps());
-    }
-
-    // Fully batched recursion uses vector dimension `dim · |joint|`; union can be
-    // large across many siblings (`dim ≈ term_bound`).  Above this budget fall back to
-    // the classic nested `zippel_helper` lifts — oracle depth improves over the legacy
-    // implementation (shared lift at outer peel) while keeping tests bounded.
-    // Allow large batched lifts for realistic `term_bound` (~20–50); tighter caps
-    // force the scalar fallback whose constant factor dominates on large `n_vars`.
-    let vec_budget = term_bound.saturating_mul(512).clamp(8192usize, 131072usize);
-    if dim.saturating_mul(m_count) > vec_budget {
-        let mut stacked: Vec<BTreeMap<Vec<u32>, u64>> = Vec::with_capacity(dim);
-        for (j, sk) in per_comp_skeletons.iter().enumerate().take(dim) {
-            if sk.is_empty() {
-                stacked.push(BTreeMap::new());
-                continue;
-            }
-            let exps_j: Vec<u32> = sk.iter().map(|(_, e)| *e).collect();
-            let tj = exps_j.len();
-            let mut pts: Vec<u64> = Vec::with_capacity(tj);
-            {
-                let mut used = std::collections::HashSet::new();
-                while pts.len() < tj {
-                    let v = rng.nonzero(prime);
-                    if used.insert(v) {
-                        pts.push(v);
-                    }
-                }
-            }
-            let mut comp_map = BTreeMap::new();
-            for k in 0..tj {
-                let e_cur = exps_j[k];
-                let sub_terms = zippel_helper(
-                    &|x_rest: &[u64]| -> u64 {
-                        let f_vals: Vec<u64> = pts
-                            .iter()
-                            .map(|&xk| {
-                                let mut args = vec![xk];
-                                args.extend_from_slice(x_rest);
-                                eval_multi(&args).get(j).copied().unwrap_or(0)
-                            })
-                            .collect();
-                        vandermonde_solve(&pts, &exps_j, &f_vals, prime)
-                            .map(|v| v[k])
-                            .unwrap_or(0)
-                    },
-                    n_vars - 1,
-                    term_bound,
-                    degree_bound,
-                    prime,
-                    g,
-                    rng,
-                )?;
-                for (mut sub_exp, coeff) in sub_terms {
-                    if coeff != 0 {
-                        let mut full = vec![e_cur];
-                        full.append(&mut sub_exp);
-                        comp_map.insert(full, coeff);
-                    }
-                }
-            }
-            stacked.push(comp_map);
-        }
-        return Ok(stacked);
-    }
-
-    let mut x_pts: Vec<u64> = Vec::with_capacity(m_count);
-    {
-        let mut used = std::collections::HashSet::new();
-        while x_pts.len() < m_count {
-            let v = rng.nonzero(prime);
-            if used.insert(v) {
-                x_pts.push(v);
-            }
-        }
-    }
-
-    let dim_next = dim * m_count;
-    let sub = zippel_helper_multi(
-        &|x_suffix: &[u64]| {
-            lifted_eval_union(
-                &x_pts,
-                &joint_exps,
-                eval_multi,
-                prime,
-                dim,
-                m_count,
-                x_suffix,
-            )
-        },
-        n_vars - 1,
-        dim_next,
-        term_bound,
-        degree_bound,
-        prime,
-        g,
-        rng,
-    )?;
-
-    let mut result: Vec<BTreeMap<Vec<u32>, u64>> = empty_maps();
-    for (j, res_j) in result.iter_mut().enumerate().take(dim) {
-        for (r, &e1) in joint_exps.iter().enumerate().take(m_count) {
-            let slot = j * m_count + r;
-            for (sub_exp, coeff) in &sub[slot] {
-                if *coeff != 0 {
-                    let mut full_exp = vec![e1];
-                    full_exp.extend_from_slice(sub_exp);
-                    res_j.insert(full_exp, *coeff);
-                }
-            }
-        }
-    }
-
-    Ok(result)
-}
-
-/// Recursive Zippel helper.  Returns a map from exponent vectors to
-/// coefficients in `F_p`.
+/// Zippel's sparse interpolation, variable by variable.
+///
+/// # Why this shape
+///
+/// The obvious recursive formulation — "interpolate the coefficients of `x₁`
+/// as polynomials in the remaining variables, recursively" — makes each level's
+/// oracle a *batched lift* that calls the level below `t` times, so the total
+/// number of black-box evaluations grows as the **product** `∏ tᵢ` down the
+/// recursion rather than the sum. Measured on the 10-variable roadmap corpus
+/// that reached 15 million calls at 5 variables and extrapolated to ~1e17 at
+/// ten, i.e. it never terminates.
+///
+/// Zippel's actual algorithm is *iterative* and costs `O(n · d · T)`. It keeps
+/// one interpolant and introduces one variable at a time:
+///
+/// 1. Interpolate `f(x₁, a₂, …, aₙ)` densely in `x₁` at the anchor point.
+///    That fixes the initial skeleton — the set of monomials.
+/// 2. To introduce `x_j`, *assume the skeleton in `x₁…x_{j-1}` is unchanged*
+///    (Zippel's probabilistic hypothesis) and write
+///    `f(x₁…x_j, a_{j+1}…aₙ) = Σᵢ Cᵢ(x_j) · Mᵢ(x₁…x_{j-1})`.
+///    For each of `d+1` values of `x_j`, recover the `S` unknown scalars
+///    `Cᵢ(b_k)` from `S` oracle evaluations by solving one linear system;
+///    then interpolate each `Cᵢ` from its `d+1` values.
+///
+/// Step 2 costs `(d+1)·S` evaluations per variable — *added*, not multiplied.
+/// For the roadmap case (`n=10`, `d=6`, `T=20`) that is ~1400 calls total.
+///
+/// The evaluation points for the already-introduced variables are chosen as
+/// `(s₁^l, …, s_{j-1}^l)` for `l = 1…S`, so the system matrix is a transposed
+/// Vandermonde in the nodes `vᵢ = Mᵢ(s)` and is non-singular exactly when those
+/// nodes are distinct — which is checked, and re-drawn when it fails.
 fn zippel_helper(
     eval: &dyn Fn(&[u64]) -> u64,
     n_vars: usize,
@@ -1096,33 +890,15 @@ fn zippel_helper(
         return Ok(m);
     }
 
-    // --- Base case: univariate ---
-    if n_vars == 1 {
-        // Use dense fallback if degree_bound is small (avoids BSGS overhead).
-        let terms = if degree_bound <= term_bound as u32 {
-            // Dense path: evaluate at degree_bound+1 points.
-            let d = degree_bound as usize + 1;
-            let v: Vec<u64> = (1..=d as u64).map(|x| eval(&[x % prime])).collect();
-            dense_interpolate(&v, prime)
-        } else {
-            bt_univariate(&|t| eval(&[t]), term_bound, prime, g, rng)?
-        };
-        let mut m = BTreeMap::new();
-        for (c, e) in terms {
-            m.insert(vec![e], c);
-        }
-        return Ok(m);
-    }
+    // Anchor values for the variables not yet introduced.
+    let anchors: Vec<u64> = (0..n_vars).map(|_| rng.nonzero(prime)).collect();
 
-    // --- Multivariate Zippel ---
-
-    // Step 1: Evaluate f(x₁, a₂, …, aₙ) for random aᵢ to get x₁-skeleton.
-    let a_rest: Vec<u64> = (0..n_vars - 1).map(|_| rng.nonzero(prime)).collect();
-
-    let skeleton: Vec<(u64, u32)> = {
+    // --- Stage 1: univariate image in x₁ at the anchor point ---
+    let stage1 = {
         let f1 = |t: u64| -> u64 {
-            let mut args = vec![t];
-            args.extend_from_slice(&a_rest);
+            let mut args = Vec::with_capacity(n_vars);
+            args.push(t);
+            args.extend_from_slice(&anchors[1..]);
             eval(&args)
         };
         if degree_bound <= term_bound as u32 {
@@ -1134,60 +910,157 @@ fn zippel_helper(
         }
     };
 
-    if skeleton.is_empty() {
-        return Ok(BTreeMap::new());
+    let mut current: BTreeMap<Vec<u32>, u64> = BTreeMap::new();
+    for (c, e) in stage1 {
+        if c != 0 {
+            current.insert(vec![e], c);
+        }
+    }
+    if n_vars == 1 {
+        return Ok(current);
     }
 
-    let x1_exps: Vec<u32> = skeleton.iter().map(|(_, e)| *e).collect();
-    let t = x1_exps.len();
+    // --- Stages 2..n: introduce one variable at a time ---
+    let d_pts = degree_bound as usize + 1;
+    for j in 1..n_vars {
+        if current.is_empty() {
+            // The image vanished identically at the anchor; nothing to lift.
+            return Ok(BTreeMap::new());
+        }
+        let monomials: Vec<Vec<u32>> = current.keys().cloned().collect();
+        let s_count = monomials.len();
+        if s_count > term_bound {
+            // More monomials than the caller promised: the bound is wrong, and
+            // continuing would silently interpolate the wrong object.
+            return Err(SparseInterpError::SingularSystem);
+        }
 
-    // Step 2: Choose t distinct evaluation points for x₁.
-    let mut x1_pts: Vec<u64> = Vec::with_capacity(t);
-    {
-        let mut used = std::collections::HashSet::new();
-        while x1_pts.len() < t {
-            let v = rng.nonzero(prime);
-            if used.insert(v) {
-                x1_pts.push(v);
+        // Pick s so the Vandermonde nodes vᵢ = Mᵢ(s) are pairwise distinct.
+        let mut nodes: Vec<u64> = Vec::new();
+        let mut s_vals: Vec<u64> = Vec::new();
+        let mut ok = false;
+        for _ in 0..NODE_DRAW_ATTEMPTS {
+            s_vals = (0..j).map(|_| rng.nonzero(prime)).collect();
+            nodes = monomials
+                .iter()
+                .map(|m| {
+                    let mut acc = 1u64;
+                    for (t, &e) in m.iter().enumerate() {
+                        if e > 0 {
+                            acc = mul_mod(acc, pow_mod(s_vals[t], e as u64, prime), prime);
+                        }
+                    }
+                    acc
+                })
+                .collect();
+            let mut seen = std::collections::HashSet::with_capacity(s_count);
+            if nodes.iter().all(|&v| v != 0 && seen.insert(v)) {
+                ok = true;
+                break;
             }
         }
-    }
-
-    // Step 3: batched Vandermonde lift → single recursion (shared oracle).
-    let eval_multi = |x_rest: &[u64]| -> Vec<u64> {
-        let mut f_vals: Vec<u64> = Vec::with_capacity(t);
-        for &xk in &x1_pts {
-            let mut args = vec![xk];
-            args.extend_from_slice(x_rest);
-            f_vals.push(eval(&args));
+        if !ok {
+            return Err(SparseInterpError::SingularSystem);
         }
-        vandermonde_solve(&x1_pts, &x1_exps, &f_vals, prime).unwrap_or_else(|| vec![0u64; t])
-    };
 
-    let sub_maps = zippel_helper_multi(
-        &eval_multi,
-        n_vars - 1,
-        t,
-        term_bound,
-        degree_bound,
-        prime,
-        g,
-        rng,
-    )?;
+        // The system matrix A[l][i] = vᵢ^(l+1) is shared by every x_j point.
+        let matrix: Vec<Vec<u64>> = (1..=s_count)
+            .map(|l| {
+                nodes
+                    .iter()
+                    .map(|&v| pow_mod(v, l as u64, prime))
+                    .collect::<Vec<u64>>()
+            })
+            .collect();
 
-    let mut result: BTreeMap<Vec<u32>, u64> = BTreeMap::new();
-    for j in 0..t {
-        let e1 = x1_exps[j];
-        for (sub_exp, coeff) in &sub_maps[j] {
-            if *coeff != 0 {
-                let mut full_exp = vec![e1];
-                full_exp.extend_from_slice(sub_exp);
-                result.insert(full_exp, *coeff);
+        // Powers of s reused across the (d+1) right-hand sides.
+        let s_powers: Vec<Vec<u64>> = (1..=s_count)
+            .map(|l| {
+                s_vals
+                    .iter()
+                    .map(|&sv| pow_mod(sv, l as u64, prime))
+                    .collect::<Vec<u64>>()
+            })
+            .collect();
+
+        // For each x_j = b_k, recover the S scalars Cᵢ(b_k).
+        let mut coeff_vals: Vec<Vec<u64>> = vec![Vec::with_capacity(d_pts); s_count];
+        for k in 0..d_pts {
+            let b_k = ((k + 1) as u64) % prime;
+            let mut rhs: Vec<u64> = Vec::with_capacity(s_count);
+            for row in s_powers.iter() {
+                let mut args = Vec::with_capacity(n_vars);
+                args.extend_from_slice(row);
+                args.push(b_k);
+                args.extend_from_slice(&anchors[j + 1..]);
+                rhs.push(eval(&args));
+            }
+            let mut mat = matrix.clone();
+            let solved = gaussian_elim(&mut mat, &mut rhs, prime)
+                .ok_or(SparseInterpError::SingularSystem)?;
+            for (i, c) in solved.into_iter().enumerate() {
+                coeff_vals[i].push(c);
             }
         }
+
+        // Interpolate each Cᵢ over the points 1…d+1 and extend the skeleton.
+        let mut next: BTreeMap<Vec<u32>, u64> = BTreeMap::new();
+        for (i, vals) in coeff_vals.iter().enumerate() {
+            for (c, e) in dense_interpolate(vals, prime) {
+                if c != 0 {
+                    let mut exp = monomials[i].clone();
+                    exp.push(e);
+                    next.insert(exp, c);
+                }
+            }
+        }
+        // Monomials whose coefficient polynomial vanished identically drop out;
+        // pad the survivors so every exponent vector has the same length.
+        current = next
+            .into_iter()
+            .map(|(mut exp, c)| {
+                exp.resize(j + 1, 0);
+                (exp, c)
+            })
+            .collect();
     }
 
-    Ok(result)
+    Ok(current)
+}
+
+/// How many times to re-draw `s` looking for distinct Vandermonde nodes.
+const NODE_DRAW_ATTEMPTS: usize = 16;
+
+/// Independent check that a recovered polynomial reproduces the oracle.
+///
+/// Zippel's skeleton hypothesis is probabilistic: an unlucky anchor can drop a
+/// monomial, and the result would then be confidently wrong. Spot-checking
+/// against the black box at random points turns that into a refusal.
+fn verify_against_oracle(
+    terms: &BTreeMap<Vec<u32>, u64>,
+    eval: &dyn Fn(&[u64]) -> u64,
+    n_vars: usize,
+    prime: u64,
+    rng: &mut Xorshift64,
+    checks: usize,
+) -> bool {
+    for _ in 0..checks {
+        let pt: Vec<u64> = (0..n_vars).map(|_| rng.nonzero(prime)).collect();
+        let mut acc = 0u64;
+        for (exp, &c) in terms {
+            let mut term = c % prime;
+            for (i, &e) in exp.iter().enumerate() {
+                if e > 0 {
+                    term = mul_mod(term, pow_mod(pt[i], e as u64, prime), prime);
+                }
+            }
+            acc = add_mod(acc, term, prime);
+        }
+        if acc != eval(&pt) % prime {
+            return false;
+        }
+    }
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -1288,12 +1161,44 @@ pub fn sparse_interpolate(
     let g = primitive_root(prime);
     let mut rng = Xorshift64::new(seed);
 
-    let terms = zippel_helper(eval, n_vars, term_bound, degree_bound, prime, g, &mut rng)?;
+    // Zippel's skeleton hypothesis is probabilistic: an unlucky anchor can make
+    // a monomial's image vanish, and the run would then return a polynomial
+    // that is confidently wrong. Verify each candidate against the black box
+    // and re-draw on mismatch; refuse if every attempt fails, rather than
+    // handing back an unverified answer.
+    let mut last_err = SparseInterpError::SingularSystem;
+    for _ in 0..ANCHOR_ATTEMPTS {
+        match zippel_helper(eval, n_vars, term_bound, degree_bound, prime, g, &mut rng) {
+            Ok(candidate) => {
+                if verify_against_oracle(
+                    &candidate,
+                    eval,
+                    n_vars,
+                    prime,
+                    &mut rng,
+                    ORACLE_VERIFY_POINTS,
+                ) {
+                    return Ok(finish_terms(candidate, vars, prime));
+                }
+                last_err = SparseInterpError::SingularSystem;
+            }
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
+}
 
+/// How many independent anchor draws to try before refusing.
+const ANCHOR_ATTEMPTS: usize = 6;
+
+/// Random points used to check a candidate against the oracle.
+const ORACLE_VERIFY_POINTS: usize = 6;
+
+/// Trim trailing zero exponents and drop zero coefficients.
+fn finish_terms(terms: BTreeMap<Vec<u32>, u64>, vars: Vec<ExprId>, prime: u64) -> MultiPolyFp {
     let trimmed_terms: BTreeMap<Vec<u32>, u64> = terms
         .into_iter()
         .map(|(mut exp, c)| {
-            // Trim trailing zeros in exponent vector.
             while exp.last() == Some(&0) {
                 exp.pop();
             }
@@ -1302,11 +1207,11 @@ pub fn sparse_interpolate(
         .filter(|(_, c)| *c != 0)
         .collect();
 
-    Ok(MultiPolyFp {
+    MultiPolyFp {
         vars,
         modulus: prime,
         terms: trimmed_terms,
-    })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1861,6 +1766,67 @@ mod tests {
         assert_eq!(*result.terms.get(&vec![2, 1]).unwrap_or(&0), 1, "x^2*y");
         assert_eq!(*result.terms.get(&vec![0, 1]).unwrap_or(&0), 5, "5*y");
         assert_eq!(*result.terms.get(&vec![1]).unwrap_or(&0), 2, "2*x");
+    }
+
+    /// The property that matters, and the one that silently regressed before:
+    /// oracle cost must grow **linearly** in the number of variables, not
+    /// multiplicatively down a recursion.
+    ///
+    /// The previous recursive lift needed 70 / 1,771 / 139,552 / 15,019,900
+    /// calls at 2 / 3 / 4 / 5 variables — a factor of ~100 per added variable,
+    /// extrapolating to ~1e17 at ten, i.e. it never returned. Zippel's actual
+    /// cost is `O(n · d · T)`. Without a test on the *call count* a rewrite of
+    /// this file could reintroduce the blow-up and every functional test would
+    /// still pass, just never finish.
+    #[test]
+    fn oracle_cost_is_linear_in_variable_count() {
+        use std::cell::Cell;
+
+        let p = 32749u64;
+        let mut counts = Vec::new();
+        for n in [3usize, 6, 9] {
+            let (_, vs) = vars(n);
+            let calls = Cell::new(0usize);
+            let eval = |pt: &[u64]| {
+                calls.set(calls.get() + 1);
+                // f = Σ_i (i+1)·x_i^2  +  x_0·x_1
+                let mut acc = 0u64;
+                for (i, &v) in pt.iter().enumerate() {
+                    let t = mul_mod((i as u64) + 1, pow_mod(v, 2, p), p);
+                    acc = add_mod(acc, t, p);
+                }
+                add_mod(acc, mul_mod(pt[0], pt[1], p), p)
+            };
+            let result = sparse_interpolate(&eval, vs, 20, 4, p, 7).unwrap();
+            // Sanity: the recovered polynomial is the right one. Exponent keys
+            // have trailing zeros trimmed, so x_0^2 is stored as `[2]`.
+            assert_eq!(
+                *result.terms.get(&vec![2u32]).unwrap_or(&0),
+                1,
+                "x_0^2 at n = {n}"
+            );
+            let mut last_sq = vec![0u32; n];
+            last_sq[n - 1] = 2;
+            assert_eq!(
+                *result.terms.get(&last_sq).unwrap_or(&0),
+                n as u64,
+                "x_{} ^2 at n = {n}",
+                n - 1
+            );
+            counts.push(calls.get());
+        }
+
+        // Linear growth: going 3 → 9 variables (3×) must not cost more than an
+        // order of magnitude. The old code multiplied by ~1e5 over that range.
+        let (c3, c9) = (counts[0], counts[2]);
+        assert!(
+            c9 <= c3 * 10,
+            "oracle calls grew super-linearly: {counts:?} for 3/6/9 variables"
+        );
+        assert!(
+            c9 < 20_000,
+            "oracle calls unexpectedly large: {counts:?} for 3/6/9 variables"
+        );
     }
 
     #[test]

--- a/tests/test_sparse_interp.py
+++ b/tests/test_sparse_interp.py
@@ -252,22 +252,11 @@ class TestMultivariate:
             assert got_c == ref, f"extra term at exp {exp}: got {got_c}, expected {ref}"
 
     @pytest.mark.slow
-    @pytest.mark.skip(
-        reason="ROADMAP target unreachable with the current Zippel recursion: oracle "
-        "calls multiply per variable instead of summing, so this never terminates. "
-        "Measured on this corpus: 2 vars 70 calls, 3 vars 1,771, 4 vars 139,552, "
-        "5 vars 15,019,900 (75 s) -- a growth factor of 25 -> 79 -> 108 per added "
-        "variable, extrapolating to ~1e17 calls at 10 vars. It previously consumed "
-        "the entire 6 h Tier 1b job cap every night and reported nothing. See "
-        "test_multivariate_stress_4var below for the feasible regression guard, and "
-        "ROADMAP.md for the algorithmic fix this needs."
-    )
     def test_roadmap_10var_15term(self):
         """ROADMAP: 10-variable 15-term polynomial, ≥ 95% success over trials.
 
-        Skipped: see the marker. Kept in the suite (rather than deleted) so the
-        roadmap acceptance criterion stays visible and re-enabling it is the
-        natural way to verify a fix to the interpolation recursion.
+        Reachable since the interpolation became iterative: ~600 oracle calls
+        per seed instead of the ~1e17 the old recursive lift required.
         """
         p = 32749
         terms = [


### PR DESCRIPTION
Follow-up to #287, which documented this defect and skipped the test it made unrunnable. This fixes the algorithm and re-enables the test.

## The defect

`sparse_interp` was formulated **recursively**: interpolate the coefficients of `x₁` as polynomials in the remaining variables, recursively. That makes each level's "oracle" a batched Vandermonde lift which calls the level below `t` times, so black-box evaluations grow as the **product** of the per-level term counts rather than the sum.

## The fix

Zippel's actual algorithm is **iterative**. Keep one interpolant and introduce one variable at a time:

1. Interpolate `f(x₁, a₂…aₙ)` densely at an anchor point — this fixes the skeleton.
2. To introduce `x_j`, assume the skeleton in `x₁…x_{j-1}` is unchanged and write `f = Σᵢ Cᵢ(x_j)·Mᵢ(x₁…x_{j-1})`. For each of `d+1` values of `x_j`, recover the `S` unknown scalars `Cᵢ(b_k)` from `S` oracle evaluations by solving one linear system; then interpolate each `Cᵢ` from its `d+1` values.

Evaluating the earlier variables at `(s₁^l, …, s_{j-1}^l)` makes the system a transposed Vandermonde in the nodes `vᵢ = Mᵢ(s)`, non-singular exactly when those nodes are distinct — which is checked, and re-drawn when it fails. Cost per variable is `(d+1)·S` **added**, not multiplied: `O(n·d·T)` overall.

## Result

| vars | before | after |
|---|---|---|
| 2 | 70 | 34 |
| 3 | 1,771 | 62 |
| 4 | 139,552 | 97 |
| 5 | 15,019,900 (75 s) | 139 |
| 10 | ~10¹⁷ (never) | **601** |

The V2-3 roadmap acceptance criterion — 10 variables, 15 terms, ≥95% success over 20 seeds — **passes for the first time, in 0.36 s**. Its test is un-skipped and the known-gap entry is removed from `ROADMAP.md`.

## Soundness

Zippel's skeleton hypothesis is probabilistic: an unlucky anchor can make a monomial's image vanish, and the run would then return a polynomial that is *confidently wrong*. Each candidate is now verified against the black box at random points, with fresh anchors drawn on mismatch and a structured refusal if every attempt fails — the same withhold-rather-than-guess discipline as the rest of the codebase.

## The test that matters

I added a Rust test asserting the oracle **call count** grows linearly in the variable count, and verified it **hangs against the previous implementation** (killed after 7 minutes).

This is the point worth dwelling on: every existing functional test passed against the old code too. They didn't catch anything because a correct-but-non-terminating implementation is indistinguishable from a correct one until you measure cost. Guarding the asymptotics is what prevents a future rewrite from silently reintroducing the blow-up.

## Verification

- `cargo test --all`: 1850 passed
- `pytest`: 1644 passed, 27 skipped; silent-error gate 149 passed
- Tier 1b command verbatim: 2 passed in 0.36 s (was: 6 h, no result)
- `cargo clippy -D warnings`, `cargo doc`, `ruff`, certificate ledger — all clean

Net **−60 lines**: the iterative form replaces the recursive lift, its batched sibling helper, and a dead union helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse polynomial interpolation performance, with oracle evaluations scaling linearly as variables increase.
  * Added candidate verification and retry handling to improve result reliability.
  * Added clearer handling for invalid or degenerate interpolation configurations.

* **Tests**
  * Enabled the 10-variable interpolation acceptance test.
  * Added regression coverage for interpolation call-count growth.

* **Documentation**
  * Updated the changelog and roadmap to reflect the completed interpolation milestone and benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->