### PR TITLE
feat(autoresearch): ansatz families, cross-CAS differential testing, SMT bridge (P2)

### DIFF
--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -193,6 +193,17 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-HOLO-002", class: "HolonomicError", cause: Cause::Resource,    remediation: Some("raise max_order and/or max_degree in ZeilbergerOpts; if the term genuinely has no such recurrence within reach, Zeilberger's algorithm does not apply") },
     ErrorSpec { code: "E-HOLO-003", class: "HolonomicError", cause: Cause::Internal,    remediation: Some("internal: report the term as a minimal failing example") },
     ErrorSpec { code: "E-HOLO-004", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("n and k must be distinct symbols; max_order and max_degree must be positive") },
+    // E-SMT — SmtError (P2 item 3: SMT/SAT bridge).
+    //
+    // Only the code Rust actually raises is registered here.  The rest of the
+    // family lives entirely in `python/alkahest/smt.py`, which drives the solver
+    // process: E-SMT-001 (no solver binary on PATH), E-SMT-003 (a model value —
+    // a `root-obj` algebraic number — that cannot be lifted exactly), and
+    // E-SMT-004 (a model that failed exact back-substitution).  Registering a
+    // code no Rust `AlkahestError` impl returns would fail
+    // `scripts/check_error_codes.py`; `E-BATCH-001` in `python/alkahest/_batch.py`
+    // is the same precedent.
+    ErrorSpec { code: "E-SMT-002", class: "SmtError", cause: Cause::Unsupported, remediation: Some("check alkahest.smt.supported(formula) before exporting; the fragment is polynomial (in)equalities over Int/Real symbols plus boolean structure and quantifiers, and float literals are refused because they are not the exact question they look like") },
 ];
 
 #[cfg(test)]

--- a/alkahest-core/src/logic/mod.rs
+++ b/alkahest-core/src/logic/mod.rs
@@ -4,6 +4,10 @@
 //! - [`satisfiable`] decides a quantifier-free fragment: conjunctions of
 //!   comparisons between **one** real symbol and a rational constant, plus `Or`
 //!   / `Not` (via NNF on relations).  Other shapes return [`Satisfiability::Unknown`].
+//! - [`smtlib`] exports a [`Formula`] as SMT-LIB 2 text for an external solver
+//!   (P2-3).  `alkahest.smt` drives the solver process from Python.
+
+pub mod smtlib;
 
 use crate::kernel::expr::PredicateKind;
 use crate::kernel::{ExprData, ExprId, ExprPool};
@@ -626,6 +630,20 @@ pub type BoolLit = i32;
 pub type BoolClause = Vec<BoolLit>;
 
 /// Very small DPLL without clause learning. Returns `Some(assign)` or `None` if UNSAT.
+///
+/// # Not an SMT engine (P2-3 design decision D6)
+///
+/// This solves the *propositional* problem it is handed — a CNF clause list over
+/// opaque propositions — and it is sound and complete for that.  It is
+/// deliberately **not** wired into [`smtlib`] or `alkahest.smt` as a fallback
+/// engine, because the only way to reach it from a [`Formula`] is to abstract
+/// each arithmetic atom to a fresh proposition, and that abstraction is sound in
+/// one direction only: it can confirm `unsat`, but it reports `x > 0 ∧ x < 0` as
+/// *sat* with a meaningless model.  Handing that back as a witness — under a
+/// bridge whose entire premise is that every `sat` model is checked exactly —
+/// would be precisely the silent-error shape the bridge exists to prevent.
+/// `alkahest.smt.solve` therefore refuses with `E-SMT-001` when no external
+/// solver is installed rather than degrading to anything in-tree.
 pub fn dpll_sat(clauses: Vec<BoolClause>, n_vars: u32) -> Option<Vec<bool>> {
     fn is_conflict(c: &BoolClause, a: &[Option<bool>]) -> bool {
         c.iter().all(|&lit| {

--- a/alkahest-core/src/logic/smtlib.rs
+++ b/alkahest-core/src/logic/smtlib.rs
@@ -261,7 +261,10 @@ impl Requirements {
 
 /// Every logic name [`to_smtlib`] accepts explicitly, in the order a planner
 /// should read them: quantifier-free first, then quantified, then the two
-/// catalog logics for mixed `Int`/`Real` (see [`Arith`]), then the catch-all.
+/// SMT-LIB catalog logics for mixed `Int`/`Real` (`AUFLIRA` / `AUFNIRA` — see
+/// the note on the internal `Arith` type for why the non-catalog `QF_LIRA` and
+/// `QF_NIRA` are still preferred for quantifier-free formulas), then the
+/// catch-all.
 pub const SUPPORTED_LOGICS: &[&str] = &[
     "QF_LIA", "QF_NIA", "QF_LRA", "QF_NRA", "QF_LIRA", "QF_NIRA", "LIA", "NIA", "LRA", "NRA",
     "LIRA", "NIRA", "AUFLIRA", "AUFNIRA", "ALL",

--- a/alkahest-core/src/logic/smtlib.rs
+++ b/alkahest-core/src/logic/smtlib.rs
@@ -1,0 +1,1397 @@
+//! SMT-LIB 2 emission for [`Formula`] — the *export* half of the SMT/SAT bridge (P2-3).
+//!
+//! The unit of exchange with an external solver is SMT-LIB 2 **text**, exactly as
+//! the unit of exchange with Lean is `.lean` text: alkahest emits a standard
+//! artifact and an independently maintained checker consumes it.  No solver is
+//! vendored into this crate and none ever should be — see
+//! `docs/mdbook/src/smt.md`.
+//!
+//! The emitter lives here, next to [`Formula`], because it must be *exhaustive*
+//! over [`Formula`] and [`PredicateKind`] and `rustc`'s match-exhaustiveness
+//! check is the enforcement mechanism.  **There is deliberately no `_ =>` arm
+//! anywhere in this file**: a node added to `ExprData`, `Formula`, or
+//! `PredicateKind` later must fail to compile here rather than silently emit
+//! wrong SMT-LIB.  `tests/test_smt.py` pins that property from the outside too.
+//!
+//! # What is emitted
+//!
+//! A complete, runnable script:
+//!
+//! ```smt2
+//! ; alkahest SMT-LIB 2 export
+//! (set-logic QF_NRA)
+//! (set-option :produce-models true)
+//! (declare-fun x () Real)
+//! (assert (> (* x x) 2))
+//! (check-sat)
+//! (get-model)
+//! ```
+//!
+//! # What is refused
+//!
+//! Everything whose SMT-LIB rendering would not mean *exactly* the same thing as
+//! the alkahest expression: float literals (write `pool.rational(1, 10)`, not
+//! `0.1`), complex-domain symbols, non-integer exponents, unregistered function
+//! heads, `BigO`, `RootSum`, and symbol names that cannot be quoted.  Every
+//! refusal is [`SmtLibError`] with the stable code `E-SMT-002`.
+
+use super::{formula_from_expr, Formula, LogicError};
+use crate::kernel::expr::PredicateKind;
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Largest integer exponent expanded into repeated multiplication.
+///
+/// SMT-LIB 2 has no standard `^`, so `x**k` is emitted as `(* x x … x)`.  That
+/// is portable across z3/cvc5/yices, but it is also an enumeration, so it is
+/// bounded: a loop must never be able to ask for a megabyte of `x`.
+pub const MAX_POW_EXPANSION: i64 = 128;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// A formula (or a sub-term of one) is outside the SMT-LIB fragment alkahest
+/// will export.
+///
+/// Every variant carries the stable code `E-SMT-002`.  The other `E-SMT-*`
+/// codes (`001` no solver, `003` inexact model value, `004` model failed
+/// back-substitution) belong to the Python driver in `alkahest/smt.py` and are
+/// deliberately *not* registered here — nothing in Rust raises them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmtLibError {
+    /// An expression node has no exact SMT-LIB rendering.
+    UnsupportedNode(String),
+    /// A symbol's [`Domain`] has no SMT-LIB sort (currently only `Complex`).
+    UnsupportedDomain(String),
+    /// A function head is not in the exactly-translatable allow-list.
+    UnsupportedFunction(String),
+    /// A power is not an integer, or expanding it would exceed [`MAX_POW_EXPANSION`].
+    UnsupportedExponent(String),
+    /// The requested logic name is unknown, or too weak for this formula.
+    UnsupportedLogic(String),
+    /// One name denotes two different sorts, or is both bound and free.
+    SymbolConflict(String),
+    /// The expression is not a predicate/quantified formula at all.
+    NotAFormula(String),
+}
+
+impl fmt::Display for SmtLibError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SmtLibError::UnsupportedNode(s) => write!(f, "to_smtlib: unsupported expression: {s}"),
+            SmtLibError::UnsupportedDomain(s) => write!(f, "to_smtlib: unsupported domain: {s}"),
+            SmtLibError::UnsupportedFunction(s) => {
+                write!(f, "to_smtlib: unsupported function: {s}")
+            }
+            SmtLibError::UnsupportedExponent(s) => write!(f, "to_smtlib: unsupported power: {s}"),
+            SmtLibError::UnsupportedLogic(s) => write!(f, "to_smtlib: unusable logic: {s}"),
+            SmtLibError::SymbolConflict(s) => write!(f, "to_smtlib: symbol conflict: {s}"),
+            SmtLibError::NotAFormula(s) => write!(f, "to_smtlib: not a formula: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for SmtLibError {}
+
+impl crate::errors::AlkahestError for SmtLibError {
+    fn code(&self) -> &'static str {
+        "E-SMT-002"
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        Some(match self {
+            SmtLibError::UnsupportedNode(_) => {
+                "the SMT-LIB fragment is polynomial (in)equalities over Int/Real symbols, \
+                 boolean structure, quantifiers and Piecewise; rewrite the expression into \
+                 that fragment, and use pool.rational(p, q) rather than a float literal"
+            }
+            SmtLibError::UnsupportedDomain(_) => {
+                "declare the symbol over Real, Integer, Positive, NonNegative or NonZero; \
+                 complex-domain symbols have no SMT-LIB arithmetic sort"
+            }
+            SmtLibError::UnsupportedFunction(_) => {
+                "only `abs` has an exact SMT-LIB rendering today; substitute or approximate \
+                 transcendental heads before exporting, or keep the query in-tree \
+                 (prove_nonneg / decide)"
+            }
+            SmtLibError::UnsupportedExponent(_) => {
+                "use a non-negative integer exponent no larger than \
+                 alkahest_core::logic::smtlib::MAX_POW_EXPANSION; SMT-LIB 2 has no portable \
+                 `^`, so powers are expanded into products and the expansion is bounded"
+            }
+            SmtLibError::UnsupportedLogic(_) => {
+                "pass logic=\"auto\" (the default) and let the emitter pick, or name a logic \
+                 at least as strong as the formula needs"
+            }
+            SmtLibError::SymbolConflict(_) => {
+                "rename one of the symbols; SMT-LIB has one namespace, so two alkahest \
+                 symbols that share a name but not a domain cannot both be declared"
+            }
+            SmtLibError::NotAFormula(_) => {
+                "pass a predicate or quantified Expr; build one with pool.gt/le/… or \
+                 alkahest.And/Or/Not"
+            }
+        })
+    }
+}
+
+impl From<LogicError> for SmtLibError {
+    fn from(e: LogicError) -> Self {
+        SmtLibError::NotAFormula(e.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sorts, requirements, logics
+// ---------------------------------------------------------------------------
+
+/// The two SMT-LIB arithmetic sorts alkahest emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Sort {
+    Int,
+    Real,
+}
+
+impl Sort {
+    /// The SMT-LIB sort name.
+    pub fn name(self) -> &'static str {
+        match self {
+            Sort::Int => "Int",
+            Sort::Real => "Real",
+        }
+    }
+}
+
+/// What a formula needs from a solver — the input to logic selection, and the
+/// thing `alkahest.smt.supported` plans against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Requirements {
+    /// At least one `Int`-sorted symbol occurs.
+    pub ints: bool,
+    /// At least one `Real`-sorted symbol, rational literal, or division occurs.
+    pub reals: bool,
+    /// At least one product of two non-constant terms (or a variable divisor).
+    pub nonlinear: bool,
+    /// At least one `Forall`/`Exists` binder occurs.
+    pub quantifiers: bool,
+}
+
+/// The arithmetic fragment of an SMT-LIB logic name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Arith {
+    Lia,
+    Nia,
+    Lra,
+    Nra,
+    Lira,
+    Nira,
+}
+
+impl Arith {
+    fn quantified(self) -> &'static str {
+        match self {
+            Arith::Lia => "LIA",
+            Arith::Nia => "NIA",
+            Arith::Lra => "LRA",
+            Arith::Nra => "NRA",
+            Arith::Lira => "LIRA",
+            Arith::Nira => "NIRA",
+        }
+    }
+
+    fn quantifier_free(self) -> &'static str {
+        match self {
+            Arith::Lia => "QF_LIA",
+            Arith::Nia => "QF_NIA",
+            Arith::Lra => "QF_LRA",
+            Arith::Nra => "QF_NRA",
+            Arith::Lira => "QF_LIRA",
+            Arith::Nira => "QF_NIRA",
+        }
+    }
+}
+
+impl Requirements {
+    /// The weakest standard SMT-LIB logic that can express this formula.
+    pub fn logic(&self) -> &'static str {
+        let arith = match (self.ints, self.reals, self.nonlinear) {
+            (true, true, false) => Arith::Lira,
+            (true, true, true) => Arith::Nira,
+            (true, false, false) => Arith::Lia,
+            (true, false, true) => Arith::Nia,
+            // No symbols at all still needs a well-formed logic; reals are the
+            // most permissive choice and cost nothing.
+            (false, false, false) | (false, true, false) => Arith::Lra,
+            (false, false, true) | (false, true, true) => Arith::Nra,
+        };
+        if self.quantifiers {
+            arith.quantified()
+        } else {
+            arith.quantifier_free()
+        }
+    }
+}
+
+/// Every logic name [`to_smtlib`] accepts explicitly, in the order a planner
+/// should read them: quantifier-free first, then quantified, then the catch-all.
+pub const SUPPORTED_LOGICS: &[&str] = &[
+    "QF_LIA", "QF_NIA", "QF_LRA", "QF_NRA", "QF_LIRA", "QF_NIRA", "LIA", "NIA", "LRA", "NRA",
+    "LIRA", "NIRA", "ALL",
+];
+
+fn check_logic(requested: &str, req: &Requirements) -> Result<(), SmtLibError> {
+    if requested == "ALL" {
+        return Ok(());
+    }
+    if !SUPPORTED_LOGICS.contains(&requested) {
+        return Err(SmtLibError::UnsupportedLogic(format!(
+            "{requested:?} is not one of {SUPPORTED_LOGICS:?}"
+        )));
+    }
+    let quantifier_free = requested.starts_with("QF_");
+    let body = requested.strip_prefix("QF_").unwrap_or(requested);
+    let linear = body.starts_with('L');
+    let has_int = body.contains('I');
+    let has_real = body.contains('R');
+
+    if req.quantifiers && quantifier_free {
+        return Err(SmtLibError::UnsupportedLogic(format!(
+            "formula has quantifiers but {requested:?} is quantifier-free"
+        )));
+    }
+    if req.nonlinear && linear {
+        return Err(SmtLibError::UnsupportedLogic(format!(
+            "formula is nonlinear but {requested:?} is a linear logic"
+        )));
+    }
+    if req.ints && !has_int {
+        return Err(SmtLibError::UnsupportedLogic(format!(
+            "formula has Int-sorted symbols but {requested:?} has no Int sort"
+        )));
+    }
+    if req.reals && !has_real {
+        return Err(SmtLibError::UnsupportedLogic(format!(
+            "formula needs Real arithmetic but {requested:?} has no Real sort"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/// Emission options for [`to_smtlib`] / [`formula_to_smtlib`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SmtLibOptions<'a> {
+    /// Logic name, or `None` to infer the weakest one that fits.
+    pub logic: Option<&'a str>,
+    /// Append `(check-sat)`.
+    pub check_sat: bool,
+    /// Set `:produce-models` and append `(get-model)`.
+    pub get_model: bool,
+}
+
+impl Default for SmtLibOptions<'_> {
+    fn default() -> Self {
+        SmtLibOptions {
+            logic: None,
+            check_sat: true,
+            get_model: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol names
+// ---------------------------------------------------------------------------
+
+/// SMT-LIB 2 reserved words and core/theory symbols that must be `|quoted|`
+/// when they occur as an alkahest symbol name.
+const RESERVED: &[&str] = &[
+    "!",
+    "_",
+    "as",
+    "let",
+    "exists",
+    "forall",
+    "match",
+    "par",
+    "assert",
+    "check-sat",
+    "declare-const",
+    "declare-fun",
+    "declare-sort",
+    "define-fun",
+    "define-sort",
+    "exit",
+    "get-model",
+    "get-value",
+    "push",
+    "pop",
+    "set-info",
+    "set-logic",
+    "set-option",
+    "Bool",
+    "Int",
+    "Real",
+    "true",
+    "false",
+    "not",
+    "and",
+    "or",
+    "xor",
+    "ite",
+    "distinct",
+    "abs",
+    "div",
+    "mod",
+    "to_real",
+    "to_int",
+    "is_int",
+    "divisible",
+];
+
+/// Characters SMT-LIB 2 allows in a *simple* symbol beyond `[a-zA-Z0-9]`.
+const SIMPLE_EXTRA: &str = "~!@$%^&*_-+=<>.?/";
+
+fn smt_symbol(name: &str) -> Result<String, SmtLibError> {
+    if name.contains('|') || name.contains('\\') {
+        return Err(SmtLibError::SymbolConflict(format!(
+            "symbol name {name:?} contains '|' or '\\', which SMT-LIB 2 cannot quote"
+        )));
+    }
+    let simple = !name.is_empty()
+        && !name.starts_with(|c: char| c.is_ascii_digit())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || SIMPLE_EXTRA.contains(c))
+        && !RESERVED.contains(&name);
+    if simple {
+        Ok(name.to_string())
+    } else {
+        Ok(format!("|{name}|"))
+    }
+}
+
+fn sort_of_domain(name: &str, domain: Domain) -> Result<Sort, SmtLibError> {
+    match domain {
+        Domain::Integer => Ok(Sort::Int),
+        Domain::Real | Domain::Positive | Domain::NonNegative | Domain::NonZero => Ok(Sort::Real),
+        Domain::Complex => Err(SmtLibError::UnsupportedDomain(format!(
+            "symbol {name:?} is Complex; SMT-LIB arithmetic is ordered and real"
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol collection (pre-pass)
+// ---------------------------------------------------------------------------
+
+/// Every symbol reachable from `id`, keyed by name.
+///
+/// Runs before emission so the emitter knows whether an `Int` sort is in play,
+/// which decides whether `to_real` coercions are legal (they exist only in the
+/// `Reals_Ints` theory; under plain `Reals`, numerals already *are* `Real`).
+fn collect_symbols_expr(
+    id: ExprId,
+    pool: &ExprPool,
+    out: &mut BTreeMap<String, (Sort, Domain)>,
+) -> Result<(), SmtLibError> {
+    match pool.get(id) {
+        ExprData::Symbol { name, domain, .. } => {
+            let sort = sort_of_domain(&name, domain)?;
+            if let Some(&(prev_sort, prev_domain)) = out.get(&name) {
+                if prev_sort != sort || prev_domain != domain {
+                    return Err(SmtLibError::SymbolConflict(format!(
+                        "symbol {name:?} occurs with domains {prev_domain} and {domain}"
+                    )));
+                }
+            }
+            out.insert(name, (sort, domain));
+            Ok(())
+        }
+        ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => Ok(()),
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for a in args {
+                collect_symbols_expr(a, pool, out)?;
+            }
+            Ok(())
+        }
+        ExprData::Pow { base, exp } => {
+            collect_symbols_expr(base, pool, out)?;
+            collect_symbols_expr(exp, pool, out)
+        }
+        ExprData::Func { name: _, args } => {
+            for a in args {
+                collect_symbols_expr(a, pool, out)?;
+            }
+            Ok(())
+        }
+        ExprData::Piecewise { branches, default } => {
+            for (cond, value) in branches {
+                collect_symbols_expr(cond, pool, out)?;
+                collect_symbols_expr(value, pool, out)?;
+            }
+            collect_symbols_expr(default, pool, out)
+        }
+        ExprData::Predicate { kind: _, args } => {
+            for a in args {
+                collect_symbols_expr(a, pool, out)?;
+            }
+            Ok(())
+        }
+        ExprData::Forall { var, body } | ExprData::Exists { var, body } => {
+            collect_symbols_expr(var, pool, out)?;
+            collect_symbols_expr(body, pool, out)
+        }
+        ExprData::BigO(inner) => collect_symbols_expr(inner, pool, out),
+        ExprData::RootSum { poly, var, body } => {
+            collect_symbols_expr(poly, pool, out)?;
+            collect_symbols_expr(var, pool, out)?;
+            collect_symbols_expr(body, pool, out)
+        }
+    }
+}
+
+fn collect_symbols_formula(
+    f: &Formula,
+    pool: &ExprPool,
+    out: &mut BTreeMap<String, (Sort, Domain)>,
+) -> Result<(), SmtLibError> {
+    match f {
+        Formula::True | Formula::False => Ok(()),
+        Formula::Atom { kind: _, args } => {
+            for &a in args {
+                collect_symbols_expr(a, pool, out)?;
+            }
+            Ok(())
+        }
+        Formula::And(a, b) | Formula::Or(a, b) => {
+            collect_symbols_formula(a, pool, out)?;
+            collect_symbols_formula(b, pool, out)
+        }
+        Formula::Not(a) => collect_symbols_formula(a, pool, out),
+        Formula::Forall { var, body } | Formula::Exists { var, body } => {
+            collect_symbols_expr(*var, pool, out)?;
+            collect_symbols_formula(body, pool, out)
+        }
+    }
+}
+
+/// Does `id` mention any symbol?  Drives the linear/nonlinear split.
+fn has_symbol(id: ExprId, pool: &ExprPool) -> bool {
+    let mut found = BTreeMap::new();
+    // A collection failure (e.g. a Complex symbol) still means "has symbols";
+    // the emitter reports the real error a moment later.
+    match collect_symbols_expr(id, pool, &mut found) {
+        Ok(()) => !found.is_empty(),
+        Err(_) => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Emitter
+// ---------------------------------------------------------------------------
+
+struct Emitter<'a> {
+    pool: &'a ExprPool,
+    /// `to_real` exists only when the script also declares `Int`-sorted symbols.
+    use_to_real: bool,
+    req: Requirements,
+    bound: Vec<String>,
+    bound_ever: BTreeSet<String>,
+}
+
+impl<'a> Emitter<'a> {
+    fn coerce(&self, text: String, from: Sort, to: Sort) -> String {
+        match (from, to) {
+            // `to_real` lives in the `Reals_Ints` theory, which the script only
+            // enters when it also declares an `Int`-sorted symbol.  Under plain
+            // `Reals` (QF_LRA / QF_NRA) numerals already *are* `Real`, and
+            // emitting `to_real` there would make the script unparseable.
+            (Sort::Int, Sort::Real) => {
+                if self.use_to_real {
+                    format!("(to_real {text})")
+                } else {
+                    text
+                }
+            }
+            (Sort::Int, Sort::Int) | (Sort::Real, Sort::Real) | (Sort::Real, Sort::Int) => text,
+        }
+    }
+
+    fn zero(&self, sort: Sort) -> String {
+        self.coerce("0".to_string(), Sort::Int, sort)
+    }
+
+    fn one(&self, sort: Sort) -> String {
+        self.coerce("1".to_string(), Sort::Int, sort)
+    }
+
+    // -- terms ------------------------------------------------------------
+
+    /// Emit `id` as an SMT-LIB term, returning `(text, sort)`.
+    fn term(&mut self, id: ExprId) -> Result<(String, Sort), SmtLibError> {
+        match self.pool.get(id) {
+            ExprData::Symbol { name, domain, .. } => {
+                let sort = sort_of_domain(&name, domain)?;
+                match sort {
+                    Sort::Int => self.req.ints = true,
+                    Sort::Real => self.req.reals = true,
+                }
+                Ok((smt_symbol(&name)?, sort))
+            }
+            ExprData::Integer(n) => Ok((fmt_int(&n.0), Sort::Int)),
+            ExprData::Rational(r) => {
+                self.req.reals = true;
+                // `/` is `Real Real -> Real`; under `Reals_Ints` the numerals are
+                // `Int` and need coercing, under plain `Reals` they already are
+                // `Real` and coercing would not parse.
+                let numer = self.coerce(fmt_int(r.0.numer()), Sort::Int, Sort::Real);
+                let denom = self.coerce(fmt_int(r.0.denom()), Sort::Int, Sort::Real);
+                Ok((format!("(/ {numer} {denom})"), Sort::Real))
+            }
+            ExprData::Float(f) => Err(SmtLibError::UnsupportedNode(format!(
+                "float literal {}; a float is not an exact rational question, so exporting \
+                 it would change what is being asked",
+                f.inner
+            ))),
+            ExprData::Add(args) => self.nary("+", &args, "0", false),
+            ExprData::Mul(args) => self.nary("*", &args, "1", true),
+            ExprData::Pow { base, exp } => self.pow(base, exp),
+            ExprData::Func { name, args } => self.func(&name, &args),
+            ExprData::Piecewise { branches, default } => self.piecewise(&branches, default),
+            ExprData::Predicate { .. } => Err(SmtLibError::UnsupportedNode(
+                "a Bool-valued predicate used where an arithmetic term is required; SMT-LIB 2 \
+                 does not coerce Bool to Int/Real"
+                    .to_string(),
+            )),
+            ExprData::Forall { .. } | ExprData::Exists { .. } => Err(SmtLibError::UnsupportedNode(
+                "a quantified formula used where an arithmetic term is required".to_string(),
+            )),
+            ExprData::BigO(_) => Err(SmtLibError::UnsupportedNode(
+                "O(...) is an asymptotic order bound, not a value an SMT solver can reason about"
+                    .to_string(),
+            )),
+            ExprData::RootSum { .. } => Err(SmtLibError::UnsupportedNode(
+                "RootSum binds an algebraic-number placeholder; SMT-LIB 2 has no such term"
+                    .to_string(),
+            )),
+        }
+    }
+
+    fn nary(
+        &mut self,
+        op: &str,
+        args: &[ExprId],
+        identity: &str,
+        track_nonlinearity: bool,
+    ) -> Result<(String, Sort), SmtLibError> {
+        if args.is_empty() {
+            // Empty sum is 0, empty product is 1 — matching the kernel.
+            return Ok((identity.to_string(), Sort::Int));
+        }
+        if track_nonlinearity {
+            let non_constant = args.iter().filter(|&&a| has_symbol(a, self.pool)).count();
+            if non_constant >= 2 {
+                self.req.nonlinear = true;
+            }
+        }
+        let mut parts = Vec::with_capacity(args.len());
+        let mut sort = Sort::Int;
+        for &a in args {
+            let (text, s) = self.term(a)?;
+            if s == Sort::Real {
+                sort = Sort::Real;
+            }
+            parts.push((text, s));
+        }
+        if parts.len() == 1 {
+            let (text, s) = parts.pop().expect("length checked");
+            return Ok((text, s));
+        }
+        let joined = parts
+            .into_iter()
+            .map(|(text, s)| self.coerce(text, s, sort))
+            .collect::<Vec<_>>()
+            .join(" ");
+        Ok((format!("({op} {joined})"), sort))
+    }
+
+    fn pow(&mut self, base: ExprId, exp: ExprId) -> Result<(String, Sort), SmtLibError> {
+        let k = match self.pool.get(exp) {
+            ExprData::Integer(n) => n.0.to_i64().ok_or_else(|| {
+                SmtLibError::UnsupportedExponent(format!("exponent {} does not fit in i64", n.0))
+            })?,
+            other => {
+                return Err(SmtLibError::UnsupportedExponent(format!(
+                    "exponent must be an integer literal, got {}",
+                    describe(&other)
+                )))
+            }
+        };
+        if k.unsigned_abs() > MAX_POW_EXPANSION as u64 {
+            return Err(SmtLibError::UnsupportedExponent(format!(
+                "|{k}| exceeds MAX_POW_EXPANSION ({MAX_POW_EXPANSION}); SMT-LIB 2 has no \
+                 portable `^`, so powers are expanded into products"
+            )));
+        }
+        let base_has_symbol = has_symbol(base, self.pool);
+        if k == 0 {
+            return Ok(("1".to_string(), Sort::Int));
+        }
+        let (base_text, base_sort) = self.term(base)?;
+        let n = k.unsigned_abs() as usize;
+        if n >= 2 && base_has_symbol {
+            self.req.nonlinear = true;
+        }
+        let repeated = if n == 1 {
+            base_text
+        } else {
+            let joined = vec![base_text.as_str(); n].join(" ");
+            format!("(* {joined})")
+        };
+        if k > 0 {
+            return Ok((repeated, base_sort));
+        }
+        // Negative exponent: real division, and dividing by a variable is not
+        // linear arithmetic even when the numerator is.
+        self.req.reals = true;
+        if base_has_symbol {
+            self.req.nonlinear = true;
+        }
+        let numer = self.one(Sort::Real);
+        let denom = self.coerce(repeated, base_sort, Sort::Real);
+        Ok((format!("(/ {numer} {denom})"), Sort::Real))
+    }
+
+    fn func(&mut self, name: &str, args: &[ExprId]) -> Result<(String, Sort), SmtLibError> {
+        // Exactly-translatable heads only.  `abs` is the whole list: anything
+        // transcendental has no SMT-LIB 2 rendering that means the same thing,
+        // and approximating it here would be the silent-error shape this
+        // subsystem exists to prevent.
+        if name == "abs" && args.len() == 1 {
+            let (text, sort) = self.term(args[0])?;
+            return Ok(match sort {
+                // SMT-LIB `abs` is Int-only; the Real case is an exact `ite`.
+                Sort::Int => (format!("(abs {text})"), Sort::Int),
+                Sort::Real => {
+                    let zero = self.zero(Sort::Real);
+                    (
+                        format!("(ite (>= {text} {zero}) {text} (- {text}))"),
+                        Sort::Real,
+                    )
+                }
+            });
+        }
+        Err(SmtLibError::UnsupportedFunction(format!(
+            "{name}/{}",
+            args.len()
+        )))
+    }
+
+    fn piecewise(
+        &mut self,
+        branches: &[(ExprId, ExprId)],
+        default: ExprId,
+    ) -> Result<(String, Sort), SmtLibError> {
+        let mut conds = Vec::with_capacity(branches.len());
+        let mut values = Vec::with_capacity(branches.len());
+        let mut sort = Sort::Int;
+        for &(cond, value) in branches {
+            let sub = formula_from_expr(cond, self.pool)?;
+            conds.push(self.formula(&sub)?);
+            let (text, s) = self.term(value)?;
+            if s == Sort::Real {
+                sort = Sort::Real;
+            }
+            values.push((text, s));
+        }
+        let (default_text, default_sort) = self.term(default)?;
+        if default_sort == Sort::Real {
+            sort = Sort::Real;
+        }
+        let mut out = self.coerce(default_text, default_sort, sort);
+        for (cond, (text, s)) in conds.into_iter().zip(values).rev() {
+            let value = self.coerce(text, s, sort);
+            out = format!("(ite {cond} {value} {out})");
+        }
+        Ok((out, sort))
+    }
+
+    // -- formulas ---------------------------------------------------------
+
+    /// Emit a comparison between two terms, coercing to a common sort.
+    fn compare(&mut self, op: &str, args: &[ExprId]) -> Result<String, SmtLibError> {
+        if args.len() != 2 {
+            return Err(SmtLibError::NotAFormula(format!(
+                "relation {op:?} needs exactly 2 operands, got {}",
+                args.len()
+            )));
+        }
+        let (lhs, lhs_sort) = self.term(args[0])?;
+        let (rhs, rhs_sort) = self.term(args[1])?;
+        let sort = if lhs_sort == Sort::Real || rhs_sort == Sort::Real {
+            Sort::Real
+        } else {
+            Sort::Int
+        };
+        let lhs = self.coerce(lhs, lhs_sort, sort);
+        let rhs = self.coerce(rhs, rhs_sort, sort);
+        Ok(format!("({op} {lhs} {rhs})"))
+    }
+
+    /// Emit an `ExprId` that must itself be a formula.
+    fn sub_formula(&mut self, id: ExprId) -> Result<String, SmtLibError> {
+        let f = formula_from_expr(id, self.pool)?;
+        self.formula(&f)
+    }
+
+    fn formula(&mut self, f: &Formula) -> Result<String, SmtLibError> {
+        match f {
+            Formula::True => Ok("true".to_string()),
+            Formula::False => Ok("false".to_string()),
+            Formula::And(a, b) => {
+                let a = self.formula(a)?;
+                let b = self.formula(b)?;
+                Ok(format!("(and {a} {b})"))
+            }
+            Formula::Or(a, b) => {
+                let a = self.formula(a)?;
+                let b = self.formula(b)?;
+                Ok(format!("(or {a} {b})"))
+            }
+            Formula::Not(a) => {
+                let a = self.formula(a)?;
+                Ok(format!("(not {a})"))
+            }
+            Formula::Forall { var, body } => self.quantifier("forall", *var, body),
+            Formula::Exists { var, body } => self.quantifier("exists", *var, body),
+            // `formula_from_expr` lifts And/Or/Not/True/False out of `Atom`, but
+            // `Formula` is public and can be built by hand, so every
+            // `PredicateKind` is handled here rather than assumed away.
+            Formula::Atom { kind, args } => match kind {
+                PredicateKind::Lt => self.compare("<", args),
+                PredicateKind::Le => self.compare("<=", args),
+                PredicateKind::Gt => self.compare(">", args),
+                PredicateKind::Ge => self.compare(">=", args),
+                PredicateKind::Eq => self.compare("=", args),
+                PredicateKind::Ne => Ok(format!("(not {})", self.compare("=", args)?)),
+                PredicateKind::And => {
+                    if args.is_empty() {
+                        return Ok("true".to_string());
+                    }
+                    let parts = args
+                        .iter()
+                        .map(|&a| self.sub_formula(a))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(if parts.len() == 1 {
+                        parts.into_iter().next().expect("length checked")
+                    } else {
+                        format!("(and {})", parts.join(" "))
+                    })
+                }
+                PredicateKind::Or => {
+                    if args.is_empty() {
+                        return Ok("false".to_string());
+                    }
+                    let parts = args
+                        .iter()
+                        .map(|&a| self.sub_formula(a))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(if parts.len() == 1 {
+                        parts.into_iter().next().expect("length checked")
+                    } else {
+                        format!("(or {})", parts.join(" "))
+                    })
+                }
+                PredicateKind::Not => {
+                    if args.len() != 1 {
+                        return Err(SmtLibError::NotAFormula(format!(
+                            "Not needs exactly 1 operand, got {}",
+                            args.len()
+                        )));
+                    }
+                    Ok(format!("(not {})", self.sub_formula(args[0])?))
+                }
+                PredicateKind::True => Ok("true".to_string()),
+                PredicateKind::False => Ok("false".to_string()),
+            },
+        }
+    }
+
+    fn quantifier(
+        &mut self,
+        binder: &str,
+        var: ExprId,
+        body: &Formula,
+    ) -> Result<String, SmtLibError> {
+        let (name, domain) = match self.pool.get(var) {
+            ExprData::Symbol { name, domain, .. } => (name, domain),
+            other => {
+                return Err(SmtLibError::NotAFormula(format!(
+                    "{binder} must bind a symbol, got {}",
+                    describe(&other)
+                )))
+            }
+        };
+        let sort = sort_of_domain(&name, domain)?;
+        match sort {
+            Sort::Int => self.req.ints = true,
+            Sort::Real => self.req.reals = true,
+        }
+        self.req.quantifiers = true;
+        let smt_name = smt_symbol(&name)?;
+        self.bound.push(name.clone());
+        self.bound_ever.insert(name);
+        let body_text = self.formula(body);
+        self.bound.pop();
+        let body_text = body_text?;
+        // A refined domain travels with the binder, not with a declaration:
+        // `∀ x:Positive . P` is `∀ x:Real . x > 0 ⇒ P`, and `∃` takes `∧`.
+        // Getting this backwards is a soundness bug, so the two are written out.
+        let scoped = match self.domain_guard(&smt_name, domain, sort) {
+            None => body_text,
+            Some(guard) => {
+                if binder == "forall" {
+                    format!("(=> {guard} {body_text})")
+                } else {
+                    format!("(and {guard} {body_text})")
+                }
+            }
+        };
+        Ok(format!(
+            "({binder} (({smt_name} {})) {scoped})",
+            sort.name()
+        ))
+    }
+
+    /// The side condition implied by a refined [`Domain`].
+    ///
+    /// Dropping these would silently widen the question: `Positive` means
+    /// `x > 0` and an SMT solver has no other way to know that.
+    fn domain_guard(&self, smt_name: &str, domain: Domain, sort: Sort) -> Option<String> {
+        let zero = self.zero(sort);
+        match domain {
+            Domain::Positive => Some(format!("(> {smt_name} {zero})")),
+            Domain::NonNegative => Some(format!("(>= {smt_name} {zero})")),
+            Domain::NonZero => Some(format!("(not (= {smt_name} {zero}))")),
+            Domain::Real | Domain::Integer | Domain::Complex => None,
+        }
+    }
+}
+
+fn fmt_int(n: &rug::Integer) -> String {
+    let s = n.to_string();
+    match s.strip_prefix('-') {
+        Some(rest) => format!("(- {rest})"),
+        None => s,
+    }
+}
+
+fn describe(data: &ExprData) -> &'static str {
+    match data {
+        ExprData::Symbol { .. } => "a symbol",
+        ExprData::Integer(_) => "an integer",
+        ExprData::Rational(_) => "a rational",
+        ExprData::Float(_) => "a float",
+        ExprData::Add(_) => "a sum",
+        ExprData::Mul(_) => "a product",
+        ExprData::Pow { .. } => "a power",
+        ExprData::Func { .. } => "a function application",
+        ExprData::Piecewise { .. } => "a piecewise expression",
+        ExprData::Predicate { .. } => "a predicate",
+        ExprData::Forall { .. } => "a universally quantified formula",
+        ExprData::Exists { .. } => "an existentially quantified formula",
+        ExprData::BigO(_) => "a big-O remainder",
+        ExprData::RootSum { .. } => "a root sum",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// A finished export: the script plus everything a planner wants to know about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmtLibExport {
+    /// The complete SMT-LIB 2 script.
+    pub text: String,
+    /// The logic named in `(set-logic …)`.
+    pub logic: String,
+    /// What the formula actually needs, independent of the logic that was named.
+    pub requirements: Requirements,
+    /// Declared (free) symbols, in declaration order, as `(name, sort)`.
+    pub symbols: Vec<(String, Sort)>,
+}
+
+/// Export a predicate/quantified `ExprId` as an SMT-LIB 2 script.
+pub fn to_smtlib(
+    expr: ExprId,
+    pool: &ExprPool,
+    opts: &SmtLibOptions<'_>,
+) -> Result<String, SmtLibError> {
+    Ok(export(expr, pool, opts)?.text)
+}
+
+/// [`to_smtlib`] plus the logic, requirements, and declared symbols.
+pub fn export(
+    expr: ExprId,
+    pool: &ExprPool,
+    opts: &SmtLibOptions<'_>,
+) -> Result<SmtLibExport, SmtLibError> {
+    let f = formula_from_expr(expr, pool)?;
+    formula_export(&f, pool, opts)
+}
+
+/// Export an already-lifted [`Formula`].
+pub fn formula_to_smtlib(
+    f: &Formula,
+    pool: &ExprPool,
+    opts: &SmtLibOptions<'_>,
+) -> Result<String, SmtLibError> {
+    Ok(formula_export(f, pool, opts)?.text)
+}
+
+/// Export an already-lifted [`Formula`], with metadata.
+pub fn formula_export(
+    f: &Formula,
+    pool: &ExprPool,
+    opts: &SmtLibOptions<'_>,
+) -> Result<SmtLibExport, SmtLibError> {
+    let mut symbols: BTreeMap<String, (Sort, Domain)> = BTreeMap::new();
+    collect_symbols_formula(f, pool, &mut symbols)?;
+    let use_to_real = symbols.values().any(|&(sort, _)| sort == Sort::Int);
+
+    let mut emitter = Emitter {
+        pool,
+        use_to_real,
+        req: Requirements::default(),
+        bound: Vec::new(),
+        bound_ever: BTreeSet::new(),
+    };
+    let body = emitter.formula(f)?;
+
+    // A name that is both quantifier-bound and free would be declared *and*
+    // shadowed; SMT-LIB would accept it and mean something different from the
+    // alkahest expression, so refuse instead.
+    let free: Vec<(String, (Sort, Domain))> = symbols
+        .iter()
+        .filter(|(name, _)| !emitter.bound_ever.contains(*name))
+        .map(|(name, spec)| (name.clone(), *spec))
+        .collect();
+    if let Some(name) = symbols
+        .keys()
+        .find(|n| emitter.bound_ever.contains(*n) && mentions_free(f, pool, n))
+    {
+        return Err(SmtLibError::SymbolConflict(format!(
+            "symbol {name:?} occurs both quantifier-bound and free"
+        )));
+    }
+
+    let requirements = emitter.req;
+    let logic = match opts.logic {
+        Some(name) => {
+            check_logic(name, &requirements)?;
+            name.to_string()
+        }
+        None => requirements.logic().to_string(),
+    };
+
+    let mut out = String::new();
+    out.push_str("; alkahest SMT-LIB 2 export\n");
+    out.push_str(&format!("(set-logic {logic})\n"));
+    if opts.get_model {
+        out.push_str("(set-option :produce-models true)\n");
+    }
+    for (name, (sort, _)) in &free {
+        let smt_name = smt_symbol(name)?;
+        out.push_str(&format!("(declare-fun {smt_name} () {})\n", sort.name()));
+    }
+    for (name, (sort, domain)) in &free {
+        let smt_name = smt_symbol(name)?;
+        if let Some(guard) = emitter.domain_guard(&smt_name, *domain, *sort) {
+            out.push_str(&format!("(assert {guard})\n"));
+        }
+    }
+    out.push_str(&format!("(assert {body})\n"));
+    if opts.check_sat {
+        out.push_str("(check-sat)\n");
+    }
+    if opts.get_model {
+        out.push_str("(get-model)\n");
+    }
+
+    Ok(SmtLibExport {
+        text: out,
+        logic,
+        requirements,
+        symbols: free
+            .into_iter()
+            .map(|(name, (sort, _))| (name, sort))
+            .collect(),
+    })
+}
+
+/// Would [`to_smtlib`] succeed on this expression?  The plan-ahead predicate.
+pub fn supported(expr: ExprId, pool: &ExprPool) -> bool {
+    to_smtlib(expr, pool, &SmtLibOptions::default()).is_ok()
+}
+
+/// Does `name` occur outside every binder that binds it?
+fn mentions_free(f: &Formula, pool: &ExprPool, name: &str) -> bool {
+    match f {
+        Formula::True | Formula::False => false,
+        Formula::Atom { kind: _, args } => args.iter().any(|&a| expr_mentions(a, pool, name)),
+        Formula::And(a, b) | Formula::Or(a, b) => {
+            mentions_free(a, pool, name) || mentions_free(b, pool, name)
+        }
+        Formula::Not(a) => mentions_free(a, pool, name),
+        Formula::Forall { var, body } | Formula::Exists { var, body } => {
+            if expr_mentions(*var, pool, name) {
+                false
+            } else {
+                mentions_free(body, pool, name)
+            }
+        }
+    }
+}
+
+fn expr_mentions(id: ExprId, pool: &ExprPool, name: &str) -> bool {
+    let mut found = BTreeMap::new();
+    let _ = collect_symbols_expr(id, pool, &mut found);
+    found.contains_key(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn opts() -> SmtLibOptions<'static> {
+        SmtLibOptions::default()
+    }
+
+    #[test]
+    fn linear_real_formula() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_and(vec![
+            p.pred_gt(x, p.integer(0_i32)),
+            p.pred_lt(x, p.integer(3_i32)),
+        ]);
+        let e = export(f, &p, &opts()).unwrap();
+        assert_eq!(e.logic, "QF_LRA");
+        assert!(e.text.contains("(declare-fun x () Real)"), "{}", e.text);
+        assert!(
+            e.text.contains("(assert (and (> x 0) (< x 3)))"),
+            "{}",
+            e.text
+        );
+        assert!(e.text.ends_with("(check-sat)\n(get-model)\n"), "{}", e.text);
+    }
+
+    #[test]
+    fn nonlinear_bumps_the_logic() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(p.mul(vec![x, x]), p.integer(2_i32));
+        let e = export(f, &p, &opts()).unwrap();
+        assert_eq!(e.logic, "QF_NRA");
+        assert!(e.requirements.nonlinear);
+    }
+
+    #[test]
+    fn powers_expand_into_products() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_ge(p.pow(x, p.integer(3_i32)), p.integer(8_i32));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(text.contains("(>= (* x x x) 8)"), "{text}");
+    }
+
+    #[test]
+    fn huge_exponent_is_refused_not_expanded() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_ge(p.pow(x, p.integer(100_000_i32)), p.integer(1_i32));
+        let err = to_smtlib(f, &p, &opts()).unwrap_err();
+        assert!(
+            matches!(err, SmtLibError::UnsupportedExponent(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn mixed_int_real_uses_to_real() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let n = p.symbol("n", Domain::Integer);
+        let f = p.pred_gt(x, n);
+        let e = export(f, &p, &opts()).unwrap();
+        assert_eq!(e.logic, "QF_LIRA");
+        assert!(e.text.contains("(> x (to_real n))"), "{}", e.text);
+        assert!(e.text.contains("(declare-fun n () Int)"), "{}", e.text);
+    }
+
+    #[test]
+    fn pure_real_does_not_coerce_numerals() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(x, p.integer(2_i32));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(!text.contains("to_real"), "{text}");
+    }
+
+    #[test]
+    fn refined_domains_emit_side_conditions() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Positive);
+        let f = p.pred_lt(x, p.integer(1_i32));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(text.contains("(assert (> x 0))"), "{text}");
+    }
+
+    #[test]
+    fn rationals_are_exact() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_eq(x, p.rational(-1, 3));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(text.contains("(/ (- 1) 3)"), "{text}");
+    }
+
+    #[test]
+    fn rational_literals_coerce_under_reals_ints() {
+        // `/` is Real→Real; under QF_LIRA the numerals are Int and must be lifted.
+        let p = ExprPool::new();
+        let n = p.symbol("n", Domain::Integer);
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_and(vec![
+            p.pred_gt(x, p.rational(1, 4)),
+            p.pred_gt(n, p.integer(0_i32)),
+        ]);
+        let e = export(f, &p, &opts()).unwrap();
+        assert_eq!(e.logic, "QF_LIRA");
+        assert!(e.text.contains("(/ (to_real 1) (to_real 4))"), "{}", e.text);
+    }
+
+    #[test]
+    fn floats_are_refused() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(x, p.float(0.1, 53));
+        let err = to_smtlib(f, &p, &opts()).unwrap_err();
+        assert!(matches!(err, SmtLibError::UnsupportedNode(_)), "{err:?}");
+    }
+
+    #[test]
+    fn complex_symbols_are_refused() {
+        let p = ExprPool::new();
+        let z = p.symbol("z", Domain::Complex);
+        let f = p.pred_gt(z, p.integer(0_i32));
+        let err = to_smtlib(f, &p, &opts()).unwrap_err();
+        assert!(matches!(err, SmtLibError::UnsupportedDomain(_)), "{err:?}");
+    }
+
+    #[test]
+    fn transcendental_heads_are_refused() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(p.func("sin", vec![x]), p.integer(0_i32));
+        let err = to_smtlib(f, &p, &opts()).unwrap_err();
+        assert!(
+            matches!(err, SmtLibError::UnsupportedFunction(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn quantifiers_drop_the_qf_prefix() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let y = p.symbol("y", Domain::Real);
+        let inner = p.pred_gt(p.add(vec![x, y]), p.integer(0_i32));
+        let f = p.forall(x, inner);
+        let e = export(f, &p, &opts()).unwrap();
+        assert_eq!(e.logic, "LRA");
+        assert!(e.text.contains("(forall ((x Real))"), "{}", e.text);
+        assert!(e.text.contains("(declare-fun y () Real)"), "{}", e.text);
+        assert!(!e.text.contains("(declare-fun x () Real)"), "{}", e.text);
+    }
+
+    #[test]
+    fn bound_and_free_same_name_is_refused() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let inner = p.pred_gt(x, p.integer(0_i32));
+        let f = p.pred_and(vec![p.forall(x, inner), inner]);
+        let err = to_smtlib(f, &p, &opts()).unwrap_err();
+        assert!(matches!(err, SmtLibError::SymbolConflict(_)), "{err:?}");
+    }
+
+    #[test]
+    fn explicit_logic_must_be_strong_enough() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(p.mul(vec![x, x]), p.integer(2_i32));
+        let mut o = opts();
+        o.logic = Some("QF_LRA");
+        let err = formula_to_smtlib(&formula_from_expr(f, &p).unwrap(), &p, &o).unwrap_err();
+        assert!(matches!(err, SmtLibError::UnsupportedLogic(_)), "{err:?}");
+        o.logic = Some("QF_NRA");
+        assert!(to_smtlib(f, &p, &o).is_ok());
+    }
+
+    #[test]
+    fn unknown_logic_name_is_refused() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(x, p.integer(0_i32));
+        let mut o = opts();
+        o.logic = Some("QF_BV");
+        assert!(matches!(
+            to_smtlib(f, &p, &o).unwrap_err(),
+            SmtLibError::UnsupportedLogic(_)
+        ));
+    }
+
+    #[test]
+    fn reserved_names_are_quoted() {
+        let p = ExprPool::new();
+        let x = p.symbol("ite", Domain::Real);
+        let f = p.pred_gt(x, p.integer(0_i32));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(text.contains("(declare-fun |ite| () Real)"), "{text}");
+    }
+
+    #[test]
+    fn ne_becomes_not_eq() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_ne(x, p.integer(0_i32));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(text.contains("(not (= x 0))"), "{text}");
+    }
+
+    #[test]
+    fn every_predicate_kind_emits() {
+        // If a `PredicateKind` is added, this fails to compile in `Emitter::formula`
+        // first; this test keeps the *behaviour* pinned too.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let z = p.integer(0_i32);
+        let leaf = p.pred_gt(x, z);
+        let cases = [
+            p.pred_lt(x, z),
+            p.pred_le(x, z),
+            p.pred_gt(x, z),
+            p.pred_ge(x, z),
+            p.pred_eq(x, z),
+            p.pred_ne(x, z),
+            p.pred_and(vec![leaf, leaf]),
+            p.pred_or(vec![leaf, leaf]),
+            p.pred_not(leaf),
+            p.pred_true(),
+            p.pred_false(),
+        ];
+        for (i, &case) in cases.iter().enumerate() {
+            assert!(to_smtlib(case, &p, &opts()).is_ok(), "case {i} failed");
+        }
+    }
+
+    #[test]
+    fn every_formula_variant_emits() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let leaf = Formula::Atom {
+            kind: PredicateKind::Gt,
+            args: vec![x, p.integer(0_i32)],
+        };
+        let variants = [
+            Formula::True,
+            Formula::False,
+            leaf.clone(),
+            Formula::and(leaf.clone(), leaf.clone()),
+            Formula::or(leaf.clone(), leaf.clone()),
+            Formula::not(leaf.clone()),
+            Formula::Forall {
+                var: x,
+                body: Box::new(leaf.clone()),
+            },
+            Formula::Exists {
+                var: x,
+                body: Box::new(leaf.clone()),
+            },
+        ];
+        for (i, v) in variants.iter().enumerate() {
+            assert!(
+                formula_to_smtlib(v, &p, &opts()).is_ok(),
+                "variant {i} failed"
+            );
+        }
+    }
+
+    #[test]
+    fn hand_built_atom_with_boolean_kind_emits() {
+        // `formula_from_expr` never produces these, but `Formula` is public.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let leaf = p.pred_gt(x, p.integer(0_i32));
+        for kind in [PredicateKind::And, PredicateKind::Or] {
+            let f = Formula::Atom {
+                kind,
+                args: vec![leaf, leaf],
+            };
+            let text = formula_to_smtlib(&f, &p, &opts()).unwrap();
+            assert!(text.contains("(> x 0) (> x 0)"), "{text}");
+        }
+        let f = Formula::Atom {
+            kind: PredicateKind::Not,
+            args: vec![leaf],
+        };
+        assert!(formula_to_smtlib(&f, &p, &opts())
+            .unwrap()
+            .contains("(not (> x 0))"));
+        for kind in [PredicateKind::True, PredicateKind::False] {
+            let f = Formula::Atom { kind, args: vec![] };
+            assert!(formula_to_smtlib(&f, &p, &opts()).is_ok());
+        }
+    }
+
+    #[test]
+    fn supported_matches_to_smtlib() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        assert!(supported(p.pred_gt(x, p.integer(0_i32)), &p));
+        assert!(!supported(
+            p.pred_gt(p.func("sin", vec![x]), p.integer(0_i32)),
+            &p
+        ));
+        assert!(!supported(x, &p));
+    }
+
+    #[test]
+    fn piecewise_becomes_ite() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let cond = p.pred_gt(x, p.integer(0_i32));
+        let pw = p.piecewise(vec![(cond, p.integer(1_i32))], p.integer(-1_i32));
+        let f = p.pred_eq(pw, p.integer(1_i32));
+        let text = to_smtlib(f, &p, &opts()).unwrap();
+        assert!(text.contains("(ite (> x 0) 1 (- 1))"), "{text}");
+    }
+
+    #[test]
+    fn negative_power_is_real_division() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(p.pow(x, p.integer(-1_i32)), p.integer(0_i32));
+        let e = export(f, &p, &opts()).unwrap();
+        assert!(e.text.contains("(/ 1 x)"), "{}", e.text);
+        assert!(e.requirements.nonlinear);
+    }
+}

--- a/alkahest-core/src/logic/smtlib.rs
+++ b/alkahest-core/src/logic/smtlib.rs
@@ -179,6 +179,31 @@ pub struct Requirements {
 }
 
 /// The arithmetic fragment of an SMT-LIB logic name.
+///
+/// # `LIRA` / `NIRA` are solver-facing names, not catalog names
+///
+/// The official SMT-LIB logic catalog (2.7) has no `QF_LIRA`, `QF_NIRA`,
+/// `LIRA`, or `NIRA`: for mixed `Int`/`Real` it stops at `AUFLIRA` /
+/// `AUFNIRA`.  Alkahest emits the `LIRA`/`NIRA` family anyway, deliberately:
+///
+/// * they are what the solvers this bridge drives actually use for the mixed
+///   fragment.  z3 accepts them silently, where an unknown name draws
+///   `ignoring unsupported logic`; Yices documents `QF_LIRA` / `QF_NIRA` among
+///   the names it recognises beyond the official set; SMT-COMP runs `QF_LIRA`
+///   and `QF_NIRA` divisions over SMT-LIB benchmarks.
+/// * the catalog alternatives are strictly worse for what alkahest emits.
+///   `AUFLIRA`/`AUFNIRA` are *quantified* logics that additionally carry arrays
+///   and free function symbols, so naming one for a quantifier-free mixed
+///   formula throws away the `QF_` hint that decides which solver core runs and
+///   claims a much larger fragment than is being used.
+///
+/// Mixed `Int`/`Real` is the capability this bridge exists to add, so the
+/// contract is stated rather than hedged: **the inferred logic name for a mixed
+/// formula is solver-facing, not catalog-standard.**  A consumer that will only
+/// accept catalog names can ask for `AUFLIRA` / `AUFNIRA` explicitly (both are
+/// in [`SUPPORTED_LOGICS`] and are sound supersets of everything emitted here),
+/// or for `ALL`.  `tests/test_smt.py` pins that the installed solver accepts
+/// the names actually emitted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Arith {
     Lia,
@@ -235,43 +260,87 @@ impl Requirements {
 }
 
 /// Every logic name [`to_smtlib`] accepts explicitly, in the order a planner
-/// should read them: quantifier-free first, then quantified, then the catch-all.
+/// should read them: quantifier-free first, then quantified, then the two
+/// catalog logics for mixed `Int`/`Real` (see [`Arith`]), then the catch-all.
 pub const SUPPORTED_LOGICS: &[&str] = &[
     "QF_LIA", "QF_NIA", "QF_LRA", "QF_NRA", "QF_LIRA", "QF_NIRA", "LIA", "NIA", "LRA", "NRA",
-    "LIRA", "NIRA", "ALL",
+    "LIRA", "NIRA", "AUFLIRA", "AUFNIRA", "ALL",
 ];
 
-fn check_logic(requested: &str, req: &Requirements) -> Result<(), SmtLibError> {
-    if requested == "ALL" {
-        return Ok(());
+/// What a logic name permits, on the four axes [`Requirements`] tracks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LogicCaps {
+    quantifiers: bool,
+    nonlinear: bool,
+    ints: bool,
+    reals: bool,
+}
+
+const fn caps(quantifiers: bool, nonlinear: bool, ints: bool, reals: bool) -> LogicCaps {
+    LogicCaps {
+        quantifiers,
+        nonlinear,
+        ints,
+        reals,
     }
-    if !SUPPORTED_LOGICS.contains(&requested) {
+}
+
+/// What every name in [`SUPPORTED_LOGICS`] permits, in the same order.
+///
+/// A table rather than a letter heuristic on the name: `AUFLIRA` is a *linear*
+/// logic that does not start with `L`, so `body.starts_with('L')` would quietly
+/// wave a nonlinear formula through it.
+const LOGIC_CAPS: &[LogicCaps] = &[
+    //   quant  nonlin ints   reals
+    caps(false, false, true, false), // QF_LIA
+    caps(false, true, true, false),  // QF_NIA
+    caps(false, false, false, true), // QF_LRA
+    caps(false, true, false, true),  // QF_NRA
+    caps(false, false, true, true),  // QF_LIRA
+    caps(false, true, true, true),   // QF_NIRA
+    caps(true, false, true, false),  // LIA
+    caps(true, true, true, false),   // NIA
+    caps(true, false, false, true),  // LRA
+    caps(true, true, false, true),   // NRA
+    caps(true, false, true, true),   // LIRA
+    caps(true, true, true, true),    // NIRA
+    // The catalog names for mixed Int/Real.  Both are quantified and also carry
+    // arrays and free function symbols, which alkahest never emits — a superset
+    // is sound, and these are the names a consumer that only knows the official
+    // SMT-LIB catalog will accept.
+    caps(true, false, true, true), // AUFLIRA
+    caps(true, true, true, true),  // AUFNIRA
+    caps(true, true, true, true),  // ALL
+];
+
+/// The fragment `name` denotes, or `None` if [`to_smtlib`] does not accept it.
+fn logic_caps(name: &str) -> Option<LogicCaps> {
+    let index = SUPPORTED_LOGICS.iter().position(|&n| n == name)?;
+    LOGIC_CAPS.get(index).copied()
+}
+
+fn check_logic(requested: &str, req: &Requirements) -> Result<(), SmtLibError> {
+    let Some(caps) = logic_caps(requested) else {
         return Err(SmtLibError::UnsupportedLogic(format!(
             "{requested:?} is not one of {SUPPORTED_LOGICS:?}"
         )));
-    }
-    let quantifier_free = requested.starts_with("QF_");
-    let body = requested.strip_prefix("QF_").unwrap_or(requested);
-    let linear = body.starts_with('L');
-    let has_int = body.contains('I');
-    let has_real = body.contains('R');
-
-    if req.quantifiers && quantifier_free {
+    };
+    if req.quantifiers && !caps.quantifiers {
         return Err(SmtLibError::UnsupportedLogic(format!(
             "formula has quantifiers but {requested:?} is quantifier-free"
         )));
     }
-    if req.nonlinear && linear {
+    if req.nonlinear && !caps.nonlinear {
         return Err(SmtLibError::UnsupportedLogic(format!(
             "formula is nonlinear but {requested:?} is a linear logic"
         )));
     }
-    if req.ints && !has_int {
+    if req.ints && !caps.ints {
         return Err(SmtLibError::UnsupportedLogic(format!(
             "formula has Int-sorted symbols but {requested:?} has no Int sort"
         )));
     }
-    if req.reals && !has_real {
+    if req.reals && !caps.reals {
         return Err(SmtLibError::UnsupportedLogic(format!(
             "formula needs Real arithmetic but {requested:?} has no Real sort"
         )));
@@ -498,7 +567,8 @@ fn has_symbol(id: ExprId, pool: &ExprPool) -> bool {
 
 struct Emitter<'a> {
     pool: &'a ExprPool,
-    /// `to_real` exists only when the script also declares `Int`-sorted symbols.
+    /// Is the script in a `Reals_Ints` logic, where `to_real` exists and an
+    /// `Int` numeral in a `Real` position needs it?  See [`formula_export`].
     use_to_real: bool,
     req: Requirements,
     bound: Vec<String>,
@@ -508,10 +578,10 @@ struct Emitter<'a> {
 impl<'a> Emitter<'a> {
     fn coerce(&self, text: String, from: Sort, to: Sort) -> String {
         match (from, to) {
-            // `to_real` lives in the `Reals_Ints` theory, which the script only
-            // enters when it also declares an `Int`-sorted symbol.  Under plain
-            // `Reals` (QF_LRA / QF_NRA) numerals already *are* `Real`, and
-            // emitting `to_real` there would make the script unparseable.
+            // `to_real` lives in the `Reals_Ints` theory.  Under plain `Reals`
+            // (QF_LRA / QF_NRA) numerals already *are* `Real` and emitting
+            // `to_real` would make the script unparseable; under `Reals_Ints`
+            // they are `Int` and omitting it would rely on mixed-sort sugar.
             (Sort::Int, Sort::Real) => {
                 if self.use_to_real {
                     format!("(to_real {text})")
@@ -640,10 +710,18 @@ impl<'a> Emitter<'a> {
             )));
         }
         let base_has_symbol = has_symbol(base, self.pool);
+        let (base_text, base_sort) = self.term(base)?;
         if k == 0 {
+            // The kernel defines `0^0 = 1`, so the *value* is `1` whatever the
+            // base is — but the base still has to be visited.  Every refusal
+            // this emitter makes (float literals, transcendental heads, complex
+            // domains) is raised by `term`, and `ExprPool::pow` interns
+            // `sin(x)^0` verbatim, so returning early would emit a script for a
+            // formula alkahest cannot translate.  Visiting also records the
+            // base's `Requirements`, which keeps logic selection consistent
+            // with the symbols `collect_symbols_expr` goes on to declare.
             return Ok(("1".to_string(), Sort::Int));
         }
-        let (base_text, base_sort) = self.term(base)?;
         let n = k.unsigned_abs() as usize;
         if n >= 2 && base_has_symbol {
             self.req.nonlinear = true;
@@ -964,7 +1042,16 @@ pub fn formula_export(
 ) -> Result<SmtLibExport, SmtLibError> {
     let mut symbols: BTreeMap<String, (Sort, Domain)> = BTreeMap::new();
     collect_symbols_formula(f, pool, &mut symbols)?;
-    let use_to_real = symbols.values().any(|&(sort, _)| sort == Sort::Int);
+    // `to_real` exists only inside a `Reals_Ints` logic, and there are two ways
+    // to be in one: an `Int`-sorted symbol forces it, or the caller named a
+    // logic that carries both sorts.  Emitting `to_real` outside such a logic
+    // would not parse; *omitting* it inside one would lean on the mixed-sort
+    // sugar that only some logics define, so both cases turn it on.
+    let use_to_real = symbols.values().any(|&(sort, _)| sort == Sort::Int)
+        || opts
+            .logic
+            .and_then(logic_caps)
+            .is_some_and(|c| c.ints && c.reals);
 
     let mut emitter = Emitter {
         pool,
@@ -1114,6 +1201,34 @@ mod tests {
     }
 
     #[test]
+    fn zero_exponent_is_one_but_still_checks_the_base() {
+        // `0^0 = 1` in the kernel, so the value is not in question — but the
+        // base is still translated, and an untranslatable base is a refusal
+        // rather than a silently emitted `1`.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+
+        let ok = p.pred_eq(p.pow(x, p.integer(0_i32)), p.integer(1_i32));
+        let text = to_smtlib(ok, &p, &opts()).unwrap();
+        assert!(text.contains("(= 1 1)"), "{text}");
+
+        let zero_zero = p.pred_eq(p.pow(p.integer(0_i32), p.integer(0_i32)), p.integer(1_i32));
+        assert!(to_smtlib(zero_zero, &p, &opts()).is_ok());
+
+        let sin_x = p.func("sin", vec![x]);
+        let bad = p.pred_eq(p.pow(sin_x, p.integer(0_i32)), p.integer(1_i32));
+        let err = to_smtlib(bad, &p, &opts()).unwrap_err();
+        assert!(
+            matches!(err, SmtLibError::UnsupportedFunction(_)),
+            "{err:?}"
+        );
+
+        let float_base = p.pred_eq(p.pow(p.float(0.1, 53), p.integer(0_i32)), p.integer(1_i32));
+        let err = to_smtlib(float_base, &p, &opts()).unwrap_err();
+        assert!(matches!(err, SmtLibError::UnsupportedNode(_)), "{err:?}");
+    }
+
+    #[test]
     fn huge_exponent_is_refused_not_expanded() {
         let p = ExprPool::new();
         let x = p.symbol("x", Domain::Real);
@@ -1244,6 +1359,54 @@ mod tests {
         assert!(matches!(err, SmtLibError::UnsupportedLogic(_)), "{err:?}");
         o.logic = Some("QF_NRA");
         assert!(to_smtlib(f, &p, &o).is_ok());
+    }
+
+    #[test]
+    fn every_supported_logic_has_a_capability_entry() {
+        assert_eq!(SUPPORTED_LOGICS.len(), LOGIC_CAPS.len());
+        for name in SUPPORTED_LOGICS {
+            assert!(logic_caps(name).is_some(), "{name} has no LogicCaps entry");
+        }
+        assert_eq!(logic_caps("QF_BV"), None);
+    }
+
+    #[test]
+    fn catalog_mixed_logics_are_accepted_and_still_checked() {
+        // `AUFLIRA`/`AUFNIRA` are the *official* mixed Int/Real names, offered
+        // for a consumer that only accepts the catalog.  `AUFLIRA` is linear
+        // despite not starting with `L`, so a nonlinear formula must still be
+        // refused under it.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let n = p.symbol("n", Domain::Integer);
+        let linear = p.pred_gt(x, n);
+        let mut o = opts();
+        o.logic = Some("AUFLIRA");
+        let text = to_smtlib(linear, &p, &o).unwrap();
+        assert!(text.contains("(set-logic AUFLIRA)"), "{text}");
+        assert!(text.contains("(> x (to_real n))"), "{text}");
+
+        let nonlinear = p.pred_gt(p.mul(vec![x, n]), p.integer(0_i32));
+        let err = to_smtlib(nonlinear, &p, &o).unwrap_err();
+        assert!(matches!(err, SmtLibError::UnsupportedLogic(_)), "{err:?}");
+        o.logic = Some("AUFNIRA");
+        assert!(to_smtlib(nonlinear, &p, &o).is_ok());
+    }
+
+    #[test]
+    fn a_reals_ints_logic_never_relies_on_mixed_sort_sugar() {
+        // Pure-real formula, but the caller named a logic that carries both
+        // sorts: the numeral is `Int` there and needs lifting.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_gt(x, p.integer(0_i32));
+        let mut o = opts();
+        o.logic = Some("ALL");
+        let text = to_smtlib(f, &p, &o).unwrap();
+        assert!(text.contains("(> x (to_real 0))"), "{text}");
+        // ... and never emits it where the theory has no such function.
+        o.logic = Some("QF_LRA");
+        assert!(!to_smtlib(f, &p, &o).unwrap().contains("to_real"));
     }
 
     #[test]

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -4756,6 +4756,62 @@ fn py_to_lean(py: Python<'_>, arg: &Bound<'_, PyAny>) -> PyResult<String> {
 }
 
 // ---------------------------------------------------------------------------
+// P2-3 — SMT-LIB 2 exporter (the export half of the SMT/SAT bridge)
+// ---------------------------------------------------------------------------
+
+fn smtlib_error_to_py(e: alkahest_core::logic::smtlib::SmtLibError) -> PyErr {
+    Python::with_gil(|py| {
+        // Deliberately *not* a dedicated PyO3 exception class: `SmtError` is a
+        // pure-Python class in `alkahest/exceptions.py` and is not in
+        // `_NATIVE_EXCEPTION_OVERLAY`, so a native `PySmtError` would be a
+        // *different* class from the `ak.SmtError` callers write `except` for.
+        // `alkahest/smt.py` re-raises this as `SmtError`, preserving `.code`.
+        let exc_type = py.get_type_bound::<PyAlkahestError>();
+        make_structured_err(py, &exc_type, &e)
+    })
+}
+
+/// `alkahest.to_smtlib(formula, logic="auto", *, check_sat=True, get_model=True) -> str`
+///
+/// Export a predicate (or quantified) :class:`Expr` as a complete, runnable
+/// SMT-LIB 2 script — the SMT counterpart of :func:`alkahest.to_lean`.
+///
+/// ``logic`` is ``"auto"`` (infer the weakest logic that fits) or one of
+/// ``QF_LIA``, ``QF_NIA``, ``QF_LRA``, ``QF_NRA``, ``QF_LIRA``, ``QF_NIRA``,
+/// their quantified counterparts, or ``ALL``.  A named logic that is too weak
+/// for the formula is an error rather than a downgrade.
+///
+/// Raises with the stable code ``E-SMT-002`` when the formula is outside the
+/// exportable fragment; :func:`alkahest.smt.supported` is the plan-ahead
+/// predicate that answers the same question without raising.
+///
+/// Example::
+///
+///     f = alkahest.And(pool.gt(x * x, pool.integer(2)), pool.lt(x, pool.integer(0)))
+///     print(alkahest.to_smtlib(f))
+#[pyfunction]
+#[pyo3(
+    name = "to_smtlib",
+    signature = (formula, logic = "auto", *, check_sat = true, get_model = true)
+)]
+fn py_to_smtlib(
+    py: Python<'_>,
+    formula: PyRef<PyExpr>,
+    logic: &str,
+    check_sat: bool,
+    get_model: bool,
+) -> PyResult<String> {
+    let pool = formula.pool.borrow(py);
+    let opts = alkahest_core::logic::smtlib::SmtLibOptions {
+        logic: if logic == "auto" { None } else { Some(logic) },
+        check_sat,
+        get_model,
+    };
+    alkahest_core::logic::smtlib::to_smtlib(formula.id, &pool.inner, &opts)
+        .map_err(smtlib_error_to_py)
+}
+
+// ---------------------------------------------------------------------------
 // subs — substitution primitive (R-6)
 // ---------------------------------------------------------------------------
 
@@ -10670,6 +10726,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_routh_hurwitz, m)?)?;
     // V5-1 — Lean 4 certificate exporter
     m.add_function(wrap_pyfunction!(py_to_lean, m)?)?;
+    m.add_function(wrap_pyfunction!(py_to_smtlib, m)?)?;
     // V5-2 — StableHLO/XLA bridge
     m.add_function(wrap_pyfunction!(py_to_stablehlo, m)?)?;
     // V5-3 — NVPTX JIT backend

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -29,4 +29,7 @@
   - [Budgets, cancellation, and determinism](./budgets.md)
   - [Batch and streaming evaluation](./batch.md)
   - [Creative telescoping (Zeilberger)](./telescoping.md)
+  - [Ansatz families and conjecture generation](./ansatz.md)
+  - [Cross-CAS differential testing](./crosscheck.md)
+  - [SMT/SAT bridge](./smt.md)
 - [Stability policy](./stability.md)

--- a/docs/mdbook/src/ansatz.md
+++ b/docs/mdbook/src/ansatz.md
@@ -75,7 +75,9 @@ under.free                                    # (d_0,)  — still symbolic in .e
 | `quadratic_form(pool, vars)` | `Σ_{i ≤ j} q_ij · xᵢ xⱼ` | Lyapunov candidates |
 
 Every constructor takes `name=` (the coefficient prefix), `max_terms=` (a hard bound), and
-`reserved=` (extra symbols the coefficients must not collide with).
+`reserved=` (extra symbols the coefficients must not collide with). `reserved=` reserves
+*names* only — it never adds an independent variable, so `linear_combination(pool, basis,
+reserved=[y])` is still a family in the basis's own symbols. Pass `vars=` to say otherwise.
 
 ### Predictable coefficient names
 
@@ -160,7 +162,11 @@ no coefficient collection over a symbolic ring is required.
 
 - `"residual"` (default) — collocation at sample points, then exact back-substitution.
 - `"exact"` — Taylor-coefficient extraction (`∂^α R / α!`), so the *system itself* is exact
-  for polynomial residuals up to `degree_bound`; still back-substituted.
+  for polynomial residuals up to `degree_bound`; still back-substituted. Every multi-index of
+  total degree ≤ `degree_bound` contributes an equation, and the bound that was reached is
+  written into the derivation log — the system is never quietly cut short. `max_points` caps
+  sample-point *draws* and therefore applies to collocation only; `degree_bound` is the knob
+  that sizes this one.
 - `"none"` — no check at all; `status="unverified"` and no re-verification recipe. For hot
   loops that verify downstream, never for anything recorded as a result.
 
@@ -253,7 +259,7 @@ undetermined form is a family, not a candidate. Instantiate first.
 | --- | --- |
 | `E-ANSATZ-001` | A coefficient name collides with a symbol already in play (or an unknown name was passed to `instantiate`). You called it wrong. |
 | `E-ANSATZ-002` | The requested family exceeds `max_terms` / `max_members`. Refused before anything was materialised. |
-| `E-ANSATZ-003` | **No member of this family satisfies the constraints.** A *result*: a closed branch a loop should record. |
+| `E-ANSATZ-003` | **No member of this family satisfies the constraints.** A *result*: a closed branch a loop should record. Also raised when no system could be built at all — the residual, or a derivative of it, is undefined everywhere the sampler looked — in which case the message says so instead of claiming anything about the family. |
 | `E-ANSATZ-004` | The residual is nonlinear in the unknowns and escalating to `solve` needs a `groebner` build, which this is not. |
 
 Only the first two mean "you called it wrong"; the other two are findings. See

--- a/docs/mdbook/src/ansatz.md
+++ b/docs/mdbook/src/ansatz.md
@@ -1,0 +1,283 @@
+# Ansatz families and conjecture generation
+
+Stage 1 of a search loop is *generate*: propose a structured family of candidates — every
+polynomial of degree ≤ 3 in `x` and `y`, a Padé approximant of type (2, 2), a quadratic
+Lyapunov candidate — and then either sweep it numerically or solve for the coefficients
+that make a residual vanish. Agents hand-roll this constantly, and the hand-rolled version
+is usually wrong in one of three specific ways: it loses the distinction between an
+unknown coefficient and an independent variable; it assumes the first *m* sample points
+give *m* independent equations; and it never substitutes the answer back, so a fit that
+only satisfies the sampled constraints is reported as if it satisfied the identity.
+
+`alkahest.ansatz` is that plumbing, done once.
+
+```python
+import alkahest as ak
+from alkahest.ansatz import polynomial, fit
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+
+A = polynomial(pool, [x], degree=2)      # c_0 + c_1*x + c_2*x^2
+target = x**2 - pool.integer(3) * x + pool.integer(2)
+
+sol = fit(A, A.expr - target)
+sol.expr          # (2 + x^2 + (x * -3))
+sol.rank, sol.free
+sol.status        # 'exactly_verified'
+```
+
+Everything here is **pure Python** composed from primitives that are already fast in Rust
+(`Matrix.rref`, `simplify`, `subs`), so it works in a build without the `groebner`
+feature. The one path that needs Gröbner — a residual genuinely nonlinear in the unknowns
+— refuses with `E-ANSATZ-004` rather than degrading silently.
+
+## Honesty invariants
+
+**Solving may be heuristic; checking is exact.** The linear system is built by
+*collocation* — evaluating the residual at sample points — which proves identical vanishing
+only for polynomial residuals of bounded degree. So the fit is never trusted on its own:
+`fit(..., certify="residual")` (the default) substitutes it back and normalises.
+
+| Outcome | `verification["status"]` | What it means |
+| --- | --- | --- |
+| The residual normalises to `0` | `exactly_verified` | A symbolic proof. The claim is machine-checked. |
+| It does not, but samples are small | `numerically_checked` | Evidence, not a proof. The surviving normal form is in `verification["residual"]`. |
+| `certify="none"` | `unverified` | Nothing was checked. There is deliberately no way to call this "solved". |
+
+Those are the existing [`research.STATUS_BADGES`](./claim-graphs.md) strings, so a fitted
+ansatz lands in a claim graph correctly labelled with no new vocabulary.
+
+**Inconsistent is a result, not a malfunction.** When no member of the family can satisfy
+the constraints, `fit` raises `AnsatzError` `E-ANSATZ-003`. For a loop that is a *closed
+branch* — a positive finding worth recording — in the same spirit as a non-elementarity
+verdict from `integrate`.
+
+**Underdetermined is also a result.** When the rank is below the number of unknowns, the
+members that work form a positive-dimensional family. `AnsatzSolution.free` returns the
+free parameters rather than picking an arbitrary member:
+
+```python
+B = polynomial(pool, [x], degree=3, name="d")
+under = fit(B, ak.diff(B.expr, x).value)      # d/dx of the family vanishes identically
+under.rank                                    # 3
+under.free                                    # (d_0,)  — still symbolic in .expr
+```
+
+## The families
+
+| Constructor | Family | Typical use |
+| --- | --- | --- |
+| `polynomial(pool, vars, degree)` | `Σ c_α · x^α`, total degree ≤ `degree` | Undetermined coefficients, invariants |
+| `rational(pool, vars, num_degree, den_degree)` | `p / q` | Padé, rational-function reconstruction |
+| `linear_combination(pool, basis)` | `Σ cᵢ · basisᵢ` | The escape hatch: any basis you can write down |
+| `exponential_polynomial(pool, var, rates, degree=…)` | `Σ pᵢ(x)·e^{λᵢ x}` | ODE / recurrence ansätze with known characteristic roots |
+| `quadratic_form(pool, vars)` | `Σ_{i ≤ j} q_ij · xᵢ xⱼ` | Lyapunov candidates |
+
+Every constructor takes `name=` (the coefficient prefix), `max_terms=` (a hard bound), and
+`reserved=` (extra symbols the coefficients must not collide with).
+
+### Predictable coefficient names
+
+Names are `c_0, c_1, …` for one variable and `c_0_0, c_1_0, c_0_1, …` (graded, then
+lexicographic with the first variable heaviest) for several. They are **never gensym-ed**:
+an agent that cannot predict the symbol names cannot write the follow-up call.
+
+If a generated name collides with a symbol already in play, the constructor raises
+`E-ANSATZ-001` instead of quietly fitting the wrong thing:
+
+```python
+c0 = pool.symbol("c_0")
+polynomial(pool, [x], degree=1, reserved=[c0])   # AnsatzError E-ANSATZ-001
+polynomial(pool, [x], degree=1, name="k", reserved=[c0])   # fine: k_0, k_1
+```
+
+The collision check sees the family's own variables, every free symbol of the expressions
+handed to the constructor, and anything passed as `reserved=`. An `ExprPool` exposes no
+symbol listing, so a symbol that appears in *none* of those is not detected at construction
+— `fit`'s back-substitution check is the backstop.
+
+### Bounds are mandatory, not advisory
+
+`C(n + d, d)` is a combinatorial explosion, so every constructor is bounded and the bound
+is checked from the *count* before anything is materialised:
+
+```python
+polynomial(pool, [x, y], degree=40, max_terms=32)
+# AnsatzError E-ANSATZ-002: … needs 861 unknown coefficients, which exceeds max_terms=32
+```
+
+### `rational` keeps the Padé case linear
+
+`p/q ≈ f` is *not* linear in the coefficients of `p` and `q`, but `p − f·q = 0` is linear
+in them jointly. `rational()` records the numerator/denominator split so that transform can
+be applied, and `fit` applies it automatically when it sees an unknown-bearing denominator:
+
+```python
+A = rational(pool, [x], num_degree=1, den_degree=1)
+A.expr                       # ((a_0 + (x * a_1)) * (1 + (x * b_1))^-1)
+A.residual(target)           # a_0 + a_1*x - target*(1 + b_1*x)   — affine in the unknowns
+
+sol = fit(A, A.expr - pool.integer(1) / (pool.integer(1) + x))
+[s["rule"] for s in sol.steps]        # includes 'ansatz_clear_denominator'
+sol.status                            # 'exactly_verified'
+```
+
+The denominator's constant term is fixed to `1` by default (`monic_denominator=True`),
+because `p/q` and `(λp)/(λq)` are the same function — without a normalisation **every**
+rational fit would report a spurious extra free parameter.
+
+A Padé approximant is a *local* match, not an identity, so it wants the exact-system route
+with an explicit degree bound:
+
+```python
+A = rational(pool, [x], num_degree=2, den_degree=2, name="u", den_name="v")
+sol = fit(A, A.residual(ak.exp(x)), certify="exact", degree_bound=4)
+# u_0=1, u_1=1/2, u_2=1/12, v_1=-1/2, v_2=1/12  — the (2,2) Padé of exp
+sol.status                   # 'numerically_checked': an approximant is not an identity,
+sol.verification["residual"] # and the check says so rather than claiming otherwise
+```
+
+Asking for the same thing as an *identity* (`fit(A, A.residual(ak.exp(x)))`, default
+certify) is correctly answered with `E-ANSATZ-003`: no rational function equals `exp`.
+
+## `fit`
+
+```python
+def fit(ansatz, residual, *, certify="residual", seed=None, oversample=None,
+        max_points=None, degree_bound=None, tolerance=1e-8, samples=5) -> AnsatzSolution: ...
+```
+
+`residual` is the expression that must vanish identically in `ansatz.vars` — usually
+`ansatz.expr - target`.
+
+**How a residual becomes a finite system.** Because the residual is affine in the unknowns,
+each row is built by *probing*: evaluate it with every unknown set to `0` for the constant
+column, then with unknown *j* set to `1` for column *j*. That is `subs` and nothing else —
+no coefficient collection over a symbolic ring is required.
+
+`certify` selects how the system is built as well as how it is graded:
+
+- `"residual"` (default) — collocation at sample points, then exact back-substitution.
+- `"exact"` — Taylor-coefficient extraction (`∂^α R / α!`), so the *system itself* is exact
+  for polynomial residuals up to `degree_bound`; still back-substituted.
+- `"none"` — no check at all; `status="unverified"` and no re-verification recipe. For hot
+  loops that verify downstream, never for anything recorded as a result.
+
+**Rank is read off the reduction, never assumed.** `fit` draws strictly more equations than
+there are unknowns (`oversample`, default `max(4, len(ansatz))`) and takes the rank from the
+reduced row echelon form. Assuming the first *m* points are independent is the specific bug
+in every hand-rolled version of this.
+
+**Points where the residual is undefined are skipped.** A vanishing denominator is detected
+exactly (not by catching a float `inf`), the point is resampled, and the count of skipped
+points appears in the derivation log.
+
+### Determinism
+
+Sample points come from a deterministic generator seeded from `budget_seed()`, so a fit is
+reproducible across runs and machines — see [Budgets](./budgets.md):
+
+```python
+with ak.context(budget=ak.Budget(seed=7)):
+    sol = fit(A, A.expr - target)
+sol.points          # the exact points used, as rational strings
+```
+
+With no budget active the seed is `ansatz.DEFAULT_SEED`, a fixed constant, so two machines
+still agree. `fit(..., seed=…)` overrides both.
+
+## `AnsatzSolution`
+
+| Field | Meaning |
+| --- | --- |
+| `expr` / `value` | The fitted member (`value` is the alias `ResearchSession` reads) |
+| `assignment` | `{unknown: Expr}` for the determined coefficients |
+| `free` | Unknowns the constraints do not pin down |
+| `rank` | Rank of the system; `rank == len(ansatz)` iff the fit is unique |
+| `status` | Mirrors `verification["status"]` |
+| `verification` | `{"status", "evidence", "method", "residual", "max_abs_residual", …}` |
+| `steps` | Derivation log in the `STEP_FIELDS` schema |
+| `check` | Re-verification recipe for `ClaimGraph.verify()` |
+| `points` | The sample points used, enough to reproduce the system |
+| `certificate` | Always `None` — this module emits no Lean certificate |
+
+It has the same shape as a `DerivedResult` where it matters, so it records unchanged:
+
+```python
+with ak.research.session(title="ansatz", pool=pool) as s:
+    sol = fit(A, A.expr - target)
+    s.record(sol, method="ansatz.fit", check=sol.check)
+
+s.graph.summary()          # {'exactly_verified': 1}
+```
+
+## `enumerate_family` — stage 2 material
+
+Enumeration and fitting stay separate. `enumerate_family` feeds the *falsify* stage
+(generate candidates, hammer them with [`compile_expr`](./codegen.md) or
+[`batch_map`](./batch.md)); `fit` is the *discover* stage. Fusing them produces an API that
+does neither well.
+
+```python
+from alkahest.ansatz import enumerate_family
+
+A = polynomial(pool, [x], degree=1)
+[str(m) for m in enumerate_family(A, [0, 1])]     # ['0', 'x', '1', '(x + 1)']
+```
+
+Enumeration is lazy **and** bounded: `len(coeffs) ** len(ansatz)` is checked against
+`max_members` before the first member is built, and exceeding it raises `E-ANSATZ-002`.
+
+## Positivity: hand off, don't reimplement
+
+The module's job ends when it has produced the candidate. `certify_nonneg` is a one-line
+adapter onto [`prove_nonneg` / `sos_decompose`](./positivity.md), and every outcome — a
+`PositivityCertificate`, an `E-SOS-003` refutation with a witness point, an `E-SOS-002`
+"no certificate of this shape at this degree" — comes back unmodified:
+
+```python
+from alkahest.ansatz import quadratic_form, certify_nonneg
+
+V = quadratic_form(pool, [x, y], name="q")
+sol = fit(V, V.expr - lyapunov_residual)
+cert = certify_nonneg(sol)          # PositivityCertificate, or the SosError as raised
+```
+
+A solution that still carries free parameters is refused (`E-ANSATZ-003`): an
+undetermined form is a family, not a candidate. Instantiate first.
+
+## Error codes
+
+| Code | Meaning |
+| --- | --- |
+| `E-ANSATZ-001` | A coefficient name collides with a symbol already in play (or an unknown name was passed to `instantiate`). You called it wrong. |
+| `E-ANSATZ-002` | The requested family exceeds `max_terms` / `max_members`. Refused before anything was materialised. |
+| `E-ANSATZ-003` | **No member of this family satisfies the constraints.** A *result*: a closed branch a loop should record. |
+| `E-ANSATZ-004` | The residual is nonlinear in the unknowns and escalating to `solve` needs a `groebner` build, which this is not. |
+
+Only the first two mean "you called it wrong"; the other two are findings. See
+[Error handling](./errors.md).
+
+## Known limits
+
+- **Collocation is not a proof of identical vanishing** except for polynomial residuals of
+  bounded degree. That is exactly why the back-substitution check exists and why a fit that
+  does not normalise to zero is never reported as verified.
+- **Transcendental bases are only as exact as the simplifier's zero test.** When the
+  collocation matrix is not over ℚ (an exponential family sampled at rational points),
+  `fit` first tries Taylor extraction, which usually recovers an exact rational system; if
+  it cannot, the reduction falls back to a symbolic elimination whose zero test is
+  best-effort. In that case an *apparent* inconsistency is corroborated numerically before
+  `E-ANSATZ-003` is claimed — a confident "no member of this family works" is exactly the
+  kind of wrong answer this package exists to avoid.
+- **The pool exposes no symbol listing**, so the `E-ANSATZ-001` collision check covers the
+  variables, the constructor's inputs, and `reserved=` — not the whole pool.
+
+## See also
+
+- [Autoresearch / agent loops](./search-plumbing.md)
+- [Claim graphs](./claim-graphs.md) — where a fitted ansatz gets recorded
+- [Batch and streaming evaluation](./batch.md) — sweeping an enumerated family
+- [Budgets, cancellation, and determinism](./budgets.md) — where the sample seed comes from
+- [Positivity certificates](./positivity.md) — the hand-off target for `quadratic_form`

--- a/docs/mdbook/src/crosscheck.md
+++ b/docs/mdbook/src/crosscheck.md
@@ -1,0 +1,327 @@
+# Cross-CAS differential testing
+
+[Lean certificates](./lean-certs.md) cover the fragment where Alkahest can *prove* its
+answer. Outside that fragment nothing is checking the answer at all, and the failure that
+matters for a search loop is not a crash but a **silent error**: a confident, plausible,
+wrong result that the loop then builds a hundred derived claims on top of. An independent
+implementation is the cheapest instrument that catches exactly those — the ones
+certificates do not cover.
+
+`alkahest.crosscheck` runs one query through Alkahest and through an oracle and reports
+whether they agree.
+
+```python
+import alkahest as ak
+from alkahest.crosscheck import check, oracles
+
+print(oracles())          # {'sympy': '1.14.0'} — or {'sympy': None} if not installed
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+
+with ak.context(pool=pool):
+    out = check("integrate", ak.sin(x) * ak.cos(x), x)
+
+print(out.outcome, out.rung_name, out.reason)
+```
+
+```text
+agree invariant invariant_holds
+```
+
+`sin(x)·cos(x)` has three standard antiderivatives that differ by constants; that is why
+the check settled on the **invariant** rung and not by comparing forms.
+
+## Four outcomes, and two of them are not "clean"
+
+`CrossCheck.outcome` is four-valued, never a boolean:
+
+| Outcome | Meaning |
+| --- | --- |
+| `agree` | Both systems answered and a named rung settled it |
+| `diverge` | Both answered and the answers are not the same |
+| `incomparable` | The question could not be posed identically to both systems |
+| `unavailable` | No oracle is installed |
+
+**`incomparable` and `unavailable` are not weaker forms of `agree`.** They say the check
+did not happen. Code that treats them as clean has reintroduced the exact failure this
+module exists to prevent: *a loop that believes it is cross-checking, and is not, is worse
+off than one that knows it isn't.* Two API decisions enforce that:
+
+- `CrossCheck` deliberately defines **no `__bool__`**, so `if check(...):` does not
+  compile into a silent "it agreed";
+- `CrossCheck.checked` is `True` only for `agree` and `diverge`, so the common mistake has
+  to be written out explicitly.
+
+With SymPy absent, `check` returns `outcome="unavailable"` and `reason="no_oracle"`. It
+never returns `agree`. Call `oracles()` at session start to find out **before** you plan
+around a check that will only ever return `unavailable` — it reports every *known* oracle,
+including the absent ones, as `None`.
+
+## The comparison ladder
+
+Structural equality is useless: the two systems normalise differently, and a naive
+comparison of antiderivatives, solution sets or factorisations produces nothing but noise.
+So comparison is a ladder, it is **per-operation**, and the rung that settled a check is
+always recorded on `CrossCheck.rung`.
+
+| Rung | Name | What it does | What it licenses |
+| --- | --- | --- | --- |
+| 1 | `syntactic` | Compare canonical forms after translation | Proof of agreement |
+| 2 | `symbolic` | `simplify(a − b) == 0`, attempted **independently in both systems** — either one proving it counts | Proof of agreement |
+| 3 | `rigorous_numeric` | Sample and evaluate with `ArbBall` / `interval_eval` | Rigorous **refutation**; agreement only "not refuted at these points" |
+| 4 | `invariant` | The operation's own defining property, checked on both answers | Proof of agreement |
+
+**Rung 4 leads wherever it exists.** It sidesteps equal-up-to-a-constant,
+up-to-ordering and up-to-a-unit entirely — the three things that make naive comparison
+useless.
+
+Rung 3 is where Alkahest has an unfair advantage over a float-only harness:
+[ball arithmetic](./ball-arithmetic.md) distinguishes "differs by 1e-16 of float noise"
+from "genuinely differs by 1e-16". Note the asymmetry, which the record carries: a ball is
+a *rigorous* enclosure of the Alkahest answer, so a value outside it is a real
+disagreement — but agreement at sampled points is only a failure to refute, and rung-3
+agreement is therefore reported with `conclusive=False` rather than being promoted or
+discarded.
+
+### The invariants, per operation
+
+| Operation | Rungs | Rung-4 invariant |
+| --- | --- | --- |
+| `integrate` (indefinite) | 4, 1, 2, 3 | `d/dx F − f ≡ 0`, in each system |
+| `simplify`, `simplify_expanded` | 4, 1, 2, 3 | `out − in ≡ 0` — a simplifier's whole contract |
+| `sum_indefinite` | 4, 1, 2, 3 | `S(k+1) − S(k) − t(k) ≡ 0` — Gosper's defining property |
+| `solve` | 4 | Substitute every solution back, **then** compare set sizes |
+| `diff` | 1, 2, 3 | — (integrating back is weaker than the derivative it would check) |
+| `limit` | 1, 2, 3 | — |
+| `series` | 1, 2, 3 | — (the `O()` remainder is stripped first; that is a normalisation, not a rung) |
+| `integrate` (definite) | 1, 2, 3 | — |
+
+`solve` is worth spelling out. Solution *sets* compare badly by construction: ordering,
+radical form and branch choice all differ. Substituting back checks each system's answers
+on their own terms, and only *then* does the set comparison mean something — with both
+sides verified, a size difference is a genuinely **missed solution**, not a formatting
+artefact.
+
+An operation with no entry in `OPERATIONS` raises `E-XCHECK-003` rather than falling back
+to a generic structural comparison. The fallback is deliberately absent: it is precisely
+how a harness starts reporting two normal forms as a divergence.
+
+## A divergence names two suspects
+
+```python
+out = check("integrate", integrand, x)
+if out.outcome == "diverge":
+    d = out.divergence
+    print(d.statement())
+    print(d.point)             # {'x': 1.257...} — the witness
+    print(d.alkahest_value, d.oracle_value)
+    print(d.support)           # 'unresolved' | 'alkahest_supported' | 'oracle_supported'
+```
+
+The record carries the witness point and **both** values, and the wording never implies
+Alkahest is right. `Divergence.support` carries whatever the rigorous escalation could
+establish, and its default is `unresolved`:
+
+- `alkahest_supported` — the oracle's answer fails the operation invariant while
+  Alkahest's satisfies it;
+- `oracle_supported` — **Alkahest's answer fails the invariant under rigorous ball
+  arithmetic** while the oracle's satisfies it. This is a silent-error finding. The
+  residual is built entirely from Alkahest expressions, so there is no oracle float in it
+  to blame, and `Divergence.silent_error_candidate` is `True` exactly here;
+- `unresolved` — the two disagree and the evidence does not say which is at fault. Most
+  findings start here, and that is the honest default.
+
+When [`verified_sign`](./validated-bounds.md) can certify that the failing residual keeps
+one sign across the whole sampling box, `Divergence.region` records the box — upgrading a
+finding from "wrong at this point" to "wrong on this interval", which is a much shorter
+argument to hand a reviewer.
+
+A `silent_error_candidate` should be routed into `tests/silent_errors/corpus.py`. That
+routing is the whole point of the feature: it converts a fuzzing signal into a permanent
+regression gate.
+
+**An honest refusal is never a divergence.** If Alkahest declines
+(`E-INT-004: no elementary antiderivative exists`, an interior-pole definite integral, a
+two-sided limit at a pole) the outcome is `incomparable` with `reason="alkahest_refused"`.
+The same holds in the other direction: SymPy returning an unevaluated `Integral` is a
+refusal, scored `reason="oracle_refused"`, not an answer to compare against.
+
+## One translator, total-or-refuse
+
+A divergence is only informative if both systems were asked the same question, and the
+ways to accidentally ask a *different* one are well known: branch cuts, assumption
+handling, `∞`, unnormalised forms. So:
+
+- every tag `Expr.node()` can emit appears in an explicit table
+  (`Translator._DISPATCH`, total over `NODE_TAGS`), and an unknown tag raises
+  **`E-XCHECK-001`**;
+- every primitive is either in `FUNCTION_MAP` or in `REFUSED_FUNCTIONS` **with the reason
+  spelt out** — `heaviside` (SymPy fixes `Heaviside(0) = 1/2` and Alkahest fixes nothing
+  there), the elliptic integrals (modulus-vs-parameter convention), `round` (no documented
+  half-way rule to compare against);
+- quantifiers refuse: SymPy has no term-level `∀`, and encoding one as something SymPy
+  *will* accept produces an object no rung can use;
+- an active `Assumptions` context that cannot be mapped faithfully refuses too.
+
+**False divergences are worse than no signal** — they train both the loop and the team to
+ignore the alarm, and a best-effort translator manufactures them by construction.
+
+```python
+from alkahest.crosscheck import to_sympy
+
+to_sympy(ak.sqrt(x**pool.integer(2)))                       # sqrt(x**2)
+to_sympy(ak.sqrt(x**pool.integer(2)), assumptions=positive) # x
+to_sympy(pool.func("heaviside", [x]))                       # raises E-XCHECK-001
+```
+
+`to_sympy` is the one translator this package ships. The four hand-rolled `_expr_to_sympy`
+helpers in `tests/` (`test_eigen_v217.py`, `test_oracle.py`, `test_gruntz_v217.py`,
+`test_diophantine_v219.py`) are meant to migrate onto it; that duplication *is* what this
+item exists to remove. Building the QA harness and the runtime mode separately would
+produce two translators that disagree, which is the worst possible outcome for a tool
+whose entire job is detecting disagreement.
+
+### Assumptions
+
+Only sign and non-zero conditions on a **bare symbol** map onto oracle symbol flags:
+
+| Alkahest predicate | SymPy symbol flag |
+| --- | --- |
+| `x > 0` | `positive=True` |
+| `x >= 0` | `nonnegative=True` |
+| `x < 0` | `negative=True` |
+| `x <= 0` | `nonpositive=True` |
+| `x != 0` | `nonzero=True` |
+
+Anything else — a relation between two symbols, a condition on a composite, a disjunction
+— has no per-symbol counterpart, so it raises rather than being dropped. Dropping it would
+ask the oracle a *weaker* question, and every legitimate refinement would then look like a
+divergence.
+
+## Opt-in per call site, not a context flag
+
+There is deliberately **no** `context(crosscheck=True)`. That is the obvious design and
+the wrong one: it puts an oracle round-trip on every call, and stage-2 falsification runs
+millions of times where SymPy is orders of magnitude slower. Call `check` where you want
+it — at [claim-recording](./claim-graphs.md) frequency, hundreds of times, not millions.
+That is "falsify fast, certify slow" applied to the QA layer.
+
+## Two tiers in CI
+
+A randomised sweep cannot be a per-PR gate: it is nondeterministic, and a SymPy upgrade
+would turn it red for reasons unrelated to the pull request. So the arrangement mirrors
+how `tests/silent_errors/` relates to `agent-benchmark/`:
+
+### Tier 1 — the seeded nightly sweep
+
+```python
+from alkahest.crosscheck import sweep
+
+report = sweep(cases=200, seed=None)   # seed defaults to budget_seed(), then to DEFAULT_SEED
+print(report.summary())                # prints the seed — always
+for finding in report.silent_error_candidates:
+    print(finding.divergence.statement())
+```
+
+The seed is recorded on the report and printed by `summary()`, because a sweep is only
+useful as a bug report if the run that found something can be reproduced exactly. Under
+`context(budget=Budget(seed=...))` the sweep takes its seed from the
+[budget](./budgets.md), so a nightly job and a local reproduction share one knob.
+`SweepReport.to_dict()` is JSON-serialisable and suitable for filing as a CI artifact.
+
+**Neither side of a check is bounded, and this module does not pretend otherwise.** The
+heavy engines hold the GIL, so a non-terminating call cannot be timed out from Python — a
+worker thread cannot be stopped, and abandoning one wedges the interpreter just the same.
+At this commit `limit(sqrt(x**2 + x) - x, x, oo)` is one such call. So:
+
+- run the nightly job under an **OS-level timeout**;
+- wrap the sweep in `context(budget=…)` for the engines that *are* cooperative
+  (`integrate`, and best-effort `simplify` — see [Budgets](./budgets.md)), where a trip
+  surfaces as `reason="alkahest_refused"` with an `E-BUDGET-00x` code, which is a fine
+  answer;
+- `SWEEP_OPERATIONS` deliberately excludes `limit` for this reason.
+
+### Tier 2 — the frozen corpus
+
+`FROZEN_CORPUS` is a tuple of `FrozenCase`s re-run on every pull request:
+
+```python
+from alkahest.crosscheck import run_frozen_corpus
+
+for case, outcome in run_frozen_corpus():
+    if outcome is None:
+        ...   # skipped: does not apply to the installed oracle version
+    else:
+        assert outcome.outcome == case.expected
+```
+
+Every case records the **oracle version range** its expectation was established against
+(`oracle_versions=">=1.12,<2"`). Without that the corpus rots silently the first time the
+oracle changes an answer — which it will — and a red gate would then be indistinguishable
+from a real regression. A case whose range excludes the installed version is *skipped*,
+never quietly passed. Cases carry `found_by` (a seed, or a provenance note) and `note`
+(what the case protects), and both are asserted non-empty.
+
+**The ratchet**: a divergence the nightly sweep finds must be promoted into a
+`FrozenCase` with `found_by` naming the seed, or it only ever gets exercised by a job
+nobody reads. Cases are added, never silently deleted — an expectation that changes is a
+re-pin with a new `oracle_versions` range, and the old range records what used to be true.
+
+### Not yet wired
+
+Two pieces are described here and not yet built, deliberately, so the shape is agreed
+before the CI surface grows:
+
+- a nightly workflow that runs `sweep`, prints the seed, and files
+  `SweepReport.to_dict()` as an artifact (SymPy already ships in the `ci-extras`
+  dependency group, so this is a job, not a new dependency);
+- `capabilities()["verification"]["oracles"]`, so an agent can see the installed oracles
+  from the same probe it already makes at session start rather than importing
+  `alkahest.crosscheck` to find out.
+
+## Oracles are a plugin interface
+
+`Oracle` is an ABC and `SymPyOracle` is the first implementation. The comparator talks to
+oracles *only* through that interface, so a second backend is a class plus one
+`register_oracle` call — no change to the ladder, the outcomes, or the corpus machinery.
+
+```python
+from alkahest.crosscheck import Oracle, register_oracle
+
+class WolframOracle(Oracle):
+    name = "wolfram"
+    ...
+
+register_oracle(WolframOracle)
+```
+
+Designing the second oracle in later would mean rewriting the comparator. With two
+present, two-out-of-three voting turns "someone is wrong" into "Alkahest is probably
+wrong", which is a materially more useful signal.
+
+Every method may answer "I don't know" — `is_zero` returns `None`, `run` raises — and the
+comparator turns that into `incomparable` rather than guessing.
+
+## Error codes
+
+| Code | Meaning |
+| --- | --- |
+| `E-XCHECK-001` | A node, a primitive, or an active assumption has no faithful translation. Surfaces as `outcome="incomparable"`, `reason="untranslatable"` |
+| `E-XCHECK-002` | No oracle is installed. Surfaces as `outcome="unavailable"` — **never** as agreement |
+| `E-XCHECK-003` | The operation has no defined comparison rung, or the oracle declined it |
+
+An unknown *operation* raises out of `check` rather than becoming an outcome: that is a
+caller mistake, not a property of the mathematics. Untranslatable input and missing
+oracles are outcomes, because a loop has to be able to keep going.
+
+## See also
+
+- [Autoresearch / agent loops](./search-plumbing.md)
+- [Ball arithmetic](./ball-arithmetic.md) — the engine behind rung 3
+- [Rigorous global bounds](./validated-bounds.md) — `verified_sign`, used to widen a
+  pointwise refutation to a region
+- [Claim graphs](./claim-graphs.md) — where a check belongs in a research session
+- [Certificate coverage](./certificate-coverage.md) — the other half: where Alkahest can
+  prove rather than compare
+- [Error handling](./errors.md)

--- a/docs/mdbook/src/crosscheck.md
+++ b/docs/mdbook/src/crosscheck.md
@@ -268,17 +268,28 @@ never quietly passed. Cases carry `found_by` (a seed, or a provenance note) and 
 nobody reads. Cases are added, never silently deleted — an expectation that changes is a
 re-pin with a new `oracle_versions` range, and the old range records what used to be true.
 
+### Visible from the session-start probe
+
+`capabilities()["verification"]` reports the installed oracles and SMT solvers, so an
+agent can see them from the probe it already makes at session start rather than
+importing `alkahest.crosscheck` to find out:
+
+```python
+caps = ak.capabilities()["verification"]
+caps["oracles"]      # {"sympy": "1.14.0"}  — absent oracles appear as None
+caps["smt_solvers"]  # {"z3": "4.13.0", "cvc5": None}
+```
+
+Absent tools are reported **negatively** rather than omitted, so "not installed" stays
+distinguishable from "agreed". Both keys probe the environment — detecting an oracle
+imports it — so they are cached for the life of the process; see the note on
+[`capabilities()`](./python-api.md).
+
 ### Not yet wired
 
-Two pieces are described here and not yet built, deliberately, so the shape is agreed
-before the CI surface grows:
-
-- a nightly workflow that runs `sweep`, prints the seed, and files
-  `SweepReport.to_dict()` as an artifact (SymPy already ships in the `ci-extras`
-  dependency group, so this is a job, not a new dependency);
-- `capabilities()["verification"]["oracles"]`, so an agent can see the installed oracles
-  from the same probe it already makes at session start rather than importing
-  `alkahest.crosscheck` to find out.
+- A nightly workflow that runs `sweep`, prints the seed, and files
+  `SweepReport.to_dict()` as an artifact. SymPy already ships in the `ci-extras`
+  dependency group, so this is a job, not a new dependency.
 
 ## Oracles are a plugin interface
 
@@ -309,7 +320,8 @@ comparator turns that into `incomparable` rather than guessing.
 | --- | --- |
 | `E-XCHECK-001` | A node, a primitive, or an active assumption has no faithful translation. Surfaces as `outcome="incomparable"`, `reason="untranslatable"` |
 | `E-XCHECK-002` | No oracle is installed. Surfaces as `outcome="unavailable"` — **never** as agreement |
-| `E-XCHECK-003` | The operation has no defined comparison rung, or the oracle declined it |
+| `E-XCHECK-003` | The operation has no defined comparison rung — a caller error, raised before any oracle is consulted |
+| `E-XCHECK-004` | The oracle itself declined, raised, or returned an unevaluated form — not a divergence |
 
 An unknown *operation* raises out of `check` rather than becoming an outcome: that is a
 caller mistake, not a property of the mathematics. Untranslatable input and missing

--- a/docs/mdbook/src/errors.md
+++ b/docs/mdbook/src/errors.md
@@ -17,6 +17,9 @@ AlkahestError (base)
 ├── JitError          (E-JIT-*)    — LLVM/JIT codegen
 ├── CudaError         (E-CUDA-*)   — CUDA kernel launch or driver
 ├── PoolError         (E-POOL-*)   — ExprPool misuse
+├── AnsatzError       (E-ANSATZ-*) — ansatz family construction or fitting, see [Ansatz families](./ansatz.md)
+├── CrossCheckError   (E-XCHECK-*) — cross-CAS check could not be posed, see [Cross-CAS testing](./crosscheck.md)
+├── SmtError          (E-SMT-*)    — SMT-LIB export, solver run, or model lift, see [SMT bridge](./smt.md)
 └── BudgetExceededError (E-BUDGET-*) — budget/cancellation trip, see [Budgets](./budgets.md)
 ```
 
@@ -122,6 +125,18 @@ Every error is classified on two independent axes: **subsystem** (determines the
 | `E-IO-*` | `IoError` *(reserved)* | Checkpoint/serde paths (`PoolPersistError`) |
 | `E-CERT-*` | `CertificateUnavailableError` | A Lean certificate was required but withheld |
 | `E-BUDGET-*` | `BudgetExceededError` | Budget/cancellation trip — see [Budgets, cancellation, and determinism](./budgets.md) |
+| `E-ANSATZ-*` | `AnsatzError` | Ansatz family construction and fitting — see [Ansatz families](./ansatz.md) |
+| `E-XCHECK-*` | `CrossCheckError` | Cross-CAS differential testing — see [Cross-CAS testing](./crosscheck.md) |
+| `E-SMT-*` | `SmtError` | SMT-LIB export, solver invocation, model lift — see [SMT bridge](./smt.md) |
+
+Three of these describe outcomes that are **results rather than malfunctions**, and
+the wording of each is deliberate. `E-ANSATZ-003` means *no member of this family
+satisfies the constraints* — for a search loop that is a closed branch worth
+recording, not a failure. `E-XCHECK-002` means no oracle is installed, and exists
+so that a missing oracle can never be mistaken for agreement. `E-SMT-003` refuses
+a model containing an algebraic number that cannot be lifted exactly, rather than
+truncating it to a float — a float witness recorded as an exact one is precisely
+the silent-error shape these subsystems exist to prevent.
 
 ### `E-CERT-*` — certificate policy
 

--- a/docs/mdbook/src/smt.md
+++ b/docs/mdbook/src/smt.md
@@ -1,0 +1,326 @@
+# SMT/SAT bridge
+
+Discrete and mixed integer/real/boolean subproblems are **not Alkahest's problem class**,
+and the fastest way to make Alkahest worse would be to pretend otherwise. What a search
+loop needs is not an in-tree SAT solver but a way to *hand the subproblem off* — and,
+crucially, a way to bring the answer back in a form the rest of the toolchain can trust.
+
+That is what this bridge is. `alkahest.to_smtlib` emits standard SMT-LIB 2 text; an
+external solver (z3, cvc5, …) consumes it; `alkahest.smt.solve` reads the answer back,
+lifts the model into exact rationals, and **checks it**. It is the same shape as
+[Lean certificates](./lean-certs.md): Alkahest emits a standard artifact, and an
+independently maintained tool it does not control does the hard part.
+
+```python
+import alkahest as ak
+
+pool = ak.ExprPool()
+x = pool.symbol("x")
+n = pool.symbol("n", "integer")
+
+# x is real, n is an integer, x sits strictly between n and sqrt(10) — mixed
+# integer/real, which is exactly what neither CAD nor `diophantine` handles.
+f = ak.And(pool.gt(x, n), ak.And(pool.lt(x * x, pool.integer(10)), pool.gt(n, pool.integer(1))))
+
+with ak.context(pool=pool):
+    result = ak.smt.solve(f, budget=ak.Budget(wall_ms=5000))
+
+print(result.status)        # 'sat'
+print(result.model)         # {'x': Fraction(3, 1), 'n': Fraction(2, 1)}
+print(result.engine)        # 'z3 Z3 version 4.13.0 - 64 bit'
+print(result.badge)         # 'the solver's model was substituted back and ...'
+```
+
+## The two asymmetries
+
+Everything else on this page follows from these.
+
+### 1. `sat` and `unsat` have different trust stories
+
+A `sat` model is checkable inside Alkahest **for free**: substitute it back and evaluate
+the formula exactly. `solve` always does this. There is no flag to turn it off, and a
+model that fails raises `SmtError` `E-SMT-004` rather than warning — a failure there means
+the emitter mistranslated the formula or the solver returned an unsound model, and neither
+belongs in a log line.
+
+`unsat` is a different matter: checking it means consuming an unsat proof, which is a large
+project against unstable formats. So an `unsat` result carries the status
+**`externally_asserted`**, whose badge reads:
+
+> an external solver asserted this; NO proof was checked and nothing in Alkahest verified it
+
+and which is deliberately **absent** from `alkahest.research.MACHINE_CHECKED_STATUSES`.
+That set means *a checker actually ran in this process*. Quietly widening it to include
+"z3 said so" would erode the one guarantee [`research.py`](./claim-graphs.md) makes.
+
+| Solver says | `verification["status"]` | Counted as machine-checked? |
+| --- | --- | --- |
+| `sat` | `exactly_verified` | **yes** — the model was substituted back in-process |
+| `unsat` | `externally_asserted` | **no** — nothing checked it |
+| `unknown` | `unverified` | no |
+
+### 2. Exactness is where a model reader breaks
+
+Rationals lift cleanly. `(/ 25.0 4.0)` becomes `Fraction(25, 4)`; `0.1` becomes
+`Fraction(1, 10)` — parsed from the **string**, so it is the exact decimal rational the
+solver meant and never the nearest binary double.
+
+Algebraic numbers do not lift. Ask z3 for a witness to `x² = 2 ∧ x > 0` and it answers
+`(root-obj (+ (^ x 2) (- 2)) 2)`. The tempting move is to evaluate that to `1.41421356…`
+and carry on. **A float witness recorded as an exact one is precisely the silent error this
+bridge exists to prevent** — a loop would go on to build a hundred derived results on a
+value that does not actually satisfy the constraints, and its own consistency checks would
+happily confirm them. So `root-obj` is refused with `E-SMT-003`, and lifting it into the
+existing real-algebraic machinery (`RootInterval` / `refine_root`) is future work.
+
+## Planning ahead: `supported()`
+
+`supported` is to this module what [`certifiable`](./certificate-coverage.md) is to Lean
+export: a loop must be able to choose a route *before* it commits.
+
+```python
+support = ak.smt.supported(f)
+bool(support)            # would solve() run?
+support.exportable       # would to_smtlib() succeed? (independent of solver install)
+support.logic            # 'QF_NIRA'
+support.reason           # 'ok' | 'outside_fragment' | 'quantified' |
+                         # 'not_exactly_checkable' | 'no_solver'
+support.recommendation   # 'smt' | 'prefer_in_tree'
+support.script           # the emitted script, so you don't pay for it twice
+```
+
+`recommendation` is the part worth reading, and it cuts against the usual instinct:
+
+- **`prefer_in_tree`** for real arithmetic with no integer variables (`QF_LRA` / `QF_NRA`).
+  [`prove_nonneg` / `sos_decompose`](./positivity.md) return a `PositivityCertificate` that
+  composes with `to_lean`; `decide` is complete. z3's `nlsat` returns an answer and **no
+  artifact**. Reach for SMT here as a *fallback* when the in-tree route refuses or exceeds
+  its budget.
+- **`smt`** for anything with integer variables — mixed integer/real/boolean is the
+  genuinely new capability, and neither CAD nor `diophantine` covers it.
+
+## What gets emitted
+
+`to_smtlib` produces a complete, runnable script:
+
+```python
+print(ak.to_smtlib(ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(3)))))
+```
+
+```smt2
+; alkahest SMT-LIB 2 export
+(set-logic QF_LRA)
+(set-option :produce-models true)
+(declare-fun x () Real)
+(assert (and (> x 0) (< x 3)))
+(check-sat)
+(get-model)
+```
+
+The emitter lives in Rust (`alkahest-core/src/logic/smtlib.rs`) next to `Formula`, for the
+same reason the Lean emitter lives in `alkahest-core/src/lean/`: it must be **exhaustive**
+over `Formula` and `PredicateKind`, and `rustc`'s match-exhaustiveness check is the
+enforcement mechanism. There is no `_ =>` arm anywhere in that file, and `tests/test_smt.py`
+asserts that from the outside as well, so a node added to the kernel later fails to compile
+rather than silently emitting plausible-but-wrong SMT-LIB.
+
+### Logic selection
+
+`logic="auto"` (the default) infers the weakest logic that fits:
+
+| Formula | Logic |
+| --- | --- |
+| linear, reals only | `QF_LRA` |
+| nonlinear, reals only | `QF_NRA` |
+| linear, integers only | `QF_LIA` |
+| nonlinear, integers only | `QF_NIA` |
+| mixed int/real | `QF_LIRA` / `QF_NIRA` |
+| any of the above with `Forall`/`Exists` | same name without the `QF_` prefix |
+
+You may name a logic explicitly (`ak.to_smtlib(f, "QF_NRA")`), and one that is **too weak**
+for the formula is an error, not a silent downgrade — sending a nonlinear problem under
+`QF_LRA` would ask a different question than the one you have.
+
+Getting this right is load-bearing, not cosmetic: under `(set-logic QF_NRA)` z3 has no
+`Int` sort at all, and under a `Reals_Ints` logic an integer numeral in a real position
+needs an explicit `to_real`. The emitter tracks sorts and inserts exactly the coercions the
+chosen theory requires — and none where they would not parse.
+
+### Translation table
+
+| Alkahest | SMT-LIB 2 |
+| --- | --- |
+| `Symbol` (Real / Positive / NonNegative / NonZero) | `(declare-fun x () Real)` |
+| `Symbol` (Integer) | `(declare-fun n () Int)` |
+| `Positive` / `NonNegative` / `NonZero` refinement | an extra `(assert (> x 0))` / `(>= x 0)` / `(not (= x 0))` |
+| `Integer(-3)` | `(- 3)` |
+| `Rational(-1, 3)` | `(/ (- 1) 3)` |
+| `Add` / `Mul` | `(+ …)` / `(* …)` |
+| `Pow(x, 3)` | `(* x x x)` — SMT-LIB 2 has no portable `^` |
+| `Pow(x, -1)` | `(/ 1 x)` |
+| `Piecewise` | `(ite c v …)` |
+| `Lt/Le/Gt/Ge/Eq` | `(< …)` / `(<= …)` / `(> …)` / `(>= …)` / `(= …)` |
+| `Ne` | `(not (= …))` |
+| `And` / `Or` / `Not` | `(and …)` / `(or …)` / `(not …)` |
+| `Forall` / `Exists` | `(forall ((x Real)) …)` / `(exists ((x Real)) …)` |
+
+A refined domain travels with its binder under a quantifier: `∀ x:Positive . P` becomes
+`(forall ((x Real)) (=> (> x 0) P))` and the existential takes `(and …)`. Getting that
+backwards would be a soundness bug, so both are written out explicitly in the emitter.
+
+### What is refused
+
+The emitter is **total-or-refuse**. Everything below raises `SmtError` `E-SMT-002`:
+
+- **Float literals.** `0.1` is a binary double, not the exact question it looks like.
+  Write `pool.rational(1, 10)`; exporting the dyadic expansion would silently change what
+  is being asked.
+- **Complex-domain symbols** — SMT-LIB arithmetic is ordered and real.
+- **Transcendental function heads** (`sin`, `exp`, `log`, …). Only `abs` has an exact
+  SMT-LIB rendering.
+- **Non-integer or very large exponents.** Powers become products, so the expansion is
+  *bounded* (`MAX_POW_EXPANSION`, 128) — a loop must never be able to ask for a megabyte
+  of `x`.
+- **`BigO`, `RootSum`, predicates in term position**, and symbol names containing `|`.
+- **Two symbols sharing a name but not a domain** — SMT-LIB has one namespace.
+
+## Driving a solver
+
+Solver discovery, subprocess management, and model parsing live in Python
+(`python/alkahest/smt.py`), where they iterate faster. This mirrors the Lean split
+exactly: emission in Rust, harness in Python.
+
+```python
+ak.smt.solvers()
+# {'z3': 'Z3 version 4.13.0 - 64 bit', 'cvc5': None}
+```
+
+Absence is reported **negatively and explicitly**, so an agent can tell before it plans
+that the hand-off is unavailable. `PATH` is searched, plus the running interpreter's script
+directory — a `pip install z3-solver` into a venv that was never `activate`d still gets
+found.
+
+If no solver is installed, `solve` raises `E-SMT-001`. It does **not** fall back to
+`alkahest.satisfiable`, the interval heuristic: that would answer `Unknown` and look for
+all the world like a solver had run and found nothing.
+
+### `SmtResult`
+
+| Field | Meaning |
+| --- | --- |
+| `status` | `"sat"` / `"unsat"` / `"unknown"` |
+| `model` | `dict[str, Fraction]` — the exact witness, and exactly what was verified |
+| `model_exprs` | the same values interned into a pool, when one was passed or is active |
+| `engine` | which solver answered, and at what version |
+| `logic` | the logic that was sent |
+| `smtlib` / `certificate` | the script that was sent — an artifact, not a checked proof |
+| `verification` | `DerivedResult`-shaped, so `ResearchSession.record` takes it unchanged |
+| `badge` | the honest one-line rendering of the status |
+| `machine_checked` | `True` only when a checker ran **in this process** |
+| `reason_unknown` | the solver's own explanation, on `unknown` |
+| `elapsed_ms` | wall-clock time in the solver process |
+
+`SmtResult` has no `__bool__` on purpose: `unsat` and `unknown` would both be falsy, and a
+loop writing `if not result:` would conflate "proved impossible" with "gave up". Branch on
+`.status`.
+
+`model` is keyed by symbol name and holds `Fraction`s rather than `Expr`s because an `Expr`
+carries no reference to its pool; `model_exprs` is populated when `solve(..., pool=…)` is
+given one or `alkahest.context(pool=…)` is active. The `Fraction` map is always present and
+always the thing that was checked, so nothing about the guarantee depends on ambient
+context.
+
+### How a `sat` model is checked
+
+Two independent exact checks, both mandatory:
+
+1. Substitute the model into the **original Alkahest formula** and evaluate it exactly
+   through the kernel. This is the invariant the bridge rests on, and
+   `tests/test_smt.py` asserts it as a property test over generated formulas rather than
+   a handful of examples.
+2. Evaluate every assertion in the **script that was actually sent**, over exact
+   rationals. A mistranslation in the emitter would have to fool both to slip through, and
+   this pass also re-checks the refined-domain side conditions, which are separate
+   assertions.
+
+A model missing a "don't care" variable is completed with `0` and then checked, so the
+witness a caller receives is always total and always substitutable.
+
+Because the guarantee is unconditional, `solve` refuses **up front** — before the solver
+runs — for a formula the kernel cannot evaluate exactly (`E-SMT-002`, reason
+`not_exactly_checkable`). `abs` is the case you will actually hit: it exports fine, so
+`to_smtlib` handles it, but `evaluate(..., mode="exact")` does not, and a refusal that
+arrives only after paying for the solver run reads like a bug in the solver.
+
+For the same reason `solve` takes **quantifier-free formulas only**. `to_smtlib` exports
+quantified ones happily — export it and drive the solver yourself, or use
+`alkahest.decide` for real quantifier elimination (see [Positivity certificates](./positivity.md)).
+
+## Budgets
+
+`solve(..., budget=ak.Budget(wall_ms=…))` passes the limit to the solver's own timeout flag
+*and* enforces a parent-side deadline as a backstop. A trip raises `BudgetExceededError`
+(`E-BUDGET-001`), not a bare `unknown`, so the loop gets the structured
+"hard, not hung" distinction [budgets](./budgets.md) were built for:
+
+```python
+try:
+    result = ak.smt.solve(candidate, budget=ak.Budget(wall_ms=250))
+except ak.BudgetExceededError:
+    log.info("deprioritising: hard, not hung")
+```
+
+Without a budget, a solver `unknown` is returned as a result with `reason_unknown` set —
+a real answer ("I could not decide this"), distinct from a resource verdict.
+
+## Recording into a claim graph
+
+`SmtResult` quacks like a `DerivedResult`, so it records unchanged:
+
+```python
+with ak.research.session(title="mixed feasibility", pool=pool) as s:
+    result = ak.smt.solve(f, budget=ak.Budget(wall_ms=5000))
+    claim = s.record(result, statement="the system is feasible", method="smt.solve")
+
+claim.status           # 'exactly_verified' for sat, 'externally_asserted' for unsat
+claim.machine_checked  # True only for the checked sat case
+```
+
+## What is *not* here, and why
+
+- **No vendored solver.** No libz3 in the Rust build: it keeps the wheel small, the
+  licensing simple, and — the real reason — an in-tree solver would become a soundness
+  liability the project has to defend, in a problem class that is not Alkahest's.
+- **No unsat-proof checking.** See the first asymmetry above; the status vocabulary is
+  honest about it rather than papering over it.
+- **`dpll_sat` is not wired in.** `alkahest_core::logic::dpll_sat` remains a standalone CNF
+  utility, sound and complete for the propositional problem it is *handed*, and it is
+  deliberately not an engine behind this bridge. The only route from a `Formula` to it is
+  to abstract each arithmetic atom to a fresh proposition, and that abstraction is sound in
+  one direction only: it can confirm `unsat`, but it calls `x > 0 ∧ x < 0` *sat* and hands
+  back a meaningless model. Under a bridge whose whole premise is that every `sat` model is
+  checked exactly, that is the silent error the design is built to exclude — so a missing
+  solver is a refusal (`E-SMT-001`), not a degradation.
+
+## Error codes
+
+| Code | Raised by | Meaning |
+| --- | --- | --- |
+| `E-SMT-001` | Python driver | No solver binary found. A refusal, never a fallback. |
+| `E-SMT-002` | Rust emitter + driver | Formula outside the supported fragment (or an unusable logic, a quantified formula passed to `solve`, or one the kernel cannot check exactly). |
+| `E-SMT-003` | Python driver | A model value (`root-obj`) cannot be lifted exactly. Refused, not rounded. |
+| `E-SMT-004` | Python driver | A model failed back-substitution. Always raised, never warned. |
+| `E-BUDGET-001` | Python driver | The solver hit `Budget.wall_ms`. |
+
+Only `E-SMT-002` appears in `alkahest_core::errors::codes::REGISTRY`, because it is the only
+one Rust raises; `scripts/check_error_codes.py` requires the registry and the Rust
+`AlkahestError` impls to agree exactly, so codes raised only from Python stay out of it
+(`E-BATCH-001` in `alkahest/_batch.py` is the same precedent).
+
+## See also
+
+- [Autoresearch / agent loops](./search-plumbing.md)
+- [Budgets, cancellation, and determinism](./budgets.md)
+- [Claim graphs](./claim-graphs.md)
+- [Lean certificates](./lean-certs.md)
+- [Error handling](./errors.md)

--- a/docs/mdbook/src/smt.md
+++ b/docs/mdbook/src/smt.md
@@ -139,7 +139,30 @@ rather than silently emitting plausible-but-wrong SMT-LIB.
 
 You may name a logic explicitly (`ak.to_smtlib(f, "QF_NRA")`), and one that is **too weak**
 for the formula is an error, not a silent downgrade — sending a nonlinear problem under
-`QF_LRA` would ask a different question than the one you have.
+`QF_LRA` would ask a different question than the one you have. The names accepted are
+`QF_LIA`, `QF_NIA`, `QF_LRA`, `QF_NRA`, `QF_LIRA`, `QF_NIRA`, their quantified forms
+without the `QF_` prefix, `AUFLIRA`, `AUFNIRA`, and `ALL`.
+
+#### The mixed names are solver-facing, not catalog-standard
+
+`QF_LIRA` / `QF_NIRA` / `LIRA` / `NIRA` are **not** in the official SMT-LIB 2.7 logic
+catalog, which stops at `AUFLIRA` / `AUFNIRA` for mixed `Int`/`Real`. Alkahest emits them
+anyway, and that is a deliberate contract rather than an oversight:
+
+- they are the names the solvers this bridge drives actually use for the mixed fragment.
+  z3 accepts them silently (an unrecognised name draws `ignoring unsupported logic`), Yices
+  documents `QF_LIRA` / `QF_NIRA` among the names it recognises beyond the official set,
+  and SMT-COMP runs `QF_LIRA` / `QF_NIRA` divisions over SMT-LIB benchmarks;
+- the catalog alternatives are strictly worse for what is emitted here. `AUFLIRA` /
+  `AUFNIRA` are *quantified* logics that additionally carry arrays and free function
+  symbols, so naming one for a quantifier-free mixed formula discards the `QF_` hint that
+  decides which solver core runs and claims a far larger fragment than is in use.
+
+If you are feeding a consumer that accepts catalog names only, ask for one explicitly:
+`ak.to_smtlib(f, "AUFLIRA")` (linear) or `ak.to_smtlib(f, "AUFNIRA")` (nonlinear) — both are
+sound supersets of everything the emitter produces — or `ALL`. `tests/test_smt.py` pins that
+the installed solver accepts the names alkahest emits, so a regression in that contract
+fails the suite rather than the user's pipeline.
 
 Getting this right is load-bearing, not cosmetic: under `(set-logic QF_NRA)` z3 has no
 `Int` sort at all, and under a `Reals_Ints` logic an integer numeral in a real position

--- a/docs/mdbook/src/smt.md
+++ b/docs/mdbook/src/smt.md
@@ -180,7 +180,7 @@ chosen theory requires — and none where they would not parse.
 | `Rational(-1, 3)` | `(/ (- 1) 3)` |
 | `Add` / `Mul` | `(+ …)` / `(* …)` |
 | `Pow(x, 3)` | `(* x x x)` — SMT-LIB 2 has no portable `^` |
-| `Pow(x, -1)` | `(/ 1 x)` |
+| `Pow(x, -1)` | `(/ 1 x)` for a `Real` base; `(/ (to_real 1) (to_real n))` for an `Int` base |
 | `Piecewise` | `(ite c v …)` |
 | `Lt/Le/Gt/Ge/Eq` | `(< …)` / `(<= …)` / `(> …)` / `(>= …)` / `(= …)` |
 | `Ne` | `(not (= …))` |
@@ -190,6 +190,13 @@ chosen theory requires — and none where they would not parse.
 A refined domain travels with its binder under a quantifier: `∀ x:Positive . P` becomes
 `(forall ((x Real)) (=> (> x 0) P))` and the existential takes `(and …)`. Getting that
 backwards would be a soundness bug, so both are written out explicitly in the emitter.
+
+A negative power over an `Int` base is coerced rather than emitted as `(/ 1 n)`, and the
+reason is semantic rather than cosmetic: in SMT-LIB `/` is **real** division and `div` is
+integer division, so `n^-1` for an integer `n` is the real reciprocal the kernel means, not
+integer division. The emitter therefore lifts both operands with `to_real` — which is also
+why such a formula selects a `Reals_Ints` logic even though only one sort appears in the
+source expression.
 
 ### What is refused
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ ci-extras = [
     "mpmath",
     "symengine",
     "wolframclient",
+    # Ships both the Python bindings and a `z3` binary, which is what
+    # alkahest.smt discovers. Without it the SMT bridge's solver round-trip
+    # tests skip, and only the emitter and the refusal paths get exercised.
+    "z3-solver",
 ]
 
 # ── Ruff ─────────────────────────────────────────────────────────────────────

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -6,10 +6,13 @@ from importlib.metadata import version as _meta_version
 
 from . import (
     _certificates,
+    ansatz,  # P2 item 1 — structured ansatz families for conjecture generation
+    crosscheck,  # P2 item 2 — cross-CAS differential testing
     lattice,
     modular,  # noqa: F401 — V2-1: expose alkahest.modular submodule
     number_theory,
     research,  # session-level claim graph (provenance objects)
+    smt,  # P2 item 3 — SMT/SAT bridge
 )
 from ._batch import (
     BatchItem,
@@ -325,11 +328,13 @@ with _suppress(ImportError):
 # have no stub (CadError, …).
 from .exceptions import (
     AlkahestError,
+    AnsatzError,
     AssumptionError,
     BudgetExceededError,
     CadError,
     CertificateUnavailableError,
     ConversionError,
+    CrossCheckError,
     DaeError,
     DiffError,
     DiophantineError,
@@ -355,6 +360,7 @@ from .exceptions import (
     ResultantError,
     RsolveError,
     SeriesError,
+    SmtError,
     SolverError,
     SosError,
     SparseGcdError,
@@ -362,6 +368,7 @@ from .exceptions import (
     SumError,
     ValidatedError,
 )
+from .smt import to_smtlib
 
 _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "AlkahestError",
@@ -1619,18 +1626,32 @@ def capabilities() -> dict:
         "features": features,
         "primitives": primitive_rows,
         "verification": {
-            # Exactly the statuses `DerivedResult.verification["status"]` can
-            # report. `lean_checked` used to be advertised here and is not in
-            # this list any more: no code path has ever produced it, because
-            # checking is out of process by construction (`checkers` below).
+            # Exactly the statuses a result object's `verification["status"]`
+            # can report — `DerivedResult` for the kernel operations, and
+            # `smt.SmtResult` for the bridge, which is the only producer of
+            # `externally_asserted`. `lean_checked` used to be advertised here
+            # and is not in this list any more: no code path has ever produced
+            # it, because checking is out of process by construction
+            # (`checkers` below). The rule is unchanged — advertise a status
+            # only if some code path can actually emit it.
             "statuses": [
                 "certificate_available",
                 "exactly_verified",
+                # An external SMT solver reported `unsat` and no proof was
+                # checked. Deliberately NOT in research.MACHINE_CHECKED_STATUSES.
+                "externally_asserted",
                 "numerically_checked",
                 "unverified",
             ],
-            "artifacts": {"lean4_source": True},
-            "checkers": {"lean4": "external"},
+            "artifacts": {"lean4_source": True, "smtlib2_script": True},
+            "checkers": {"lean4": "external", "smt": "external"},
+            # Independent implementations available for cross-checking, and
+            # external SMT solvers found on PATH. Both are reported *negatively*
+            # too: a missing oracle or solver appears as None rather than being
+            # omitted, so an agent can tell "absent" from "not asked about" and
+            # can never read a missing checker as agreement.
+            "oracles": crosscheck.oracles(),
+            "smt_solvers": smt.solvers(),
             # Where certificate emission stops, tabulated from observed
             # behaviour. Full table: alkahest.certificate_coverage().
             "coverage": _certificates.coverage_summary(),
@@ -1701,6 +1722,7 @@ __all__ = [
     # Exceptions (V1-3 — stable diagnostic codes)
     "AlkahestError",
     "And",
+    "AnsatzError",
     # Phase 22
     "ArbBall",
     "AssumptionError",
@@ -1721,6 +1743,7 @@ __all__ = [
     "CompiledTracedFn",
     "Component",
     "ConversionError",
+    "CrossCheckError",
     "DaeError",
     "DaeIndexReduction",
     "DerivedResult",
@@ -1787,6 +1810,7 @@ __all__ = [
     "SensitivitySystem",
     "Series",
     "SeriesError",
+    "SmtError",
     "SolverError",
     # P1 item 8 — positivity certificates (SOS / Positivstellensatz)
     "SosError",
@@ -1814,6 +1838,7 @@ __all__ = [
     "active_domain",
     "active_pool",
     "adjoint_system",
+    "ansatz",
     "apart",
     "arg",
     "asin",
@@ -1847,6 +1872,7 @@ __all__ = [
     "context",
     "cos",
     "cosh",
+    "crosscheck",
     "dae_index_reduce",
     # V3-3 — FOFormula / V2-9 CAD
     "decide",
@@ -1976,6 +2002,7 @@ __all__ = [
     # Math functions (core 5)
     "sin",
     "sinh",
+    "smt",
     # V1-4 / V1-16: Polynomial system solver + Gröbner basis (default since 2.3.1)
     "solve",
     "solve_linear_recurrence_homogeneous",
@@ -1996,6 +2023,7 @@ __all__ = [
     "tanh",
     # V5-1
     "to_lean",
+    "to_smtlib",
     # V5-2
     "to_stablehlo",
     "together",

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1569,6 +1569,27 @@ if "solve" not in dir():
 # ---------------------------------------------------------------------------
 
 
+@_functools.lru_cache(maxsize=1)
+def _probe_oracles() -> tuple[tuple[str, str | None], ...]:
+    """Cached view of :func:`alkahest.crosscheck.oracles`.
+
+    Detecting an oracle imports it, which is far more expensive than the rest
+    of :func:`capabilities`. Cached so the cost is paid at most once per
+    process rather than on every contract read.
+    """
+    return tuple(sorted(crosscheck.oracles().items()))
+
+
+@_functools.lru_cache(maxsize=1)
+def _probe_smt_solvers() -> tuple[tuple[str, str | None], ...]:
+    """Cached view of :func:`alkahest.smt.solvers`.
+
+    Detecting a solver executes each found binary to read its version, so this
+    is cached for the same reason as :func:`_probe_oracles`.
+    """
+    return tuple(sorted(smt.solvers().items()))
+
+
 def capabilities() -> dict:
     """Return the versioned agent contract for this installed build.
 
@@ -1576,6 +1597,19 @@ def capabilities() -> dict:
     operation. The ``features`` mapping is authoritative for the installed
     extension; it does not infer availability from project defaults or Python
     fallback functions.
+
+    .. note::
+       ``verification["oracles"]`` and ``verification["smt_solvers"]`` probe
+       the environment: detecting an oracle imports it, and detecting a solver
+       runs its binary to read a version. Both are cached for the life of the
+       process, so the cost lands on the first call and not on later ones —
+       but the first call is not free, and it is not a pure read of build
+       metadata like the rest of this contract.
+
+       Because they are cached, these two keys are a *session-start snapshot*.
+       A tool installed later in the same process will not appear here.
+       :func:`alkahest.smt.solvers` and :func:`alkahest.crosscheck.oracles`
+       re-probe on every call and are the live view.
 
     Returns
     -------
@@ -1650,8 +1684,10 @@ def capabilities() -> dict:
             # too: a missing oracle or solver appears as None rather than being
             # omitted, so an agent can tell "absent" from "not asked about" and
             # can never read a missing checker as agreement.
-            "oracles": crosscheck.oracles(),
-            "smt_solvers": smt.solvers(),
+            # dict(...) per call: the cache holds an immutable tuple, and
+            # callers must not be able to mutate the shared cached value.
+            "oracles": dict(_probe_oracles()),
+            "smt_solvers": dict(_probe_smt_solvers()),
             # Where certificate emission stops, tabulated from observed
             # behaviour. Full table: alkahest.certificate_coverage().
             "coverage": _certificates.coverage_summary(),

--- a/python/alkahest/ansatz.py
+++ b/python/alkahest/ansatz.py
@@ -113,6 +113,14 @@ DEFAULT_MAX_MEMBERS = 100_000
 #: it (see :func:`alkahest.budget_seed`).
 DEFAULT_SEED = 0x5EED_A115
 
+#: Initial half-width of the sample-point numerator window (coordinates start
+#: out drawn from ``-12..12`` over ``1..4``) and the number of repeats that
+#: widens it. See :func:`_sample_points`: the window has to grow, or the point
+#: set is finite and a caller can ask for more points than exist.
+_SAMPLE_SPAN = 12
+_SAMPLE_DENOMINATORS = 4
+_SAMPLE_REPEATS_BEFORE_WIDENING = 16
+
 
 def _ak() -> Any:
     """Resolve the parent package at call time.
@@ -376,12 +384,31 @@ def _lcg(seed: int) -> Iterator[int]:
 
 
 def _sample_points(n_vars: int, seed: int) -> Iterator[tuple[Fraction, ...]]:
-    """Yield distinct deterministic rational points in ``n_vars`` variables."""
+    """Yield distinct deterministic rational points in ``n_vars`` variables.
+
+    The draw window **grows** as repeats accumulate. A fixed window is a finite
+    set of points (65 of them in one variable), so a caller asking for more
+    points than it holds would spin forever inside ``next()`` once the set was
+    exhausted — and a caller's own attempt counter cannot save it, because that
+    counter is only reached after this generator yields. Widening keeps the
+    stream genuinely infinite; the first points of a given seed are unchanged,
+    so recorded fits still reproduce.
+    """
     stream = _lcg(seed)
     seen: set[tuple[Fraction, ...]] = set()
+    span, denominators, repeats = _SAMPLE_SPAN, _SAMPLE_DENOMINATORS, 0
     while True:
-        point = tuple(Fraction(next(stream) % 25 - 12, 1 + next(stream) % 4) for _ in range(n_vars))
+        point = tuple(
+            Fraction(next(stream) % (2 * span + 1) - span, 1 + next(stream) % denominators)
+            for _ in range(n_vars)
+        )
         if point in seen:
+            repeats += 1
+            if repeats >= _SAMPLE_REPEATS_BEFORE_WIDENING:
+                # A run of repeats means the window is saturating. Doubling it
+                # (and admitting one more denominator) makes the reachable set
+                # grow without bound, so a fresh point always exists.
+                span, denominators, repeats = span * 2, denominators + 1, 0
             continue
         seen.add(point)
         yield point
@@ -903,10 +930,13 @@ def linear_combination(
         basis simply shows up as free parameters in the fit, which is the
         honest answer.
     vars : sequence of Expr, optional
-        Independent variables. Inferred from the basis's free symbols (sorted
-        by name) when omitted.
+        Independent variables. Inferred from the *basis's* free symbols (sorted
+        by name) when omitted — never from ``reserved``, which only reserves
+        names.
     name, max_terms, reserved
-        As :func:`polynomial`.
+        As :func:`polynomial`. ``reserved`` keeps the coefficients from
+        colliding with symbols the basis does not mention; it does not make
+        those symbols variables of the family.
 
     Returns
     -------
@@ -932,9 +962,13 @@ def linear_combination(
     _check_size(len(terms), max_terms, f"linear_combination({len(terms)} basis functions)")
     names = tuple(f"{name}_{i}" for i in range(len(terms)))
     unknowns = tuple(pool.symbol(n) for n in names)
-    symbols = _reserved_from(terms, reserved)
-    _check_collision(names, symbols, name)
+    # The two roles are separate: `reserved=` says "these names are taken", not
+    # "these are variables of the family". Folding it into the inference would
+    # promote a symbol the caller only wanted excluded from coefficient naming
+    # into an independent variable, changing what the fit is asked to prove.
+    _check_collision(names, _reserved_from(terms, reserved), name)
     if vars is None:
+        symbols = _reserved_from(terms, ())
         variables = tuple(symbols[key] for key in sorted(symbols) if symbols[key] is not None)
     else:
         variables = tuple(_value(v) for v in vars)
@@ -1652,7 +1686,6 @@ def _derivative_rows(
     *,
     seed: int,
     degree_bound: int,
-    max_rows: int,
 ) -> tuple[list[list[Any]], list[tuple[Fraction, ...]], int]:
     """Build the system by Taylor-coefficient extraction (``certify="exact"``).
 
@@ -1660,18 +1693,24 @@ def _derivative_rows(
     ``|α| ≤ degree_bound`` contributes one equation. Exact for polynomial
     residuals of that degree — no sampling argument required — at the cost of
     one differentiation per multi-index.
+
+    All-or-nothing on purpose. Every multi-index of the bound is part of the
+    exactness argument, so a run that loses one of them has not built *this*
+    system, it has built a weaker one; that would be exactly the silent
+    degradation the module refuses elsewhere. A base point at which some
+    derivative is undefined is retried at a fresh point, and when no base point
+    works the result is empty and the caller reports the failure.
     """
     ak = _ak()
     pool = ansatz.pool
-    multi = _exponents(len(ansatz.vars), degree_bound)[:max_rows]
+    multi = _exponents(len(ansatz.vars), degree_bound)
     stream = _sample_points(len(ansatz.vars), seed)
     base_point = tuple(Fraction(0) for _ in ansatz.vars)
-    rows: list[list[Any]] = []
-    used: list[tuple[Fraction, ...]] = []
     skipped = 0
-    for attempt in range(8):
+    for _attempt in range(8):
         bindings = {var: _to_expr(pool, value) for var, value in zip(ansatz.vars, base_point)}
-        rows, used = [], []
+        rows: list[list[Any]] = []
+        used: list[tuple[Fraction, ...]] = []
         ok = True
         for alpha in multi:
             derivative = residual
@@ -1679,21 +1718,22 @@ def _derivative_rows(
                 for var, order in zip(ansatz.vars, alpha):
                     for _ in range(order):
                         derivative = _value(ak.diff(derivative, var))
-                rows.append(_probe(pool, derivative, ansatz.unknowns, bindings))
+                row = _probe(pool, derivative, ansatz.unknowns, bindings)
             except _Undefined:
                 ok = False
                 break
             except Exception:
                 ok = False
                 break
+            # Appended together, so `rows` and `used` never disagree about how
+            # much of the system exists.
+            rows.append(row)
             used.append(tuple(Fraction(a) for a in alpha))
         if ok and rows:
             return rows, used, skipped
         skipped += 1
         base_point = next(stream)
-        if attempt == 7:  # pragma: no cover - exhausted
-            break
-    return rows, used, skipped
+    return [], [], skipped
 
 
 def _default_degree_bound(ansatz: Ansatz, wanted: int) -> int:
@@ -1951,9 +1991,15 @@ def fit(
         off the ``rref`` instead of assumed.
     max_points : int, optional
         Cap on sample-point draws, including those skipped for being poles.
+        Applies to collocation only — the ``certify="exact"`` path draws a base
+        point, not a system, so capping *its* equation count here would return
+        a smaller system than the degree bound promises. Size that one with
+        ``degree_bound=``.
     degree_bound : int, optional
-        Multi-index degree for ``certify="exact"``. Defaults to the family's
-        own total degree plus two.
+        Multi-index degree for ``certify="exact"``; every multi-index up to it
+        contributes an equation, and the bound reached is recorded in
+        :attr:`AnsatzSolution.steps`. Defaults to the smallest degree that
+        supplies at least as many equations as the collocation path would use.
     tolerance : float
         Numeric residual below which a non-normalising fit is still reported as
         ``"numerically_checked"`` rather than as a stated failure.
@@ -2029,8 +2075,12 @@ def fit(
 
     bound = _default_degree_bound(ansatz, n_rows) if degree_bound is None else int(degree_bound)
     if certify == "exact":
+        # No `max_points` here: that is a cap on sample-point *draws*, and the
+        # Taylor system has no draws to cap. Slicing the multi-index list with
+        # it would silently return a smaller system than the degree bound
+        # promises; `degree_bound=` is the honest, visible knob for that.
         rows, used, skipped = _derivative_rows(
-            ansatz, target_residual, seed=resolved_seed, degree_bound=bound, max_rows=point_cap
+            ansatz, target_residual, seed=resolved_seed, degree_bound=bound
         )
         method = "taylor_extraction"
     else:
@@ -2053,13 +2103,24 @@ def fit(
                 target_residual,
                 seed=resolved_seed,
                 degree_bound=bound,
-                max_rows=point_cap,
             )
             if exact_rows and _is_exact_system(exact_rows):
                 rows, used, skipped = exact_rows, exact_used, exact_skipped
                 method = "taylor_extraction"
 
     if not rows:
+        if method == "taylor_extraction":
+            raise AnsatzError(
+                "[E-ANSATZ-003] could not extract the Taylor system: some multi-index of "
+                f"degree <= {bound} is undefined at every base point tried, so the family "
+                "cannot be constrained at all",
+                code="E-ANSATZ-003",
+                remediation=(
+                    "a derivative of the residual is undefined wherever the sampler looked; "
+                    "pass a different seed=, lower degree_bound=, use certify='residual', "
+                    "or check the target for a pole"
+                ),
+            )
         raise AnsatzError(
             "[E-ANSATZ-003] could not evaluate the residual at any sample point, so the "
             "family cannot be constrained at all",
@@ -2069,12 +2130,17 @@ def fit(
                 "different seed=, raise max_points=, or check the target for a pole"
             ),
         )
+    conditions = [f"{skipped} point(s) skipped as undefined"] if skipped else []
+    if method == "taylor_extraction":
+        # The system's reach is the degree bound, so state it: a reader must be
+        # able to see which multi-indices were and were not constrained.
+        conditions.append(f"one equation per multi-index of total degree <= {bound}")
     steps.append(
         {
             "rule": f"ansatz_{method}",
             "before": str(target_residual),
             "after": f"{len(rows)} x {width + 1} augmented system over Q",
-            "side_conditions": [f"{skipped} point(s) skipped as undefined"] if skipped else [],
+            "side_conditions": conditions,
         }
     )
 

--- a/python/alkahest/ansatz.py
+++ b/python/alkahest/ansatz.py
@@ -1,0 +1,2384 @@
+"""Ansatz families — structured conjecture generation for search loops.
+
+P2 item 1 — see ``docs/mdbook/src/ansatz.md``.
+
+Stage 1 of an autoresearch loop is *generate*: propose a structured family of
+candidate objects ("every polynomial of degree ≤ 3 in x and y", "a Padé
+approximant of type (2, 2)", "a quadratic Lyapunov candidate"), then either
+sweep it numerically or solve for the coefficients that make some residual
+vanish. Agents hand-roll this constantly, and the hand-rolled version is
+usually wrong in one of three specific ways:
+
+* it loses the distinction between an *unknown coefficient* and an
+  *independent variable*, so the follow-up substitution solves for the wrong
+  thing;
+* it assumes the first *m* sample points give *m* independent equations, which
+  is false exactly when the family is degenerate — the interesting case;
+* it never substitutes the fitted answer back, so a fit that only satisfies the
+  sampled constraints is reported as if it satisfied the identity.
+
+This module is that plumbing, done once. :class:`Ansatz` keeps the unknowns and
+the variables apart; :func:`fit` over-samples and reads the rank off the
+reduced row echelon form rather than assuming independence; and ``fit(..., certify="residual")``
+— the default — substitutes the solution back and only reports
+``"exactly_verified"`` when the residual provably normalises to zero.
+
+Honesty invariants
+------------------
+**Solving may be heuristic; checking is exact.** The linear system is built by
+*collocation* (probing the residual at sample points), which is a sufficient
+condition for identical vanishing only for polynomial residuals of bounded
+degree. So the fit is never trusted on its own: it is substituted back and
+normalised. A solution that normalises to zero is
+``verification["status"] == "exactly_verified"``; one that does not is returned
+**intact** but labelled ``"numerically_checked"``, with the surviving residual
+stated in ``verification["residual"]``. There is no status meaning "solved".
+
+**Inconsistent is a result, not a malfunction.** When no member of the family
+can satisfy the constraints, :func:`fit` raises
+:class:`~alkahest.AnsatzError` ``E-ANSATZ-003``. For a loop that is a *closed
+branch* — a positive finding worth recording — in the same spirit as a
+non-elementarity verdict from :func:`alkahest.integrate`.
+
+**Underdetermined is also a result.** When the rank is below the number of
+unknowns, the members that work form a positive-dimensional family. That is
+often the answer the loop wanted, so :attr:`AnsatzSolution.free` returns the
+free parameters rather than picking an arbitrary member of the space.
+
+Quick start
+-----------
+>>> import alkahest as ak
+>>> from alkahest.ansatz import polynomial, fit
+>>> pool = ak.ExprPool()
+>>> x = pool.symbol("x")
+>>> A = polynomial(pool, [x], degree=2)
+>>> len(A.unknowns)
+3
+>>> target = x**2 - pool.integer(3) * x + pool.integer(2)
+>>> sol = fit(A, A.expr - target)
+>>> sol.status
+'exactly_verified'
+>>> sol.rank, sol.free
+(3, ())
+
+Everything here is pure Python composed from primitives that are already fast
+in Rust (``Matrix.rref``, ``simplify``, ``subs``), so it works in a build
+without the ``groebner`` feature — see :func:`fit` for the one path that needs
+it, and refuses rather than degrading when it is absent.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from dataclasses import dataclass, field
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any
+
+from .exceptions import AnsatzError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
+
+__all__ = [
+    "DEFAULT_MAX_MEMBERS",
+    "DEFAULT_MAX_TERMS",
+    "DEFAULT_SEED",
+    "Ansatz",
+    "AnsatzSolution",
+    "certify_nonneg",
+    "enumerate_family",
+    "exponential_polynomial",
+    "fit",
+    "linear_combination",
+    "polynomial",
+    "quadratic_form",
+    "rational",
+]
+
+#: Default ceiling on the number of unknown coefficients a family may carry.
+#: ``C(n + d, d)`` is a combinatorial explosion, so every constructor is
+#: bounded; exceeding the bound raises ``E-ANSATZ-002`` *before* anything is
+#: materialised. Raise it deliberately, per call, rather than globally.
+DEFAULT_MAX_TERMS = 256
+
+#: Default ceiling on the number of members :func:`enumerate_family` will
+#: produce. Enumeration is lazy *and* bounded — the bound is checked from the
+#: family size before the first member is built.
+DEFAULT_MAX_MEMBERS = 100_000
+
+#: Seed used for sample-point selection when no :class:`~alkahest.Budget`
+#: carrying one is active. Fixing it means two runs on two machines fit at the
+#: same points; entering ``ak.context(budget=ak.Budget(seed=...))`` overrides
+#: it (see :func:`alkahest.budget_seed`).
+DEFAULT_SEED = 0x5EED_A115
+
+
+def _ak() -> Any:
+    """Resolve the parent package at call time.
+
+    ``alkahest/__init__.py`` imports this module during its own
+    initialisation, so a module-level ``import alkahest`` would bind a
+    half-built namespace. Mirrors ``alkahest._batch._ak``.
+    """
+    import alkahest
+
+    return alkahest
+
+
+def _value(obj: Any) -> Any:
+    """Coerce a :class:`~alkahest.DerivedResult` to its ``.value``.
+
+    Several kernel entry points (``cancel``, ``together``, ...) return a bare
+    ``Expr`` in some builds and a ``DerivedResult`` in others; this normalises
+    both.
+    """
+    value = getattr(obj, "value", None)
+    if value is not None and hasattr(obj, "verification"):
+        return value
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Expression inspection
+# ---------------------------------------------------------------------------
+
+
+class _NotExact(Exception):
+    """The expression has no exact rational value (a symbol, or transcendental)."""
+
+
+class _Undefined(Exception):
+    """The expression is mathematically undefined here (a vanishing denominator)."""
+
+
+_MAX_EXPONENT = 4096
+
+
+def _rational_value(expr: Any) -> Fraction:
+    """Evaluate a closed arithmetic expression exactly.
+
+    Parameters
+    ----------
+    expr : Expr
+        Expression built from integers, rationals, floats, ``+``, ``*``, and
+        integer powers.
+
+    Returns
+    -------
+    Fraction
+
+    Raises
+    ------
+    _NotExact
+        A free symbol, a function application, or an irrational power.
+    _Undefined
+        A negative power of zero — i.e. the point is a pole. This is the check
+        that lets :func:`fit` *skip* a sample point instead of quietly building
+        a row out of ``2 * 0^-1``.
+    """
+    node = expr.node()
+    tag = node[0]
+    if tag == "integer":
+        return Fraction(int(node[1]))
+    if tag == "rational":
+        return Fraction(int(node[1]), int(node[2]))
+    if tag == "float":
+        return Fraction(str(node[1]))
+    if tag == "add":
+        total = Fraction(0)
+        for arg in node[1]:
+            total += _rational_value(arg)
+        return total
+    if tag == "mul":
+        product = Fraction(1)
+        for arg in node[1]:
+            product *= _rational_value(arg)
+        return product
+    if tag == "pow":
+        exponent = _rational_value(node[2])
+        if exponent.denominator != 1 or abs(exponent) > _MAX_EXPONENT:
+            raise _NotExact(f"non-integer or oversized exponent in {expr}")
+        base = _rational_value(node[1])
+        if base == 0 and exponent < 0:
+            raise _Undefined(f"zero denominator in {expr}")
+        return base ** int(exponent)
+    raise _NotExact(f"no exact rational value for {expr}")
+
+
+def _free_symbols(expr: Any, out: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return ``{name: Expr}`` for every free symbol reachable from *expr*."""
+    found: dict[str, Any] = {} if out is None else out
+    stack = [expr]
+    while stack:
+        current = stack.pop()
+        node = current.node()
+        if node[0] == "symbol":
+            found.setdefault(str(node[1]), current)
+            continue
+        for item in node[1:]:
+            if isinstance(item, (list, tuple)):
+                stack.extend(i for i in item if hasattr(i, "node"))
+            elif hasattr(item, "node"):
+                stack.append(item)
+    return found
+
+
+def _degree_in(expr: Any, names: frozenset[str]) -> int | None:
+    """Total degree of *expr* in the symbols *names*, or ``None`` if > 1.
+
+    A purely syntactic, conservative test. ``0`` means the unknowns do not
+    occur, ``1`` means the expression is affine in them, and ``None`` means
+    "nonlinear, or not decidable by inspection" — which :func:`fit` treats as
+    nonlinear, since the cost of guessing wrong is a silently wrong fit.
+    """
+    node = expr.node()
+    tag = node[0]
+    if tag == "symbol":
+        return 1 if str(node[1]) in names else 0
+    if tag in {"integer", "rational", "float"}:
+        return 0
+    if tag == "add":
+        best = 0
+        for arg in node[1]:
+            degree = _degree_in(arg, names)
+            if degree is None:
+                return None
+            best = max(best, degree)
+        return best
+    if tag == "mul":
+        total = 0
+        for arg in node[1]:
+            degree = _degree_in(arg, names)
+            if degree is None:
+                return None
+            total += degree
+        return None if total > 1 else total
+    if tag == "pow":
+        if _degree_in(node[2], names) != 0:
+            return None  # an unknown in the exponent
+        base = _degree_in(node[1], names)
+        if base == 0:
+            return 0
+        if base is None:
+            return None
+        try:
+            exponent = _rational_value(node[2])
+        except (_NotExact, _Undefined):
+            return None
+        return base if exponent == 1 else None
+    if tag == "func":
+        for arg in node[2]:
+            if _degree_in(arg, names) != 0:
+                return None  # an unknown inside sin/exp/...
+        return 0
+    return None if _free_symbols(expr).keys() & names else 0
+
+
+def _is_affine(expr: Any, names: frozenset[str]) -> bool:
+    """True when *expr* is affine (degree ≤ 1) in the symbols *names*."""
+    return _degree_in(expr, names) is not None
+
+
+def _unknown_denominators(expr: Any, names: frozenset[str]) -> list[tuple[Any, int]]:
+    """Sub-expressions ``base**-k`` whose *base* involves the unknowns.
+
+    These are what makes a Padé-style residual nonlinear, and multiplying them
+    out is what makes it linear again — see :func:`_clear_denominators`.
+    """
+    found: dict[str, tuple[Any, int]] = {}
+    stack = [expr]
+    while stack:
+        current = stack.pop()
+        node = current.node()
+        if node[0] == "pow":
+            try:
+                exponent = _rational_value(node[2])
+            except (_NotExact, _Undefined):
+                exponent = Fraction(0)
+            base = node[1]
+            if exponent < 0 and exponent.denominator == 1 and _free_symbols(base).keys() & names:
+                key = str(base)
+                power = -int(exponent)
+                previous = found.get(key)
+                if previous is None or previous[1] < power:
+                    found[key] = (base, power)
+        for item in node[1:]:
+            if isinstance(item, (list, tuple)):
+                stack.extend(i for i in item if hasattr(i, "node"))
+            elif hasattr(item, "node"):
+                stack.append(item)
+    return [found[key] for key in sorted(found)]
+
+
+def _clear_denominators(expr: Any, names: frozenset[str]) -> tuple[Any, str] | None:
+    """Multiply out unknown-bearing denominators, returning ``(expr, note)``.
+
+    ``p/q − f`` is not linear in the coefficients of *p* and *q*; ``p − f·q``
+    is. This is the transform that keeps the Padé / rational-function case on
+    the default (linear, ``groebner``-free) path, and it is applied
+    automatically by :func:`fit` — see design note D2 in the module docs.
+
+    Returns ``None`` when there is nothing to clear or the result is still not
+    affine.
+    """
+    ak = _ak()
+    denominators = _unknown_denominators(expr, names)
+    if not denominators:
+        return None
+    scaled = expr
+    parts: list[str] = []
+    for base, power in denominators:
+        for _ in range(power):
+            scaled = scaled * base
+        parts.append(f"({base})^{power}" if power != 1 else f"({base})")
+    for transform in (ak.cancel, ak.together, lambda e: ak.simplify(e)):
+        try:
+            candidate = _value(transform(scaled))
+        except Exception:
+            continue
+        if _is_affine(candidate, names):
+            return candidate, "multiplied through by " + " * ".join(parts)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic sample points
+# ---------------------------------------------------------------------------
+
+
+def _resolve_seed(seed: int | None) -> int:
+    """Seed to use: the explicit one, else the active budget's, else the default."""
+    if seed is not None:
+        return int(seed)
+    try:
+        from ._budget import budget_seed
+    except ImportError:  # pragma: no cover - defensive
+        return DEFAULT_SEED
+    try:
+        active = budget_seed()
+    except Exception:
+        active = None
+    return DEFAULT_SEED if active is None else int(active)
+
+
+def _lcg(seed: int) -> Iterator[int]:
+    """A deterministic 64-bit LCG.
+
+    Deliberately *not* :mod:`random`: this stream must be identical across
+    Python versions and platforms so that a fit recorded in a claim graph can
+    be reproduced from its seed alone.
+    """
+    state = (int(seed) ^ 0x9E3779B97F4A7C15) & 0xFFFF_FFFF_FFFF_FFFF
+    while True:
+        state = (state * 6364136223846793005 + 1442695040888963407) & 0xFFFF_FFFF_FFFF_FFFF
+        yield (state >> 17) & 0xFFFF_FFFF
+
+
+def _sample_points(n_vars: int, seed: int) -> Iterator[tuple[Fraction, ...]]:
+    """Yield distinct deterministic rational points in ``n_vars`` variables."""
+    stream = _lcg(seed)
+    seen: set[tuple[Fraction, ...]] = set()
+    while True:
+        point = tuple(Fraction(next(stream) % 25 - 12, 1 + next(stream) % 4) for _ in range(n_vars))
+        if point in seen:
+            continue
+        seen.add(point)
+        yield point
+
+
+def _to_expr(pool: Any, value: Fraction) -> Any:
+    """Intern a :class:`~fractions.Fraction` into *pool*."""
+    if value.denominator == 1:
+        return pool.integer(value.numerator)
+    return pool.rational(value.numerator, value.denominator)
+
+
+# ---------------------------------------------------------------------------
+# Ansatz
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Ansatz:
+    """A parametric family of expressions with named unknown coefficients.
+
+    An ansatz is an object rather than a bare :class:`~alkahest.Expr` because a
+    bare expression loses the distinction between an *unknown coefficient* and
+    an *independent variable*, and every downstream step needs it. Construct
+    one with :func:`polynomial`, :func:`rational`, :func:`linear_combination`,
+    :func:`exponential_polynomial`, or :func:`quadratic_form` rather than
+    directly.
+
+    Attributes
+    ----------
+    expr : Expr
+        The family member with symbolic coefficients, e.g.
+        ``c_0 + c_1*x + c_2*x^2``.
+    unknowns : tuple of Expr
+        The coefficient symbols, in a deterministic order (graded, then
+        lexicographic by exponent).
+    basis : tuple of Expr
+        Parallel to *unknowns*: the expression each unknown multiplies. For
+        :func:`rational` this is the numerator basis followed by the
+        denominator basis, since the two blocks multiply into different places
+        — read ``metadata["numerator_terms"]`` for the split.
+    vars : tuple of Expr
+        The independent variables. Disjoint from *unknowns* by construction.
+    family : str
+        Which constructor produced this, e.g. ``"polynomial"``.
+    name : str
+        Prefix used for the coefficient symbol names.
+    pool : ExprPool
+        Pool everything is interned in.
+    metadata : dict
+        Family-specific detail (degree, rates, the numerator/denominator split).
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import polynomial
+    >>> pool = ak.ExprPool()
+    >>> x, y = pool.symbol("x"), pool.symbol("y")
+    >>> A = polynomial(pool, [x, y], degree=1, name="c")
+    >>> A.names
+    ('c_0_0', 'c_1_0', 'c_0_1')
+    >>> A.expr
+    (c_0_0 + (x * c_1_0) + (y * c_0_1))
+    """
+
+    expr: Any
+    unknowns: tuple[Any, ...]
+    basis: tuple[Any, ...]
+    vars: tuple[Any, ...]
+    family: str
+    name: str
+    pool: Any
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __len__(self) -> int:
+        """Number of unknown coefficients."""
+        return len(self.unknowns)
+
+    def __repr__(self) -> str:
+        variables = ", ".join(str(v) for v in self.vars)
+        return f"Ansatz({self.family}, vars=({variables}), unknowns={len(self.unknowns)})"
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Coefficient symbol names, parallel to :attr:`unknowns`.
+
+        Names are **predictable**, never gensym-ed: an agent that cannot
+        predict them cannot write the follow-up call.
+        """
+        return tuple(str(u) for u in self.unknowns)
+
+    @property
+    def symbols(self) -> dict[str, Any]:
+        """``{name: Expr}`` for the unknowns, for keying an
+        :meth:`instantiate` mapping by name."""
+        return dict(zip(self.names, self.unknowns))
+
+    def instantiate(self, assignment: Mapping[Any, Any], *, simplify: bool = True) -> Any:
+        """Substitute coefficient values, returning a concrete member.
+
+        Parameters
+        ----------
+        assignment : mapping
+            ``{Expr or str: Expr or int or float}``. Unknowns left out stay
+            symbolic, which is how an underdetermined fit is returned.
+        simplify : bool
+            Fold the substituted expression (so a zeroed coefficient really
+            disappears). Turn off for a hot enumeration whose consumer
+            normalises anyway.
+
+        Returns
+        -------
+        Expr
+
+        Examples
+        --------
+        >>> import alkahest as ak
+        >>> from alkahest.ansatz import polynomial
+        >>> pool = ak.ExprPool()
+        >>> x = pool.symbol("x")
+        >>> A = polynomial(pool, [x], degree=1)
+        >>> A.instantiate({"c_0": 2, "c_1": -1})
+        (2 + (x * -1))
+        """
+        substituted = _substitute(self.pool, self.expr, assignment, self.symbols)
+        return _value(_ak().simplify(substituted)) if simplify else substituted
+
+    def residual(self, target: Any) -> Any:
+        """The residual whose vanishing means "this member equals *target*".
+
+        For most families this is just ``self.expr - target``. For
+        :func:`rational` it is the **denominator-cleared** form
+        ``numerator - target * denominator``, which is affine in the unknowns
+        where ``p/q - f`` is not. Passing the naive difference to :func:`fit`
+        works too — it clears denominators itself — but this states the intent.
+
+        Examples
+        --------
+        >>> import alkahest as ak
+        >>> from alkahest.ansatz import rational
+        >>> pool = ak.ExprPool()
+        >>> x = pool.symbol("x")
+        >>> A = rational(pool, [x], num_degree=1, den_degree=1)
+        >>> A.residual(pool.integer(1))
+        (a_0 + (x * a_1) + ((1 + (x * b_1)) * -1))
+        """
+        ak = _ak()
+        target = _value(target)
+        numerator = self.metadata.get("numerator")
+        denominator = self.metadata.get("denominator")
+        if numerator is not None and denominator is not None:
+            return _value(ak.simplify(numerator - target * denominator))
+        return self.expr - target
+
+    def with_prefix(self, name: str) -> Ansatz:
+        """A copy of this family with the coefficient prefix *name*.
+
+        Useful when two ansätze are fitted jointly and their coefficient names
+        would otherwise collide.
+        """
+        return _rebuild(self, name)
+
+
+def _substitute(
+    pool: Any, expr: Any, assignment: Mapping[Any, Any], symbols: Mapping[str, Any]
+) -> Any:
+    """``ak.subs`` with string keys and :class:`~fractions.Fraction` values allowed."""
+    ak = _ak()
+    mapping: dict[Any, Any] = {}
+    for key, value in assignment.items():
+        symbol = symbols.get(key) if isinstance(key, str) else key
+        if symbol is None:
+            raise AnsatzError(
+                f"[E-ANSATZ-001] unknown coefficient name {key!r}",
+                code="E-ANSATZ-001",
+                remediation=f"expected one of {sorted(symbols)}",
+            )
+        mapping[symbol] = _to_expr(pool, value) if isinstance(value, Fraction) else value
+    if not mapping:
+        return expr
+    return _value(ak.subs(expr, mapping))
+
+
+# ---------------------------------------------------------------------------
+# Family constructors
+# ---------------------------------------------------------------------------
+
+
+def _exponents(n_vars: int, degree: int, *, min_degree: int = 0) -> list[tuple[int, ...]]:
+    """Exponent tuples with ``min_degree <= |a| <= degree``, graded then lex."""
+    out: list[tuple[int, ...]] = []
+    for total in range(min_degree, degree + 1):
+        block = [c for c in itertools.product(range(total + 1), repeat=n_vars) if sum(c) == total]
+        out.extend(sorted(block, reverse=True))
+    return out
+
+
+def _count_exponents(n_vars: int, degree: int, *, min_degree: int = 0) -> int:
+    """``len(_exponents(...))`` without materialising it."""
+    upper = math.comb(n_vars + degree, n_vars)
+    lower = math.comb(n_vars + min_degree - 1, n_vars) if min_degree > 0 else 0
+    return upper - lower
+
+
+def _check_size(count: int, max_terms: int, what: str) -> None:
+    if count > max_terms:
+        raise AnsatzError(
+            f"[E-ANSATZ-002] {what} needs {count} unknown coefficients, "
+            f"which exceeds max_terms={max_terms}",
+            code="E-ANSATZ-002",
+            remediation=(
+                "lower the degree, or pass an explicit max_terms= if you really want a "
+                f"{count}-term family — nothing is materialised until this check passes"
+            ),
+        )
+
+
+def _check_collision(names: Sequence[str], reserved: Mapping[str, Any], name: str) -> None:
+    """Refuse a coefficient prefix whose names collide with existing symbols.
+
+    A family named ``c`` fitted against an expression that already contains a
+    symbol ``c_0`` silently solves for the wrong thing. There is deliberately
+    no gensym fallback: unpredictable names are unusable from a follow-up call.
+
+    ``reserved`` is what this module can see — the family's own variables plus
+    every free symbol of the expressions handed to the constructor, plus
+    anything the caller declared. The pool itself exposes no symbol listing, so
+    a symbol that exists in the pool but appears in none of those is not
+    detected here; ``fit``'s back-substitution check is the backstop.
+    """
+    duplicates = [n for n in names if n in reserved]
+    if duplicates:
+        raise AnsatzError(
+            f"[E-ANSATZ-001] coefficient name(s) {sorted(set(duplicates))} already "
+            f"denote symbols in this problem; the fit would solve for the wrong thing",
+            code="E-ANSATZ-001",
+            remediation=(
+                f"pass a different name= (currently {name!r}) — coefficient names are "
+                "never gensym-ed, because an agent that cannot predict them cannot "
+                "write the follow-up call"
+            ),
+        )
+    seen: set[str] = set()
+    for candidate in names:
+        if candidate in seen:
+            raise AnsatzError(
+                f"[E-ANSATZ-001] coefficient name {candidate!r} generated twice",
+                code="E-ANSATZ-001",
+                remediation=("internal naming clash; report it with the call that caused it"),
+            )
+        seen.add(candidate)
+
+
+def _reserved_from(exprs: Iterable[Any], extra: Iterable[Any]) -> dict[str, Any]:
+    reserved: dict[str, Any] = {}
+    for expr in exprs:
+        _free_symbols(_value(expr), reserved)
+    for item in extra:
+        if isinstance(item, str):
+            reserved.setdefault(item, None)
+        else:
+            _free_symbols(_value(item), reserved)
+    return reserved
+
+
+def _coefficient_name(name: str, exponents: Sequence[int], *, univariate: bool) -> str:
+    if univariate:
+        return f"{name}_{exponents[0]}"
+    return name + "".join(f"_{e}" for e in exponents)
+
+
+def _make_terms(
+    pool: Any,
+    variables: Sequence[Any],
+    exponents: Sequence[Sequence[int]],
+    name: str,
+) -> tuple[tuple[Any, ...], tuple[Any, ...], tuple[str, ...]]:
+    """Build ``(unknowns, basis, names)`` for a monomial family."""
+    univariate = len(variables) == 1
+    names = tuple(_coefficient_name(name, e, univariate=univariate) for e in exponents)
+    unknowns = tuple(pool.symbol(n) for n in names)
+    basis: list[Any] = []
+    for combo in exponents:
+        term = pool.integer(1)
+        for var, power in zip(variables, combo):
+            for _ in range(power):
+                term = term * var
+        basis.append(term)
+    return unknowns, tuple(basis), names
+
+
+def _sum_terms(pool: Any, unknowns: Sequence[Any], basis: Sequence[Any]) -> Any:
+    total = pool.integer(0)
+    for coefficient, term in zip(unknowns, basis):
+        total = total + coefficient * term
+    return _value(_ak().simplify(total))
+
+
+def polynomial(
+    pool: Any,
+    vars: Sequence[Any],
+    degree: int,
+    *,
+    name: str = "c",
+    min_degree: int = 0,
+    max_terms: int = DEFAULT_MAX_TERMS,
+    reserved: Sequence[Any] = (),
+) -> Ansatz:
+    """Every polynomial of total degree ≤ *degree* in *vars*, with unknown coefficients.
+
+    Parameters
+    ----------
+    pool : ExprPool
+        Pool the coefficient symbols are interned in.
+    vars : sequence of Expr
+        Independent variables, in the order the exponent tuples index them.
+    degree : int
+        Maximum **total** degree.
+    name : str
+        Coefficient prefix. Names are ``f"{name}_{i}"`` for one variable and
+        ``f"{name}_{i}_{j}..."`` for several — always predictable, never
+        gensym-ed. Collides → ``E-ANSATZ-001``.
+    min_degree : int
+        Drop monomials of total degree below this (``min_degree=degree`` gives
+        the homogeneous forms).
+    max_terms : int
+        Refuse rather than materialise a family bigger than this
+        (``E-ANSATZ-002``). ``C(n + d, d)`` grows fast.
+    reserved : sequence of Expr or str
+        Extra symbols (or names) the coefficients must not collide with — pass
+        the target function here when it carries symbols of its own.
+
+    Returns
+    -------
+    Ansatz
+
+    Raises
+    ------
+    AnsatzError
+        ``E-ANSATZ-001`` on a name collision, ``E-ANSATZ-002`` if the family
+        exceeds *max_terms*.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import polynomial
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> A = polynomial(pool, [x], degree=3)
+    >>> A.names
+    ('c_0', 'c_1', 'c_2', 'c_3')
+    >>> try:
+    ...     polynomial(pool, [x], degree=99, max_terms=10)
+    ... except ak.AnsatzError as exc:
+    ...     exc.code
+    'E-ANSATZ-002'
+    """
+    variables = tuple(_value(v) for v in vars)
+    if not variables:
+        raise AnsatzError(
+            "[E-ANSATZ-001] polynomial() needs at least one variable",
+            code="E-ANSATZ-001",
+            remediation="pass vars=[x] (or use linear_combination for a basis with no variables)",
+        )
+    if degree < 0 or min_degree < 0 or min_degree > degree:
+        raise ValueError("polynomial() requires 0 <= min_degree <= degree")
+    count = _count_exponents(len(variables), degree, min_degree=min_degree)
+    _check_size(
+        count,
+        max_terms,
+        f"polynomial(degree={degree}, {len(variables)} variable(s))",
+    )
+    exponents = _exponents(len(variables), degree, min_degree=min_degree)
+    unknowns, basis, names = _make_terms(pool, variables, exponents, name)
+    _check_collision(names, _reserved_from(variables, reserved), name)
+    return Ansatz(
+        expr=_sum_terms(pool, unknowns, basis),
+        unknowns=unknowns,
+        basis=basis,
+        vars=variables,
+        family="polynomial",
+        name=name,
+        pool=pool,
+        metadata={
+            "degree": degree,
+            "min_degree": min_degree,
+            "exponents": exponents,
+            "max_terms": max_terms,
+        },
+    )
+
+
+def rational(
+    pool: Any,
+    vars: Sequence[Any],
+    num_degree: int,
+    den_degree: int,
+    *,
+    name: str = "a",
+    den_name: str = "b",
+    monic_denominator: bool = True,
+    max_terms: int = DEFAULT_MAX_TERMS,
+    reserved: Sequence[Any] = (),
+) -> Ansatz:
+    """A rational-function family ``p / q`` — the Padé case, kept linear.
+
+    ``p/q ≈ f`` is *not* linear in the coefficients of ``p`` and ``q``, but
+    ``p − f·q = 0`` is linear in them jointly. This constructor records the
+    numerator/denominator split so :meth:`Ansatz.residual` (and :func:`fit`,
+    which clears denominators itself) can apply that transform, keeping the
+    default solve path exact linear algebra with no ``groebner`` dependency.
+
+    Parameters
+    ----------
+    pool, vars, max_terms, reserved
+        As :func:`polynomial`.
+    num_degree, den_degree : int
+        Total degrees of the numerator and denominator.
+    name, den_name : str
+        Coefficient prefixes for the numerator and denominator.
+    monic_denominator : bool
+        When true (default), the denominator's constant term is fixed to ``1``.
+        Without a normalisation ``p/q`` and ``(λp)/(λq)`` are the same function,
+        so **every** such fit would report a spurious extra free parameter.
+
+    Returns
+    -------
+    Ansatz
+        ``.expr`` is the quotient; ``.metadata["numerator"]`` and
+        ``["denominator"]`` are the two polynomials, and
+        ``["numerator_terms"]`` is how many of ``.unknowns`` belong to the
+        numerator.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import rational
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> A = rational(pool, [x], num_degree=1, den_degree=1)
+    >>> A.names
+    ('a_0', 'a_1', 'b_1')
+    >>> A.expr
+    ((a_0 + (x * a_1)) * (1 + (x * b_1))^-1)
+    """
+    variables = tuple(_value(v) for v in vars)
+    if not variables:
+        raise AnsatzError(
+            "[E-ANSATZ-001] rational() needs at least one variable",
+            code="E-ANSATZ-001",
+            remediation="pass vars=[x]",
+        )
+    if num_degree < 0 or den_degree < 0:
+        raise ValueError("rational() requires non-negative degrees")
+    den_min = 1 if monic_denominator else 0
+    count = _count_exponents(len(variables), num_degree) + _count_exponents(
+        len(variables), den_degree, min_degree=den_min
+    )
+    _check_size(
+        count,
+        max_terms,
+        f"rational(num_degree={num_degree}, den_degree={den_degree})",
+    )
+    num_exponents = _exponents(len(variables), num_degree)
+    den_exponents = _exponents(len(variables), den_degree, min_degree=den_min)
+    num_unknowns, num_basis, num_names = _make_terms(pool, variables, num_exponents, name)
+    den_unknowns, den_basis, den_names = _make_terms(pool, variables, den_exponents, den_name)
+    _check_collision(
+        num_names + den_names,
+        _reserved_from(variables, reserved),
+        f"{name}/{den_name}",
+    )
+    numerator = _sum_terms(pool, num_unknowns, num_basis)
+    denominator = _sum_terms(pool, den_unknowns, den_basis)
+    if monic_denominator:
+        denominator = _value(_ak().simplify(pool.integer(1) + denominator))
+    return Ansatz(
+        expr=numerator / denominator,
+        unknowns=num_unknowns + den_unknowns,
+        basis=num_basis + den_basis,
+        vars=variables,
+        family="rational",
+        name=name,
+        pool=pool,
+        metadata={
+            "num_degree": num_degree,
+            "den_degree": den_degree,
+            "numerator": numerator,
+            "denominator": denominator,
+            "numerator_terms": len(num_unknowns),
+            "den_name": den_name,
+            "monic_denominator": monic_denominator,
+            "max_terms": max_terms,
+        },
+    )
+
+
+def linear_combination(
+    pool: Any,
+    basis: Sequence[Any],
+    *,
+    vars: Sequence[Any] | None = None,
+    name: str = "c",
+    max_terms: int = DEFAULT_MAX_TERMS,
+    reserved: Sequence[Any] = (),
+) -> Ansatz:
+    """``Σ cᵢ · basisᵢ`` — the general escape hatch.
+
+    Whenever the family is "an unknown linear combination of *these* things"
+    — a Lyapunov basis, a set of candidate integrals, ζ(3) and π³ and log³2 —
+    this is the constructor. Everything else in this module is a convenience
+    wrapper that computes a basis for you.
+
+    Parameters
+    ----------
+    pool : ExprPool
+    basis : sequence of Expr
+        The basis functions. Not checked for linear independence — a dependent
+        basis simply shows up as free parameters in the fit, which is the
+        honest answer.
+    vars : sequence of Expr, optional
+        Independent variables. Inferred from the basis's free symbols (sorted
+        by name) when omitted.
+    name, max_terms, reserved
+        As :func:`polynomial`.
+
+    Returns
+    -------
+    Ansatz
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import linear_combination
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> A = linear_combination(pool, [ak.sin(x), ak.cos(x)])
+    >>> A.expr
+    ((sin(x) * c_0) + (cos(x) * c_1))
+    """
+    terms = tuple(_value(b) for b in basis)
+    if not terms:
+        raise AnsatzError(
+            "[E-ANSATZ-001] linear_combination() needs a non-empty basis",
+            code="E-ANSATZ-001",
+            remediation="pass basis=[...] with at least one expression",
+        )
+    _check_size(len(terms), max_terms, f"linear_combination({len(terms)} basis functions)")
+    names = tuple(f"{name}_{i}" for i in range(len(terms)))
+    unknowns = tuple(pool.symbol(n) for n in names)
+    symbols = _reserved_from(terms, reserved)
+    _check_collision(names, symbols, name)
+    if vars is None:
+        variables = tuple(symbols[key] for key in sorted(symbols) if symbols[key] is not None)
+    else:
+        variables = tuple(_value(v) for v in vars)
+    return Ansatz(
+        expr=_sum_terms(pool, unknowns, terms),
+        unknowns=unknowns,
+        basis=terms,
+        vars=variables,
+        family="linear_combination",
+        name=name,
+        pool=pool,
+        metadata={"max_terms": max_terms},
+    )
+
+
+def exponential_polynomial(
+    pool: Any,
+    var: Any,
+    rates: Sequence[Any],
+    *,
+    degree: int | Sequence[int] = 0,
+    name: str = "c",
+    max_terms: int = DEFAULT_MAX_TERMS,
+    reserved: Sequence[Any] = (),
+) -> Ansatz:
+    """``Σᵢ pᵢ(x)·e^{λᵢ x}`` with polynomial ``pᵢ`` of the given degree.
+
+    The standard ansatz for a linear ODE or recurrence whose characteristic
+    roots ``λᵢ`` are already known — the polynomial factor's degree is the
+    multiplicity minus one. Because the ``λᵢ`` are *given*, the family stays
+    linear in the unknowns and fits through the default path.
+
+    Parameters
+    ----------
+    pool : ExprPool
+    var : Expr
+        The independent variable.
+    rates : sequence of Expr or int
+        The exponents ``λᵢ``. Duplicates are allowed but pointless — raise the
+        corresponding *degree* instead.
+    degree : int or sequence of int
+        Degree of each polynomial factor; a scalar applies to every rate.
+    name, max_terms, reserved
+        As :func:`polynomial`. Coefficient names are ``f"{name}_{i}_{k}"`` for
+        rate *i* and power *k*.
+
+    Returns
+    -------
+    Ansatz
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import exponential_polynomial
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> A = exponential_polynomial(pool, x, [1, -1])
+    >>> A.names
+    ('c_0_0', 'c_1_0')
+    >>> A.expr
+    ((exp(x) * c_0_0) + (exp((x * -1)) * c_1_0))
+    """
+    ak = _ak()
+    variable = _value(var)
+    rate_exprs = [r if hasattr(r, "node") else pool.integer(int(r)) for r in rates]
+    if not rate_exprs:
+        raise AnsatzError(
+            "[E-ANSATZ-001] exponential_polynomial() needs at least one rate",
+            code="E-ANSATZ-001",
+            remediation="pass rates=[lambda_0, ...]",
+        )
+    if isinstance(degree, int):
+        degrees = [degree] * len(rate_exprs)
+    else:
+        degrees = [int(d) for d in degree]
+        if len(degrees) != len(rate_exprs):
+            raise ValueError("exponential_polynomial(): len(degree) must match len(rates)")
+    if any(d < 0 for d in degrees):
+        raise ValueError("exponential_polynomial() requires non-negative degrees")
+    count = sum(d + 1 for d in degrees)
+    _check_size(count, max_terms, f"exponential_polynomial({len(rate_exprs)} rates)")
+
+    names: list[str] = []
+    basis: list[Any] = []
+    for index, (rate, deg) in enumerate(zip(rate_exprs, degrees)):
+        envelope = ak.exp(rate * variable)
+        for power in range(deg + 1):
+            term = envelope
+            for _ in range(power):
+                term = term * variable
+            names.append(f"{name}_{index}_{power}")
+            basis.append(_value(ak.simplify(term)))
+    unknowns = tuple(pool.symbol(n) for n in names)
+    _check_collision(tuple(names), _reserved_from([variable, *rate_exprs], reserved), name)
+    return Ansatz(
+        expr=_sum_terms(pool, unknowns, basis),
+        unknowns=unknowns,
+        basis=tuple(basis),
+        vars=(variable,),
+        family="exponential_polynomial",
+        name=name,
+        pool=pool,
+        metadata={"rates": tuple(rate_exprs), "degrees": tuple(degrees), "max_terms": max_terms},
+    )
+
+
+def quadratic_form(
+    pool: Any,
+    vars: Sequence[Any],
+    *,
+    name: str = "q",
+    max_terms: int = DEFAULT_MAX_TERMS,
+    reserved: Sequence[Any] = (),
+) -> Ansatz:
+    """``Σ_{i ≤ j} q_ij · xᵢ xⱼ`` — the Lyapunov-candidate family.
+
+    Only the upper triangle carries an unknown, because ``q_ij xᵢxⱼ`` and
+    ``q_ji xⱼxᵢ`` are the same term and carrying both would make every fit
+    report spurious free parameters.
+
+    This module's job **ends** when it has produced the candidate. Deciding
+    whether a fitted form is non-negative is :func:`alkahest.prove_nonneg` /
+    :func:`alkahest.sos_decompose`'s job, and :func:`certify_nonneg` is the
+    one-line hand-off — positivity is not reimplemented here.
+
+    Parameters
+    ----------
+    pool, vars, name, max_terms, reserved
+        As :func:`polynomial`. Coefficient names are ``f"{name}_{i}_{j}"`` with
+        ``i <= j`` indexing *vars*.
+
+    Returns
+    -------
+    Ansatz
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import quadratic_form
+    >>> pool = ak.ExprPool()
+    >>> x, y = pool.symbol("x"), pool.symbol("y")
+    >>> A = quadratic_form(pool, [x, y])
+    >>> A.names
+    ('q_0_0', 'q_0_1', 'q_1_1')
+    """
+    variables = tuple(_value(v) for v in vars)
+    if not variables:
+        raise AnsatzError(
+            "[E-ANSATZ-001] quadratic_form() needs at least one variable",
+            code="E-ANSATZ-001",
+            remediation="pass vars=[x, y]",
+        )
+    pairs = [(i, j) for i in range(len(variables)) for j in range(i, len(variables))]
+    _check_size(len(pairs), max_terms, f"quadratic_form({len(variables)} variables)")
+    names = tuple(f"{name}_{i}_{j}" for i, j in pairs)
+    unknowns = tuple(pool.symbol(n) for n in names)
+    basis = tuple(variables[i] * variables[j] for i, j in pairs)
+    _check_collision(names, _reserved_from(variables, reserved), name)
+    return Ansatz(
+        expr=_sum_terms(pool, unknowns, basis),
+        unknowns=unknowns,
+        basis=basis,
+        vars=variables,
+        family="quadratic_form",
+        name=name,
+        pool=pool,
+        metadata={"pairs": tuple(pairs), "max_terms": max_terms},
+    )
+
+
+def _rebuild(ansatz: Ansatz, name: str) -> Ansatz:
+    """Re-run *ansatz*'s constructor with a different coefficient prefix."""
+    meta = ansatz.metadata
+    if ansatz.family == "polynomial":
+        return polynomial(
+            ansatz.pool,
+            ansatz.vars,
+            meta["degree"],
+            name=name,
+            min_degree=meta["min_degree"],
+            max_terms=meta["max_terms"],
+        )
+    if ansatz.family == "rational":
+        return rational(
+            ansatz.pool,
+            ansatz.vars,
+            meta["num_degree"],
+            meta["den_degree"],
+            name=name,
+            den_name=meta["den_name"] + "_" + name,
+            monic_denominator=meta["monic_denominator"],
+            max_terms=meta["max_terms"],
+        )
+    if ansatz.family == "exponential_polynomial":
+        return exponential_polynomial(
+            ansatz.pool,
+            ansatz.vars[0],
+            meta["rates"],
+            degree=meta["degrees"],
+            name=name,
+            max_terms=meta["max_terms"],
+        )
+    if ansatz.family == "quadratic_form":
+        return quadratic_form(ansatz.pool, ansatz.vars, name=name, max_terms=meta["max_terms"])
+    return linear_combination(
+        ansatz.pool,
+        ansatz.basis,
+        vars=ansatz.vars,
+        name=name,
+        max_terms=meta.get("max_terms", DEFAULT_MAX_TERMS),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enumeration (stage 2 material)
+# ---------------------------------------------------------------------------
+
+
+def enumerate_family(
+    ansatz: Ansatz,
+    coeffs: Iterable[Any] = (-1, 0, 1),
+    *,
+    max_members: int = DEFAULT_MAX_MEMBERS,
+) -> Iterator[Any]:
+    """Lazily enumerate concrete members over a finite coefficient set.
+
+    Enumeration and fitting stay separate on purpose: this feeds *stage 2* of a
+    search loop (generate candidates, then hammer them with
+    :func:`alkahest.compile_expr` or :func:`alkahest.batch_map`), while
+    :func:`fit` is *stage 3* (turn data into a symbolic claim). Fusing them
+    produces an API that does neither well.
+
+    The bound is checked **before** the first member is built, from
+    ``len(coeffs) ** len(ansatz)`` — enumeration is lazy *and* bounded.
+
+    Parameters
+    ----------
+    ansatz : Ansatz
+    coeffs : iterable
+        Values each coefficient ranges over. Materialised once.
+    max_members : int
+        Refuse (``E-ANSATZ-002``) rather than start an enumeration longer than
+        this.
+
+    Yields
+    ------
+    Expr
+        One member per assignment, coefficients varying last-unknown-fastest.
+
+    Raises
+    ------
+    AnsatzError
+        ``E-ANSATZ-002`` when the family size exceeds *max_members*.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import enumerate_family, polynomial
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> A = polynomial(pool, [x], degree=1)
+    >>> [str(m) for m in enumerate_family(A, [0, 1])]
+    ['0', 'x', '1', '(x + 1)']
+    >>> try:
+    ...     next(enumerate_family(A, range(10 ** 6), max_members=10))
+    ... except ak.AnsatzError as exc:
+    ...     exc.code
+    'E-ANSATZ-002'
+    """
+    values = list(coeffs)
+    total = len(values) ** len(ansatz.unknowns)
+    _check_size(total, max_members, f"enumerate_family over {len(values)} value(s)")
+    for assignment in itertools.product(values, repeat=len(ansatz.unknowns)):
+        yield ansatz.instantiate(dict(zip(ansatz.unknowns, assignment)))
+
+
+# ---------------------------------------------------------------------------
+# AnsatzSolution
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnsatzSolution:
+    """The outcome of fitting an :class:`Ansatz`.
+
+    Shaped so that :meth:`alkahest.research.ResearchSession.record` accepts it
+    unchanged: it exposes ``.value``, ``.steps``, ``.verification``, and
+    ``.certificate`` exactly as a :class:`~alkahest.DerivedResult` does, and
+    ``verification["status"]`` is one of the existing
+    :data:`alkahest.research.STATUS_BADGES` keys — no new vocabulary.
+
+    Attributes
+    ----------
+    expr : Expr
+        The fitted member. When the system is underdetermined this still
+        contains the free unknowns, symbolically.
+    assignment : dict
+        ``{unknown: Expr}`` for the determined coefficients. Values may mention
+        the free unknowns.
+    free : tuple of Expr
+        Unknowns the constraints do not pin down. Non-empty means the members
+        that work form a positive-dimensional family — often the interesting
+        answer, so no arbitrary member is picked for you.
+    rank : int
+        Rank of the collocation system; ``rank == len(ansatz)`` iff the fit is
+        unique.
+    status : str
+        Mirrors ``verification["status"]``: ``"exactly_verified"``,
+        ``"numerically_checked"``, or ``"unverified"``.
+    verification : dict
+        ``{"status", "evidence", "method", "externally_verified", ...}``.
+        ``"residual"`` carries the surviving normal form when the exact check
+        did not close, and ``"max_abs_residual"`` the worst numeric sample.
+    steps : tuple of dict
+        Derivation log in the ``STEP_FIELDS`` schema.
+    residual : Expr
+        The residual as fitted (after any denominator clearing).
+    check : dict
+        A re-verification recipe in the shape
+        :meth:`alkahest.research.ClaimGraph.verify` understands
+        (``{"kind": "zero", "expr": ...}`` — the back-substituted residual,
+        which must normalise to zero). Pass it through as
+        ``session.record(solution, check=solution.check)`` so a graph loaded
+        from disk months later can re-derive the check rather than trust it.
+    points : tuple
+        The rows' provenance, as nested rational strings: the sample points
+        actually used for ``certify="residual"``, or the multi-indices
+        ``α`` for ``certify="exact"``. Enough to reproduce the system.
+    ansatz : Ansatz
+        The family this came from.
+    certificate : None
+        Always ``None``: this module emits no Lean certificate. Withholding
+        beats emitting one nothing checked.
+    """
+
+    expr: Any
+    assignment: dict[Any, Any]
+    free: tuple[Any, ...]
+    rank: int
+    status: str
+    verification: dict[str, Any]
+    steps: tuple[dict[str, Any], ...]
+    residual: Any
+    check: dict[str, Any]
+    points: tuple[tuple[str, ...], ...]
+    ansatz: Ansatz
+    certificate: None = None
+
+    @property
+    def value(self) -> Any:
+        """Alias of :attr:`expr` — the attribute ``ResearchSession`` reads."""
+        return self.expr
+
+    @property
+    def determined(self) -> bool:
+        """True when the constraints pin down a unique member."""
+        return not self.free
+
+    @property
+    def badge(self) -> str:
+        """Honest one-line rendering of :attr:`status`."""
+        from .research import STATUS_BADGES
+
+        return STATUS_BADGES.get(self.status, "unrecognised status")
+
+    def __repr__(self) -> str:
+        return (
+            f"AnsatzSolution({self.ansatz.family}, rank={self.rank}, "
+            f"free={len(self.free)}, status={self.status!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The linear system
+# ---------------------------------------------------------------------------
+
+
+def _probe(
+    pool: Any,
+    residual: Any,
+    unknowns: Sequence[Any],
+    bindings: Mapping[Any, Any],
+) -> list[Any]:
+    """One row: ``[C_0, ..., C_{m-1}, -R_0]`` for the residual under *bindings*.
+
+    Because the residual is affine in the unknowns, evaluating it with every
+    unknown set to zero gives the constant term ``R_0``, and setting unknown
+    *j* to one (the rest zero) gives ``R_0 + C_j``. That is ``subs`` and
+    nothing else — no coefficient collection over a symbolic ring is needed.
+    """
+    ak = _ak()
+    zeros = {u: pool.integer(0) for u in unknowns}
+    base = _entry(_value(ak.subs(residual, {**zeros, **bindings})))
+    row: list[Any] = []
+    for unknown in unknowns:
+        probe = dict(zeros)
+        probe[unknown] = pool.integer(1)
+        shifted = _entry(_value(ak.subs(residual, {**probe, **bindings})))
+        row.append(_difference(pool, shifted, base))
+    row.append(_negate(pool, base))
+    return row
+
+
+def _fold_exp(expr: Any) -> Any:
+    """Rewrite ``e^a · e^b → e^{a+b}`` and ``(e^a)^k → e^{ka}`` bottom-up.
+
+    The kernel's ``simplify_log_exp`` merges some of these but not all — it
+    leaves ``e^{-9/2} · e^{9/2}`` standing inside an n-ary product — and an
+    exponential ansatz's elimination is *made* of such products. Without this
+    the entries grow without ever cancelling, so a genuine zero row is never
+    recognised. Only ``add``/``mul``/``pow``/``exp`` nodes are rebuilt;
+    anything else is returned untouched.
+    """
+    ak = _ak()
+    node = expr.node()
+    tag = node[0]
+    if tag == "add":
+        total = None
+        for arg in node[1]:
+            folded = _fold_exp(arg)
+            total = folded if total is None else total + folded
+        return expr if total is None else total
+    if tag == "mul":
+        exponents: list[Any] = []
+        rest: list[Any] = []
+        for arg in node[1]:
+            folded = _fold_exp(arg)
+            inner = folded.node()
+            if inner[0] == "func" and str(inner[1]) == "exp" and len(inner[2]) == 1:
+                exponents.append(inner[2][0])
+            else:
+                rest.append(folded)
+        if len(exponents) > 1:
+            combined = exponents[0]
+            for extra in exponents[1:]:
+                combined = combined + extra
+            rest.append(ak.exp(_value(ak.simplify(combined))))
+        elif exponents:
+            rest.append(ak.exp(exponents[0]))
+        if not rest:
+            return expr
+        product = rest[0]
+        for factor in rest[1:]:
+            product = product * factor
+        return product
+    if tag == "pow":
+        base = _fold_exp(node[1])
+        inner = base.node()
+        try:
+            power = _rational_value(node[2])
+        except (_NotExact, _Undefined):
+            power = None
+        if (
+            power is not None
+            and power.denominator == 1
+            and abs(power) <= _MAX_EXPONENT
+            and inner[0] == "func"
+            and str(inner[1]) == "exp"
+            and len(inner[2]) == 1
+        ):
+            return ak.exp(_value(ak.simplify(inner[2][0] * int(power))))
+        return base ** node[2]
+    if tag == "func" and str(node[1]) == "exp" and len(node[2]) == 1:
+        return ak.exp(_fold_exp(node[2][0]))
+    return expr
+
+
+def _number_like(sample: Any, value: Fraction) -> Any:
+    """A numeric literal interned in the same pool as *sample*."""
+    result = sample * 0 + value.numerator
+    if value.denominator != 1:
+        result = result / value.denominator
+    return _value(_ak().simplify(result))
+
+
+def _split_term(term: Any) -> tuple[Fraction, list[Any]]:
+    """Split a product into its rational coefficient and its other factors."""
+    node = term.node()
+    if node[0] == "mul":
+        coefficient = Fraction(1)
+        factors: list[Any] = []
+        for factor in node[1]:
+            try:
+                coefficient *= _rational_value(factor)
+            except (_NotExact, _Undefined):
+                factors.append(_collect_rational(factor))
+        return coefficient, factors
+    try:
+        return _rational_value(term), []
+    except (_NotExact, _Undefined):
+        return Fraction(1), [_collect_rational(term)]
+
+
+def _collect_rational(expr: Any) -> Any:
+    """Collect like terms whose coefficients are rational.
+
+    The kernel's collector is over ℤ: ``simplify`` leaves
+    ``t·31/3 + t·(−31/3)`` standing and ``cancel``/``poly_normal`` refuse it
+    outright with ``E-POLY-002`` (non-integer coefficient). Elimination
+    produces exactly that shape at every step, so without this the entries
+    never cancel and a genuine zero row is never recognised. Grouping is
+    syntactic — two terms merge only when their non-numeric factors render
+    identically — so this can only ever *find* cancellations, never assert one
+    that is not there.
+    """
+    node = expr.node()
+    if node[0] == "mul":
+        coefficient, factors = _split_term(expr)
+        return _rebuild_term(expr, coefficient, factors)
+    if node[0] != "add":
+        return expr
+    groups: dict[tuple[str, ...], tuple[Fraction, list[Any]]] = {}
+    order: list[tuple[str, ...]] = []
+    for term in node[1]:
+        coefficient, factors = _split_term(term)
+        key = tuple(sorted(str(f) for f in factors))
+        if key in groups:
+            groups[key] = (groups[key][0] + coefficient, groups[key][1])
+        else:
+            groups[key] = (coefficient, factors)
+            order.append(key)
+    result = None
+    for key in order:
+        coefficient, factors = groups[key]
+        if coefficient == 0:
+            continue
+        term = _rebuild_term(expr, coefficient, factors)
+        result = term if result is None else result + term
+    return _number_like(expr, Fraction(0)) if result is None else result
+
+
+def _rebuild_term(sample: Any, coefficient: Fraction, factors: Sequence[Any]) -> Any:
+    if not factors:
+        return _number_like(sample, coefficient)
+    product = factors[0]
+    for factor in factors[1:]:
+        product = product * factor
+    if coefficient == 1:
+        return product
+    product = product * coefficient.numerator
+    if coefficient.denominator != 1:
+        product = product / coefficient.denominator
+    return product
+
+
+def _normalise(expr: Any) -> Any:
+    """Best-effort normal form for a transcendental matrix entry.
+
+    ``simplify`` alone leaves ``a + (-1 * (a + b))`` uncollected and
+    ``e^a · e^b`` uncombined, and an uncollected entry becomes a phantom pivot
+    in :func:`_solve_rows`, so the distributing and exp/log-collecting
+    simplifiers each get a pass. Cheap: entries are point evaluations, not
+    whole residuals.
+    """
+    ak = _ak()
+    current = expr
+    for _ in range(3):
+        before = str(current)
+        for transform in (_fold_exp, _collect_rational, ak.simplify_expanded, ak.simplify):
+            try:
+                current = _value(transform(current))
+            except Exception:
+                continue
+        after = str(current)
+        if after == "0" or after == before:
+            break
+    return current
+
+
+def _entry(expr: Any) -> Fraction | Any:
+    """Normalise one matrix entry to a :class:`~fractions.Fraction` when possible.
+
+    ``_Undefined`` deliberately propagates: it means the sample point is a
+    pole, and the caller's job is to skip that point rather than to build a row
+    out of ``2 * 0^-1``.
+    """
+    try:
+        return _rational_value(expr)
+    except _NotExact:
+        pass
+    normalised = _normalise(expr)
+    try:
+        return _rational_value(normalised)
+    except (_NotExact, _Undefined):
+        return normalised
+
+
+def _as_expr(pool: Any, value: Any) -> Any:
+    """Intern a mixed ``Fraction``/``Expr`` entry as an :class:`~alkahest.Expr`."""
+    return _to_expr(pool, value) if isinstance(value, Fraction) else value
+
+
+def _reciprocal(pool: Any, value: Any) -> Any:
+    """``1 / value``, pushed inwards so exponentials stay collectable.
+
+    The kernel does not rewrite ``exp(a)^-1`` as ``exp(-a)``, so a plain
+    ``x ** -1`` during elimination produces entries that
+    :func:`alkahest.simplify_log_exp` can no longer combine — and an entry that
+    will not combine is an entry whose zero test fails. Distributing the
+    reciprocal over products and turning ``exp(a)`` into ``exp(-a)`` here keeps
+    every intermediate in a shape the exp collector can close.
+    """
+    if isinstance(value, Fraction):
+        return _to_expr(pool, Fraction(1) / value)
+    node = value.node()
+    tag = node[0]
+    if tag == "func" and str(node[1]) == "exp" and len(node[2]) == 1:
+        return _ak().exp(node[2][0] * pool.integer(-1))
+    if tag == "mul":
+        product = pool.integer(1)
+        for factor in node[1]:
+            product = product * _reciprocal(pool, factor)
+        return product
+    if tag == "pow":
+        try:
+            exponent = _rational_value(node[2])
+        except (_NotExact, _Undefined):
+            return value ** pool.integer(-1)
+        if exponent.denominator == 1 and abs(exponent) <= _MAX_EXPONENT:
+            return _reciprocal(pool, node[1]) ** pool.integer(int(exponent))
+        return value ** pool.integer(-1)
+    if tag in {"integer", "rational"}:
+        return _to_expr(pool, Fraction(1) / _rational_value(value))
+    return value ** pool.integer(-1)
+
+
+def _divide(pool: Any, value: Any, divisor: Any) -> Any:
+    """``value / divisor`` for mixed ``Fraction``/``Expr`` entries."""
+    if isinstance(value, Fraction) and isinstance(divisor, Fraction):
+        return value / divisor
+    return _normalise(_as_expr(pool, value) * _reciprocal(pool, divisor))
+
+
+def _difference(pool: Any, left: Any, right: Any) -> Any:
+    if isinstance(left, Fraction) and isinstance(right, Fraction):
+        return left - right
+    return _entry(_as_expr(pool, left) - _as_expr(pool, right))
+
+
+def _negate(pool: Any, value: Any) -> Any:
+    if isinstance(value, Fraction):
+        return -value
+    return _entry(_as_expr(pool, value) * pool.integer(-1))
+
+
+def _is_zero_entry(value: Any) -> bool:
+    """Decide whether a reduced-matrix entry is zero, conservatively.
+
+    Rational entries — the common case, and every entry of a polynomial or
+    rational fit — are decided exactly. A transcendental entry is put through
+    :func:`alkahest.simplify` first, because ``rref`` leaves cancelling terms
+    like ``t + (-1 * t)`` uncollected and treating those as pivots would
+    manufacture phantom rank. Anything the simplifier cannot reduce is treated
+    as **non-zero**, which costs rank rather than inventing a solution.
+    """
+    if isinstance(value, Fraction):
+        return value == 0
+    try:
+        return _rational_value(value) == 0
+    except (_NotExact, _Undefined):
+        pass
+    if str(value).strip() == "0":
+        return True
+    return str(_normalise(value)).strip() == "0"
+
+
+def _rows_to_matrix(pool: Any, rows: Sequence[Sequence[Any]]) -> Any:
+    """Intern a mixed ``Fraction``/``Expr`` row set as an :class:`~alkahest.Matrix`."""
+    ak = _ak()
+    interned = [[_as_expr(pool, cell) for cell in row] for row in rows]
+    return ak.Matrix.from_rows(interned)
+
+
+def _collocation_rows(
+    ansatz: Ansatz,
+    residual: Any,
+    *,
+    seed: int,
+    n_rows: int,
+    max_points: int,
+) -> tuple[list[list[Any]], list[tuple[Fraction, ...]], int]:
+    """Build the system by evaluating the residual at deterministic points.
+
+    Points where the residual is undefined (a pole of the target, a vanishing
+    denominator) are **skipped and resampled**, with a bounded retry count, so
+    a bad draw degrades into a slightly smaller system rather than a row of
+    nonsense.
+    """
+    pool = ansatz.pool
+    rows: list[list[Any]] = []
+    used: list[tuple[Fraction, ...]] = []
+    skipped = 0
+    stream = _sample_points(len(ansatz.vars), seed)
+    attempts = 0
+    while len(rows) < n_rows and attempts < max_points:
+        attempts += 1
+        point = next(stream)
+        bindings = {var: _to_expr(pool, value) for var, value in zip(ansatz.vars, point)}
+        try:
+            row = _probe(pool, residual, ansatz.unknowns, bindings)
+        except _Undefined:
+            skipped += 1
+            continue
+        except Exception:
+            skipped += 1
+            continue
+        rows.append(row)
+        used.append(point)
+    return rows, used, skipped
+
+
+def _derivative_rows(
+    ansatz: Ansatz,
+    residual: Any,
+    *,
+    seed: int,
+    degree_bound: int,
+    max_rows: int,
+) -> tuple[list[list[Any]], list[tuple[Fraction, ...]], int]:
+    """Build the system by Taylor-coefficient extraction (``certify="exact"``).
+
+    ``R ≡ 0`` iff every coefficient ``∂^α R / α!`` vanishes, so each multi-index
+    ``|α| ≤ degree_bound`` contributes one equation. Exact for polynomial
+    residuals of that degree — no sampling argument required — at the cost of
+    one differentiation per multi-index.
+    """
+    ak = _ak()
+    pool = ansatz.pool
+    multi = _exponents(len(ansatz.vars), degree_bound)[:max_rows]
+    stream = _sample_points(len(ansatz.vars), seed)
+    base_point = tuple(Fraction(0) for _ in ansatz.vars)
+    rows: list[list[Any]] = []
+    used: list[tuple[Fraction, ...]] = []
+    skipped = 0
+    for attempt in range(8):
+        bindings = {var: _to_expr(pool, value) for var, value in zip(ansatz.vars, base_point)}
+        rows, used = [], []
+        ok = True
+        for alpha in multi:
+            derivative = residual
+            try:
+                for var, order in zip(ansatz.vars, alpha):
+                    for _ in range(order):
+                        derivative = _value(ak.diff(derivative, var))
+                rows.append(_probe(pool, derivative, ansatz.unknowns, bindings))
+            except _Undefined:
+                ok = False
+                break
+            except Exception:
+                ok = False
+                break
+            used.append(tuple(Fraction(a) for a in alpha))
+        if ok and rows:
+            return rows, used, skipped
+        skipped += 1
+        base_point = next(stream)
+        if attempt == 7:  # pragma: no cover - exhausted
+            break
+    return rows, used, skipped
+
+
+def _default_degree_bound(ansatz: Ansatz, wanted: int) -> int:
+    """Smallest multi-index degree giving at least *wanted* Taylor equations."""
+    n_vars = len(ansatz.vars)
+    for degree in range(64):
+        if _count_exponents(n_vars, degree) >= wanted:
+            return degree
+    return 64  # pragma: no cover - unreachable for any realistic family
+
+
+def _is_exact_system(rows: Sequence[Sequence[Any]]) -> bool:
+    """True when every entry is a :class:`~fractions.Fraction`.
+
+    Polynomial, rational and quadratic-form fits always land here; a family
+    whose basis takes transcendental values at rational points (an exponential
+    ansatz) does not.
+    """
+    return all(isinstance(cell, Fraction) for row in rows for cell in row)
+
+
+def _symbolic_rref(pool: Any, rows: Sequence[Sequence[Any]], width: int) -> list[list[Any]]:
+    """Row-reduce a system whose entries are not all rational.
+
+    :meth:`alkahest.Matrix.rref` is used for the exact-rational case, which is
+    the overwhelming majority and the one the design specifies. It is *not*
+    used here: its internal zero test does not apply the exp/log collector, so
+    on a matrix of ``e^{λ x_k}`` entries it fails to cancel a redundant row and
+    reports a phantom pivot in the augmented column — i.e. a spurious
+    "inconsistent". This does the same elimination with :func:`_normalise` as
+    the zero test instead.
+    """
+    matrix = [[_as_expr(pool, cell) for cell in row] for row in rows]
+    pivot_row = 0
+    for column in range(width):
+        candidate = next(
+            (i for i in range(pivot_row, len(matrix)) if not _is_zero_entry(matrix[i][column])),
+            None,
+        )
+        if candidate is None:
+            continue
+        matrix[pivot_row], matrix[candidate] = matrix[candidate], matrix[pivot_row]
+        pivot = matrix[pivot_row][column]
+        matrix[pivot_row] = [_divide(pool, cell, pivot) for cell in matrix[pivot_row]]
+        for index in range(len(matrix)):
+            if index == pivot_row or _is_zero_entry(matrix[index][column]):
+                continue
+            factor = matrix[index][column]
+            matrix[index] = [
+                _normalise(matrix[index][j] - factor * matrix[pivot_row][j])
+                for j in range(width + 1)
+            ]
+        pivot_row += 1
+        if pivot_row == len(matrix):
+            break
+    return matrix
+
+
+def _numerically_inconsistent(rows: Sequence[Sequence[Any]], width: int) -> bool:
+    """Corroborate an inconsistency verdict in floating point.
+
+    Only consulted for a system that is **not** over ℚ, where an apparent
+    inconsistency may be nothing but a zero test the simplifier could not
+    settle. Claiming ``E-ANSATZ-003`` — "no member of this family works" — on
+    that basis would be exactly the kind of confident wrong answer this package
+    exists to avoid, so the claim is only made when an independent numeric rank
+    comparison agrees. Failure to evaluate returns ``False``: no corroboration,
+    no claim.
+    """
+    ak = _ak()
+    try:
+        matrix = [
+            [
+                float(cell) if isinstance(cell, Fraction) else float(ak.eval_expr(cell, {}))
+                for cell in row
+            ]
+            for row in rows
+        ]
+    except Exception:
+        return False
+    return _float_rank(matrix, width) < _float_rank(matrix, width + 1)
+
+
+def _float_rank(matrix: Sequence[Sequence[float]], columns: int) -> int:
+    """Rank of the first *columns* columns, by float Gaussian elimination."""
+    work = [list(row[:columns]) for row in matrix]
+    scale = max((abs(v) for row in work for v in row), default=0.0)
+    tolerance = 1e-9 * (scale if scale > 0 else 1.0)
+    rank = 0
+    for column in range(columns):
+        pivot = max(range(rank, len(work)), key=lambda i: abs(work[i][column]), default=None)
+        if pivot is None or abs(work[pivot][column]) <= tolerance:
+            continue
+        work[rank], work[pivot] = work[pivot], work[rank]
+        head = work[rank]
+        for index in range(len(work)):
+            if index == rank or abs(work[index][column]) <= tolerance:
+                continue
+            factor = work[index][column] / head[column]
+            work[index] = [a - factor * b for a, b in zip(work[index], head)]
+        rank += 1
+    return rank
+
+
+def _solve_rows(
+    ansatz: Ansatz, rows: Sequence[Sequence[Any]]
+) -> tuple[dict[Any, Any], tuple[Any, ...], int]:
+    """Reduce the augmented system and read off the solution.
+
+    Rank is **read off the reduced form**, never assumed from the number of
+    points: assuming the first *m* samples are independent is the specific bug
+    in every hand-rolled version of this, and it is why :func:`fit` over-samples.
+    """
+    pool = ansatz.pool
+    unknowns = ansatz.unknowns
+    width = len(unknowns)
+    exact = _is_exact_system(rows)
+    if exact:
+        reduced = _rows_to_matrix(pool, rows).rref().to_list()
+    else:
+        reduced = _symbolic_rref(pool, rows, width)
+
+    pivots: list[tuple[int, int]] = []
+    inconsistent = False
+    for index, row in enumerate(reduced):
+        for column, cell in enumerate(row):
+            if _is_zero_entry(cell):
+                continue
+            if column == width:
+                inconsistent = True
+            else:
+                pivots.append((index, column))
+            break
+    if inconsistent and (exact or _numerically_inconsistent(rows, width)):
+        raise AnsatzError(
+            "[E-ANSATZ-003] the constraints are inconsistent: no member of this "
+            f"{ansatz.family} family satisfies them",
+            code="E-ANSATZ-003",
+            remediation=(
+                "this is a result, not a malfunction — record the closed branch. "
+                "To reopen it, enlarge the family (raise the degree, add basis "
+                "functions) or weaken the constraint"
+            ),
+        )
+
+    pivot_columns = {column for _, column in pivots}
+    free = tuple(u for index, u in enumerate(unknowns) if index not in pivot_columns)
+    assignment: dict[Any, Any] = {}
+    for row_index, column in pivots:
+        row = reduced[row_index]
+        value = _as_expr(pool, row[width])
+        for other in range(column + 1, width):
+            if other in pivot_columns or _is_zero_entry(row[other]):
+                continue
+            value = value - _as_expr(pool, row[other]) * unknowns[other]
+        assignment[unknowns[column]] = _normalise(value)
+    return assignment, free, len(pivots)
+
+
+# ---------------------------------------------------------------------------
+# Certification
+# ---------------------------------------------------------------------------
+
+
+def _normal_form(expr: Any, variables: Sequence[Any]) -> Any:
+    """Best-effort normal form for the back-substituted residual.
+
+    ``poly_normal`` is the strongest normaliser when it applies (a genuine
+    polynomial normal form over ℤ), so it gets first refusal; otherwise the
+    entry normaliser, which also collects transcendental like terms, decides.
+    Only a form that renders as ``0`` is ever treated as a proof.
+    """
+    ak = _ak()
+    simplified = _normalise(expr)
+    if str(simplified).strip() == "0":
+        return simplified
+    names = _free_symbols(simplified)
+    try:
+        return ak.poly_normal(simplified, [names[key] for key in sorted(names)] or list(variables))
+    except Exception:
+        return simplified
+
+
+def _numeric_residual(
+    expr: Any, variables: Sequence[Any], free: Sequence[Any], seed: int, samples: int
+) -> float | None:
+    """Largest ``|residual|`` over fresh sample points, or ``None`` if unevaluable."""
+    ak = _ak()
+    stream = _sample_points(len(variables) + len(free), seed ^ 0xA5A5_A5A5)
+    worst: float | None = None
+    for _ in range(samples):
+        point = next(stream)
+        bindings = {symbol: float(value) for symbol, value in zip((*variables, *free), point)}
+        try:
+            magnitude = abs(float(ak.eval_expr(expr, bindings)))
+        except Exception:
+            continue
+        worst = magnitude if worst is None else max(worst, magnitude)
+    return worst
+
+
+# ---------------------------------------------------------------------------
+# fit
+# ---------------------------------------------------------------------------
+
+
+def fit(
+    ansatz: Ansatz,
+    residual: Any,
+    *,
+    certify: str = "residual",
+    seed: int | None = None,
+    oversample: int | None = None,
+    max_points: int | None = None,
+    degree_bound: int | None = None,
+    tolerance: float = 1e-8,
+    samples: int = 5,
+) -> AnsatzSolution:
+    """Solve for the coefficients that make *residual* vanish identically.
+
+    The default path is **exact linear algebra, not Gröbner**. Undetermined
+    coefficients, series matching, Lyapunov forms and Padé are all linear in
+    the unknowns once denominators are cleared, so the system is built by
+    probing with :func:`alkahest.subs` and reduced with
+    :meth:`alkahest.Matrix.rref` over exact rationals. Nothing here needs the
+    ``groebner`` feature; the one path that does (a residual genuinely
+    nonlinear in the unknowns) refuses with ``E-ANSATZ-004`` when it is absent
+    rather than degrading silently.
+
+    Parameters
+    ----------
+    ansatz : Ansatz
+        The family to fit.
+    residual : Expr or DerivedResult
+        The expression that must vanish identically in ``ansatz.vars`` —
+        typically ``ansatz.expr - target``. If it is not affine in the unknowns
+        because of an unknown-bearing denominator (the Padé case), the
+        denominator is cleared automatically and the fact is recorded in
+        :attr:`AnsatzSolution.steps`.
+    certify : {"residual", "exact", "none"}
+        ``"residual"`` (default) builds the system by collocation and checks it
+        by exact back-substitution. ``"exact"`` builds the system by
+        Taylor-coefficient extraction instead, so the *system itself* is exact
+        for polynomial residuals, and still back-substitutes. ``"none"`` skips
+        the check entirely and returns ``status="unverified"`` — for hot loops
+        that will verify downstream, never for anything recorded as a result.
+    seed : int, optional
+        Sample-point seed. Defaults to :func:`alkahest.budget_seed` (so
+        ``with ak.context(budget=ak.Budget(seed=7))`` controls it), and to
+        :data:`DEFAULT_SEED` when no budget is active. Two runs with the same
+        seed use the same points on any machine.
+    oversample : int, optional
+        Extra equations beyond the unknown count. Defaults to
+        ``max(4, len(ansatz))``. Over-sampling is what lets the rank be *read*
+        off the ``rref`` instead of assumed.
+    max_points : int, optional
+        Cap on sample-point draws, including those skipped for being poles.
+    degree_bound : int, optional
+        Multi-index degree for ``certify="exact"``. Defaults to the family's
+        own total degree plus two.
+    tolerance : float
+        Numeric residual below which a non-normalising fit is still reported as
+        ``"numerically_checked"`` rather than as a stated failure.
+    samples : int
+        Fresh points used for that numeric check.
+
+    Returns
+    -------
+    AnsatzSolution
+
+    Raises
+    ------
+    AnsatzError
+        ``E-ANSATZ-003`` when the system is inconsistent — **no member of the
+        family satisfies the constraints**, which is a positive result for a
+        search loop and should be recorded as a closed branch.
+        ``E-ANSATZ-004`` when the residual is nonlinear in the unknowns and
+        this build has no ``groebner`` feature to escalate to.
+
+    Examples
+    --------
+    Round-trip a known polynomial:
+
+    >>> import alkahest as ak
+    >>> from alkahest.ansatz import fit, polynomial
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> A = polynomial(pool, [x], degree=2)
+    >>> sol = fit(A, A.expr - (x**2 + pool.integer(1)))
+    >>> sol.expr
+    (1 + x^2)
+    >>> sol.status, sol.free
+    ('exactly_verified', ())
+
+    An underdetermined family returns its free parameters rather than an
+    arbitrary member:
+
+    >>> B = polynomial(pool, [x], degree=3, name="d")
+    >>> under = fit(B, ak.diff(B.expr, x).value - pool.integer(0))
+    >>> under.rank, [str(f) for f in under.free]
+    (3, ['d_0'])
+    """
+    ak = _ak()
+    if certify not in {"residual", "exact", "none"}:
+        raise ValueError("fit(certify=...) must be 'residual', 'exact', or 'none'")
+
+    unknowns = ansatz.unknowns
+    names = frozenset(ansatz.names)
+    target_residual = _value(residual)
+    steps: list[dict[str, Any]] = []
+
+    # -- linearise -------------------------------------------------------
+    if not _is_affine(target_residual, names):
+        cleared = _clear_denominators(target_residual, names)
+        if cleared is not None:
+            steps.append(
+                {
+                    "rule": "ansatz_clear_denominator",
+                    "before": str(target_residual),
+                    "after": str(cleared[0]),
+                    "side_conditions": [f"{cleared[1]} != 0"],
+                }
+            )
+            target_residual = cleared[0]
+        else:
+            return _fit_nonlinear(ansatz, target_residual, seed=seed, steps=steps)
+
+    resolved_seed = _resolve_seed(seed)
+    width = len(unknowns)
+    extra = max(4, width) if oversample is None else int(oversample)
+    n_rows = width + extra
+    point_cap = 8 * n_rows + 32 if max_points is None else int(max_points)
+
+    bound = _default_degree_bound(ansatz, n_rows) if degree_bound is None else int(degree_bound)
+    if certify == "exact":
+        rows, used, skipped = _derivative_rows(
+            ansatz, target_residual, seed=resolved_seed, degree_bound=bound, max_rows=point_cap
+        )
+        method = "taylor_extraction"
+    else:
+        rows, used, skipped = _collocation_rows(
+            ansatz,
+            target_residual,
+            seed=resolved_seed,
+            n_rows=n_rows,
+            max_points=point_cap,
+        )
+        method = "collocation"
+        if rows and not _is_exact_system(rows):
+            # Collocating a transcendental basis gives entries like e^{λ x_k},
+            # and exact linear algebra over those is only as good as the
+            # simplifier's zero test. Taylor extraction at the origin usually
+            # gives the *same* constraints over ℚ (e^0 = 1), so prefer it when
+            # it does — an exact system is worth one extra attempt.
+            exact_rows, exact_used, exact_skipped = _derivative_rows(
+                ansatz,
+                target_residual,
+                seed=resolved_seed,
+                degree_bound=bound,
+                max_rows=point_cap,
+            )
+            if exact_rows and _is_exact_system(exact_rows):
+                rows, used, skipped = exact_rows, exact_used, exact_skipped
+                method = "taylor_extraction"
+
+    if not rows:
+        raise AnsatzError(
+            "[E-ANSATZ-003] could not evaluate the residual at any sample point, so the "
+            "family cannot be constrained at all",
+            code="E-ANSATZ-003",
+            remediation=(
+                "the residual may be undefined everywhere the sampler looked; pass a "
+                "different seed=, raise max_points=, or check the target for a pole"
+            ),
+        )
+    steps.append(
+        {
+            "rule": f"ansatz_{method}",
+            "before": str(target_residual),
+            "after": f"{len(rows)} x {width + 1} augmented system over Q",
+            "side_conditions": [f"{skipped} point(s) skipped as undefined"] if skipped else [],
+        }
+    )
+
+    assignment, free, rank = _solve_rows(ansatz, rows)
+    steps.append(
+        {
+            "rule": "ansatz_rref",
+            "before": f"{len(rows)} equations in {width} unknowns",
+            "after": f"rank {rank}, {len(free)} free parameter(s)",
+            "side_conditions": [],
+        }
+    )
+
+    fitted = _value(ak.simplify(_substitute(ansatz.pool, ansatz.expr, assignment, ansatz.symbols)))
+    verification = _certify(
+        ansatz,
+        target_residual,
+        assignment,
+        free,
+        certify=certify,
+        method=method,
+        seed=resolved_seed,
+        tolerance=tolerance,
+        samples=samples,
+        steps=steps,
+    )
+    return AnsatzSolution(
+        expr=fitted,
+        assignment=assignment,
+        free=free,
+        rank=rank,
+        status=verification["status"],
+        verification=verification,
+        steps=tuple(steps),
+        residual=target_residual,
+        check=_check_recipe(verification),
+        points=tuple(tuple(str(v) for v in point) for point in used),
+        ansatz=ansatz,
+    )
+
+
+def _check_recipe(verification: Mapping[str, Any]) -> dict[str, Any]:
+    """A ``ClaimGraph.verify`` recipe, or ``{}`` when nothing was checked.
+
+    ``certify="none"`` deliberately yields no recipe: a re-verification pass
+    must report such a claim as ``skipped``, not re-derive a check that was
+    never run.
+    """
+    substituted = verification.get("substituted")
+    return {"kind": "zero", "expr": str(substituted)} if substituted else {}
+
+
+def _certify(
+    ansatz: Ansatz,
+    residual: Any,
+    assignment: Mapping[Any, Any],
+    free: Sequence[Any],
+    *,
+    certify: str,
+    method: str,
+    seed: int,
+    tolerance: float,
+    samples: int,
+    steps: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Substitute the fit back and grade it, honestly.
+
+    Solving is heuristic (collocation proves identical vanishing only for
+    polynomial residuals of bounded degree); checking is exact and cheap. So
+    the grade comes from the check, never from the solve.
+    """
+    if certify == "none":
+        return {
+            "status": "unverified",
+            "evidence": "none",
+            "method": f"ansatz_{method}",
+            "externally_verified": False,
+            "side_conditions": [],
+        }
+
+    substituted = _substitute(ansatz.pool, residual, assignment, ansatz.symbols)
+    normal = _normal_form(substituted, (*ansatz.vars, *free))
+    if str(normal).strip() == "0":
+        steps.append(
+            {
+                "rule": "ansatz_back_substitution",
+                "before": str(substituted),
+                "after": "0",
+                "side_conditions": [],
+            }
+        )
+        return {
+            "status": "exactly_verified",
+            "evidence": "symbolic_residual_zero",
+            "method": f"ansatz_{method}+back_substitution",
+            "externally_verified": False,
+            "side_conditions": [],
+            "residual": "0",
+            "substituted": str(substituted),
+        }
+
+    worst = _numeric_residual(substituted, ansatz.vars, free, seed, samples)
+    steps.append(
+        {
+            "rule": "ansatz_back_substitution",
+            "before": str(substituted),
+            "after": str(normal),
+            "side_conditions": ["residual did not normalise to 0"],
+        }
+    )
+    if worst is None:
+        evidence = (
+            f"residual did not normalise to 0 (got {normal}) and could not be sampled "
+            "numerically; the fit satisfies the collocation constraints only"
+        )
+    elif worst <= tolerance:
+        evidence = (
+            f"floating-point samples only: |residual| <= {worst:.3g} at {samples} fresh "
+            f"point(s); the exact normal form is {normal}, not 0"
+        )
+    else:
+        evidence = (
+            f"the fit does NOT satisfy the residual: |residual| = {worst:.6g} at a fresh "
+            f"point, exact normal form {normal}. It satisfies only the sampled constraints"
+        )
+    return {
+        "status": "numerically_checked",
+        "evidence": evidence,
+        "method": f"ansatz_{method}+back_substitution",
+        "externally_verified": False,
+        "side_conditions": [],
+        "residual": str(normal),
+        "max_abs_residual": worst,
+        "substituted": str(substituted),
+    }
+
+
+def _fit_nonlinear(
+    ansatz: Ansatz, residual: Any, *, seed: int | None, steps: list[dict[str, Any]]
+) -> AnsatzSolution:
+    """Escalate a genuinely nonlinear residual to :func:`alkahest.solve`.
+
+    Reached only when the residual is nonlinear in the unknowns *and* clearing
+    denominators did not fix it. Requires a ``groebner`` build; refuses with
+    ``E-ANSATZ-004`` otherwise instead of pretending the linear path applies.
+    """
+    ak = _ak()
+    if not ak.capabilities().get("groebner", False):
+        raise AnsatzError(
+            "[E-ANSATZ-004] the residual is nonlinear in the unknowns "
+            f"{list(ansatz.names)} and escalating to alkahest.solve needs a groebner build, "
+            "which this is not",
+            code="E-ANSATZ-004",
+            remediation=(
+                "rebuild with --features groebner, or reformulate the family so the "
+                "residual is affine in the unknowns (for p/q use ansatz.rational, whose "
+                "denominator-clearing transform keeps it linear)"
+            ),
+        )
+    resolved_seed = _resolve_seed(seed)
+    width = len(ansatz.unknowns)
+    # Over-sample here too: one equation per unknown can be satisfiable while
+    # the identity is not, and an overdetermined Groebner solve returning no
+    # solution is what makes E-ANSATZ-003 reachable on this path at all.
+    wanted = width + max(2, width)
+    equations: list[Any] = []
+    used: list[tuple[Fraction, ...]] = []
+    stream = _sample_points(len(ansatz.vars), resolved_seed)
+    attempts = 0
+    while len(equations) < wanted and attempts < 8 * wanted + 32:
+        attempts += 1
+        point = next(stream)
+        bindings = {var: _to_expr(ansatz.pool, value) for var, value in zip(ansatz.vars, point)}
+        try:
+            equation = _value(ak.subs(residual, bindings))
+            _rational_value(_value(ak.subs(equation, dict.fromkeys(ansatz.unknowns, 0))))
+        except _Undefined:
+            continue
+        except _NotExact:
+            pass
+        except Exception:
+            continue
+        equations.append(equation)
+        used.append(point)
+
+    steps.append(
+        {
+            "rule": "ansatz_nonlinear_escalation",
+            "before": str(residual),
+            "after": f"{len(equations)} polynomial equation(s) handed to alkahest.solve",
+            "side_conditions": ["residual is nonlinear in the unknowns"],
+        }
+    )
+    solutions = ak.solve(equations, list(ansatz.unknowns))
+    if not solutions:
+        raise AnsatzError(
+            "[E-ANSATZ-003] the constraints are inconsistent: no member of this "
+            f"{ansatz.family} family satisfies them (nonlinear system, no solutions)",
+            code="E-ANSATZ-003",
+            remediation=(
+                "this is a result, not a malfunction — record the closed branch, or "
+                "enlarge the family and re-fit"
+            ),
+        )
+    chosen = min(solutions, key=lambda s: sorted((str(k), str(v)) for k, v in s.items()))
+    assignment = {key: _value(value) for key, value in chosen.items()}
+    fitted = _value(ak.simplify(_substitute(ansatz.pool, ansatz.expr, assignment, ansatz.symbols)))
+    verification = _certify(
+        ansatz,
+        residual,
+        assignment,
+        (),
+        certify="residual",
+        method="groebner_escalation",
+        seed=resolved_seed,
+        tolerance=1e-8,
+        samples=5,
+        steps=steps,
+    )
+    return AnsatzSolution(
+        expr=fitted,
+        assignment=assignment,
+        free=(),
+        rank=len(assignment),
+        status=verification["status"],
+        verification=verification,
+        steps=tuple(steps),
+        residual=residual,
+        check=_check_recipe(verification),
+        points=tuple(tuple(str(v) for v in point) for point in used),
+        ansatz=ansatz,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hand-off to positivity
+# ---------------------------------------------------------------------------
+
+
+def certify_nonneg(
+    candidate: Any,
+    vars: Sequence[Any] | None = None,
+    *,
+    constraints: Sequence[Any] = (),
+    **kwargs: Any,
+) -> Any:
+    """Hand a fitted candidate to :func:`alkahest.prove_nonneg`.
+
+    The ansatz module's job ends when it has produced the candidate. Positivity
+    is decided by the existing certificate machinery — this is a one-line
+    adapter that unwraps an :class:`AnsatzSolution` or :class:`Ansatz` and
+    forwards, so that a Lyapunov workflow reads
+
+    ``cert = certify_nonneg(fit(quadratic_form(pool, [x, y]), residual))``
+
+    and every outcome (a :class:`~alkahest.PositivityCertificate`, an
+    ``E-SOS-003`` refutation with a witness, an ``E-SOS-002`` "no certificate
+    of this shape at this degree") comes back unmodified. Nothing about
+    positivity is reimplemented or reinterpreted here.
+
+    Parameters
+    ----------
+    candidate : AnsatzSolution, Ansatz, Expr or DerivedResult
+        The expression to certify. An :class:`AnsatzSolution` still carrying
+        free parameters is refused — an undetermined form is not a candidate.
+    vars : sequence of Expr, optional
+        Variables; taken from the ansatz when *candidate* carries one.
+    constraints : sequence of Expr
+        Forwarded as ``prove_nonneg(constraints=...)``.
+    **kwargs
+        Forwarded verbatim.
+
+    Returns
+    -------
+    PositivityCertificate
+
+    Raises
+    ------
+    AnsatzError
+        ``E-ANSATZ-003`` if the candidate still has free parameters.
+    SosError
+        Whatever :func:`alkahest.prove_nonneg` raises — passed through.
+    """
+    ak = _ak()
+    variables = vars
+    if isinstance(candidate, AnsatzSolution):
+        if candidate.free:
+            raise AnsatzError(
+                "[E-ANSATZ-003] this fit still has free parameters "
+                f"{[str(f) for f in candidate.free]}, so it is a family, not a candidate",
+                code="E-ANSATZ-003",
+                remediation=(
+                    "instantiate the free parameters first, e.g. "
+                    "solution.ansatz.instantiate({...}), then certify that member"
+                ),
+            )
+        variables = variables if variables is not None else candidate.ansatz.vars
+        expr = candidate.expr
+    elif isinstance(candidate, Ansatz):
+        variables = variables if variables is not None else candidate.vars
+        expr = candidate.expr
+    else:
+        expr = _value(candidate)
+    if variables is None:
+        symbols = _free_symbols(expr)
+        variables = [symbols[key] for key in sorted(symbols)]
+    return ak.prove_nonneg(expr, list(variables), constraints=list(constraints), **kwargs)

--- a/python/alkahest/crosscheck.py
+++ b/python/alkahest/crosscheck.py
@@ -695,7 +695,7 @@ class Oracle(ABC):
         Raises
         ------
         CrossCheckError
-            ``E-XCHECK-003`` when the oracle declines or returns an
+            ``E-XCHECK-004`` when the oracle declines or returns an
             unevaluated form; a refusal is not a divergence.
         """
 
@@ -840,7 +840,7 @@ class SymPyOracle(Oracle):
         if runner is None:
             raise _refuse(
                 f"SymPy oracle has no implementation of {operation!r}",
-                code="E-XCHECK-003",
+                code="E-XCHECK-004",
                 remediation=(
                     "Add it to alkahest.crosscheck._SYMPY_RUNNERS together with a "
                     "comparison rung in OPERATIONS."
@@ -853,7 +853,7 @@ class SymPyOracle(Oracle):
         except Exception as exc:
             raise _refuse(
                 f"SymPy declined {operation}: {type(exc).__name__}: {exc}",
-                code="E-XCHECK-003",
+                code="E-XCHECK-004",
                 remediation=(
                     "The oracle refused. That is not a divergence and is not recorded "
                     "as one; the check reports outcome='incomparable'."
@@ -878,7 +878,7 @@ class SymPyOracle(Oracle):
                 if isinstance(value, sp.Basic) and value.has(*unevaluated):
                     raise _refuse(
                         f"SymPy returned an unevaluated form for {operation}: {value}",
-                        code="E-XCHECK-003",
+                        code="E-XCHECK-004",
                         remediation=(
                             "SymPy did not answer. Reported as 'incomparable' — an "
                             "unevaluated Integral is a refusal and comparing against it "
@@ -1006,7 +1006,7 @@ def _sympy_sum_indefinite(sp: Any, args: Mapping[str, Any]) -> Any:
     if out is None:
         raise _refuse(
             "SymPy's Gosper implementation found no hypergeometric antidifference",
-            code="E-XCHECK-003",
+            code="E-XCHECK-004",
             remediation="A refusal, not a divergence; reported as 'incomparable'.",
         )
     return out
@@ -1654,7 +1654,12 @@ def check(
         reason = {
             "E-XCHECK-001": "untranslatable",
             "E-XCHECK-002": "no_oracle",
-            "E-XCHECK-003": "oracle_refused",
+            # 003 is the caller error "this operation has no comparison rung",
+            # raised before any oracle work; 004 is "the oracle declined". They
+            # were one code, which meant a caller could not tell "I asked for
+            # something unsupported" from "the oracle had nothing to say".
+            "E-XCHECK-003": "unsupported_operation",
+            "E-XCHECK-004": "oracle_refused",
         }.get(str(getattr(exc, "code", "")), "incomparable")
         return CrossCheck(
             operation=operation,
@@ -1698,7 +1703,7 @@ def _compare(
     if not oracle.supports(spec.name):
         raise _refuse(
             f"oracle {oracle.name!r} cannot answer {spec.name!r}",
-            code="E-XCHECK-003",
+            code="E-XCHECK-004",
             remediation="Use a different oracle, or a different operation.",
         )
 

--- a/python/alkahest/crosscheck.py
+++ b/python/alkahest/crosscheck.py
@@ -1,0 +1,2932 @@
+"""Cross-CAS differential testing — ask a second CAS the same question.
+
+Certificates cover the fragment where Alkahest can *prove* its answer. Outside
+that fragment there is nothing checking the answer at all, and the failure that
+matters for a search loop is not a crash but a **silent error**: a confident,
+plausible, wrong result that the loop then builds a hundred derived claims on
+top of (see ``tests/silent_errors/README.md``). An independent implementation
+is the cheapest instrument that catches exactly those.
+
+This module runs one query through Alkahest and through an oracle and reports
+whether they agree — as a four-valued outcome, never a boolean:
+
+``agree``
+    Both systems answered, and a named comparison rung settled it.
+``diverge``
+    Both systems answered and the answers are not the same. The record names
+    **two suspects**, carries the witness point and both values, and never
+    words itself as "Alkahest is right".
+``incomparable``
+    The question could not be posed identically to both systems (an
+    untranslatable node, an assumption context with no faithful mapping, an
+    operation one side refused). **Never** collapsed into ``agree``.
+``unavailable``
+    No oracle is installed. Also never ``agree`` — a loop that believes it is
+    cross-checking and is not is worse off than one that knows it isn't.
+
+Quick start
+-----------
+>>> import alkahest as ak
+>>> from alkahest.crosscheck import check, oracles
+>>> "sympy" in oracles()          # None when SymPy is not installed
+True
+>>> pool = ak.ExprPool()
+>>> x = pool.symbol("x")
+>>> out = check("integrate", ak.sin(x), x)
+>>> out.outcome in {"agree", "unavailable"}
+True
+
+Design notes
+------------
+*One translator, not four.* ``tests/`` already carries four hand-rolled
+``_expr_to_sympy`` helpers, each covering a different subset. :class:`Translator`
+is the one implementation; the tests are meant to migrate onto it. Building the
+QA harness and the runtime mode separately would produce two translators that
+disagree, which is the worst possible outcome for a tool whose entire job is
+detecting disagreement.
+
+*Total-or-refuse.* Every tag :meth:`alkahest.Expr.node` can emit appears in
+:data:`Translator._DISPATCH`; an unknown tag, an unmapped primitive, or an
+assumption context with no faithful counterpart raises
+:class:`~alkahest.CrossCheckError` (``E-XCHECK-001``), which :func:`check` turns
+into ``incomparable``. **False divergences are worse than no signal** — they
+train both the loop and the team to ignore the alarm, and a best-effort
+translator manufactures them by construction.
+
+*Opt-in per call site.* There is deliberately no ``context(crosscheck=True)``:
+that would put an oracle round-trip on every call, and stage-2 falsification
+runs millions of times. Call :func:`check` where you want it — at stage-5
+recording frequency, hundreds of times, not millions.
+
+See ``docs/mdbook/src/crosscheck.md``.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable
+
+from .exceptions import CrossCheckError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Iterator, Mapping, Sequence
+
+__all__ = [
+    "FROZEN_CORPUS",
+    "FUNCTION_MAP",
+    "NODE_TAGS",
+    "OPERATIONS",
+    "OUTCOMES",
+    "PREDICATE_KINDS",
+    "REFUSED_FUNCTIONS",
+    "RUNG_NAMES",
+    "SAMPLE_BOX",
+    "SWEEP_OPERATIONS",
+    "CrossCheck",
+    "Divergence",
+    "FrozenCase",
+    "Operation",
+    "Oracle",
+    "SweepReport",
+    "SymPyOracle",
+    "SymPyTranslator",
+    "Translator",
+    "check",
+    "oracles",
+    "register_oracle",
+    "run_frozen_corpus",
+    "sweep",
+    "to_sympy",
+]
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+#: The four outcomes, in decreasing order of how much they let you conclude.
+#: ``incomparable`` and ``unavailable`` are *not* weaker forms of ``agree``;
+#: they say the check did not happen, and code that treats them as agreement
+#: has reintroduced the exact failure this module exists to prevent.
+OUTCOMES = ("agree", "diverge", "incomparable", "unavailable")
+
+#: Comparison ladder. The rung that settled a check is always recorded, because
+#: the rungs differ in what they license: 1, 2 and 4 are proofs of agreement
+#: within their scope, while 3 only ever *fails to refute* at the points sampled.
+RUNG_NAMES: dict[int, str] = {
+    1: "syntactic",
+    2: "symbolic",
+    3: "rigorous_numeric",
+    4: "invariant",
+}
+
+RUNG_SYNTACTIC = 1
+RUNG_SYMBOLIC = 2
+RUNG_NUMERIC = 3
+RUNG_INVARIANT = 4
+
+#: Every tag :meth:`alkahest.Expr.node` can emit. Authoritative mirror of the
+#: ``ExprData`` match in ``alkahest-py/src/lib.rs``; ``tests/test_crosscheck.py``
+#: re-derives the set from that source so the table cannot silently drift when a
+#: new node kind lands.
+NODE_TAGS = frozenset(
+    {
+        "symbol",
+        "integer",
+        "rational",
+        "float",
+        "add",
+        "mul",
+        "pow",
+        "func",
+        "piecewise",
+        "predicate",
+        "forall",
+        "exists",
+        "big_o",
+        "root_sum",
+    }
+)
+
+#: Every ``kind`` a ``predicate`` node can carry.
+PREDICATE_KINDS = frozenset(
+    {"lt", "le", "gt", "ge", "eq", "ne", "and", "or", "not", "true", "false"}
+)
+
+#: Alkahest primitive name -> SymPy callable name, for the primitives whose
+#: conventions provably coincide. Deliberately *not* ``getattr(sympy, name)``:
+#: that is how a translator ends up quietly mapping ``ceil`` onto nothing, or
+#: ``EllipticK`` onto a function of a different argument.
+FUNCTION_MAP: dict[str, str] = {
+    "abs": "Abs",
+    "acos": "acos",
+    "acosh": "acosh",
+    "arg": "arg",
+    "asin": "asin",
+    "asinh": "asinh",
+    "atan": "atan",
+    "atan2": "atan2",
+    "atanh": "atanh",
+    "ceil": "ceiling",
+    "conjugate": "conjugate",
+    "cos": "cos",
+    "cosh": "cosh",
+    "digamma": "digamma",
+    "diracdelta": "DiracDelta",
+    "erf": "erf",
+    "erfc": "erfc",
+    "exp": "exp",
+    "floor": "floor",
+    "gamma": "gamma",
+    "im": "im",
+    "lambert_w": "LambertW",
+    "log": "log",
+    "max": "Max",
+    "min": "Min",
+    "re": "re",
+    "sign": "sign",
+    "sin": "sin",
+    "sinh": "sinh",
+    "sqrt": "sqrt",
+    "tan": "tan",
+    "tanh": "tanh",
+}
+
+#: Bessel functions of fixed integer order, which SymPy spells with the order as
+#: an argument. Faithful, just not a name-for-name rename.
+_FIXED_ORDER_BESSEL: dict[str, int] = {"bessel_j0": 0, "bessel_j1": 1}
+
+#: Primitives with a *known* convention mismatch, refused with the reason spelt
+#: out. Each of these would translate "successfully" and then manufacture
+#: divergences that say nothing about either system's correctness.
+REFUSED_FUNCTIONS: dict[str, str] = {
+    "heaviside": (
+        "SymPy's Heaviside(0) defaults to 1/2 while Alkahest fixes no value there, "
+        "so the two agree everywhere except on a point the comparison would sample"
+    ),
+    "round": (
+        "SymPy has no symbolic rounding function with a documented half-way rule to compare against"
+    ),
+    "EllipticK": "elliptic integrals differ in modulus-vs-parameter convention between systems",
+    "EllipticE": "elliptic integrals differ in modulus-vs-parameter convention between systems",
+    "EllipticF": "elliptic integrals differ in modulus-vs-parameter convention between systems",
+    "EllipticPi": "elliptic integrals differ in modulus-vs-parameter convention between systems",
+}
+
+#: Pool symbols with a reserved meaning. ``ExprPool.pos_infinity()`` and
+#: ``ExprPool.imaginary_unit()`` intern ordinary symbols with these names, so a
+#: translator that treats them as free variables silently asks the oracle a
+#: different question.
+RESERVED_SYMBOLS = ("∞", "I")
+
+
+# ---------------------------------------------------------------------------
+# Lazy package handles (this module is imported from ``alkahest/__init__.py``)
+# ---------------------------------------------------------------------------
+
+
+def _ak() -> Any:
+    import alkahest
+
+    return alkahest
+
+
+def _refuse(message: str, *, code: str = "E-XCHECK-001", remediation: str) -> CrossCheckError:
+    return CrossCheckError(message, code=code, remediation=remediation)
+
+
+# ---------------------------------------------------------------------------
+# The translator
+# ---------------------------------------------------------------------------
+
+
+class Translator(ABC):
+    """Walk an :class:`alkahest.Expr` into another CAS's term language.
+
+    Subclass once per oracle. The walk, the dispatch table, and the refusal
+    discipline live here; a subclass supplies only the leaf and node
+    constructors of its target language.
+
+    The dispatch table is **total over** :data:`NODE_TAGS` — that is the
+    property that makes a divergence informative, and
+    ``tests/test_crosscheck.py`` asserts it against the tags the Rust binding
+    can actually emit rather than against this list, so a new node kind fails
+    the build instead of quietly translating to nothing.
+
+    Assumptions
+    -----------
+    :meth:`translate` accepts the governing :class:`alkahest.Assumptions` and
+    maps its predicates onto per-symbol flags. A predicate with no faithful
+    counterpart (a relation between two symbols, a disjunction, a bound on a
+    composite expression) raises rather than being dropped: dropping it asks
+    the oracle a *weaker* question and any divergence that follows is an
+    artefact of the harness.
+    """
+
+    #: Node tag -> handler method name. Total over :data:`NODE_TAGS`.
+    _DISPATCH: Mapping[str, str] = {
+        "symbol": "_symbol",
+        "integer": "_integer",
+        "rational": "_rational",
+        "float": "_float",
+        "add": "_add",
+        "mul": "_mul",
+        "pow": "_pow",
+        "func": "_func",
+        "piecewise": "_piecewise",
+        "predicate": "_predicate",
+        "forall": "_forall",
+        "exists": "_exists",
+        "big_o": "_big_o",
+        "root_sum": "_root_sum",
+    }
+
+    def __init__(self) -> None:
+        self._flags: dict[str, dict[str, bool]] = {}
+
+    # -- public entry point -------------------------------------------------
+
+    def translate(self, expr: Any, *, assumptions: Any = None) -> Any:
+        """Translate *expr*, honouring *assumptions*, or refuse.
+
+        Parameters
+        ----------
+        expr : Expr or DerivedResult
+            The expression to translate.
+        assumptions : Assumptions, optional
+            Governing assumption context. When ``None``, the ambient
+            :func:`alkahest.active_assumptions` context is used, so a check run
+            inside ``with alkahest.context(assumptions=...)`` asks the oracle
+            the same conditioned question the caller asked Alkahest.
+
+        Returns
+        -------
+        object
+            A term in the oracle's language.
+
+        Raises
+        ------
+        CrossCheckError
+            ``E-XCHECK-001`` for an unknown node tag, an unmapped primitive, or
+            an assumption with no faithful counterpart.
+        """
+        ak = _ak()
+        if isinstance(expr, ak.DerivedResult):
+            expr = expr.value
+        if assumptions is None:
+            assumptions = ak.active_assumptions()
+        self._flags = self._symbol_flags(assumptions)
+        return self._walk(expr)
+
+    def assumption_flags(self, assumptions: Any) -> dict[str, dict[str, bool]]:
+        """Public view of the symbol-flag mapping derived from *assumptions*."""
+        return self._symbol_flags(assumptions)
+
+    # -- the walk -----------------------------------------------------------
+
+    def _walk(self, expr: Any) -> Any:
+        node = expr.node()
+        tag = node[0]
+        handler = self._DISPATCH.get(tag)
+        if handler is None:
+            raise _refuse(
+                f"no faithful translation for node tag {tag!r}",
+                remediation=(
+                    "alkahest.crosscheck refuses rather than guessing: a best-effort "
+                    "translation of an unknown node manufactures divergences that say "
+                    "nothing about either system. Add the tag to Translator._DISPATCH "
+                    "with a mapping you can defend, or cross-check a different route."
+                ),
+            )
+        return getattr(self, handler)(node)
+
+    def _walk_all(self, exprs: Sequence[Any]) -> list[Any]:
+        return [self._walk(e) for e in exprs]
+
+    # -- assumptions --------------------------------------------------------
+
+    def _symbol_flags(self, assumptions: Any) -> dict[str, dict[str, bool]]:
+        """Map assumption predicates onto per-symbol flags, or refuse."""
+        if assumptions is None:
+            return {}
+        flags: dict[str, dict[str, bool]] = {}
+        for predicate in assumptions.predicates:
+            node = predicate.node()
+            if node[0] != "predicate":
+                raise _refuse(
+                    f"assumption {predicate} is not a predicate",
+                    remediation="Assumption contexts must contain predicate expressions.",
+                )
+            kind, args = node[1], node[2]
+            name = self._assumption_flag(kind, args)
+            if name is None:
+                raise _refuse(
+                    f"no faithful translation for the active assumption {predicate}",
+                    remediation=(
+                        "Only sign and non-zero conditions on a bare symbol map onto "
+                        "oracle symbol flags. Drop the assumption for the duration of "
+                        "the check, or accept outcome='incomparable' — asking the "
+                        "oracle a weaker question would turn every legitimate "
+                        "refinement into a false divergence."
+                    ),
+                )
+            symbol_name, flag = name
+            flags.setdefault(symbol_name, {})[flag] = True
+        return flags
+
+    @staticmethod
+    def _assumption_flag(kind: str, args: Sequence[Any]) -> tuple[str, str] | None:
+        """``(symbol_name, flag)`` for a mappable predicate, else ``None``.
+
+        Mappable shapes are exactly ``sym <rel> 0`` for the four order relations
+        and ``sym != 0`` — the conditions that correspond one-for-one to a
+        symbol-level flag in every CAS that has such flags. Everything else
+        (relations between symbols, conditions on composites, boolean
+        combinations, quantified statements) has no per-symbol counterpart.
+        """
+        flag_by_kind = {
+            "gt": "positive",
+            "ge": "nonnegative",
+            "lt": "negative",
+            "le": "nonpositive",
+            "ne": "nonzero",
+        }
+        flag = flag_by_kind.get(kind)
+        if flag is None or len(args) != 2:
+            return None
+        lhs, rhs = args
+        if lhs.node()[0] != "symbol":
+            return None
+        rhs_node = rhs.node()
+        if rhs_node[0] != "integer" or int(rhs_node[1]) != 0:
+            return None
+        return str(lhs.node()[1]), flag
+
+    # -- leaf and node constructors (per oracle) ----------------------------
+
+    @abstractmethod
+    def _symbol(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _integer(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _rational(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _float(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _add(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _mul(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _pow(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _func(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _piecewise(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _predicate(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _forall(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _exists(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _big_o(self, node: Sequence[Any]) -> Any: ...
+
+    @abstractmethod
+    def _root_sum(self, node: Sequence[Any]) -> Any: ...
+
+
+class SymPyTranslator(Translator):
+    """:class:`Translator` into SymPy's expression language."""
+
+    def __init__(self, sympy_module: Any) -> None:
+        super().__init__()
+        self.sympy = sympy_module
+
+    # -- leaves -------------------------------------------------------------
+
+    def _symbol(self, node: Sequence[Any]) -> Any:
+        name = str(node[1])
+        if name == "∞":
+            return self.sympy.oo
+        if name == "I":
+            return self.sympy.I
+        return self.sympy.Symbol(name, **self._flags.get(name, {}))
+
+    def _integer(self, node: Sequence[Any]) -> Any:
+        return self.sympy.Integer(int(node[1]))
+
+    def _rational(self, node: Sequence[Any]) -> Any:
+        return self.sympy.Rational(int(node[1]), int(node[2]))
+
+    def _float(self, node: Sequence[Any]) -> Any:
+        # Alkahest prints floats at full precision; ``Float(str)`` keeps every
+        # digit, where ``Float(float(...))`` would re-round through binary.
+        return self.sympy.Float(str(node[1]))
+
+    # -- structure ----------------------------------------------------------
+
+    def _add(self, node: Sequence[Any]) -> Any:
+        return self.sympy.Add(*self._walk_all(node[1]))
+
+    def _mul(self, node: Sequence[Any]) -> Any:
+        return self.sympy.Mul(*self._walk_all(node[1]))
+
+    def _pow(self, node: Sequence[Any]) -> Any:
+        return self.sympy.Pow(self._walk(node[1]), self._walk(node[2]))
+
+    def _func(self, node: Sequence[Any]) -> Any:
+        name = str(node[1])
+        args = self._walk_all(node[2])
+        reason = REFUSED_FUNCTIONS.get(name)
+        if reason is not None:
+            raise _refuse(
+                f"no faithful translation for primitive {name!r}: {reason}",
+                remediation=(
+                    "Cross-check a route that avoids this primitive. Translating it "
+                    "anyway would produce divergences caused by the convention "
+                    "mismatch rather than by either system being wrong."
+                ),
+            )
+        order = _FIXED_ORDER_BESSEL.get(name)
+        if order is not None:
+            return self.sympy.besselj(order, *args)
+        mapped = FUNCTION_MAP.get(name)
+        if mapped is None:
+            raise _refuse(
+                f"no faithful translation for primitive {name!r}",
+                remediation=(
+                    "Add it to alkahest.crosscheck.FUNCTION_MAP once you have checked "
+                    "that the two systems use the same branch and the same argument "
+                    "convention, or to REFUSED_FUNCTIONS with the reason they do not."
+                ),
+            )
+        return getattr(self.sympy, mapped)(*args)
+
+    def _piecewise(self, node: Sequence[Any]) -> Any:
+        branches = [(self._walk(value), self._walk(cond)) for cond, value in node[1]]
+        branches.append((self._walk(node[2]), self.sympy.true))
+        return self.sympy.Piecewise(*branches)
+
+    def _predicate(self, node: Sequence[Any]) -> Any:
+        kind = str(node[1])
+        args = self._walk_all(node[2])
+        builders: dict[str, Callable[..., Any]] = {
+            "lt": self.sympy.StrictLessThan,
+            "le": self.sympy.LessThan,
+            "gt": self.sympy.StrictGreaterThan,
+            "ge": self.sympy.GreaterThan,
+            "eq": self.sympy.Eq,
+            "ne": self.sympy.Ne,
+            "and": self.sympy.And,
+            "or": self.sympy.Or,
+            "not": self.sympy.Not,
+        }
+        if kind == "true":
+            return self.sympy.true
+        if kind == "false":
+            return self.sympy.false
+        builder = builders.get(kind)
+        if builder is None:
+            raise _refuse(
+                f"no faithful translation for predicate kind {kind!r}",
+                remediation="Extend SymPyTranslator._predicate with a defended mapping.",
+            )
+        return builder(*args)
+
+    def _forall(self, node: Sequence[Any]) -> Any:
+        return _refuse_quantifier("∀")
+
+    def _exists(self, node: Sequence[Any]) -> Any:
+        return _refuse_quantifier("∃")
+
+    def _big_o(self, node: Sequence[Any]) -> Any:
+        return self.sympy.O(self._walk(node[1]))
+
+    def _root_sum(self, node: Sequence[Any]) -> Any:
+        poly = self._walk(node[1])
+        var = self._walk(node[2])
+        body = self._walk(node[3])
+        return self.sympy.RootSum(self.sympy.Poly(poly, var), self.sympy.Lambda(var, body))
+
+
+def _refuse_quantifier(label: str) -> Any:
+    """Refuse to translate a quantifier.
+
+    SymPy has no first-order quantifier that composes with its arithmetic —
+    ``Q``/``ask`` is an assumption query, not a term former, and neither
+    ``simplify`` nor ``evalf`` means anything on one. Encoding ``∀`` as anything
+    SymPy *will* accept produces an object the comparison ladder cannot use,
+    and every rung would then answer "not equal" for reasons that have nothing
+    to do with the mathematics.
+    """
+    raise _refuse(
+        f"no faithful translation for a {label} quantifier",
+        remediation=(
+            "SymPy has no term-level quantifier to compare against. Cross-check the "
+            "quantifier-free matrix, or use alkahest.decide, whose answer is a truth "
+            "value the ladder can compare."
+        ),
+    )
+
+
+def to_sympy(expr: Any, *, assumptions: Any = None) -> Any:
+    """Translate an Alkahest expression into SymPy, or refuse.
+
+    The one translator this package ships, exposed directly for callers who
+    want the term rather than a comparison. Total over :data:`NODE_TAGS`:
+    anything it cannot map faithfully raises rather than degrading.
+
+    Parameters
+    ----------
+    expr : Expr or DerivedResult
+        Expression to translate.
+    assumptions : Assumptions, optional
+        Governing assumption context; defaults to
+        :func:`alkahest.active_assumptions`.
+
+    Returns
+    -------
+    sympy.Basic
+
+    Raises
+    ------
+    CrossCheckError
+        ``E-XCHECK-002`` if SymPy is not installed, ``E-XCHECK-001`` if the
+        expression or the assumption context has no faithful mapping.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.crosscheck import oracles, to_sympy
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> if oracles()["sympy"]:
+    ...     str(to_sympy(ak.sin(x) ** 2))
+    ... else:
+    ...     'sin(x)**2'
+    'sin(x)**2'
+    """
+    oracle = SymPyOracle()
+    return oracle.translate(expr, assumptions=assumptions)
+
+
+# ---------------------------------------------------------------------------
+# Oracles
+# ---------------------------------------------------------------------------
+
+
+class Oracle(ABC):
+    """An independent CAS the comparator can interrogate.
+
+    The comparator talks to oracles **only** through this interface, so a
+    second implementation (Wolfram, Maxima, a pinned older Alkahest) drops in
+    without the ladder changing. Two consequences worth stating:
+
+    * every method may answer "I don't know" — :meth:`is_zero` returns ``None``,
+      :meth:`run` raises — and the comparator turns that into ``incomparable``
+      rather than guessing;
+    * :meth:`lift` is optional in effect but not in signature: it is what lets
+      rung 2 be attempted *independently in both systems*, which is what makes
+      "either one proved it" a defensible notion of agreement.
+
+    Attributes
+    ----------
+    name : str
+        Stable short identifier, used as the key in :func:`oracles`.
+    """
+
+    name: str = "oracle"
+
+    # -- availability -------------------------------------------------------
+
+    @classmethod
+    @abstractmethod
+    def available(cls) -> bool:
+        """Is this oracle usable in this process right now?"""
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """Version string of the backing system. Recorded on every result."""
+
+    # -- language -----------------------------------------------------------
+
+    @abstractmethod
+    def translate(self, expr: Any, *, assumptions: Any = None) -> Any:
+        """Alkahest :class:`~alkahest.Expr` -> a term in this oracle's language."""
+
+    @abstractmethod
+    def lift(self, obj: Any, pool: Any) -> Any:
+        """This oracle's term -> an Alkahest :class:`~alkahest.Expr`, or refuse."""
+
+    @abstractmethod
+    def render(self, obj: Any) -> str:
+        """Human-readable rendering, for witnesses and reports."""
+
+    @abstractmethod
+    def canonical(self, obj: Any) -> str:
+        """Canonical string form, for rung 1."""
+
+    # -- operations ---------------------------------------------------------
+
+    @abstractmethod
+    def supports(self, operation: str) -> bool:
+        """Can this oracle answer *operation* at all?"""
+
+    @abstractmethod
+    def run(self, operation: str, args: Mapping[str, Any]) -> Any:
+        """Perform *operation* in this oracle's own engine.
+
+        Raises
+        ------
+        CrossCheckError
+            ``E-XCHECK-003`` when the oracle declines or returns an
+            unevaluated form; a refusal is not a divergence.
+        """
+
+    # -- reasoning primitives the ladder needs ------------------------------
+
+    @abstractmethod
+    def is_zero(self, obj: Any) -> bool | None:
+        """``True``/``False`` if decided, ``None`` if the oracle could not."""
+
+    @abstractmethod
+    def diff(self, obj: Any, var: Any) -> Any:
+        """Derivative of *obj* with respect to the translated variable *var*."""
+
+    @abstractmethod
+    def subs(self, obj: Any, bindings: Mapping[Any, Any]) -> Any:
+        """Substitute translated terms for translated symbols."""
+
+    @abstractmethod
+    def subs_by_name(self, obj: Any, point: Mapping[str, float]) -> Any:
+        """Substitute numbers for free symbols matched **by name**.
+
+        Distinct from :meth:`subs` because the comparator only ever knows the
+        Alkahest symbol *names* at a witness point, and rebuilding an oracle
+        symbol from a name would have to re-derive its assumption flags — get
+        that wrong and the substitution silently misses.
+        """
+
+    @abstractmethod
+    def to_float(self, obj: Any) -> float | None:
+        """Numeric value of *obj*, or ``None`` when it has none."""
+
+
+class SymPyOracle(Oracle):
+    """SymPy as the reference implementation.
+
+    The first oracle, and the one the frozen corpus is pinned against. Its
+    version is recorded on **every** record: without that the corpus rots
+    silently the first time SymPy changes an answer, which it will.
+
+    Raises
+    ------
+    CrossCheckError
+        ``E-XCHECK-002`` on construction when SymPy is not importable. The
+        absence is loud by construction — there is no code path in which a
+        missing SymPy yields agreement.
+    """
+
+    name = "sympy"
+
+    def __init__(self) -> None:
+        self.sympy = _import_sympy()
+        self._translator = SymPyTranslator(self.sympy)
+
+    # -- availability -------------------------------------------------------
+
+    @classmethod
+    def available(cls) -> bool:
+        try:
+            _import_sympy()
+        except CrossCheckError:
+            return False
+        return True
+
+    @property
+    def version(self) -> str:
+        return str(self.sympy.__version__)
+
+    # -- language -----------------------------------------------------------
+
+    def translate(self, expr: Any, *, assumptions: Any = None) -> Any:
+        return self._translator.translate(expr, assumptions=assumptions)
+
+    def lift(self, obj: Any, pool: Any) -> Any:
+        """SymPy term -> Alkahest ``Expr``, refusing anything not exactly representable.
+
+        Deliberately narrow. A lift that "mostly works" would put an
+        approximated value into the Alkahest-side rung-2 attempt, and a wrong
+        answer there is indistinguishable from the divergence the module exists
+        to find.
+        """
+        sp = self.sympy
+        ak = _ak()
+
+        def go(o: Any) -> Any:
+            if o is sp.oo:
+                return pool.pos_infinity()
+            if o is sp.I:
+                return pool.imaginary_unit()
+            if o.is_Integer:
+                return pool.integer(int(o))
+            if o.is_Rational:
+                return pool.rational(int(o.p), int(o.q))
+            if o.is_Float:
+                return pool.float(float(o))
+            if o.is_Symbol:
+                return pool.symbol(str(o.name))
+            if o.is_Add:
+                return _fold(go(a) for a in o.args)
+            if o.is_Mul:
+                terms = [go(a) for a in o.args]
+                out = terms[0]
+                for t in terms[1:]:
+                    out = out * t
+                return out
+            if o.is_Pow:
+                return go(o.base) ** go(o.exp)
+            head = type(o).__name__
+            inverse = _SYMPY_TO_ALKAHEST.get(head)
+            if inverse is not None and hasattr(ak, inverse):
+                return getattr(ak, inverse)(*[go(a) for a in o.args])
+            raise _refuse(
+                f"cannot lift SymPy {head} back into Alkahest exactly",
+                remediation=(
+                    "The oracle's answer stays in the oracle for this check; the "
+                    "Alkahest-side symbolic rung is skipped rather than run against an "
+                    "approximation."
+                ),
+            )
+
+        def _fold(parts: Iterator[Any]) -> Any:
+            items = list(parts)
+            out = items[0]
+            for item in items[1:]:
+                out = out + item
+            return out
+
+        return go(self.sympy.sympify(obj))
+
+    def render(self, obj: Any) -> str:
+        return str(obj)
+
+    def canonical(self, obj: Any) -> str:
+        return self.sympy.srepr(self.sympy.sympify(obj))
+
+    # -- operations ---------------------------------------------------------
+
+    def supports(self, operation: str) -> bool:
+        return operation in _SYMPY_RUNNERS
+
+    def run(self, operation: str, args: Mapping[str, Any]) -> Any:
+        runner = _SYMPY_RUNNERS.get(operation)
+        if runner is None:
+            raise _refuse(
+                f"SymPy oracle has no implementation of {operation!r}",
+                code="E-XCHECK-003",
+                remediation=(
+                    "Add it to alkahest.crosscheck._SYMPY_RUNNERS together with a "
+                    "comparison rung in OPERATIONS."
+                ),
+            )
+        try:
+            result = runner(self.sympy, args)
+        except CrossCheckError:
+            raise
+        except Exception as exc:
+            raise _refuse(
+                f"SymPy declined {operation}: {type(exc).__name__}: {exc}",
+                code="E-XCHECK-003",
+                remediation=(
+                    "The oracle refused. That is not a divergence and is not recorded "
+                    "as one; the check reports outcome='incomparable'."
+                ),
+            ) from exc
+        self._reject_unevaluated(operation, result)
+        return result
+
+    def _reject_unevaluated(self, operation: str, result: Any) -> None:
+        """An unevaluated ``Integral``/``Sum``/``Limit`` is a refusal, not an answer."""
+        sp = self.sympy
+        unevaluated = (sp.Integral, sp.Sum, sp.Limit, sp.Derivative)
+        candidates = result if isinstance(result, (list, tuple)) else [result]
+        for item in candidates:
+            if isinstance(item, dict):
+                items = list(item.values())
+            elif isinstance(item, (list, tuple)):
+                items = list(item)
+            else:
+                items = [item]
+            for value in items:
+                if isinstance(value, sp.Basic) and value.has(*unevaluated):
+                    raise _refuse(
+                        f"SymPy returned an unevaluated form for {operation}: {value}",
+                        code="E-XCHECK-003",
+                        remediation=(
+                            "SymPy did not answer. Reported as 'incomparable' — an "
+                            "unevaluated Integral is a refusal and comparing against it "
+                            "would fabricate a divergence."
+                        ),
+                    )
+
+    # -- reasoning primitives ----------------------------------------------
+
+    def is_zero(self, obj: Any) -> bool | None:
+        sp = self.sympy
+        try:
+            simplified = sp.simplify(sp.expand(obj))
+        except Exception:
+            return None
+        if simplified == 0:
+            return True
+        try:
+            verdict = simplified.is_zero
+        except Exception:
+            return None
+        return None if verdict is None else bool(verdict)
+
+    def diff(self, obj: Any, var: Any) -> Any:
+        return self.sympy.diff(obj, var)
+
+    def subs(self, obj: Any, bindings: Mapping[Any, Any]) -> Any:
+        return self.sympy.sympify(obj).subs(dict(bindings))
+
+    def subs_by_name(self, obj: Any, point: Mapping[str, float]) -> Any:
+        term = self.sympy.sympify(obj)
+        bindings = {s: point[str(s)] for s in term.free_symbols if str(s) in point}
+        return term.subs(bindings)
+
+    def to_float(self, obj: Any) -> float | None:
+        try:
+            value = complex(self.sympy.sympify(obj).evalf(30))
+        except Exception:
+            return None
+        if abs(value.imag) > 1e-18:
+            return None
+        real = value.real
+        if real != real or real in (float("inf"), float("-inf")):
+            return None
+        return real
+
+
+#: SymPy head name -> the ``alkahest`` callable that rebuilds it, for
+#: :meth:`SymPyOracle.lift`. Only the round-trippable half of
+#: :data:`FUNCTION_MAP`; anything absent makes ``lift`` refuse.
+_SYMPY_TO_ALKAHEST: dict[str, str] = {
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "asin": "asin",
+    "acos": "acos",
+    "atan": "atan",
+    "sinh": "sinh",
+    "cosh": "cosh",
+    "tanh": "tanh",
+    "exp": "exp",
+    "log": "log",
+    "sqrt": "sqrt",
+    "erf": "erf",
+    "gamma": "gamma",
+    "Abs": "abs",
+    "sign": "sign",
+}
+
+
+def _import_sympy() -> Any:
+    try:
+        import sympy
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise CrossCheckError(
+            "no cross-check oracle is installed (SymPy import failed)",
+            code="E-XCHECK-002",
+            remediation=(
+                "pip install sympy. Until then alkahest.crosscheck.check returns "
+                "outcome='unavailable' — never 'agree'. Call "
+                "alkahest.crosscheck.oracles() at session start to find out before "
+                "you plan around the check."
+            ),
+        ) from exc
+    return sympy
+
+
+# -- SymPy operation runners ------------------------------------------------
+#
+# One per entry in OPERATIONS. Keyed by the same names as the alkahest module
+# namespace, so `check("integrate", ...)` runs `alkahest.integrate` on one side
+# and this table's `integrate` on the other.
+
+
+def _sympy_diff(sp: Any, args: Mapping[str, Any]) -> Any:
+    return sp.diff(args["expr"], args["var"])
+
+
+def _sympy_integrate(sp: Any, args: Mapping[str, Any]) -> Any:
+    if args.get("lower") is not None:
+        return sp.integrate(args["expr"], (args["var"], args["lower"], args["upper"]))
+    return sp.integrate(args["expr"], args["var"])
+
+
+def _sympy_simplify(sp: Any, args: Mapping[str, Any]) -> Any:
+    return sp.simplify(args["expr"])
+
+
+def _sympy_expand(sp: Any, args: Mapping[str, Any]) -> Any:
+    return sp.expand(args["expr"])
+
+
+def _sympy_limit(sp: Any, args: Mapping[str, Any]) -> Any:
+    return sp.limit(args["expr"], args["var"], args["point"])
+
+
+def _sympy_series(sp: Any, args: Mapping[str, Any]) -> Any:
+    return sp.series(args["expr"], args["var"], args["point"], args["order"]).removeO()
+
+
+def _sympy_sum_indefinite(sp: Any, args: Mapping[str, Any]) -> Any:
+    from sympy.concrete.gosper import gosper_sum
+
+    out = gosper_sum(args["expr"], args["var"])
+    if out is None:
+        raise _refuse(
+            "SymPy's Gosper implementation found no hypergeometric antidifference",
+            code="E-XCHECK-003",
+            remediation="A refusal, not a divergence; reported as 'incomparable'.",
+        )
+    return out
+
+
+def _sympy_solve(sp: Any, args: Mapping[str, Any]) -> Any:
+    solutions = sp.solve(list(args["equations"]), list(args["vars"]), dict=True)
+    return [{str(k): v for k, v in sol.items()} for sol in solutions]
+
+
+_SYMPY_RUNNERS: dict[str, Callable[[Any, Mapping[str, Any]], Any]] = {
+    "diff": _sympy_diff,
+    "integrate": _sympy_integrate,
+    "simplify": _sympy_simplify,
+    "simplify_expanded": _sympy_expand,
+    "limit": _sympy_limit,
+    "series": _sympy_series,
+    "sum_indefinite": _sympy_sum_indefinite,
+    "solve": _sympy_solve,
+}
+
+
+# ---------------------------------------------------------------------------
+# Oracle registry
+# ---------------------------------------------------------------------------
+
+_ORACLE_CLASSES: dict[str, type[Oracle]] = {"sympy": SymPyOracle}
+
+
+def register_oracle(oracle_cls: type[Oracle]) -> None:
+    """Register an :class:`Oracle` implementation under its ``name``.
+
+    The comparator resolves oracles through this registry, so a new backend is
+    a class plus one call — no change to the ladder, the outcomes, or the
+    frozen corpus machinery.
+
+    Parameters
+    ----------
+    oracle_cls : type[Oracle]
+        Class (not instance); it is constructed lazily, and only when
+        :meth:`Oracle.available` says it can be.
+    """
+    _ORACLE_CLASSES[oracle_cls.name] = oracle_cls
+
+
+def oracles() -> dict[str, str | None]:
+    """Which oracles are installed, and at what version.
+
+    Reports every *known* oracle, including the absent ones — an agent must be
+    able to tell that SymPy is missing **before** it plans around a check that
+    will only ever return ``unavailable``.
+
+    Returns
+    -------
+    dict
+        ``{"sympy": "1.14.0", "wolfram": None}``-shaped; ``None`` means
+        "known to this build, not installed here".
+
+    Examples
+    --------
+    >>> from alkahest.crosscheck import oracles
+    >>> sorted(oracles())
+    ['sympy']
+    """
+    out: dict[str, str | None] = {}
+    for name, cls in sorted(_ORACLE_CLASSES.items()):
+        if not cls.available():
+            out[name] = None
+            continue
+        try:
+            out[name] = cls().version
+        except Exception:  # pragma: no cover - a broken install is "absent"
+            out[name] = None
+    return out
+
+
+def _resolve_oracle(oracle: Oracle | str | None) -> Oracle | None:
+    """Return a usable oracle, or ``None`` when none is installed."""
+    if isinstance(oracle, Oracle):
+        return oracle
+    names = [oracle] if isinstance(oracle, str) else sorted(_ORACLE_CLASSES)
+    for name in names:
+        cls = _ORACLE_CLASSES.get(name)
+        if cls is None or not cls.available():
+            continue
+        try:
+            return cls()
+        except CrossCheckError:  # pragma: no cover - available() already checked
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Operation table
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Operation:
+    """How one operation is posed to both systems, and how it is compared.
+
+    Attributes
+    ----------
+    name : str
+        Matches the ``alkahest`` module attribute of the same name.
+    rungs : tuple of int
+        Ladder rungs to attempt, **in order**. Rung 4 leads wherever it exists,
+        because it sidesteps equal-up-to-a-constant, up-to-ordering and
+        up-to-a-unit entirely — the three things that make naive comparison of
+        antiderivatives, solution sets and factorisations produce nothing but
+        noise.
+    invariant : str or None
+        Name of the rung-4 invariant, or ``None`` when the operation has none.
+    result : {"expr", "solutions"}
+        Shape of the answer, which decides how it is compared and rendered.
+    normalize : str or None
+        Operation-specific normalisation applied to the Alkahest answer before
+        the ladder runs — currently only ``"strip_big_o"``. This is *not* a
+        rung: it removes a difference in how the two systems spell the same
+        answer, and it must never remove a difference in the answer itself.
+    """
+
+    name: str
+    rungs: tuple[int, ...]
+    invariant: str | None
+    result: str = "expr"
+    normalize: str | None = None
+
+
+#: Operations with a defined comparison rung. Anything else raises
+#: ``E-XCHECK-003`` rather than being compared by a generic fallback: a generic
+#: fallback is precisely how a harness starts reporting divergences that are
+#: really just two systems using different normal forms.
+OPERATIONS: dict[str, Operation] = {
+    # d/dx has no invariant that is not itself the thing under test
+    # (integrating back is weaker than the derivative it would check), so the
+    # ladder runs 1 -> 2 -> 3.
+    "diff": Operation("diff", (1, 2, 3), None),
+    # Antiderivatives agree up to a constant; differentiating both removes the
+    # constant and turns the comparison into an exact one.
+    "integrate": Operation("integrate", (4, 1, 2, 3), "antiderivative"),
+    # A simplifier's contract is that it preserves value. Checking each
+    # system's output against the shared *input* compares the two claims
+    # without ever asking whether two normal forms happen to coincide.
+    "simplify": Operation("simplify", (4, 1, 2, 3), "value_preserving"),
+    "simplify_expanded": Operation("simplify_expanded", (4, 1, 2, 3), "value_preserving"),
+    "limit": Operation("limit", (1, 2, 3), None),
+    # The two systems spell the remainder differently — Alkahest carries an
+    # explicit O() term inside the expression, SymPy has removeO(). Stripping
+    # it is a normalisation, not a rung: what is compared afterwards is still
+    # the whole truncated polynomial, coefficient for coefficient.
+    "series": Operation("series", (1, 2, 3), None, normalize="strip_big_o"),
+    # Gosper: S(k+1) - S(k) = t(k) pins the antidifference up to a constant.
+    "sum_indefinite": Operation("sum_indefinite", (4, 1, 2, 3), "antidifference"),
+    # Substituting solutions back checks each system's answers on their own
+    # terms; the set comparison then finds *missed* solutions, which is the
+    # divergence worth having.
+    "solve": Operation("solve", (4,), "substitution", result="solutions"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Divergence:
+    """Two systems answered, and the answers are not the same.
+
+    The wording is constrained on purpose. A divergence names **two suspects**:
+    it is evidence that one of the two is wrong, and on its own it is never
+    evidence about *which*. :attr:`support` carries whatever the rigorous
+    escalation could establish, and its default is ``"unresolved"``.
+
+    Attributes
+    ----------
+    operation : str
+        Operation that diverged.
+    oracle, oracle_version : str
+        Which independent system, at which version. Without the version a
+        recorded divergence rots the first time the oracle changes an answer.
+    point : dict
+        Witness: symbol name -> value at which the two disagree. Empty when
+        the divergence is symbolic rather than pointwise.
+    alkahest_value, oracle_value : str
+        Both values, rendered. Never one without the other.
+    alkahest_enclosure : tuple of float, optional
+        Rigorous ball-arithmetic enclosure computed on the Alkahest side.
+    support : {"unresolved", "alkahest_supported", "oracle_supported"}
+        What the rigorous escalation established. ``"oracle_supported"`` means
+        an operation invariant was **rigorously refuted on the Alkahest side**
+        — a silent-error finding, and the case that should be routed into
+        ``tests/silent_errors/corpus.py``.
+    region : dict or None
+        When :func:`alkahest.verified_sign` certified that the failing
+        invariant residual keeps one sign across the whole sampling box, the
+        box: ``{"x": [0.35, 2.65]}``. That upgrades a finding from "wrong at
+        this point" to "wrong on this interval", which is a much shorter
+        argument to hand a reviewer.
+    detail : str
+        One sentence, phrased symmetrically.
+    """
+
+    operation: str
+    oracle: str
+    oracle_version: str
+    point: dict[str, float] = field(default_factory=dict)
+    alkahest_value: str = ""
+    oracle_value: str = ""
+    alkahest_enclosure: tuple[float, float] | None = None
+    support: str = "unresolved"
+    region: dict[str, list[float]] | None = None
+    detail: str = ""
+
+    @property
+    def silent_error_candidate(self) -> bool:
+        """Is this a case for ``tests/silent_errors/corpus.py``?
+
+        True exactly when rigorous ball arithmetic refuted the *Alkahest* side
+        of an operation invariant. That is the finding worth converting into a
+        permanent regression gate; everything else is a lead.
+        """
+        return self.support == "oracle_supported"
+
+    def statement(self) -> str:
+        """One-line rendering that attributes blame to neither system."""
+        where = (
+            " at " + ", ".join(f"{k}={v!r}" for k, v in sorted(self.point.items()))
+            if self.point
+            else ""
+        )
+        return (
+            f"{self.operation}: alkahest and {self.oracle} {self.oracle_version} "
+            f"disagree{where} — alkahest {self.alkahest_value!r} vs "
+            f"{self.oracle} {self.oracle_value!r}; {self.detail}"
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """JSON-serialisable view."""
+        return {
+            "operation": self.operation,
+            "oracle": self.oracle,
+            "oracle_version": self.oracle_version,
+            "point": dict(self.point),
+            "alkahest_value": self.alkahest_value,
+            "oracle_value": self.oracle_value,
+            "alkahest_enclosure": list(self.alkahest_enclosure)
+            if self.alkahest_enclosure
+            else None,
+            "support": self.support,
+            "region": self.region,
+            "silent_error_candidate": self.silent_error_candidate,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class CrossCheck:
+    """The outcome of one differential check.
+
+    Attributes
+    ----------
+    operation : str
+        Operation checked.
+    outcome : {"agree", "diverge", "incomparable", "unavailable"}
+        See the module docstring. Truthiness is deliberately **not** defined on
+        this class: ``if check(...)`` would read as "it agreed" and would be
+        true for three of the four outcomes under any obvious convention.
+    rung : int or None
+        Which rung settled it (see :data:`RUNG_NAMES`); ``None`` when nothing
+        did.
+    reason : str
+        Stable short code for *why* — ``"invariant_holds"``,
+        ``"no_oracle"``, ``"untranslatable"``, ``"alkahest_refused"``,
+        ``"oracle_refused"``, ``"ladder_exhausted"``, and so on. Machine
+        triage should switch on this, not on :attr:`detail`.
+    detail : str
+        One human sentence.
+    oracle, oracle_version : str or None
+        Which system answered, at which version.
+    alkahest_value, oracle_value : str or None
+        Both answers, rendered.
+    witness : dict or None
+        ``{"point", "alkahest", "oracle", "enclosure"}`` when a pointwise
+        witness exists.
+    divergence : Divergence or None
+        Populated iff ``outcome == "diverge"``.
+    conclusive : bool
+        Whether the settling rung *proves* what it reports. Rung 3 agreement is
+        sampled, so it is reported as agreement with ``conclusive=False``
+        rather than being silently promoted or silently discarded.
+    elapsed_ms : float
+        Wall-clock cost of the check, oracle round trip included.
+    """
+
+    operation: str
+    outcome: str
+    rung: int | None = None
+    reason: str = ""
+    detail: str = ""
+    oracle: str | None = None
+    oracle_version: str | None = None
+    alkahest_value: str | None = None
+    oracle_value: str | None = None
+    witness: dict[str, Any] | None = None
+    divergence: Divergence | None = None
+    conclusive: bool = False
+    elapsed_ms: float = 0.0
+
+    @property
+    def rung_name(self) -> str | None:
+        """Human name of :attr:`rung` (see :data:`RUNG_NAMES`)."""
+        return RUNG_NAMES.get(self.rung) if self.rung is not None else None
+
+    @property
+    def checked(self) -> bool:
+        """Did a comparison actually happen?
+
+        ``False`` for ``incomparable`` and ``unavailable``. Provided so the
+        common mistake — treating "no signal" as "clean" — has to be written
+        out explicitly.
+        """
+        return self.outcome in ("agree", "diverge")
+
+    def as_dict(self) -> dict[str, Any]:
+        """JSON-serialisable view."""
+        return {
+            "operation": self.operation,
+            "outcome": self.outcome,
+            "rung": self.rung,
+            "rung_name": self.rung_name,
+            "reason": self.reason,
+            "detail": self.detail,
+            "oracle": self.oracle,
+            "oracle_version": self.oracle_version,
+            "alkahest_value": self.alkahest_value,
+            "oracle_value": self.oracle_value,
+            "witness": self.witness,
+            "divergence": self.divergence.as_dict() if self.divergence else None,
+            "conclusive": self.conclusive,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"CrossCheck({self.outcome!r}, operation={self.operation!r}, "
+            f"rung={self.rung_name!r}, reason={self.reason!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Expression helpers
+# ---------------------------------------------------------------------------
+
+
+def _walk_expr(expr: Any) -> Iterator[Any]:
+    """Yield *expr* and every subexpression, depth-first."""
+    yield expr
+    node = expr.node()
+    tag = node[0]
+    if tag in ("add", "mul"):
+        for arg in node[1]:
+            yield from _walk_expr(arg)
+    elif tag == "func":
+        for arg in node[2]:
+            yield from _walk_expr(arg)
+    elif tag == "pow":
+        yield from _walk_expr(node[1])
+        yield from _walk_expr(node[2])
+    elif tag == "big_o":
+        yield from _walk_expr(node[1])
+    elif tag == "predicate":
+        for arg in node[2]:
+            yield from _walk_expr(arg)
+    elif tag in ("forall", "exists"):
+        yield from _walk_expr(node[1])
+        yield from _walk_expr(node[2])
+    elif tag == "piecewise":
+        for cond, value in node[1]:
+            yield from _walk_expr(cond)
+            yield from _walk_expr(value)
+        yield from _walk_expr(node[2])
+    elif tag == "root_sum":
+        yield from _walk_expr(node[1])
+        yield from _walk_expr(node[2])
+        yield from _walk_expr(node[3])
+
+
+def _free_symbols(expr: Any) -> dict[str, Any]:
+    """Free symbols of *expr*, excluding the reserved ``∞`` / ``I`` names."""
+    out: dict[str, Any] = {}
+    for sub in _walk_expr(expr):
+        node = sub.node()
+        if node[0] == "symbol":
+            name = str(node[1])
+            if name not in RESERVED_SYMBOLS:
+                out[name] = sub
+    return out
+
+
+def _is_exact_zero(expr: Any) -> bool:
+    node = expr.node()
+    return node[0] == "integer" and int(node[1]) == 0
+
+
+def _unwrap(value: Any) -> Any:
+    """Reduce an Alkahest return value to the expression it carries.
+
+    ``DerivedResult`` exposes ``.value``; ``Series`` exposes ``.expr``. Both
+    are unwrapped, because the ladder compares expressions and a caller should
+    not have to know which wrapper an operation happens to return.
+    """
+    if isinstance(value, (list, tuple, dict)) or hasattr(value, "node"):
+        return value
+    for attr in ("value", "expr"):
+        inner = getattr(value, attr, None)
+        if inner is not None and hasattr(inner, "node"):
+            return inner
+    return value
+
+
+def _alkahest_is_zero(expr: Any) -> bool | None:
+    """Try to prove ``expr == 0`` with Alkahest's own simplifiers."""
+    ak = _ak()
+    for route in (ak.simplify, ak.simplify_expanded):
+        try:
+            out = _unwrap(route(expr))
+        except Exception:
+            continue
+        if hasattr(out, "node") and _is_exact_zero(out):
+            return True
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rigorous numeric machinery
+# ---------------------------------------------------------------------------
+
+#: Absolute slack allowed when comparing a rigorous Alkahest enclosure against
+#: an oracle's floating value. The enclosure is rigorous; the oracle's number is
+#: not, so the slack is entirely the oracle's error budget. Without it every
+#: check would "diverge" on the oracle's last ulp — the exact false-alarm shape
+#: that trains people to ignore the alarm.
+ORACLE_SLACK_ABS = 1e-9
+ORACLE_SLACK_REL = 1e-9
+
+#: Default sample count and seed for the pointwise rungs. The seed is only used
+#: when no :class:`alkahest.Budget` seed is active, so a sweep run under
+#: ``context(budget=Budget(seed=...))`` is reproducible from that seed alone.
+DEFAULT_POINTS = 5
+DEFAULT_SEED = 20260810
+
+
+def _seed(explicit: int | None = None) -> int:
+    if explicit is not None:
+        return explicit
+    ak = _ak()
+    try:
+        active = ak.budget_seed()
+    except Exception:  # pragma: no cover - native budget unavailable
+        active = None
+    return DEFAULT_SEED if active is None else int(active)
+
+
+#: The band every sample point is drawn from, and the box the region-level
+#: refutation is certified over. Positive and away from zero on purpose:
+#: negative and near-zero arguments put ``log``, ``sqrt`` and negative powers on
+#: or across a branch cut, where the two systems legitimately differ and the
+#: resulting "divergence" would be about conventions rather than correctness.
+SAMPLE_BOX = (0.35, 2.65)
+
+
+def _sample_points(names: Sequence[str], rng: random.Random, count: int) -> list[dict[str, float]]:
+    """Deterministic sample points inside :data:`SAMPLE_BOX`."""
+    lo, hi = SAMPLE_BOX
+    return [{name: round(rng.uniform(lo, hi), 6) for name in names} for _ in range(count)]
+
+
+def _region_refutes_zero(expr: Any, symbols: Mapping[str, Any]) -> dict[str, list[float]] | None:
+    """Certify that *expr* keeps one sign across :data:`SAMPLE_BOX`, or ``None``.
+
+    :func:`alkahest.verified_sign` answers this over a whole box in one call,
+    which is strictly more than the pointwise enclosure can say. It is used
+    only to *strengthen* a refutation that ball arithmetic already made — never
+    to create one — so the primary rung stays the one that also yields the
+    enclosure a witness needs.
+    """
+    ak = _ak()
+    if not symbols:
+        return None
+    lo, hi = SAMPLE_BOX
+    box = [(symbol, lo, hi) for _name, symbol in sorted(symbols.items())]
+    for predicate in ("positive", "negative"):
+        try:
+            verdict = ak.verified_sign(expr, box, predicate)
+        except Exception:
+            return None
+        if verdict == "true":
+            return {name: [lo, hi] for name in sorted(symbols)}
+    return None
+
+
+def _enclose(expr: Any, point: Mapping[str, float], symbols: Mapping[str, Any]) -> Any:
+    """Rigorous ball enclosure of *expr* at *point*, or ``None``."""
+    ak = _ak()
+    try:
+        bindings = {symbols[name]: ak.ArbBall(value, 0.0) for name, value in point.items()}
+        return ak.interval_eval(expr, bindings)
+    except Exception:
+        return None
+
+
+def _ball_bounds(ball: Any) -> tuple[float, float] | None:
+    try:
+        lo, hi = float(ball.lo), float(ball.hi)
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if lo != lo or hi != hi:
+        return None
+    return (lo, hi)
+
+
+def _excludes(bounds: tuple[float, float], value: float) -> bool:
+    """Does a rigorous enclosure exclude *value*, allowing the oracle its slack?"""
+    lo, hi = bounds
+    slack = ORACLE_SLACK_ABS + ORACLE_SLACK_REL * max(abs(lo), abs(hi), abs(value))
+    return value < lo - slack or value > hi + slack
+
+
+def _excludes_zero(bounds: tuple[float, float]) -> bool:
+    """Rigorous: the enclosure is built entirely from Alkahest expressions."""
+    lo, hi = bounds
+    return lo > 0.0 or hi < 0.0
+
+
+# ---------------------------------------------------------------------------
+# check()
+# ---------------------------------------------------------------------------
+
+
+def check(
+    operation: str,
+    *args: Any,
+    oracle: Oracle | str | None = None,
+    assumptions: Any = None,
+    points: int = DEFAULT_POINTS,
+    seed: int | None = None,
+    pool: Any = None,
+    **kwargs: Any,
+) -> CrossCheck:
+    """Run one query through Alkahest and through an oracle, and compare.
+
+    Parameters
+    ----------
+    operation : str
+        Name of an :data:`OPERATIONS` entry; also the ``alkahest`` module
+        attribute that is called on the Alkahest side.
+    *args
+        The arguments you would pass to ``alkahest.<operation>``.
+    oracle : Oracle or str, optional
+        Which oracle to use. Defaults to the first installed one.
+    assumptions : Assumptions, optional
+        Governing assumption context; defaults to
+        :func:`alkahest.active_assumptions`. An assumption with no faithful
+        mapping into the oracle's language yields ``incomparable``.
+    points : int
+        Sample count for the rigorous-numeric rung.
+    seed : int, optional
+        Sampling seed. Defaults to the active :class:`alkahest.Budget` seed,
+        then to :data:`DEFAULT_SEED`, so a check is reproducible.
+    pool : ExprPool, optional
+        Pool the arguments live in; defaults to :func:`alkahest.active_pool`.
+        Only needed to attempt the **Alkahest side** of the symbolic rung — the
+        oracle's answer has to be lifted back into a pool to be subtracted
+        there. Without it the rung still runs, in the oracle only, and the
+        record says which system proved what.
+    **kwargs
+        Forwarded to the Alkahest call.
+
+    Returns
+    -------
+    CrossCheck
+        Four-valued: ``agree`` / ``diverge`` / ``incomparable`` /
+        ``unavailable``. **A missing oracle is ``unavailable``, never
+        ``agree``.**
+
+    Raises
+    ------
+    CrossCheckError
+        ``E-XCHECK-003`` if *operation* has no defined comparison rung.
+        Untranslatable input and missing oracles are *outcomes*, not
+        exceptions; an unknown operation is a caller mistake.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> from alkahest.crosscheck import check
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> out = check("diff", ak.sin(x), x)
+    >>> out.outcome in {"agree", "unavailable"}
+    True
+    >>> out.outcome == "agree" or out.reason == "no_oracle"
+    True
+    """
+    started = time.perf_counter()
+    spec = OPERATIONS.get(operation)
+    if spec is None:
+        raise CrossCheckError(
+            f"no comparison rung is defined for operation {operation!r}",
+            code="E-XCHECK-003",
+            remediation=(
+                "Comparable operations: "
+                + ", ".join(sorted(OPERATIONS))
+                + ". A generic structural fallback is deliberately absent — it would "
+                "report the two systems' differing normal forms as divergences."
+            ),
+        )
+
+    resolved = _resolve_oracle(oracle)
+    if resolved is None:
+        return CrossCheck(
+            operation=operation,
+            outcome="unavailable",
+            reason="no_oracle",
+            detail=(
+                "no cross-check oracle is installed, so nothing was compared; this is not agreement"
+            ),
+            elapsed_ms=(time.perf_counter() - started) * 1000.0,
+        )
+
+    try:
+        return _compare(
+            spec,
+            resolved,
+            args,
+            kwargs,
+            assumptions=assumptions,
+            points=points,
+            seed=seed,
+            pool=pool,
+            started=started,
+        )
+    except CrossCheckError as exc:
+        reason = {
+            "E-XCHECK-001": "untranslatable",
+            "E-XCHECK-002": "no_oracle",
+            "E-XCHECK-003": "oracle_refused",
+        }.get(str(getattr(exc, "code", "")), "incomparable")
+        return CrossCheck(
+            operation=operation,
+            outcome="unavailable" if reason == "no_oracle" else "incomparable",
+            reason=reason,
+            detail=str(exc),
+            oracle=resolved.name,
+            oracle_version=_safe_version(resolved),
+            elapsed_ms=(time.perf_counter() - started) * 1000.0,
+        )
+
+
+def _safe_version(oracle: Oracle) -> str | None:
+    try:
+        return oracle.version
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _compare(
+    spec: Operation,
+    oracle: Oracle,
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any],
+    *,
+    assumptions: Any,
+    points: int,
+    seed: int | None,
+    pool: Any,
+    started: float,
+) -> CrossCheck:
+    ak = _ak()
+    version = _safe_version(oracle)
+
+    def finish(**fields: Any) -> CrossCheck:
+        fields.setdefault("oracle", oracle.name)
+        fields.setdefault("oracle_version", version)
+        fields["elapsed_ms"] = (time.perf_counter() - started) * 1000.0
+        return CrossCheck(operation=spec.name, **fields)
+
+    if not oracle.supports(spec.name):
+        raise _refuse(
+            f"oracle {oracle.name!r} cannot answer {spec.name!r}",
+            code="E-XCHECK-003",
+            remediation="Use a different oracle, or a different operation.",
+        )
+
+    # --- pose the same question to both sides ------------------------------
+    # Translation first: if the question cannot be posed identically there is
+    # nothing to compare, and running the Alkahest side anyway would tempt a
+    # caller to read the (uncompared) value as endorsed.
+    oracle_args = _translate_args(spec, oracle, args, kwargs, assumptions=assumptions)
+
+    try:
+        alkahest_raw = getattr(ak, spec.name)(*args, **kwargs)
+    except Exception as exc:
+        return finish(
+            outcome="incomparable",
+            reason="alkahest_refused",
+            detail=(
+                f"alkahest declined {spec.name} ({type(exc).__name__}: {exc}); "
+                "a refusal is not a divergence"
+            ),
+        )
+
+    oracle_answer = oracle.run(spec.name, oracle_args)
+
+    if spec.result == "solutions":
+        return _compare_solutions(spec, oracle, alkahest_raw, oracle_answer, oracle_args, finish)
+
+    alkahest_answer = _unwrap(alkahest_raw)
+    if not hasattr(alkahest_answer, "node"):
+        return finish(
+            outcome="incomparable",
+            reason="unsupported_result_shape",
+            detail=(
+                f"alkahest returned {type(alkahest_answer).__name__}, which has no comparison rung"
+            ),
+        )
+
+    if spec.normalize == "strip_big_o":
+        stripped = _strip_big_o(alkahest_answer)
+        if stripped is None:
+            return finish(
+                outcome="incomparable",
+                reason="empty_after_normalisation",
+                detail="the alkahest series has no terms below its O() remainder",
+            )
+        alkahest_answer = stripped
+
+    ctx = _Comparison(
+        spec=spec,
+        oracle=oracle,
+        alkahest_answer=alkahest_answer,
+        oracle_answer=oracle_answer,
+        oracle_args=oracle_args,
+        source_args=args,
+        assumptions=assumptions,
+        points=points,
+        rng=random.Random(_seed(seed)),
+        version=version or "unknown",
+        pool=pool if pool is not None else _active_pool(),
+    )
+
+    for rung in spec.rungs:
+        verdict = ctx.attempt(rung)
+        if verdict is not None:
+            return finish(**verdict)
+
+    return finish(
+        outcome="incomparable",
+        reason="ladder_exhausted",
+        alkahest_value=str(alkahest_answer),
+        oracle_value=oracle.render(oracle_answer),
+        detail=(
+            "no rung settled it: the two forms are not syntactically equal, neither "
+            "system proved the difference zero, and no point could be evaluated "
+            "rigorously — reported as incomparable rather than agreement"
+        ),
+    )
+
+
+def _translate_args(
+    spec: Operation,
+    oracle: Oracle,
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any],
+    *,
+    assumptions: Any,
+) -> dict[str, Any]:
+    """Build the oracle-side argument bundle, refusing anything untranslatable."""
+
+    def tr(expr: Any) -> Any:
+        return oracle.translate(expr, assumptions=assumptions)
+
+    if spec.name == "solve":
+        equations, variables = args[0], args[1]
+        return {
+            "equations": [tr(e) for e in equations],
+            "vars": [tr(v) for v in variables],
+        }
+
+    out: dict[str, Any] = {"expr": tr(args[0])}
+    if spec.name in ("simplify", "simplify_expanded"):
+        return out
+    if len(args) > 1:
+        out["var"] = tr(args[1])
+    if spec.name == "integrate":
+        out["lower"] = tr(args[2]) if len(args) > 2 else None
+        out["upper"] = tr(args[3]) if len(args) > 3 else None
+    elif spec.name == "limit":
+        out["point"] = tr(args[2]) if len(args) > 2 else None
+    elif spec.name == "series":
+        out["point"] = tr(args[2]) if len(args) > 2 else None
+        out["order"] = int(args[3]) if len(args) > 3 else int(kwargs.get("order", 6))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The ladder
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ResidualVerdict:
+    """One side's answer to "does this invariant residual vanish?".
+
+    ``proved`` is separate from ``status`` on purpose: "no sampled point
+    refuted it" and "a normaliser proved it zero" are both ``"holds"``, and
+    reporting the first as though it were the second is precisely how a
+    differential harness starts producing false confidence.
+    """
+
+    status: str
+    proved: bool
+    via: str
+    point: dict[str, float] | None = None
+    bounds: tuple[float, float] | None = None
+    region: dict[str, list[float]] | None = None
+
+
+@dataclass
+class _Comparison:
+    """Per-check state shared by the rungs."""
+
+    spec: Operation
+    oracle: Oracle
+    alkahest_answer: Any
+    oracle_answer: Any
+    oracle_args: Mapping[str, Any]
+    source_args: Sequence[Any]
+    assumptions: Any
+    points: int
+    rng: random.Random
+    version: str
+    pool: Any = None
+
+    def attempt(self, rung: int) -> dict[str, Any] | None:
+        """Run one rung; ``None`` means "inconclusive, try the next"."""
+        return {
+            RUNG_SYNTACTIC: self._syntactic,
+            RUNG_SYMBOLIC: self._symbolic,
+            RUNG_NUMERIC: self._numeric,
+            RUNG_INVARIANT: self._invariant,
+        }[rung]()
+
+    # -- shared -------------------------------------------------------------
+
+    @property
+    def may_refute(self) -> bool:
+        """May the answer-comparing rungs (1–3) report a *divergence*?
+
+        Only when the operation's answer is pinned exactly. Where an invariant
+        exists, the operation leaves freedom the answers are allowed to differ
+        by — ``+ C`` for an antiderivative, the additive constant in a Gosper
+        antidifference — so "the two answers are not equal" is not evidence of
+        disagreement, and reporting it as one would make the harness fire on
+        every correctly-integrated example that happened to reach these rungs.
+
+        Rung 4 runs first precisely so it settles those cases. When it comes
+        back inconclusive, rungs 1–3 may still *confirm* agreement (equal
+        answers agree under any freedom) but must fall through rather than
+        refute.
+        """
+        return self.spec.invariant is None
+
+    @property
+    def rendered(self) -> tuple[str, str]:
+        return str(self.alkahest_answer), self.oracle.render(self.oracle_answer)
+
+    def _translated_answer(self) -> Any | None:
+        try:
+            return self.oracle.translate(self.alkahest_answer, assumptions=self.assumptions)
+        except CrossCheckError:
+            return None
+
+    # -- rung 1 -------------------------------------------------------------
+
+    def _syntactic(self) -> dict[str, Any] | None:
+        translated = self._translated_answer()
+        if translated is None:
+            return None
+        try:
+            same = self.oracle.canonical(translated) == self.oracle.canonical(self.oracle_answer)
+        except Exception:
+            return None
+        if not same:
+            return None
+        ak_value, oracle_value = self.rendered
+        return {
+            "outcome": "agree",
+            "rung": RUNG_SYNTACTIC,
+            "reason": "identical_canonical_form",
+            "detail": "both systems produced the same canonical form",
+            "alkahest_value": ak_value,
+            "oracle_value": oracle_value,
+            "conclusive": True,
+        }
+
+    # -- rung 2 -------------------------------------------------------------
+
+    def _symbolic(self) -> dict[str, Any] | None:
+        """``simplify(a - b) == 0``, attempted independently in both systems.
+
+        Either system proving it counts as agreement — the point of running two
+        implementations is that they fail to normalise different things.
+        """
+        ak_value, oracle_value = self.rendered
+        prover: str | None = None
+
+        translated = self._translated_answer()
+        if translated is not None:
+            verdict = self.oracle.is_zero(translated - self.oracle_answer)
+            if verdict is True:
+                prover = self.oracle.name
+            elif verdict is False:
+                if not self.may_refute:
+                    return None
+                return self._symbolic_divergence(ak_value, oracle_value)
+
+        if prover is None:
+            lifted = self._lift_oracle_answer()
+            if lifted is not None and _alkahest_is_zero(self.alkahest_answer - lifted):
+                prover = "alkahest"
+
+        if prover is None:
+            return None
+        return {
+            "outcome": "agree",
+            "rung": RUNG_SYMBOLIC,
+            "reason": "difference_proved_zero",
+            "detail": f"{prover} proved the difference of the two answers is identically zero",
+            "alkahest_value": ak_value,
+            "oracle_value": oracle_value,
+            "conclusive": True,
+        }
+
+    def _symbolic_divergence(self, ak_value: str, oracle_value: str) -> dict[str, Any]:
+        divergence = Divergence(
+            operation=self.spec.name,
+            oracle=self.oracle.name,
+            oracle_version=self.version,
+            alkahest_value=ak_value,
+            oracle_value=oracle_value,
+            support="unresolved",
+            detail=(
+                f"{self.oracle.name} determined the difference of the two answers is "
+                "not identically zero; which of the two is wrong is not established here"
+            ),
+        )
+        return {
+            "outcome": "diverge",
+            "rung": RUNG_SYMBOLIC,
+            "reason": "difference_proved_nonzero",
+            "detail": divergence.detail,
+            "alkahest_value": ak_value,
+            "oracle_value": oracle_value,
+            "divergence": divergence,
+            "conclusive": True,
+        }
+
+    def _lift_oracle_answer(self) -> Any | None:
+        if self.pool is None:
+            return None
+        try:
+            return self.oracle.lift(self.oracle_answer, self.pool)
+        except Exception:
+            return None
+
+    # -- rung 3 -------------------------------------------------------------
+
+    def _numeric(self) -> dict[str, Any] | None:
+        """Sample and evaluate with rigorous ball arithmetic.
+
+        The asymmetry is the point: a ball is a *rigorous* enclosure of the
+        Alkahest answer, so a value outside it is a real disagreement rather
+        than float noise — while agreement here is only ever "not refuted at
+        the points sampled", which is why :attr:`CrossCheck.conclusive` is
+        ``False`` for this rung.
+        """
+        symbols = _free_symbols(self.alkahest_answer)
+        ak_value, oracle_value = self.rendered
+        checked = 0
+        for point in _sample_points(sorted(symbols), self.rng, self.points):
+            ball = _enclose(self.alkahest_answer, point, symbols)
+            bounds = _ball_bounds(ball) if ball is not None else None
+            if bounds is None:
+                continue
+            value = self._oracle_at(point)
+            if value is None:
+                continue
+            checked += 1
+            if _excludes(bounds, value):
+                if not self.may_refute:
+                    # The answers differ at this point, but the operation lets
+                    # them (see `may_refute`). Not agreement either — fall
+                    # through to `incomparable` rather than call it clean.
+                    return None
+                divergence = Divergence(
+                    operation=self.spec.name,
+                    oracle=self.oracle.name,
+                    oracle_version=self.version,
+                    point=dict(point),
+                    alkahest_value=f"{ak_value} = {bounds[0]!r}..{bounds[1]!r}",
+                    oracle_value=f"{oracle_value} = {value!r}",
+                    alkahest_enclosure=bounds,
+                    support="unresolved",
+                    detail=(
+                        "the rigorous enclosure of the alkahest answer excludes the "
+                        f"{self.oracle.name} value at this point; one of the two is "
+                        "wrong and this rung does not say which"
+                    ),
+                )
+                return {
+                    "outcome": "diverge",
+                    "rung": RUNG_NUMERIC,
+                    "reason": "enclosure_excludes_oracle_value",
+                    "detail": divergence.detail,
+                    "alkahest_value": ak_value,
+                    "oracle_value": oracle_value,
+                    "witness": _witness(divergence),
+                    "divergence": divergence,
+                    "conclusive": True,
+                }
+        if checked == 0:
+            return None
+        return {
+            "outcome": "agree",
+            "rung": RUNG_NUMERIC,
+            "reason": "not_refuted_numerically",
+            "detail": (
+                f"rigorous enclosures at {checked} sampled point(s) contain the "
+                f"{self.oracle.name} value; sampling cannot prove agreement, only fail "
+                "to refute it"
+            ),
+            "alkahest_value": ak_value,
+            "oracle_value": oracle_value,
+            "conclusive": False,
+        }
+
+    def _oracle_at(self, point: Mapping[str, float]) -> float | None:
+        try:
+            substituted = self.oracle.subs_by_name(self.oracle_answer, point)
+        except Exception:
+            return None
+        return self.oracle.to_float(substituted)
+
+    # -- rung 4 -------------------------------------------------------------
+
+    def _invariant(self) -> dict[str, Any] | None:
+        builder = _INVARIANTS.get(self.spec.invariant or "")
+        if builder is None:
+            return None
+        try:
+            residuals = builder(self)
+        except CrossCheckError:
+            raise
+        except Exception:
+            return None
+        if residuals is None:
+            return None
+        ak_residual, oracle_residual = residuals
+
+        ak_side = self._residual_verdict(ak_residual)
+        oracle_side = self._oracle_residual_verdict(oracle_residual)
+        ak_verdict, oracle_verdict = ak_side.status, oracle_side.status
+        ak_point, ak_bounds, ak_region = ak_side.point, ak_side.bounds, ak_side.region
+
+        ak_value, oracle_value = self.rendered
+        if ak_verdict == "holds" and oracle_verdict == "holds":
+            proved = ak_side.proved and oracle_side.proved
+            return {
+                "outcome": "agree",
+                "rung": RUNG_INVARIANT,
+                "reason": "invariant_holds" if proved else "invariant_not_refuted",
+                "detail": (
+                    f"both answers satisfy the {self.spec.invariant} invariant "
+                    f"({ak_side.via} / {oracle_side.via}), so they agree up to the "
+                    "freedom the operation leaves"
+                    if proved
+                    else (
+                        f"neither answer's {self.spec.invariant} residual could be "
+                        f"refuted ({ak_side.via} / {oracle_side.via}), but neither was "
+                        "proved zero either — this is sampled evidence, not a proof"
+                    )
+                ),
+                "alkahest_value": ak_value,
+                "oracle_value": oracle_value,
+                "conclusive": proved,
+            }
+        if ak_verdict == "refuted" or oracle_verdict == "refuted":
+            support = {
+                ("refuted", "holds"): "oracle_supported",
+                ("holds", "refuted"): "alkahest_supported",
+            }.get((ak_verdict, oracle_verdict), "unresolved")
+            detail = {
+                "oracle_supported": (
+                    f"the alkahest answer fails the {self.spec.invariant} invariant under "
+                    f"rigorous ball arithmetic while the {self.oracle.name} answer satisfies "
+                    "it — a silent-error candidate for tests/silent_errors/corpus.py"
+                ),
+                "alkahest_supported": (
+                    f"the {self.oracle.name} answer fails the {self.spec.invariant} "
+                    "invariant while the alkahest answer satisfies it"
+                ),
+                "unresolved": (
+                    f"at least one answer fails the {self.spec.invariant} invariant; the "
+                    "evidence does not establish which system is at fault"
+                ),
+            }[support]
+            if ak_region is not None:
+                detail += (
+                    "; the alkahest residual is certified to keep one sign across "
+                    f"{SAMPLE_BOX[0]}..{SAMPLE_BOX[1]}, so the failure is not pointwise"
+                )
+            divergence = Divergence(
+                operation=self.spec.name,
+                oracle=self.oracle.name,
+                oracle_version=self.version,
+                point=dict(ak_point or {}),
+                alkahest_value=ak_value,
+                oracle_value=oracle_value,
+                alkahest_enclosure=ak_bounds,
+                support=support,
+                region=ak_region,
+                detail=detail,
+            )
+            return {
+                "outcome": "diverge",
+                "rung": RUNG_INVARIANT,
+                "reason": f"invariant_failed_{support}",
+                "detail": detail,
+                "alkahest_value": ak_value,
+                "oracle_value": oracle_value,
+                "witness": _witness(divergence),
+                "divergence": divergence,
+                "conclusive": True,
+            }
+        return None
+
+    def _residual_verdict(self, residual: Any) -> _ResidualVerdict:
+        """Does the Alkahest-side invariant residual vanish?
+
+        Three routes, tried in order of what they license:
+
+        1. Alkahest's own simplifiers prove it zero — a proof, and the one
+           route with no second system in it.
+        2. Rigorous ball arithmetic **excludes** zero at a sampled point — also
+           a proof, of the opposite. This residual is built purely from
+           Alkahest expressions, so there is no oracle float in it to blame:
+           a refutation here says the Alkahest answer is wrong, full stop.
+        3. The oracle's normaliser is asked about the *translated* residual.
+           This still cross-checks Alkahest's engine — the residual came out of
+           Alkahest's own ``diff``/``subs`` — it just borrows a second
+           normaliser to decide it, which is the whole point of having one.
+
+        Falling through all three leaves sampled non-refutation, reported with
+        ``proved=False`` so rung-4 agreement built on it is not dressed up as a
+        proof.
+        """
+        if residual is None:
+            return _ResidualVerdict("unknown", False, "no residual available")
+        if _alkahest_is_zero(residual):
+            return _ResidualVerdict("holds", True, "alkahest proved the residual zero")
+        symbols = _free_symbols(residual)
+        checked = 0
+        for point in _sample_points(sorted(symbols), self.rng, self.points):
+            ball = _enclose(residual, point, symbols)
+            bounds = _ball_bounds(ball) if ball is not None else None
+            if bounds is None:
+                continue
+            checked += 1
+            if _excludes_zero(bounds):
+                return _ResidualVerdict(
+                    "refuted",
+                    True,
+                    "a rigorous enclosure of the alkahest residual excludes zero",
+                    point=dict(point),
+                    bounds=bounds,
+                    region=_region_refutes_zero(residual, symbols),
+                )
+        try:
+            translated = self.oracle.translate(residual, assumptions=self.assumptions)
+        except CrossCheckError:
+            translated = None
+        if translated is not None:
+            verdict = self.oracle.is_zero(translated)
+            if verdict is True:
+                return _ResidualVerdict(
+                    "holds", True, f"{self.oracle.name} normalised the alkahest residual to zero"
+                )
+            if verdict is False and checked == 0:
+                # No rigorous enclosure was available, so this is the oracle's
+                # word alone; recorded as a refutation but not as a proof.
+                return _ResidualVerdict(
+                    "refuted",
+                    False,
+                    f"{self.oracle.name} determined the alkahest residual is non-zero",
+                )
+        if checked:
+            return _ResidualVerdict(
+                "holds", False, f"zero is inside every enclosure at {checked} sampled point(s)"
+            )
+        return _ResidualVerdict("unknown", False, "the residual could not be decided or evaluated")
+
+    def _oracle_residual_verdict(self, residual: Any) -> _ResidualVerdict:
+        if residual is None:
+            return _ResidualVerdict("unknown", False, "no residual available")
+        verdict = self.oracle.is_zero(residual)
+        if verdict is True:
+            return _ResidualVerdict(
+                "holds", True, f"{self.oracle.name} proved its own residual zero"
+            )
+        if verdict is False:
+            return _ResidualVerdict(
+                "refuted", True, f"{self.oracle.name} determined its own residual is non-zero"
+            )
+        return _ResidualVerdict("unknown", False, f"{self.oracle.name} could not decide")
+
+
+def _witness(divergence: Divergence) -> dict[str, Any]:
+    return {
+        "point": dict(divergence.point),
+        "alkahest": divergence.alkahest_value,
+        "oracle": divergence.oracle_value,
+        "enclosure": list(divergence.alkahest_enclosure) if divergence.alkahest_enclosure else None,
+    }
+
+
+def _active_pool() -> Any:
+    """The ambient pool, or ``None``.
+
+    :class:`alkahest.Expr` deliberately does not expose the pool it was interned
+    in, so the only routes to one are the caller's ``pool=`` argument and the
+    ambient context. When neither is available the pool-dependent half of the
+    ladder is skipped rather than guessed at — mixing pools raises ``E-POOL-*``,
+    and a check must not fail for a reason that has nothing to do with the
+    mathematics.
+    """
+    ak = _ak()
+    try:
+        return ak.active_pool()
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+# -- the rung-4 invariants ---------------------------------------------------
+#
+# Each returns ``(alkahest_residual_expr | None, oracle_residual_obj | None)``;
+# both must vanish. Returning ``None`` on a side means "this side could not be
+# checked", which makes the rung inconclusive rather than a divergence.
+
+
+def _inv_antiderivative(ctx: _Comparison) -> tuple[Any, Any] | None:
+    """``d/dx F - f == 0`` — the check that ignores ``+ C``."""
+    ak = _ak()
+    integrand, var = ctx.source_args[0], ctx.source_args[1]
+    if len(ctx.source_args) > 2:  # definite integral: no antiderivative to check
+        return None
+    ak_residual = _unwrap(ak.diff(ctx.alkahest_answer, var)) - integrand
+    oracle_residual = (
+        ctx.oracle.diff(ctx.oracle_answer, ctx.oracle_args["var"]) - ctx.oracle_args["expr"]
+    )
+    return (ak_residual, oracle_residual)
+
+
+def _inv_value_preserving(ctx: _Comparison) -> tuple[Any, Any] | None:
+    """``simplified - original == 0`` — a simplifier's whole contract."""
+    original = ctx.source_args[0]
+    ak_residual = ctx.alkahest_answer - original
+    oracle_residual = ctx.oracle_answer - ctx.oracle_args["expr"]
+    return (ak_residual, oracle_residual)
+
+
+def _inv_antidifference(ctx: _Comparison) -> tuple[Any, Any] | None:
+    """``S(k+1) - S(k) - t(k) == 0`` — Gosper's defining property."""
+    ak = _ak()
+    term, var = ctx.source_args[0], ctx.source_args[1]
+    shifted = _unwrap(ak.subs(ctx.alkahest_answer, {var: var + 1}))
+    ak_residual = shifted - ctx.alkahest_answer - term
+    ovar = ctx.oracle_args["var"]
+    oracle_residual = (
+        ctx.oracle.subs(ctx.oracle_answer, {ovar: ovar + 1})
+        - ctx.oracle_answer
+        - ctx.oracle_args["expr"]
+    )
+    return (ak_residual, oracle_residual)
+
+
+_INVARIANTS: dict[str, Callable[[_Comparison], tuple[Any, Any] | None]] = {
+    "antiderivative": _inv_antiderivative,
+    "value_preserving": _inv_value_preserving,
+    "antidifference": _inv_antidifference,
+}
+
+
+def _strip_big_o(expr: Any) -> Any | None:
+    """Drop top-level ``O(...)`` terms from a series expression."""
+    node = expr.node()
+    if node[0] == "big_o":
+        return None
+    if node[0] != "add":
+        return expr
+    kept = [term for term in node[1] if term.node()[0] != "big_o"]
+    if not kept:
+        return None
+    out = kept[0]
+    for term in kept[1:]:
+        out = out + term
+    return out
+
+
+# ---------------------------------------------------------------------------
+# solve: substitute both solution sets back
+# ---------------------------------------------------------------------------
+
+
+def _compare_solutions(
+    spec: Operation,
+    oracle: Oracle,
+    alkahest_raw: Any,
+    oracle_answer: Any,
+    oracle_args: Mapping[str, Any],
+    finish: Callable[..., CrossCheck],
+) -> CrossCheck:
+    """Rung 4 for ``solve``: verify both sides, then compare the sets.
+
+    Solution *sets* compare badly by construction — ordering, radical form, and
+    which branch a root is written in all differ. Substituting back checks each
+    system's answers on their own terms, and only then does the set comparison
+    mean something: with both sides verified, a size difference is a genuinely
+    **missed solution**, not a formatting artefact.
+    """
+    if not isinstance(alkahest_raw, list):
+        return finish(
+            outcome="incomparable",
+            reason="unsupported_result_shape",
+            detail=f"alkahest.solve returned {type(alkahest_raw).__name__}",
+        )
+
+    equations = list(oracle_args["equations"])
+    ak_sets: list[frozenset[tuple[str, str]]] = []
+    for solution in alkahest_raw:
+        bindings = {oracle.translate(k): oracle.translate(v) for k, v in solution.items()}
+        translated = {str(k): oracle.translate(v) for k, v in solution.items()}
+        for equation in equations:
+            residual = oracle.subs(equation, bindings)
+            if oracle.is_zero(residual) is False:
+                divergence = Divergence(
+                    operation=spec.name,
+                    oracle=oracle.name,
+                    oracle_version=_safe_version(oracle) or "unknown",
+                    point={str(k): 0.0 for k in solution},
+                    alkahest_value=_render_solutions(alkahest_raw),
+                    oracle_value=_render_oracle_solutions(oracle, oracle_answer),
+                    support="oracle_supported",
+                    detail=(
+                        f"an alkahest solution does not satisfy the system when "
+                        f"substituted back ({oracle.name} evaluated the residual as "
+                        "non-zero) — a silent-error candidate"
+                    ),
+                )
+                return finish(
+                    outcome="diverge",
+                    rung=RUNG_INVARIANT,
+                    reason="invariant_failed_oracle_supported",
+                    detail=divergence.detail,
+                    alkahest_value=divergence.alkahest_value,
+                    oracle_value=divergence.oracle_value,
+                    witness=_witness(divergence),
+                    divergence=divergence,
+                    conclusive=True,
+                )
+        ak_sets.append(frozenset((k, oracle.canonical(v)) for k, v in translated.items()))
+
+    oracle_sets = [
+        frozenset((k, oracle.canonical(v)) for k, v in solution.items())
+        for solution in oracle_answer
+    ]
+
+    if len(ak_sets) != len(oracle_sets):
+        divergence = Divergence(
+            operation=spec.name,
+            oracle=oracle.name,
+            oracle_version=_safe_version(oracle) or "unknown",
+            alkahest_value=_render_solutions(alkahest_raw),
+            oracle_value=_render_oracle_solutions(oracle, oracle_answer),
+            support="unresolved",
+            detail=(
+                f"alkahest returned {len(ak_sets)} solution(s) and {oracle.name} returned "
+                f"{len(oracle_sets)}; every alkahest solution verified, so one of the two "
+                "systems has a different solution *set*, and this does not say which is "
+                "complete"
+            ),
+        )
+        return finish(
+            outcome="diverge",
+            rung=RUNG_INVARIANT,
+            reason="solution_set_size_differs",
+            detail=divergence.detail,
+            alkahest_value=divergence.alkahest_value,
+            oracle_value=divergence.oracle_value,
+            divergence=divergence,
+            conclusive=True,
+        )
+
+    return finish(
+        outcome="agree",
+        rung=RUNG_INVARIANT,
+        reason="invariant_holds",
+        detail=(
+            "every alkahest solution satisfies the system when substituted back, and both "
+            "systems returned the same number of solutions"
+        ),
+        alkahest_value=_render_solutions(alkahest_raw),
+        oracle_value=_render_oracle_solutions(oracle, oracle_answer),
+        conclusive=True,
+    )
+
+
+def _render_solutions(solutions: Sequence[Mapping[Any, Any]]) -> str:
+    rendered = [
+        "{" + ", ".join(f"{k}: {v}" for k, v in sorted(s.items(), key=lambda kv: str(kv[0]))) + "}"
+        for s in solutions
+    ]
+    return "[" + ", ".join(rendered) + "]"
+
+
+def _render_oracle_solutions(oracle: Oracle, solutions: Sequence[Mapping[str, Any]]) -> str:
+    rendered = [
+        "{" + ", ".join(f"{k}: {oracle.render(v)}" for k, v in sorted(s.items())) + "}"
+        for s in solutions
+    ]
+    return "[" + ", ".join(rendered) + "]"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: the seeded sweep
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SweepReport:
+    """Result of a seeded differential sweep.
+
+    Attributes
+    ----------
+    seed : int
+        **Print this.** A sweep is only useful as a bug report if the run that
+        found something can be reproduced exactly.
+    oracle, oracle_version : str or None
+        Which system, at which version. A sweep that turns red after a SymPy
+        upgrade is a different event from one that turns red after an Alkahest
+        change, and only the recorded version tells them apart.
+    checks : tuple of CrossCheck
+        Every check run, in order.
+    """
+
+    seed: int
+    oracle: str | None
+    oracle_version: str | None
+    checks: tuple[CrossCheck, ...]
+
+    @property
+    def findings(self) -> tuple[CrossCheck, ...]:
+        """Checks whose outcome was ``diverge``."""
+        return tuple(c for c in self.checks if c.outcome == "diverge")
+
+    @property
+    def silent_error_candidates(self) -> tuple[CrossCheck, ...]:
+        """Findings where Alkahest's side was rigorously refuted."""
+        return tuple(
+            c for c in self.findings if c.divergence and c.divergence.silent_error_candidate
+        )
+
+    def counts(self) -> dict[str, int]:
+        """Outcome histogram, total over :data:`OUTCOMES`."""
+        out = dict.fromkeys(OUTCOMES, 0)
+        for c in self.checks:
+            out[c.outcome] = out.get(c.outcome, 0) + 1
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serialisable view, suitable for filing as a CI artifact."""
+        return {
+            "seed": self.seed,
+            "oracle": self.oracle,
+            "oracle_version": self.oracle_version,
+            "counts": self.counts(),
+            "checks": [c.as_dict() for c in self.checks],
+        }
+
+    def summary(self) -> str:
+        """One-screen report; print it from the nightly job."""
+        counts = self.counts()
+        lines = [
+            f"crosscheck sweep: seed={self.seed} oracle={self.oracle} "
+            f"version={self.oracle_version}",
+            "  " + "  ".join(f"{k}={counts[k]}" for k in OUTCOMES),
+        ]
+        for finding in self.findings:
+            lines.append(f"  DIVERGE {finding.operation}: {finding.detail}")
+        return "\n".join(lines)
+
+
+#: Operations the default sweep exercises. Chosen so the *comparator* is what
+#: gets stressed — every one of these has a rung 4 or a rigorous rung 3.
+#:
+#: ``limit`` is deliberately absent, and the reason is worth recording: at this
+#: commit ``limit(sqrt(x**2 + x) - x, x, oo)`` does not terminate, and because
+#: the kernel holds the GIL throughout there is no in-process way to bound it —
+#: a worker thread cannot be stopped, and an abandoned one wedges the
+#: interpreter just the same. See :func:`sweep` for what to do about that.
+SWEEP_OPERATIONS = ("diff", "integrate", "simplify")
+
+
+def sweep(
+    *,
+    seed: int | None = None,
+    cases: int = 40,
+    operations: Sequence[str] = SWEEP_OPERATIONS,
+    oracle: Oracle | str | None = None,
+    pool: Any = None,
+    points: int = DEFAULT_POINTS,
+) -> SweepReport:
+    """Run a seeded differential sweep and report what diverged.
+
+    This is the **nightly** tier of the two-tier arrangement described in
+    ``docs/mdbook/src/crosscheck.md``. It is deliberately not a per-PR gate: it
+    is randomised, and an oracle upgrade would turn it red for reasons that have
+    nothing to do with the pull request under review. Its findings are meant to
+    be promoted into :data:`FROZEN_CORPUS`, which *is* the per-PR gate.
+
+    .. warning::
+
+       **Neither side is bounded, and this module does not pretend otherwise.**
+       Alkahest's heavy engines hold the GIL, so a non-terminating call cannot
+       be timed out from Python: a worker thread cannot be stopped, and
+       abandoning one wedges the interpreter anyway. SymPy is no better placed.
+       Run the nightly job under an OS-level timeout, and wrap the sweep in
+       ``context(budget=...)`` for the engines that *are* cooperative
+       (:func:`alkahest.integrate`, best-effort :func:`alkahest.simplify` — see
+       ``docs/mdbook/src/budgets.md``). :data:`SWEEP_OPERATIONS` is chosen to
+       stay clear of the paths known not to terminate.
+
+    Parameters
+    ----------
+    seed : int, optional
+        Defaults to the active :class:`alkahest.Budget` seed, then to
+        :data:`DEFAULT_SEED`. Always recorded on the report.
+    cases : int
+        Number of expressions to generate.
+    operations : sequence of str
+        Which :data:`OPERATIONS` entries to exercise.
+    oracle : Oracle or str, optional
+        Defaults to the first installed oracle. With none installed the report
+        is all ``unavailable`` — the sweep does not pretend to have run.
+    pool : ExprPool, optional
+        Pool to build candidates in; a fresh one by default.
+    points : int
+        Sample count passed to :func:`check`.
+    Returns
+    -------
+    SweepReport
+    """
+    ak = _ak()
+    resolved_seed = _seed(seed)
+    rng = random.Random(resolved_seed)
+    pool = pool if pool is not None else ak.ExprPool()
+    x = pool.symbol("x")
+    resolved = _resolve_oracle(oracle)
+
+    checks: list[CrossCheck] = []
+    for index in range(cases):
+        operation = operations[index % len(operations)]
+        expr = _random_expr(pool, x, rng)
+        args = (expr,) if operation == "simplify" else (expr, x)
+        checks.append(
+            check(
+                operation,
+                *args,
+                oracle=resolved,
+                points=points,
+                seed=resolved_seed + index,
+                pool=pool,
+            )
+        )
+    return SweepReport(
+        seed=resolved_seed,
+        oracle=resolved.name if resolved else None,
+        oracle_version=_safe_version(resolved) if resolved else None,
+        checks=tuple(checks),
+    )
+
+
+def _random_expr(pool: Any, x: Any, rng: random.Random, depth: int = 0) -> Any:
+    """A small deterministic grammar of expressions both systems should handle.
+
+    Kept simple on purpose. The job of the sweep is to exercise the
+    *comparator* — translation, the ladder, the witness machinery — not to find
+    the hardest integrand in the world; a corpus tuned to whatever the current
+    build happens to be good at measures the corpus, not the build.
+    """
+    ak = _ak()
+    if depth >= 2 or rng.random() < 0.45:
+        choice = rng.randrange(6)
+        if choice == 0:
+            return x ** pool.integer(rng.randint(1, 4))
+        if choice == 1:
+            return ak.sin(x)
+        if choice == 2:
+            return ak.cos(x)
+        if choice == 3:
+            return ak.exp(x)
+        if choice == 4:
+            return pool.integer(rng.randint(1, 5)) * x
+        return pool.integer(rng.randint(-4, 4))
+    left = _random_expr(pool, x, rng, depth + 1)
+    right = _random_expr(pool, x, rng, depth + 1)
+    return left + right if rng.random() < 0.6 else left * right
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: the frozen corpus
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FrozenCase:
+    """One previously-observed comparison, pinned to an oracle version range.
+
+    The per-PR half of the two-tier arrangement. Every case records the oracle
+    version range its expectation was established against: without that the
+    corpus rots silently the first time the oracle changes an answer, which it
+    will, and a red gate would then be indistinguishable from a real regression.
+
+    Attributes
+    ----------
+    id : str
+        Stable, never reused.
+    operation : str
+        An :data:`OPERATIONS` key.
+    build : callable
+        ``pool -> tuple`` of arguments for :func:`check`. Takes the pool so each
+        run gets a fresh one.
+    expected : str
+        Expected :attr:`CrossCheck.outcome`.
+    expected_reason : str or None
+        Expected :attr:`CrossCheck.reason`, when the case is pinning *why*.
+    oracle : str
+        Oracle name the expectation belongs to.
+    oracle_versions : str
+        Comma-separated PEP-440-ish range, e.g. ``">=1.12,<2"``. A case whose
+        range excludes the installed version is skipped, not failed.
+    found_by : str
+        ``"seeded sweep, seed=..."`` or a hand-written provenance note. The
+        ratchet: a divergence the nightly finds must land here.
+    note : str
+        What this case is protecting.
+    """
+
+    id: str
+    operation: str
+    build: Callable[[Any], tuple[Any, ...]]
+    expected: str
+    oracle: str = "sympy"
+    oracle_versions: str = ">=1.12"
+    found_by: str = ""
+    note: str = ""
+    expected_reason: str | None = None
+
+    def applies_to(self, version: str) -> bool:
+        """Does this case's expectation cover *version* of its oracle?"""
+        return _version_in_range(version, self.oracle_versions)
+
+
+def _parse_version(text: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for chunk in str(text).split("."):
+        digits = ""
+        for character in chunk:
+            if not character.isdigit():
+                break
+            digits += character
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _version_in_range(version: str, spec: str) -> bool:
+    """Tiny comparator for ``">=1.12,<2"``-style ranges.
+
+    Deliberately dependency-free: pulling ``packaging`` in for five operators
+    would put a new install requirement on a module whose entire point is to
+    work in whatever environment the loop happens to have.
+    """
+    actual = _parse_version(version)
+    for clause in (c.strip() for c in spec.split(",") if c.strip()):
+        for operator in ("!=", ">=", "<=", "==", ">", "<"):
+            if clause.startswith(operator):
+                bound = _parse_version(clause[len(operator) :])
+                width = max(len(actual), len(bound))
+                left = actual + (0,) * (width - len(actual))
+                right = bound + (0,) * (width - len(bound))
+                ok = {
+                    ">=": left >= right,
+                    "<=": left <= right,
+                    "==": left == right,
+                    "!=": left != right,
+                    ">": left > right,
+                    "<": left < right,
+                }[operator]
+                if not ok:
+                    return False
+                break
+        else:  # pragma: no cover - malformed spec
+            raise ValueError(f"unparseable version clause {clause!r}")
+    return True
+
+
+def _case_polynomial_antiderivative(pool: Any) -> tuple[Any, ...]:
+    x = pool.symbol("x")
+    return (x ** pool.integer(3) + pool.integer(2) * x, x)
+
+
+def _case_trig_antiderivative(pool: Any) -> tuple[Any, ...]:
+    ak = _ak()
+    x = pool.symbol("x")
+    return (ak.sin(x) * ak.cos(x), x)
+
+
+def _case_chain_rule(pool: Any) -> tuple[Any, ...]:
+    ak = _ak()
+    x = pool.symbol("x")
+    return (ak.sin(ak.exp(x)), x)
+
+
+def _case_pythagorean_simplify(pool: Any) -> tuple[Any, ...]:
+    ak = _ak()
+    x = pool.symbol("x")
+    return (ak.sin(x) ** pool.integer(2) + ak.cos(x) ** pool.integer(2),)
+
+
+def _case_gosper_linear(pool: Any) -> tuple[Any, ...]:
+    k = pool.symbol("k")
+    return (k, k)
+
+
+def _case_quadratic_solve(pool: Any) -> tuple[Any, ...]:
+    x = pool.symbol("x")
+    return ([x ** pool.integer(2) - pool.integer(4)], [x])
+
+
+def _case_exp_series(pool: Any) -> tuple[Any, ...]:
+    ak = _ak()
+    x = pool.symbol("x")
+    return (ak.exp(x), x, pool.integer(0), 5)
+
+
+def _case_root_sum_antiderivative(pool: Any) -> tuple[Any, ...]:
+    x = pool.symbol("x")
+    return (x / (x ** pool.integer(4) + pool.integer(1)), x)
+
+
+def _case_pythagorean_derivative(pool: Any) -> tuple[Any, ...]:
+    ak = _ak()
+    x = pool.symbol("x")
+    return (ak.sin(ak.exp(x)) * ak.cos(x), x)
+
+
+#: Previously-observed comparisons, re-run on every pull request.
+#:
+#: This is the ratchet's downstream end: a divergence the nightly sweep finds
+#: must be promoted into a case here (with ``found_by`` naming the seed), or it
+#: only ever gets exercised by a job nobody reads. Cases are added, never
+#: silently deleted — an expectation that changes is a re-pin with a new
+#: ``oracle_versions`` range, and the old range says what used to be true.
+FROZEN_CORPUS: tuple[FrozenCase, ...] = (
+    FrozenCase(
+        id="integrate_polynomial",
+        operation="integrate",
+        build=_case_polynomial_antiderivative,
+        expected="agree",
+        expected_reason="invariant_holds",
+        found_by="hand-written baseline",
+        note=(
+            "The rung-4 control. Both antiderivatives differ by a constant and by "
+            "term order, so any rung below 4 would report noise here."
+        ),
+    ),
+    FrozenCase(
+        id="integrate_sin_cos",
+        operation="integrate",
+        build=_case_trig_antiderivative,
+        expected="agree",
+        expected_reason="invariant_holds",
+        found_by="hand-written baseline",
+        note=(
+            "sin(x)cos(x) has three standard antiderivatives that differ by "
+            "constants; differentiating both is the only comparison that survives it."
+        ),
+    ),
+    FrozenCase(
+        id="integrate_root_sum",
+        operation="integrate",
+        build=_case_root_sum_antiderivative,
+        expected="agree",
+        expected_reason="invariant_holds",
+        found_by="hand probe, 2026-08-11: the only observed route through the root_sum node",
+        note=(
+            "Alkahest answers with a RootSum and SymPy with atan(x^2)/2. Nothing below "
+            "rung 4 settles it, ball arithmetic cannot evaluate a RootSum at all, and "
+            "the case only lands on 'agree' because the invariant rung falls back to "
+            "the oracle's normaliser for the alkahest-side residual. It is the case "
+            "that pins that fallback, and the root_sum translation with it."
+        ),
+    ),
+    FrozenCase(
+        id="diff_chain_rule",
+        operation="diff",
+        build=_case_chain_rule,
+        expected="agree",
+        found_by="hand-written baseline",
+        note="Composite derivative — exercises the ladder where no invariant exists.",
+    ),
+    FrozenCase(
+        id="diff_product_of_composites",
+        operation="diff",
+        build=_case_pythagorean_derivative,
+        expected="agree",
+        found_by="hand-written baseline",
+        note=(
+            "Product and chain rule together; the two systems order the factors "
+            "differently, so this exercises rungs 2 and 3 rather than rung 1."
+        ),
+    ),
+    FrozenCase(
+        id="simplify_pythagorean",
+        operation="simplify",
+        build=_case_pythagorean_simplify,
+        expected="agree",
+        expected_reason="invariant_holds",
+        found_by="hand-written baseline",
+        note=(
+            "SymPy folds sin^2 + cos^2 to 1 and Alkahest may not. That is a strength "
+            "difference, not a divergence, and the value-preserving invariant is what "
+            "keeps the gate from mistaking one for the other."
+        ),
+    ),
+    FrozenCase(
+        id="sum_indefinite_linear",
+        operation="sum_indefinite",
+        build=_case_gosper_linear,
+        expected="agree",
+        expected_reason="invariant_holds",
+        found_by="hand-written baseline",
+        note=(
+            "Gosper antidifferences are pinned only up to a constant, and the two "
+            "systems pick different ones; the telescoping invariant removes it."
+        ),
+    ),
+    FrozenCase(
+        id="solve_quadratic",
+        operation="solve",
+        build=_case_quadratic_solve,
+        expected="agree",
+        expected_reason="invariant_holds",
+        found_by="hand-written baseline",
+        note="Substitute-back plus a set-size comparison; catches a missed root.",
+    ),
+    FrozenCase(
+        id="series_exp",
+        operation="series",
+        build=_case_exp_series,
+        expected="agree",
+        found_by="hand-written baseline",
+        note="Exercises the big_o node and the truncation-convention invariant.",
+    ),
+)
+
+
+def run_frozen_corpus(
+    *,
+    oracle: Oracle | str | None = None,
+    cases: Sequence[FrozenCase] = FROZEN_CORPUS,
+) -> list[tuple[FrozenCase, CrossCheck | None]]:
+    """Re-run :data:`FROZEN_CORPUS` against the installed oracle.
+
+    Parameters
+    ----------
+    oracle : Oracle or str, optional
+        Defaults to the first installed oracle.
+    cases : sequence of FrozenCase
+        Defaults to the whole corpus.
+
+    Returns
+    -------
+    list of (FrozenCase, CrossCheck or None)
+        ``None`` means the case does not apply to the installed oracle version
+        and was skipped — a skip, never a pass.
+    """
+    ak = _ak()
+    resolved = _resolve_oracle(oracle)
+    version = _safe_version(resolved) if resolved else None
+    out: list[tuple[FrozenCase, CrossCheck | None]] = []
+    for case in cases:
+        if resolved is None or version is None or not case.applies_to(version):
+            out.append((case, None))
+            continue
+        if case.oracle != resolved.name:
+            out.append((case, None))
+            continue
+        pool = ak.ExprPool()
+        with ak.context(pool=pool):
+            out.append((case, check(case.operation, *case.build(pool), oracle=resolved)))
+    return out

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -46,7 +46,7 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
                                  batch_map/batch_map_iter item whose exception carried no
                                  .code of its own — see docs/mdbook/src/batch.md)
     E-ANSATZ-001 … E-ANSATZ-004 AnsatzError (Python-only; P2 item 1 — conjecture generation)
-    E-XCHECK-001 … E-XCHECK-003 CrossCheckError (Python-only; P2 item 2 — differential testing)
+    E-XCHECK-001 … E-XCHECK-004 CrossCheckError (Python-only; P2 item 2 — differential testing)
     E-SMT-001 … E-SMT-004       SmtError (P2 item 3 — SMT/SAT bridge)
 """
 
@@ -611,7 +611,12 @@ class CrossCheckError(AlkahestError):
       assumption) with no faithful mapping into the oracle's language.
     - ``E-XCHECK-002`` — no oracle is installed. Never reported as agreement;
       see :func:`alkahest.crosscheck.oracles`.
-    - ``E-XCHECK-003`` — the operation has no defined comparison rung.
+    - ``E-XCHECK-003`` — the operation has no defined comparison rung. A caller
+      error, raised before any oracle is consulted.
+    - ``E-XCHECK-004`` — the oracle itself declined: it has no implementation
+      for the operation, raised, or returned an unevaluated form. An
+      environmental outcome rather than a caller error, and **not** a
+      divergence — comparing against a refusal would fabricate one.
     """
 
     def __init__(

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -45,6 +45,9 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
     E-BATCH-001                 (Python-only; alkahest._batch fallback for a
                                  batch_map/batch_map_iter item whose exception carried no
                                  .code of its own — see docs/mdbook/src/batch.md)
+    E-ANSATZ-001 … E-ANSATZ-004 AnsatzError (Python-only; P2 item 1 — conjecture generation)
+    E-XCHECK-001 … E-XCHECK-003 CrossCheckError (Python-only; P2 item 2 — differential testing)
+    E-SMT-001 … E-SMT-004       SmtError (P2 item 3 — SMT/SAT bridge)
 """
 
 from __future__ import annotations
@@ -564,6 +567,89 @@ class BudgetExceededError(AlkahestError):
         span: tuple[int, int] | None = None,
     ):
         super().__init__(message, code="E-BUDGET-001", remediation=remediation, span=span)
+
+
+class AnsatzError(AlkahestError):
+    """An ansatz family could not be built, or could not be fitted.
+
+    Raised by :mod:`alkahest.ansatz` (P2 item 1 — conjecture generation).
+    ``.code`` distinguishes the causes, and note that only the first two are
+    "you called it wrong"; the others are *results*:
+
+    - ``E-ANSATZ-001`` — a coefficient symbol name collides with a symbol
+      already interned in the pool, so the fit would silently solve for the
+      wrong thing.
+    - ``E-ANSATZ-002`` — the requested family exceeds ``max_terms``.
+      ``C(n+d, d)`` grows fast; refusing beats materialising it.
+    - ``E-ANSATZ-003`` — the constraints are inconsistent: **no member of this
+      family satisfies them**. For a search loop this is a positive result — a
+      closed branch — not a malfunction.
+    - ``E-ANSATZ-004`` — the residual is nonlinear in the unknowns and the
+      escalation path (:func:`alkahest.solve`) needs a ``groebner`` build,
+      which this one is not.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "E-ANSATZ-001",
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code=code, remediation=remediation, span=span)
+
+
+class CrossCheckError(AlkahestError):
+    """A cross-CAS differential check could not be *posed*, so it was refused.
+
+    Raised by :mod:`alkahest.crosscheck` (P2 item 2). A refusal here always
+    beats a guess: a divergence is only informative if both systems were asked
+    the same question, and a best-effort translation manufactures false
+    divergences, which are worse than no signal at all.
+
+    - ``E-XCHECK-001`` — the expression contains a node (or an active
+      assumption) with no faithful mapping into the oracle's language.
+    - ``E-XCHECK-002`` — no oracle is installed. Never reported as agreement;
+      see :func:`alkahest.crosscheck.oracles`.
+    - ``E-XCHECK-003`` — the operation has no defined comparison rung.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "E-XCHECK-001",
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code=code, remediation=remediation, span=span)
+
+
+class SmtError(AlkahestError):
+    """An SMT-LIB export, solver invocation, or model lift failed.
+
+    Raised by :mod:`alkahest.smt` (P2 item 3).
+
+    - ``E-SMT-001`` — no solver binary was found. Reported as a refusal rather
+      than a silent fallback to the weak interval :func:`alkahest.satisfiable`,
+      which would answer ``Unknown`` and look like the solver had run.
+    - ``E-SMT-002`` — the formula is outside the supported SMT-LIB fragment;
+      check :func:`alkahest.smt.supported` first.
+    - ``E-SMT-003`` — the model contains a value (an ``root-obj`` algebraic
+      number) that cannot yet be lifted **exactly**. Refused rather than
+      truncated to a float: a float witness recorded as an exact one is the
+      silent-error shape this whole subsystem exists to avoid.
+    - ``E-SMT-004`` — a returned model failed back-substitution. The bridge or
+      the solver is broken; this must never be downgraded to a warning.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "E-SMT-001",
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code=code, remediation=remediation, span=span)
 
 
 class ParseError(AlkahestError):

--- a/python/alkahest/research.py
+++ b/python/alkahest/research.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import inspect
 import json
 import threading
 from contextlib import ExitStack, contextmanager, suppress
@@ -655,6 +656,25 @@ def _run_crosscheck(name: str, args: tuple, kwargs: dict) -> Any:
         return None
     if name not in getattr(_crosscheck, "OPERATIONS", ()):
         return None
+
+    # `check()` has keyword-only parameters of its own (`oracle`, `points`,
+    # `pool`, ...). Forwarding the captured operation's kwargs blindly would let
+    # a same-named argument be swallowed as a cross-check *setting*, so the
+    # comparison would silently run against a different call than the one being
+    # recorded — a wrong "agree" rather than an honest "we could not check
+    # this". Refuse instead. Introspected rather than hard-coded so the guard
+    # cannot drift out of step with `check`'s signature.
+    reserved = {
+        p.name
+        for p in inspect.signature(_crosscheck.check).parameters.values()
+        if p.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+    clashing = sorted(reserved & set(kwargs))
+    if clashing:
+        return _StubCrossCheck(
+            "operation arguments collide with cross-check parameters: " + ", ".join(clashing)
+        )
+
     with _suppress_capture():
         try:
             return _crosscheck.check(name, *args, **kwargs)

--- a/python/alkahest/research.py
+++ b/python/alkahest/research.py
@@ -101,6 +101,9 @@ STATUS_BADGES: dict[str, str] = {
     "exactly_verified": "the kernel proved the symbolic residual is zero",
     "certificate_available": ("Lean 4 source was generated but has NOT been machine-checked"),
     "numerically_checked": "floating-point samples only; evidence, not a proof",
+    "externally_asserted": (
+        "an external solver asserted this; no proof was checked and none was produced"
+    ),
     "unverified": "recorded without verification evidence",
     "refuted": "re-verification contradicted this claim",
 }
@@ -110,6 +113,7 @@ _STATUS_MARK: dict[str, str] = {
     "exactly_verified": "[VERIFIED]",
     "certificate_available": "[CERT ONLY, UNCHECKED]",
     "numerically_checked": "[NUMERIC ONLY]",
+    "externally_asserted": "[EXTERNAL, UNCHECKED]",
     "unverified": "[UNVERIFIED]",
     "refuted": "[REFUTED]",
 }
@@ -603,6 +607,69 @@ class Claim:
             tags=tuple(data.get("tags", ()) or ()),
             notes=data.get("notes"),
         )
+
+
+def _crosscheck_record(cc: Any) -> dict[str, Any] | None:
+    """Flatten a :class:`alkahest.crosscheck.CrossCheck` for storage in a claim.
+
+    Returns ``None`` for ``None`` so callers can pass the value through
+    unconditionally.  Everything stored is a plain JSON-serialisable scalar, and
+    the ``outcome`` key is always present — including for an *unavailable*
+    oracle, which must stay distinguishable from agreement.
+    """
+    if cc is None:
+        return None
+    outcome = str(getattr(cc, "outcome", "incomparable"))
+    record: dict[str, Any] = {
+        "outcome": outcome,
+        "conclusive": bool(getattr(cc, "conclusive", False)),
+        "checked": bool(getattr(cc, "checked", False)),
+    }
+    for attr in ("rung", "rung_name", "reason", "oracle", "oracle_version", "witness"):
+        value = getattr(cc, attr, None)
+        if value is not None:
+            record[attr] = value if isinstance(value, (int, float, bool)) else str(value)
+    divergence = getattr(cc, "divergence", None)
+    if divergence is not None:
+        record["divergence"] = str(divergence)
+    return record
+
+
+def _run_crosscheck(name: str, args: tuple, kwargs: dict) -> Any:
+    """Best-effort cross-check for a captured operation; never raises.
+
+    A cross-check is an optional extra signal, so a failure to *pose* one must
+    not take down the recording of an otherwise good claim.  Any failure is
+    turned into an ``incomparable`` record carrying the reason, which is the
+    honest reading: we learned nothing, as opposed to we agree.
+
+    The whole call runs under :func:`_suppress_capture`.  A cross-check drives
+    ``integrate``/``diff``/``simplify`` to evaluate its comparison rungs, and
+    those are captured operations: without the guard each recorded claim would
+    record the claims generated while checking it, which recurses without
+    terminating.
+    """
+    try:
+        from . import crosscheck as _crosscheck
+    except Exception:  # pragma: no cover - crosscheck is always importable
+        return None
+    if name not in getattr(_crosscheck, "OPERATIONS", ()):
+        return None
+    with _suppress_capture():
+        try:
+            return _crosscheck.check(name, *args, **kwargs)
+        except Exception as exc:
+            return _StubCrossCheck(f"{type(exc).__name__}: {exc}")
+
+
+@dataclass(frozen=True)
+class _StubCrossCheck:
+    """Stand-in recorded when a cross-check could not even be posed."""
+
+    reason: str
+    outcome: str = "incomparable"
+    conclusive: bool = False
+    checked: bool = False
 
 
 def _jsonable(obj: Any) -> Any:
@@ -1419,12 +1486,21 @@ class ResearchSession:
         normalize: bool = True,
         graph: ClaimGraph | None = None,
         metadata: Mapping[str, Any] | None = None,
+        crosscheck: bool = False,
     ) -> None:
         self.graph = graph if graph is not None else ClaimGraph(title=title)
         self.pool = pool
         self.assumptions = assumptions
         self.capture = bool(capture)
         self.normalize = bool(normalize)
+        #: Run an independent-implementation cross-check as each captured
+        #: operation is recorded (P2-2 design decision D8).  Deliberately a
+        #: *recording-time* policy rather than an ``ak.context`` flag: an oracle
+        #: round-trip costs orders of magnitude more than the kernel call, so it
+        #: belongs at stage-5 frequency (hundreds of claims) and not at stage-2
+        #: frequency (millions of candidates).  It never changes a claim's
+        #: status — see :meth:`record`.
+        self.crosscheck = bool(crosscheck)
         #: Exceptions raised *inside* the capture hook, recorded rather than
         #: swallowed so an incomplete graph is never silently incomplete.
         self.capture_errors: list[str] = []
@@ -1493,6 +1569,7 @@ class ResearchSession:
         notes: str | None = None,
         check: Mapping[str, Any] | None = None,
         arguments: Sequence[str] | None = None,
+        crosscheck: Any = None,
     ) -> Claim:
         """Record a :class:`~alkahest.DerivedResult` (or bare ``Expr``) as a claim.
 
@@ -1526,6 +1603,17 @@ class ResearchSession:
             A re-verification recipe (see :meth:`ClaimGraph.verify`).
         arguments : sequence of str, optional
             Rendered arguments stored in the claim's provenance.
+        crosscheck : CrossCheck, optional
+            An already-computed :class:`alkahest.crosscheck.CrossCheck`,
+            attached to the claim under ``verification["crosscheck"]`` and
+            surfaced as a ``crosscheck:<outcome>`` tag.
+
+            It is **evidence, never a verdict**.  Agreement with an independent
+            implementation does not upgrade the status, and a divergence does
+            not set ``"refuted"`` either: a divergence names two suspects, not
+            one (P2-2 design decision D5), so which side is wrong is for a human
+            or a later check to adjudicate.  The recording layer's honesty
+            invariant — it may never raise confidence — is preserved exactly.
 
         Returns
         -------
@@ -1539,6 +1627,13 @@ class ResearchSession:
             verification = dict(result.verification or {})
             certificate = result.certificate
             derivation = tuple(dict(step) for step in (result.steps or ()))
+        cc_record = _crosscheck_record(crosscheck)
+        extra_tags: tuple[str, ...] = ()
+        if cc_record is not None:
+            verification = dict(verification)
+            verification["crosscheck"] = cc_record
+            extra_tags = (f"crosscheck:{cc_record['outcome']}",)
+
         status = str(verification.get("status", "unverified"))
         evidence = str(verification.get("evidence", "none"))
         certificate_format = verification.get("artifact_format")
@@ -1579,7 +1674,7 @@ class ResearchSession:
             provenance=self._provenance(resolved_method, arguments),
             recorded_at=_utcnow(),
             label=label,
-            tags=tuple(tags),
+            tags=tuple(dict.fromkeys((*tags, *extra_tags))),
             notes=notes,
         )
         stored = self.graph.add(claim)
@@ -1711,6 +1806,7 @@ class ResearchSession:
             sources=sources,
             arguments=rendered,
             check=_infer_check(name, sources, result),
+            crosscheck=_run_crosscheck(name, args, kwargs) if self.crosscheck else None,
         )
 
     def _hypotheses(self) -> tuple[str, ...]:
@@ -1824,6 +1920,7 @@ def session(
     normalize: bool = True,
     graph: ClaimGraph | None = None,
     metadata: Mapping[str, Any] | None = None,
+    crosscheck: bool = False,
 ) -> ResearchSession:
     """Open a research session (see :class:`ResearchSession`).
 
@@ -1843,6 +1940,7 @@ def session(
         normalize=normalize,
         graph=graph,
         metadata=metadata,
+        crosscheck=crosscheck,
     )
 
 

--- a/python/alkahest/smt.py
+++ b/python/alkahest/smt.py
@@ -1,0 +1,1292 @@
+"""SMT/SAT bridge — hand a discrete or mixed subproblem to an external solver.
+
+P2 item 3 — see ``docs/mdbook/src/smt.md``.
+
+Discrete and mixed integer/real/boolean problems are not Alkahest's problem
+class and should not become one.  What a search loop needs is not an in-tree
+solver but a way to *hand the subproblem off* — and to bring the answer back in
+a form the rest of the toolchain can trust.  This module is that hand-off:
+
+``to_smtlib``
+    Re-exported from the Rust emitter (``alkahest_core::logic::smtlib``).  Turns
+    a predicate :class:`~alkahest.Expr` into a complete SMT-LIB 2 script.  The
+    emitter is exhaustive over ``Formula`` and ``PredicateKind`` by construction
+    — `rustc` refuses to compile a missing case — so a node added later cannot
+    silently emit wrong SMT-LIB.
+
+:func:`supported`
+    The plan-ahead predicate, in the spirit of :func:`alkahest.certifiable`: can
+    this formula be sent at all, is a solver installed, and *should* it be sent
+    rather than kept in-tree.
+
+:func:`solve`
+    Runs the solver in a subprocess and returns an :class:`SmtResult`.
+
+Two asymmetries drive the whole design and are worth stating up front.
+
+**`sat` and `unsat` are not equally trustworthy.**  A `sat` model is checkable
+inside Alkahest for free: substitute it back and evaluate the formula exactly.
+:func:`solve` always does this — it is not optional and there is no flag to skip
+it — and a model that fails raises :class:`~alkahest.SmtError` ``E-SMT-004``
+rather than warning, because a failure there means the bridge or the solver is
+broken.  `unsat`, by contrast, is not machine-checked here at all: consuming an
+unsat proof is a large project with unstable formats.  So an `unsat` result gets
+the status :data:`EXTERNALLY_ASSERTED`, which is deliberately **not** in
+``alkahest.research.MACHINE_CHECKED_STATUSES``.  "z3 said so" is a fact about
+z3, not a proof, and the claim graph must keep being able to tell the two apart.
+
+**Exactness is where a model reader breaks.**  Rationals lift cleanly; algebraic
+numbers (z3's ``root-obj``) do not, and the tempting move — round to a float —
+would record an approximation as an exact witness.  That is the precise silent
+error this subsystem exists to prevent, so ``root-obj`` is refused with
+``E-SMT-003`` until it can be lifted into the real-algebraic machinery
+(``RootInterval`` / ``refine_root``) that already exists for it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import time
+from dataclasses import dataclass, field
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+from .exceptions import SmtError
+
+__all__ = [
+    "EXTERNALLY_ASSERTED",
+    "SOLVERS",
+    "STATUS_BADGES",
+    "SmtResult",
+    "SmtSupport",
+    "solve",
+    "solvers",
+    "supported",
+    "to_smtlib",
+]
+
+# ---------------------------------------------------------------------------
+# Verification vocabulary
+# ---------------------------------------------------------------------------
+
+#: Status for a result an external tool asserted and nothing in-process checked.
+#:
+#: Introduced by this module for `unsat`.  It is **not** a member of
+#: ``alkahest.research.MACHINE_CHECKED_STATUSES`` — that set means a checker
+#: actually ran, and widening it to include an unverified external assertion
+#: would erode the one guarantee ``research.py`` makes.  ``tests/test_smt.py``
+#: pins that exclusion.
+EXTERNALLY_ASSERTED = "externally_asserted"
+
+#: Badges for the statuses this module produces, worded as unflatteringly as the
+#: ones in ``alkahest.research.STATUS_BADGES``.
+STATUS_BADGES: dict[str, str] = {
+    "exactly_verified": (
+        "the solver's model was substituted back and the kernel evaluated the formula "
+        "to true exactly"
+    ),
+    EXTERNALLY_ASSERTED: (
+        "an external solver asserted this; NO proof was checked and nothing in Alkahest verified it"
+    ),
+    "unverified": "the solver returned no verdict; nothing was established either way",
+}
+
+# ---------------------------------------------------------------------------
+# Solver registry and discovery
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SolverSpec:
+    """How to invoke one SMT-LIB 2 solver."""
+
+    name: str
+    binary: str
+    version_args: tuple[str, ...]
+    script_args: tuple[str, ...]
+    #: ``str.format``-style template taking ``ms``; ``None`` if the solver has
+    #: no wall-clock flag (the parent-side deadline still applies).
+    timeout_flag: str | None
+
+
+_SPECS: dict[str, _SolverSpec] = {
+    "z3": _SolverSpec(
+        name="z3",
+        binary="z3",
+        version_args=("--version",),
+        script_args=("-smt2",),
+        timeout_flag="-t:{ms}",
+    ),
+    "cvc5": _SolverSpec(
+        name="cvc5",
+        binary="cvc5",
+        version_args=("--version",),
+        script_args=("--lang=smt2",),
+        timeout_flag="--tlimit={ms}",
+    ),
+}
+
+#: Solver names this module knows how to drive, in preference order.
+SOLVERS: tuple[str, ...] = tuple(_SPECS)
+
+# Version strings are cached per resolved path (a given binary's version does
+# not change under us).  Discovery itself is *not* cached, so a solver that
+# appears on PATH mid-session is seen.
+_VERSION_CACHE: dict[str, str] = {}
+
+
+def _search_path() -> str:
+    """``PATH`` plus the running interpreter's script directory.
+
+    A ``pip install z3-solver`` drops the ``z3`` binary in the environment's
+    script directory, which is on ``PATH`` only when the environment has been
+    *activated*.  A loop that runs ``.venv/bin/python`` directly would otherwise
+    report "no solver installed" while one sits right next to the interpreter.
+    """
+    parts = [os.environ.get("PATH", os.defpath)]
+    for extra in (sysconfig.get_path("scripts"), os.path.dirname(sys.executable)):
+        if extra and extra not in parts:
+            parts.append(extra)
+    return os.pathsep.join(p for p in parts if p)
+
+
+def _find_binary(binary: str) -> str | None:
+    return shutil.which(binary, path=_search_path())
+
+
+def _version_of(path: str, spec: _SolverSpec) -> str:
+    cached = _VERSION_CACHE.get(path)
+    if cached is not None:
+        return cached
+    try:
+        proc = subprocess.run(
+            [path, *spec.version_args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        line = (proc.stdout or proc.stderr or "").strip().splitlines()
+        version = line[0].strip() if line else "unknown"
+    except (OSError, subprocess.SubprocessError):
+        version = "unknown"
+    _VERSION_CACHE[path] = version
+    return version
+
+
+def solvers() -> dict[str, str | None]:
+    """Which SMT solvers are installed, and at what version.
+
+    Returns a mapping over every name in :data:`SOLVERS`; the value is the
+    solver's self-reported version string, or ``None`` when the binary was not
+    found.  Absence is reported **negatively and explicitly** so an agent can
+    tell before it plans that the hand-off is unavailable, rather than
+    discovering it as a refusal mid-loop.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> ak.smt.solvers()                      # doctest: +SKIP
+    {'z3': 'Z3 version 4.13.0 - 64 bit', 'cvc5': None}
+    """
+    out: dict[str, str | None] = {}
+    for name, spec in _SPECS.items():
+        path = _find_binary(spec.binary)
+        out[name] = _version_of(path, spec) if path else None
+    return out
+
+
+def _resolve_solver(solver: str) -> tuple[_SolverSpec, str]:
+    """Return ``(spec, path)`` or raise ``E-SMT-001``."""
+    if solver == "auto":
+        wanted = list(_SPECS.values())
+    else:
+        spec = _SPECS.get(solver)
+        if spec is None:
+            raise SmtError(
+                f"[E-SMT-001] unknown solver {solver!r}; known solvers are {list(SOLVERS)}",
+                code="E-SMT-001",
+                remediation=(
+                    "pass solver='auto' to use the first installed solver, or one of "
+                    f"{list(SOLVERS)}"
+                ),
+            )
+        wanted = [spec]
+    for spec in wanted:
+        path = _find_binary(spec.binary)
+        if path:
+            return spec, path
+    names = [s.binary for s in wanted]
+    raise SmtError(
+        f"[E-SMT-001] no SMT solver binary found (looked for {names} on PATH and "
+        f"{os.path.dirname(sys.executable)!r})",
+        code="E-SMT-001",
+        remediation=(
+            "install z3 (`pip install z3-solver`) or cvc5 and make it visible on PATH. "
+            "This is a refusal, not a fallback: alkahest.satisfiable is an interval "
+            "heuristic that answers Unknown for almost everything a solver would settle, "
+            "so silently routing to it would look like the solver had run and found "
+            "nothing"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# to_smtlib — the native emitter, with the error type callers expect
+# ---------------------------------------------------------------------------
+
+
+def _native() -> Any:
+    from . import alkahest as _alkahest_native
+
+    return _alkahest_native
+
+
+def _as_smt_error(exc: BaseException) -> SmtError:
+    """Re-raise a native ``E-SMT-*`` failure as :class:`~alkahest.SmtError`.
+
+    The native emitter raises the base ``AlkahestError`` class rather than a
+    dedicated PyO3 ``SmtError``: ``SmtError`` is a pure-Python class and is not
+    in ``alkahest.__init__._NATIVE_EXCEPTION_OVERLAY``, so a native one would be
+    a *different* class from the ``ak.SmtError`` callers write ``except`` for.
+    """
+    return SmtError(
+        str(exc),
+        code=str(getattr(exc, "code", "E-SMT-002")),
+        remediation=getattr(exc, "remediation", None),
+    )
+
+
+def to_smtlib(
+    formula: Any,
+    logic: str = "auto",
+    *,
+    check_sat: bool = True,
+    get_model: bool = True,
+) -> str:
+    """Export a predicate :class:`~alkahest.Expr` as an SMT-LIB 2 script.
+
+    The SMT counterpart of :func:`alkahest.to_lean`: Alkahest emits a standard
+    artifact and an independently maintained external tool consumes it.  The
+    emitter itself lives in Rust (``alkahest_core::logic::smtlib``) so that
+    match exhaustiveness over ``Formula`` / ``PredicateKind`` enforces total
+    coverage; this wrapper only maps the error type.
+
+    Parameters
+    ----------
+    formula : Expr
+        A predicate or quantified expression — built with ``pool.gt``/``lt``/…
+        and :func:`alkahest.And` / :func:`alkahest.Or` / :func:`alkahest.Not`,
+        or :func:`alkahest.Forall` / :func:`alkahest.Exists`.
+    logic : str
+        ``"auto"`` (default) infers the weakest logic that fits: ``QF_LIA``,
+        ``QF_NIA``, ``QF_LRA``, ``QF_NRA``, ``QF_LIRA``, ``QF_NIRA``, their
+        quantified counterparts, or ``ALL``.  Naming a logic too weak for the
+        formula is an error (``E-SMT-002``), not a silent downgrade.
+    check_sat, get_model : bool
+        Append ``(check-sat)`` / ``(get-model)`` and set ``:produce-models``.
+
+    Raises
+    ------
+    SmtError
+        ``E-SMT-002`` when the formula is outside the exportable fragment.  Use
+        :func:`supported` to ask the same question without raising.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> pool = ak.ExprPool()
+    >>> x = pool.symbol("x")
+    >>> print(ak.to_smtlib(ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(3)))))
+    ... # doctest: +SKIP
+    ; alkahest SMT-LIB 2 export
+    (set-logic QF_LRA)
+    ...
+    """
+    try:
+        return _native().to_smtlib(formula, logic, check_sat=check_sat, get_model=get_model)
+    except Exception as exc:
+        code = getattr(exc, "code", None)
+        if isinstance(code, str) and code.startswith("E-SMT-"):
+            raise _as_smt_error(exc) from None
+        raise
+
+
+# ---------------------------------------------------------------------------
+# supported() — the plan-ahead predicate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SmtSupport:
+    """The answer to "can I hand this formula to a solver, and should I?".
+
+    Truthy exactly when :func:`solve` would run, so it drops into
+    ``if supported(f):`` — but it carries the *reason*, which is what a
+    planning loop actually needs.  This mirrors
+    :class:`alkahest._certificates.Certifiability`.
+
+    Attributes
+    ----------
+    supported : bool
+        The verdict: exportable, quantifier-free, and a solver is installed.
+        ``bool(self)`` is the same value.
+    exportable : bool
+        :func:`to_smtlib` would succeed.  Independent of solver installation,
+        so an emitter-only workflow can rely on it.
+    quantified : bool
+        The formula contains ``Forall``/``Exists``.  :func:`to_smtlib` handles
+        these; :func:`solve` refuses them, because it guarantees exact
+        in-process model checking and a quantified model has nothing to check.
+    solver : str or None
+        The solver :func:`solve` would use, or ``None`` if none is installed.
+    logic : str or None
+        The SMT-LIB logic the emitter chose, e.g. ``"QF_NRA"``.
+    reason : str
+        Stable reason code: ``"ok"``, ``"outside_fragment"``, ``"quantified"``,
+        or ``"no_solver"``.
+    detail : str
+        One-sentence human explanation.
+    recommendation : str
+        ``"smt"`` or ``"prefer_in_tree"`` — see :func:`supported`.
+    script : str or None
+        The emitted script, handed back so a caller that goes on to use it does
+        not pay for the export twice.
+    error : SmtError or None
+        The refusal, when ``exportable`` is ``False``.
+    """
+
+    supported: bool
+    exportable: bool
+    quantified: bool
+    solver: str | None
+    logic: str | None
+    reason: str
+    detail: str
+    recommendation: str
+    script: str | None = None
+    error: SmtError | None = None
+
+    def __bool__(self) -> bool:
+        return self.supported
+
+
+_LOGIC_RE = re.compile(r"^\(set-logic\s+(\S+?)\)\s*$", re.MULTILINE)
+
+#: Logics for which the in-tree certified route is preferred over SMT.
+_IN_TREE_LOGICS = frozenset({"QF_LRA", "QF_NRA", "LRA", "NRA"})
+
+_PREFER_IN_TREE_DETAIL = (
+    "this is real arithmetic with no integer variables, where the in-tree route is "
+    "strictly better evidence: sos_decompose / prove_nonneg return a PositivityCertificate "
+    "that composes with to_lean, and decide is complete. z3's nlsat returns an answer and "
+    "no artifact. Use SMT here as a fallback when the in-tree route refuses or exceeds "
+    "its budget"
+)
+
+
+def _walk_exprs(obj: Any):
+    """Every :class:`~alkahest.Expr` reachable from ``obj``, including itself.
+
+    Structural rather than tag-driven on purpose: it stays total when a node
+    kind is added to ``Expr.node()``.
+    """
+    if hasattr(obj, "node") and hasattr(obj, "node_tag"):
+        yield obj
+        for child in obj.node()[1:]:
+            yield from _walk_exprs(child)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            yield from _walk_exprs(item)
+
+
+def _formula_symbols(formula: Any) -> dict[str, Any]:
+    """Symbol name → the :class:`~alkahest.Expr` for it, for back-substitution."""
+    out: dict[str, Any] = {}
+    for expr in _walk_exprs(formula):
+        node = expr.node()
+        if node[0] == "symbol":
+            out.setdefault(node[1], expr)
+    return out
+
+
+def _is_quantified(formula: Any) -> bool:
+    return any(expr.node()[0] in ("forall", "exists") for expr in _walk_exprs(formula))
+
+
+#: Probe assignments used to decide whether a formula can be checked exactly.
+#: A fixed list rather than a sample, so the verdict is deterministic; several
+#: points because a single one can land on a pole (``1/x`` at ``0``) and say
+#: "unsupported" about a formula that is perfectly evaluable elsewhere.
+_PROBE_POINTS: tuple[Fraction, ...] = (
+    Fraction(1),
+    Fraction(2),
+    Fraction(-1),
+    Fraction(1, 2),
+    Fraction(0),
+    Fraction(7, 3),
+)
+
+
+def _exactly_checkable(formula: Any) -> tuple[bool, str | None]:
+    """Can the kernel evaluate this formula exactly at a rational point?
+
+    :func:`solve` guarantees that every ``sat`` model is checked exactly, so a
+    formula it cannot evaluate is refused **before** the solver runs rather than
+    after — a refusal that arrives only once an answer is in hand costs the
+    caller the whole solver run and reads like a bug in the solver.
+
+    Derived from the kernel by probing rather than from a hand-maintained list
+    of evaluable heads, so it cannot drift away from what ``evaluate`` actually
+    supports.
+    """
+    from . import evaluate as _evaluate
+
+    symbols = _formula_symbols(formula)
+    reason: str | None = None
+    for point in _PROBE_POINTS:
+        result = _evaluate(formula, dict.fromkeys(symbols.values(), point), mode="exact")
+        if result.status == "ok":
+            return True, None
+        reason = result.reason or reason
+    return False, reason
+
+
+def _refuse_uncheckable(reason: str | None) -> SmtError:
+    return SmtError(
+        "[E-SMT-002] solve() cannot check a model for this formula: the kernel's exact "
+        f"evaluator refused it at every probe point ({reason})",
+        code="E-SMT-002",
+        remediation=(
+            "solve() only answers about formulas whose sat models it can verify exactly "
+            "in-process, and this one contains a head the exact evaluator does not "
+            "implement. Restrict the formula to polynomial (in)equalities (Piecewise is "
+            "fine), or use alkahest.to_smtlib to export it and take the solver's word for "
+            "the answer yourself"
+        ),
+    )
+
+
+def supported(formula: Any, *, solver: str = "auto") -> SmtSupport:
+    """Can this formula be handed to an SMT solver — and should it be?
+
+    The plan-ahead predicate, for the same reason
+    :func:`alkahest.certifiable` exists: a loop must be able to choose a route
+    *before* it commits, not discover a refusal after paying for the setup.
+
+    The "should it be" half matters and cuts the opposite way to the usual
+    instinct.  For real arithmetic with no integer variables (``QF_LRA`` /
+    ``QF_NRA``), ``recommendation`` is ``"prefer_in_tree"``:
+    :func:`alkahest.prove_nonneg` and :func:`alkahest.sos_decompose` yield a
+    ``PositivityCertificate`` that composes with :func:`alkahest.to_lean`,
+    whereas an SMT solver yields an answer and no artifact.  The genuinely new
+    capability the bridge buys is **mixed integer/real/boolean** problems, which
+    neither CAD nor :func:`alkahest.diophantine` handles — there
+    ``recommendation`` is ``"smt"``.
+
+    Returns
+    -------
+    SmtSupport
+        Truthy when :func:`solve` would run.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> pool = ak.ExprPool()
+    >>> n = pool.symbol("n", "integer")
+    >>> s = ak.smt.supported(pool.gt(n * n, pool.integer(10)))
+    >>> s.recommendation                                      # doctest: +SKIP
+    'smt'
+    """
+    quantified = _is_quantified(formula)
+    script: str | None = None
+    logic: str | None = None
+    error: SmtError | None = None
+    try:
+        script = to_smtlib(formula)
+    except SmtError as exc:
+        error = exc
+    if script is not None:
+        match = _LOGIC_RE.search(script)
+        logic = match.group(1) if match else None
+
+    solver_name: str | None = None
+    try:
+        spec, _path = _resolve_solver(solver)
+        solver_name = spec.name
+    except SmtError:
+        solver_name = None
+
+    recommendation = "prefer_in_tree" if logic in _IN_TREE_LOGICS else "smt"
+
+    if error is not None:
+        return SmtSupport(
+            supported=False,
+            exportable=False,
+            quantified=quantified,
+            solver=solver_name,
+            logic=None,
+            reason="outside_fragment",
+            detail=str(error),
+            recommendation=recommendation,
+            error=error,
+        )
+    if quantified:
+        return SmtSupport(
+            supported=False,
+            exportable=True,
+            quantified=True,
+            solver=solver_name,
+            logic=logic,
+            reason="quantified",
+            detail=(
+                "to_smtlib exports this, but solve() takes quantifier-free formulas only: "
+                "it guarantees every sat model is back-substituted and checked exactly "
+                "in-process, and a model for a quantified formula binds nothing that can be "
+                "checked. Export it and drive the solver yourself, or use alkahest.decide "
+                "for real quantifier elimination"
+            ),
+            recommendation=recommendation,
+            script=script,
+        )
+    checkable, why = _exactly_checkable(formula)
+    if not checkable:
+        refusal = _refuse_uncheckable(why)
+        return SmtSupport(
+            supported=False,
+            exportable=True,
+            quantified=False,
+            solver=solver_name,
+            logic=logic,
+            reason="not_exactly_checkable",
+            detail=str(refusal),
+            recommendation=recommendation,
+            script=script,
+            error=refusal,
+        )
+    if solver_name is None:
+        return SmtSupport(
+            supported=False,
+            exportable=True,
+            quantified=False,
+            solver=None,
+            logic=logic,
+            reason="no_solver",
+            detail=(
+                f"the formula exports cleanly as {logic}, but no solver binary was found; "
+                "see alkahest.smt.solvers()"
+            ),
+            recommendation=recommendation,
+            script=script,
+        )
+    detail = (
+        f"{logic}; {_PREFER_IN_TREE_DETAIL}"
+        if recommendation == "prefer_in_tree"
+        else f"{logic}; mixed/integer arithmetic is what the bridge is for"
+    )
+    return SmtSupport(
+        supported=True,
+        exportable=True,
+        quantified=False,
+        solver=solver_name,
+        logic=logic,
+        reason="ok",
+        detail=detail,
+        recommendation=recommendation,
+        script=script,
+    )
+
+
+# ---------------------------------------------------------------------------
+# S-expression reading — the hard half
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r"""
+      ;[^\n]*                      # comment
+    | \|[^|]*\|                    # quoted symbol
+    | "(?:[^"]|"")*"               # string literal
+    | [()]                         # parens
+    | [^\s()|";]+                  # simple symbol / numeral
+    """,
+    re.VERBOSE,
+)
+
+
+def _parse_sexprs(text: str) -> list[Any]:
+    """Parse SMT-LIB 2 solver output into nested lists of atom strings."""
+    stack: list[list[Any]] = []
+    out: list[Any] = []
+    for token in _TOKEN_RE.findall(text):
+        if token.startswith(";"):
+            continue
+        if token == "(":
+            new: list[Any] = []
+            stack.append(new)
+            continue
+        if token == ")":
+            if not stack:
+                # Unbalanced output; drop the stray close rather than crash —
+                # the caller decides what a missing model means.
+                continue
+            done = stack.pop()
+            (stack[-1] if stack else out).append(done)
+            continue
+        (stack[-1] if stack else out).append(token)
+    # An unterminated form at EOF is dropped for the same reason.
+    return out
+
+
+_INT_RE = re.compile(r"^-?\d+$")
+_DEC_RE = re.compile(r"^-?\d+\.\d+$")
+
+
+def _inexact(name: str, rendered: str, why: str) -> SmtError:
+    return SmtError(
+        f"[E-SMT-003] model value for {name!r} cannot be lifted exactly: {rendered} ({why})",
+        code="E-SMT-003",
+        remediation=(
+            "this is refused, not rounded. A float witness recorded as an exact one is the "
+            "silent error this bridge exists to prevent: the loop would build on a value "
+            "that does not actually satisfy the constraints. Constrain the variable to a "
+            "rational range, or use alkahest.real_roots / refine_root for the algebraic case"
+        ),
+    )
+
+
+def _render(sexp: Any) -> str:
+    if isinstance(sexp, str):
+        return sexp
+    return "(" + " ".join(_render(item) for item in sexp) + ")"
+
+
+def _lift_value(sexp: Any, name: str) -> Fraction:
+    """Lift one SMT-LIB model value to an exact :class:`~fractions.Fraction`.
+
+    Refuses anything that is not exactly a rational — most importantly z3's
+    ``root-obj`` algebraic numbers.
+    """
+    if isinstance(sexp, str):
+        if _INT_RE.match(sexp):
+            return Fraction(int(sexp))
+        if _DEC_RE.match(sexp):
+            # SMT-LIB decimals are exact decimal rationals, and `Fraction` parses
+            # the *string*, so `1.1` becomes 11/10 and never a binary float.
+            return Fraction(sexp)
+        raise _inexact(name, sexp, "not a numeral")
+    if not sexp:
+        raise _inexact(name, "()", "empty term")
+    head = sexp[0]
+    if head == "-" and len(sexp) == 2:
+        return -_lift_value(sexp[1], name)
+    if head == "/" and len(sexp) == 3:
+        numer = _lift_value(sexp[1], name)
+        denom = _lift_value(sexp[2], name)
+        if denom == 0:
+            raise _inexact(name, _render(sexp), "zero denominator")
+        return numer / denom
+    if head == "root-obj":
+        raise _inexact(
+            name,
+            _render(sexp),
+            "an algebraic number of degree > 1; lifting these into RootInterval / "
+            "refine_root is not implemented yet",
+        )
+    raise _inexact(name, _render(sexp), f"unhandled term head {head!r}")
+
+
+def _parse_model(sexprs: list[Any]) -> dict[str, Any]:
+    """Collect ``(define-fun name () Sort value)`` bindings from solver output.
+
+    Handles both the bare ``( (define-fun …) … )`` shape modern z3 prints and
+    the older ``(model (define-fun …) …)`` wrapper.
+    """
+    out: dict[str, Any] = {}
+
+    def visit(form: Any) -> None:
+        if not isinstance(form, list):
+            return
+        if form and form[0] == "define-fun" and len(form) == 5 and form[2] == []:
+            name = form[1]
+            if name.startswith("|") and name.endswith("|") and len(name) >= 2:
+                name = name[1:-1]
+            out[name] = form[4]
+            return
+        for item in form:
+            visit(item)
+
+    for form in sexprs:
+        visit(form)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Exact evaluation of the emitted script against a model
+# ---------------------------------------------------------------------------
+
+_DECL_RE = re.compile(r"^\(declare-fun\s+(\|[^|]*\||\S+)\s+\(\)\s+(Int|Real)\)\s*$", re.MULTILINE)
+
+
+def _declared_sorts(script: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name, sort in _DECL_RE.findall(script):
+        if name.startswith("|") and name.endswith("|"):
+            name = name[1:-1]
+        out[name] = sort
+    return out
+
+
+class _ScriptCheckFailure(Exception):
+    """An assertion in the emitted script is false (or unevaluable) under the model."""
+
+
+def _num(value: Fraction | bool) -> Fraction:
+    """Require an arithmetic operand to be an exact rational.
+
+    The emitter never produces arithmetic over booleans, so this cannot fire on
+    a script alkahest wrote. It is *enforced* rather than assumed because the
+    alternative is Python's own coercion: ``-True`` is ``-1`` and ``True / True``
+    is ``1.0`` — a float. A float reaching this checker would silently weaken
+    the one guarantee it exists to provide, so an impossible operand is a hard
+    failure rather than a quiet numeric downgrade.
+    """
+    if isinstance(value, bool) or not isinstance(value, Fraction):
+        raise _ScriptCheckFailure(f"arithmetic on a non-rational operand: {value!r}")
+    return value
+
+
+def _eval_term(sexp: Any, env: Mapping[str, Fraction]) -> Fraction | bool:
+    """Evaluate an emitted SMT-LIB term/formula exactly over ``Fraction``.
+
+    Deliberately narrow: it understands exactly the operators
+    ``alkahest_core::logic::smtlib`` emits, and raises on anything else rather
+    than guessing.  This is the second, independent check on a `sat` model — the
+    first evaluates the *original* Alkahest formula through the kernel, this one
+    evaluates the *script that was actually sent*, so a mistranslation in the
+    emitter cannot pass both.
+    """
+    if isinstance(sexp, str):
+        if sexp == "true":
+            return True
+        if sexp == "false":
+            return False
+        if _INT_RE.match(sexp):
+            return Fraction(int(sexp))
+        if _DEC_RE.match(sexp):
+            return Fraction(sexp)
+        key = sexp[1:-1] if sexp.startswith("|") and sexp.endswith("|") else sexp
+        if key in env:
+            return env[key]
+        raise _ScriptCheckFailure(f"unbound symbol {key!r}")
+    if not sexp:
+        raise _ScriptCheckFailure("empty term")
+    head, args = sexp[0], sexp[1:]
+    vals = [_eval_term(a, env) for a in args]
+
+    if head == "-" and len(vals) == 1:
+        return -_num(vals[0])
+    if head in ("+", "-", "*", "/"):
+        acc = _num(vals[0])
+        for raw in vals[1:]:
+            v = _num(raw)
+            if head == "+":
+                acc = acc + v
+            elif head == "-":
+                acc = acc - v
+            elif head == "*":
+                acc = acc * v
+            else:
+                if v == 0:
+                    raise _ScriptCheckFailure("division by zero")
+                acc = acc / v
+        return acc
+    if head == "to_real" and len(vals) == 1:
+        return vals[0]
+    if head == "abs" and len(vals) == 1:
+        return abs(_num(vals[0]))
+    if head == "ite" and len(vals) == 3:
+        return vals[1] if vals[0] else vals[2]
+    if head == "not" and len(vals) == 1:
+        return not vals[0]
+    if head == "and":
+        return all(bool(v) for v in vals)
+    if head == "or":
+        return any(bool(v) for v in vals)
+    if head == "=>" and len(vals) == 2:
+        return (not vals[0]) or bool(vals[1])
+    if head in ("=", "<", "<=", ">", ">=") and len(vals) == 2:
+        lhs, rhs = vals
+        if head == "=":
+            return lhs == rhs
+        if head == "<":
+            return lhs < rhs
+        if head == "<=":
+            return lhs <= rhs
+        if head == ">":
+            return lhs > rhs
+        return lhs >= rhs
+    raise _ScriptCheckFailure(f"unhandled operator {head!r}/{len(vals)}")
+
+
+def _check_script(script: str, model: Mapping[str, Fraction]) -> list[str]:
+    """Return the emitted assertions that the model does **not** satisfy."""
+    failures: list[str] = []
+    for form in _parse_sexprs(script):
+        if not (isinstance(form, list) and len(form) == 2 and form[0] == "assert"):
+            continue
+        try:
+            value = _eval_term(form[1], model)
+        except _ScriptCheckFailure as exc:
+            failures.append(f"{_render(form[1])} — {exc}")
+            continue
+        if value is not True:
+            failures.append(_render(form[1]))
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# SmtResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SmtResult:
+    """What an external solver said, and how much of it was checked here.
+
+    Quacks like a :class:`~alkahest.DerivedResult` (``value`` / ``steps`` /
+    ``verification`` / ``certificate``) so ``ResearchSession.record`` accepts it
+    unchanged — and so the honest status travels with it.
+
+    Attributes
+    ----------
+    status : {"sat", "unsat", "unknown"}
+        The solver's verdict.
+    model : dict[str, Fraction]
+        Exact rational witness, on ``sat``.  Always the values that were
+        actually verified.
+    model_exprs : dict[str, Expr]
+        The same values interned into an :class:`~alkahest.ExprPool`, when one
+        was passed or was active via ``alkahest.context(pool=...)``.  Empty
+        otherwise — an ``Expr`` carries no reference to its pool, so this is not
+        always constructible, and :attr:`model` never depends on it.
+    engine : str
+        Which solver answered, and at what version.  A result that does not say
+        what produced it is not something a loop can weigh.
+    logic : str
+        The SMT-LIB logic that was sent.
+    smtlib : str
+        The exact script that was sent.  Also exposed as ``certificate``.
+    verification : dict
+        ``DerivedResult``-shaped: ``status`` is ``exactly_verified`` for a
+        checked ``sat`` model, :data:`EXTERNALLY_ASSERTED` for ``unsat``, and
+        ``unverified`` for ``unknown``.
+    badge : str
+        The unflattering one-line rendering of ``verification["status"]``.
+    reason_unknown : str or None
+        The solver's own explanation, on ``unknown``.
+    elapsed_ms : float
+        Wall-clock time spent in the solver process.
+    """
+
+    status: str
+    model: dict[str, Fraction]
+    model_exprs: dict[str, Any]
+    engine: str
+    logic: str
+    smtlib: str
+    verification: dict[str, Any]
+    reason_unknown: str | None
+    elapsed_ms: float
+    raw_output: str
+    steps: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+
+    @property
+    def value(self) -> Any:
+        """The formula that was asked about — ``DerivedResult``-compatible."""
+        return self._formula
+
+    @property
+    def certificate(self) -> str:
+        """The SMT-LIB script.  An artifact, explicitly *not* a checked proof."""
+        return self.smtlib
+
+    @property
+    def badge(self) -> str:
+        """Honest one-line description of what was actually established."""
+        return STATUS_BADGES.get(self.verification.get("status", ""), "unrecognised status")
+
+    @property
+    def machine_checked(self) -> bool:
+        """``True`` only when a checker ran **in this process**.
+
+        ``unsat`` is never machine-checked here, however confident the solver
+        was.
+        """
+        return self.verification.get("status") == "exactly_verified"
+
+    _formula: Any = None
+
+    # Deliberately no `__bool__`: `unsat` and `unknown` would both be falsy, and
+    # a loop that wrote `if not result:` would treat "proved impossible" and
+    # "gave up" as the same outcome. Branch on `.status`.
+
+
+# ---------------------------------------------------------------------------
+# solve()
+# ---------------------------------------------------------------------------
+
+_STATUS_TOKENS = ("sat", "unsat", "unknown")
+_REASON_RE = re.compile(r"\(\s*:reason-unknown\s+(.*?)\s*\)\s*$", re.MULTILINE | re.DOTALL)
+_TIMEOUT_REASONS = ("timeout", "canceled", "cancelled", "resourceout", "resource")
+
+
+def _budget_exceeded_error(message: str) -> BaseException:
+    from ._budget import _budget_exceeded
+
+    return _budget_exceeded(
+        message,
+        remediation=(
+            "raise Budget(wall_ms=...), or record this candidate as hard-not-hung and move "
+            "on; a solver timeout is a resource verdict, not a mathematical one"
+        ),
+    )
+
+
+def _run_solver(
+    spec: _SolverSpec, path: str, script: str, wall_ms: float | None
+) -> tuple[str, float]:
+    args = [path, *spec.script_args]
+    if wall_ms is not None and spec.timeout_flag is not None:
+        args.append(spec.timeout_flag.format(ms=max(1, int(wall_ms))))
+    # A grace window on top of the solver's own limit: the parent deadline is a
+    # backstop for a solver that ignores or overshoots its flag, not the primary
+    # mechanism.
+    deadline = None if wall_ms is None else max(wall_ms / 1000.0 * 1.5, wall_ms / 1000.0 + 0.5)
+
+    handle, filename = tempfile.mkstemp(suffix=".smt2", prefix="alkahest-")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            fh.write(script)
+        started = time.monotonic()
+        try:
+            proc = subprocess.run(
+                [*args, filename],
+                capture_output=True,
+                text=True,
+                timeout=deadline,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise _budget_exceeded_error(
+                f"[E-BUDGET-001] budget exceeded: {spec.name} did not answer within {wall_ms} ms"
+            ) from exc
+        elapsed_ms = (time.monotonic() - started) * 1000.0
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(filename)
+    return (proc.stdout or "") + (proc.stderr or ""), elapsed_ms
+
+
+def _extract_status(output: str) -> str | None:
+    for line in output.splitlines():
+        token = line.strip()
+        if token in _STATUS_TOKENS:
+            return token
+    return None
+
+
+def solve(
+    formula: Any,
+    *,
+    solver: str = "auto",
+    logic: str = "auto",
+    budget: Any = None,
+    pool: Any = None,
+) -> SmtResult:
+    """Ask an external SMT solver about ``formula``.
+
+    Parameters
+    ----------
+    formula : Expr
+        A **quantifier-free** predicate expression.  Quantified formulas export
+        fine with :func:`to_smtlib` but are refused here (``E-SMT-002``): this
+        function guarantees that every ``sat`` model is checked exactly
+        in-process, and there is nothing to check for a quantified model.
+    solver : str
+        ``"auto"`` (first installed, in :data:`SOLVERS` order) or a name.
+    logic : str
+        Forwarded to :func:`to_smtlib`.
+    budget : Budget, optional
+        ``budget.wall_ms`` is passed to the solver's own timeout flag *and*
+        enforced as a parent-side deadline.  A timeout raises
+        :class:`~alkahest.BudgetExceededError` (``E-BUDGET-001``), so a loop
+        gets the structured "hard, not hung" distinction rather than a bare
+        ``unknown``.
+    pool : ExprPool, optional
+        Pool for :attr:`SmtResult.model_exprs`; defaults to
+        :func:`alkahest.active_pool`.  :attr:`SmtResult.model` is exact and
+        present either way.
+
+    Returns
+    -------
+    SmtResult
+
+    Raises
+    ------
+    SmtError
+        ``E-SMT-001`` no solver installed — a refusal, never a silent fallback
+        to the weak interval :func:`alkahest.satisfiable`.
+        ``E-SMT-002`` formula outside the exportable/solvable fragment.
+        ``E-SMT-003`` a model value (``root-obj``) cannot be lifted exactly.
+        ``E-SMT-004`` the model failed back-substitution.  This is raised, never
+        warned: it means the bridge or the solver is broken.
+    BudgetExceededError
+        The solver hit ``budget.wall_ms``.
+
+    Examples
+    --------
+    >>> import alkahest as ak
+    >>> pool = ak.ExprPool()
+    >>> n = pool.symbol("n", "integer")
+    >>> x = pool.symbol("x")
+    >>> f = ak.And(pool.gt(x, n), pool.lt(x * x, pool.integer(10)))
+    >>> r = ak.smt.solve(f)                     # doctest: +SKIP
+    >>> r.status, r.badge                       # doctest: +SKIP
+    ('sat', 'the solver's model was substituted back and ...')
+    """
+    if _is_quantified(formula):
+        raise SmtError(
+            "[E-SMT-002] solve() takes quantifier-free formulas only; this one is quantified",
+            code="E-SMT-002",
+            remediation=(
+                "solve() guarantees that every sat model is back-substituted and checked "
+                "exactly in-process, and a model for a quantified formula binds nothing "
+                "that can be checked. Use alkahest.to_smtlib to export it and drive the "
+                "solver yourself, or alkahest.decide for real quantifier elimination"
+            ),
+        )
+    spec, path = _resolve_solver(solver)
+    script = to_smtlib(formula, logic)
+    checkable, why = _exactly_checkable(formula)
+    if not checkable:
+        raise _refuse_uncheckable(why)
+    match = _LOGIC_RE.search(script)
+    logic_used = match.group(1) if match else logic
+    # `(get-info :reason-unknown)` is appended rather than emitted, so the
+    # golden-file artifact stays exactly what `to_smtlib` produced.
+    driver_script = script + "(get-info :reason-unknown)\n(exit)\n"
+
+    wall_ms = getattr(budget, "wall_ms", None) if budget is not None else None
+    output, elapsed_ms = _run_solver(spec, path, driver_script, wall_ms)
+    engine = f"{spec.name} {_version_of(path, spec)}"
+
+    status = _extract_status(output)
+    if status is None:
+        raise SmtError(
+            f"[E-SMT-002] {spec.name} returned no sat/unsat/unknown verdict; output was:\n"
+            f"{output.strip()[:2000]}",
+            code="E-SMT-002",
+            remediation=(
+                "the emitted script was rejected by the solver. Report this with the script "
+                "from alkahest.to_smtlib(formula) — a script alkahest emits and a solver "
+                "cannot read is an emitter bug, not a user error"
+            ),
+        )
+
+    reason_match = _REASON_RE.search(output)
+    reason_unknown = reason_match.group(1).strip('"') if reason_match else None
+    if status == "unknown" and reason_unknown:
+        lowered = reason_unknown.lower()
+        if wall_ms is not None and any(token in lowered for token in _TIMEOUT_REASONS):
+            raise _budget_exceeded_error(
+                f"[E-BUDGET-001] budget exceeded: {spec.name} stopped after {wall_ms} ms "
+                f"(reason-unknown: {reason_unknown})"
+            )
+
+    model: dict[str, Fraction] = {}
+    model_exprs: dict[str, Any] = {}
+    if status == "sat":
+        model = _lift_model(output, script, formula)
+        _verify_model(formula, script, model, engine)
+        model_exprs = _intern_model(model, pool)
+
+    verification = _verification_for(status, engine, reason_unknown, logic_used)
+    return SmtResult(
+        status=status,
+        model=model,
+        model_exprs=model_exprs,
+        engine=engine,
+        logic=logic_used,
+        smtlib=script,
+        verification=verification,
+        reason_unknown=reason_unknown,
+        elapsed_ms=elapsed_ms,
+        raw_output=output,
+        steps=(
+            {
+                "rule": "smt_export",
+                "detail": f"emitted {logic_used} SMT-LIB 2 and ran {engine}",
+                "result": status,
+            },
+        ),
+        _formula=formula,
+    )
+
+
+def _lift_model(output: str, script: str, formula: Any) -> dict[str, Fraction]:
+    """Parse, lift, and complete the solver's model."""
+    raw = _parse_model(_parse_sexprs(output))
+    model: dict[str, Fraction] = {}
+    for name, sexp in raw.items():
+        model[name] = _lift_value(sexp, name)
+
+    sorts = _declared_sorts(script)
+    for name, sort in sorts.items():
+        if name not in model:
+            # A solver may omit a "don't care" variable.  Completing it here (and
+            # then checking the completed model) keeps the witness total: a model
+            # a caller cannot substitute is not a witness.
+            model[name] = Fraction(0)
+        if sort == "Int" and model[name].denominator != 1:
+            raise SmtError(
+                f"[E-SMT-004] model assigns the Int-sorted symbol {name!r} the "
+                f"non-integer value {model[name]}",
+                code="E-SMT-004",
+                remediation=(
+                    "the solver returned a model that violates its own declaration; report "
+                    "this with the script from alkahest.to_smtlib(formula)"
+                ),
+            )
+    # Symbols the formula mentions but the script never declared would mean the
+    # emitter dropped something; the back-substitution check below catches it.
+    for name in _formula_symbols(formula):
+        model.setdefault(name, Fraction(0))
+    return model
+
+
+def _verify_model(formula: Any, script: str, model: Mapping[str, Fraction], engine: str) -> None:
+    """Two independent exact checks on a ``sat`` model.  Never optional.
+
+    1. Substitute the model into the **original Alkahest formula** and evaluate
+       it exactly through the kernel.  This is the invariant the whole bridge
+       rests on.
+    2. Evaluate every assertion in the **script that was actually sent**.  A
+       mistranslation in the emitter would have to fool both to slip through,
+       and this one also re-checks the refined-domain side conditions
+       (``Positive``/``NonNegative``/``NonZero``) that are asserted separately.
+    """
+    from . import evaluate as _evaluate
+
+    symbols = _formula_symbols(formula)
+    bindings = {expr: model[name] for name, expr in symbols.items() if name in model}
+    missing = sorted(name for name in symbols if name not in model)
+    if missing:
+        raise SmtError(
+            f"[E-SMT-004] {engine} returned a model with no value for {missing}",
+            code="E-SMT-004",
+            remediation=_BROKEN_BRIDGE,
+        )
+
+    result = _evaluate(formula, bindings, mode="exact")
+    if result.status != "ok":
+        raise SmtError(
+            f"[E-SMT-004] the model from {engine} could not be checked: exact evaluation "
+            f"of the formula reported {result.status} ({result.reason})",
+            code="E-SMT-004",
+            remediation=(
+                "an unchecked sat model is not a result this bridge will hand back. Reduce "
+                "the formula to the exactly-evaluable fragment, or use alkahest.to_smtlib "
+                "and drive the solver yourself if you are willing to take the model on "
+                "trust"
+            ),
+        )
+    if result.value != 1:
+        raise SmtError(
+            f"[E-SMT-004] the model from {engine} does not satisfy the formula: "
+            f"back-substitution evaluated it to false. Model: "
+            f"{ {k: str(v) for k, v in sorted(model.items())} }",
+            code="E-SMT-004",
+            remediation=_BROKEN_BRIDGE,
+        )
+
+    failures = _check_script(script, model)
+    if failures:
+        raise SmtError(
+            f"[E-SMT-004] the model from {engine} does not satisfy the emitted script; "
+            f"unsatisfied assertions: {failures}",
+            code="E-SMT-004",
+            remediation=_BROKEN_BRIDGE,
+        )
+
+
+_BROKEN_BRIDGE = (
+    "this is raised, never warned: either the SMT-LIB emitter mistranslated the formula or "
+    "the solver returned an unsound model, and both are bugs that must not be absorbed as a "
+    "log line. Report it with the script from alkahest.to_smtlib(formula)"
+)
+
+
+def _intern_model(model: Mapping[str, Fraction], pool: Any) -> dict[str, Any]:
+    if pool is None:
+        from . import active_pool
+
+        pool = active_pool()
+    if pool is None:
+        return {}
+    return {
+        name: pool.rational(value.numerator, value.denominator) for name, value in model.items()
+    }
+
+
+def _verification_for(
+    status: str, engine: str, reason_unknown: str | None, logic: str
+) -> dict[str, Any]:
+    if status == "sat":
+        return {
+            "status": "exactly_verified",
+            "evidence": "model_back_substitution",
+            "externally_verified": False,
+            "method": "smt_model_check",
+            "engine": engine,
+            "logic": logic,
+            "artifact_format": "smtlib2",
+            "side_conditions": [],
+        }
+    if status == "unsat":
+        return {
+            "status": EXTERNALLY_ASSERTED,
+            "evidence": "external_solver_assertion",
+            "externally_verified": False,
+            "method": "smt_solver",
+            "engine": engine,
+            "logic": logic,
+            "artifact_format": "smtlib2",
+            # Stated in the record itself, so a reader who never looks up the
+            # badge still cannot mistake this for a proof.
+            "note": (
+                "no unsat proof was consumed or checked; this status is not in "
+                "research.MACHINE_CHECKED_STATUSES"
+            ),
+            "side_conditions": [],
+        }
+    return {
+        "status": "unverified",
+        "evidence": "none",
+        "externally_verified": False,
+        "method": "smt_solver",
+        "engine": engine,
+        "logic": logic,
+        "artifact_format": "smtlib2",
+        "reason_unknown": reason_unknown,
+        "side_conditions": [],
+    }

--- a/python/alkahest/smt.py
+++ b/python/alkahest/smt.py
@@ -353,8 +353,13 @@ class SmtSupport:
     logic : str or None
         The SMT-LIB logic the emitter chose, e.g. ``"QF_NRA"``.
     reason : str
-        Stable reason code: ``"ok"``, ``"outside_fragment"``, ``"quantified"``,
-        or ``"no_solver"``.
+        Stable reason code, and the complete set a caller may branch on:
+        ``"ok"``, ``"outside_fragment"``, ``"quantified"``,
+        ``"not_exactly_checkable"``, or ``"no_solver"``.
+        ``"not_exactly_checkable"`` is the one that is easy to miss: the formula
+        exports fine, but the kernel cannot evaluate it exactly at a rational
+        model (``abs`` is the case you will actually hit), so :func:`solve`
+        refuses it rather than return a ``sat`` it did not check.
     detail : str
         One-sentence human explanation.
     recommendation : str
@@ -363,7 +368,10 @@ class SmtSupport:
         The emitted script, handed back so a caller that goes on to use it does
         not pay for the export twice.
     error : SmtError or None
-        The refusal, when ``exportable`` is ``False``.
+        The refusal :func:`solve` would raise: the export error when
+        ``exportable`` is ``False`` (``reason="outside_fragment"``), or the
+        ``E-SMT-002`` refusal when ``reason`` is ``"not_exactly_checkable"``.
+        ``None`` otherwise — including for ``"quantified"`` and ``"no_solver"``.
     """
 
     supported: bool

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -109,12 +109,31 @@ def test_capabilities_describes_verification_boundary():
     assert verification["statuses"] == [
         "certificate_available",
         "exactly_verified",
+        # Emitted only by the SMT bridge, for an external `unsat` that carries
+        # no checked proof. It is advertised because `smt.solve` really does
+        # produce it, and it is deliberately absent from
+        # `research.MACHINE_CHECKED_STATUSES`.
+        "externally_asserted",
         "numerically_checked",
         "unverified",
     ]
-    assert verification["artifacts"] == {"lean4_source": True}
-    assert verification["checkers"] == {"lean4": "external"}
+    assert verification["artifacts"] == {"lean4_source": True, "smtlib2_script": True}
+    assert verification["checkers"] == {"lean4": "external", "smt": "external"}
     assert verification["coverage"]["shape_classes"]["certified"] > 0
+
+    # Independent implementations and solvers are reported *negatively* too: an
+    # absent one appears as a falsy value rather than being omitted, so a caller
+    # can never mistake "not installed" for "agreed" or "checked".
+    assert "sympy" in verification["oracles"]
+    assert {"z3", "cvc5"} <= set(verification["smt_solvers"])
+
+
+def test_externally_asserted_is_advertised_because_it_can_be_emitted():
+    """The list must track reality, not intent — pin it to a real emission."""
+    verification = alkahest.capabilities()["verification"]
+    assert alkahest.smt.EXTERNALLY_ASSERTED in verification["statuses"]
+    # ...and it must never count as machine-checked.
+    assert alkahest.smt.EXTERNALLY_ASSERTED not in alkahest.research.MACHINE_CHECKED_STATUSES
 
 
 def test_derived_result_labels_emitted_lean_source_as_unchecked_evidence():

--- a/tests/test_ansatz.py
+++ b/tests/test_ansatz.py
@@ -16,10 +16,12 @@ to zero.
 
 from __future__ import annotations
 
+import itertools
 from fractions import Fraction
 
 import alkahest as ak
 import pytest
+from alkahest import ansatz as ansatz_module
 from alkahest.ansatz import (
     DEFAULT_SEED,
     Ansatz,
@@ -184,6 +186,21 @@ def test_linear_combination_infers_its_variables(pool, x):
     family = linear_combination(pool, [ak.sin(x), ak.cos(x)])
     assert family.names == ("c_0", "c_1")
     assert [str(v) for v in family.vars] == ["x"]
+
+
+def test_reserved_names_do_not_become_independent_variables(pool, x, y):
+    # `reserved=` says "this name is taken", not "this is a variable". Inferring
+    # vars from it would silently change what the fit is asked to prove: the
+    # family below is a combination of sin and cos in x alone, and y is only
+    # kept away from the coefficient names.
+    family = linear_combination(pool, [ak.sin(x), ak.cos(x)], name="rv", reserved=[y])
+    assert [str(v) for v in family.vars] == ["x"]
+    solution = fit(family, family.expr - ak.sin(x))
+    assert solution.status == "exactly_verified"
+    # ... and the reservation still does its own job.
+    with pytest.raises(AnsatzError) as excinfo:
+        linear_combination(pool, [ak.sin(x)], name="k", reserved=[pool.symbol("k_0")])
+    assert excinfo.value.code == "E-ANSATZ-001"
 
 
 def test_max_terms_refuses_before_materialising(pool, x, y):
@@ -518,6 +535,63 @@ def test_collocation_and_derivative_extraction_agree(pool, x, y):
         assert_identical(by_points.expr, by_taylor.expr)
 
 
+def _break_probe_after(monkeypatch, successes: int) -> None:
+    """Make ``_probe`` fail from its *successes*-th call onward, every attempt."""
+    real_probe = ansatz_module._probe
+    calls = itertools.count()
+
+    def flaky(*args, **kwargs):
+        if next(calls) % (successes + 1) == successes:
+            raise ZeroDivisionError("undefined here")
+        return real_probe(*args, **kwargs)
+
+    monkeypatch.setattr(ansatz_module, "_probe", flaky)
+
+
+def test_a_half_built_taylor_system_is_never_returned(pool, x, monkeypatch):
+    # Every base point dies on its second multi-index. The rows that did get
+    # built are not a system anybody asked for, and returning them alongside a
+    # shorter list of multi-indices would misreport which equations exist.
+    family = polynomial(pool, [x], degree=2, name="ht")
+    _break_probe_after(monkeypatch, successes=1)
+    rows, used, skipped = ansatz_module._derivative_rows(
+        family, family.expr - x**2, seed=DEFAULT_SEED, degree_bound=3
+    )
+    assert rows == []
+    assert used == []
+    assert skipped == 8
+
+
+def test_an_unbuildable_taylor_system_is_reported_not_silently_truncated(pool, x, monkeypatch):
+    family = polynomial(pool, [x], degree=2, name="ut")
+    _break_probe_after(monkeypatch, successes=1)
+    with pytest.raises(AnsatzError) as excinfo:
+        fit(family, family.expr - x**2, certify="exact")
+    assert excinfo.value.code == "E-ANSATZ-003"
+    # Worded as the build failure it is, not as a claim about the family.
+    assert "could not extract the Taylor system" in str(excinfo.value)
+
+
+def test_max_points_does_not_shrink_the_taylor_system(pool, x):
+    # max_points caps sample-point *draws*; the Taylor path draws one base
+    # point and derives its equations from the degree bound, so a small cap
+    # must not quietly hand back a smaller (weaker) system.
+    family = polynomial(pool, [x], degree=3, name="mp")
+    residual = family.expr - x**3
+
+    def extraction(solution):
+        return next(s for s in solution.steps if s["rule"] == "ansatz_taylor_extraction")
+
+    uncapped = fit(family, residual, certify="exact")
+    capped = fit(family, residual, certify="exact", max_points=2)
+    assert extraction(capped)["after"] == extraction(uncapped)["after"]
+    assert capped.rank == uncapped.rank == 4
+    assert capped.status == "exactly_verified"
+    assert capped.free == ()
+    # The bound the system actually covers is stated, not implied.
+    assert any("total degree <=" in c for c in extraction(capped)["side_conditions"])
+
+
 # ---------------------------------------------------------------------------
 # Determinism
 # ---------------------------------------------------------------------------
@@ -560,12 +634,38 @@ def test_the_default_seed_is_a_fixed_constant():
     assert isinstance(DEFAULT_SEED, int)
 
 
+@pytest.mark.timeout(120)
+def test_the_sampler_outlives_its_initial_draw_window():
+    # A fixed draw window (-12..12 over 1..4) holds only 65 distinct points in
+    # one variable. Asking for more than that from a stream that rejects
+    # repeats but never widens hangs forever inside next(), which no caller's
+    # attempt counter can interrupt, so this must run rather than wedge.
+    points = list(itertools.islice(ansatz_module._sample_points(1, DEFAULT_SEED), 400))
+    assert len(set(points)) == 400
+    # Determinism is unaffected: the same seed still replays the same stream,
+    # starting from the same first points.
+    again = list(itertools.islice(ansatz_module._sample_points(1, DEFAULT_SEED), 400))
+    assert again == points
+
+
+@pytest.mark.timeout(120)
+def test_a_fit_can_ask_for_more_points_than_the_initial_window_holds(pool, x):
+    # Same hazard reached through the public API: 203 collocation rows in one
+    # variable is more than the un-widened window could ever supply.
+    family = polynomial(pool, [x], degree=2, name="wide")
+    solution = fit(family, family.expr - x**2, oversample=200)
+    assert len(solution.points) == 203
+    assert len(set(solution.points)) == 203
+    assert solution.status == "exactly_verified"
+    assert_identical(solution.expr, x**2)
+
+
 # ---------------------------------------------------------------------------
 # Nonlinear escalation
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not ak.capabilities()["groebner"], reason="needs a groebner build")
+@pytest.mark.skipif(not ak.capabilities().get("groebner", False), reason="needs a groebner build")
 def test_nonlinear_residual_escalates_to_solve(pool, x):
     family = polynomial(pool, [x], degree=0, name="nl")
     unknown = family.unknowns[0]
@@ -575,14 +675,16 @@ def test_nonlinear_residual_escalates_to_solve(pool, x):
     assert solution.status == "exactly_verified"
 
 
-@pytest.mark.skipif(ak.capabilities()["groebner"], reason="only meaningful without groebner")
+@pytest.mark.skipif(
+    ak.capabilities().get("groebner", False), reason="only meaningful without groebner"
+)
 def test_nonlinear_residual_refuses_without_groebner(pool, x):  # pragma: no cover - build gated
     family = polynomial(pool, [x], degree=0, name="nl")
     unknown = family.unknowns[0]
     assert _fit_code(family, unknown * unknown - pool.integer(4)) == "E-ANSATZ-004"
 
 
-@pytest.mark.skipif(not ak.capabilities()["groebner"], reason="needs a groebner build")
+@pytest.mark.skipif(not ak.capabilities().get("groebner", False), reason="needs a groebner build")
 def test_unsatisfiable_nonlinear_residual_is_also_e_ansatz_003(pool, x):
     # c^2 * x = 1 cannot hold at two different sample points at once.
     family = polynomial(pool, [x], degree=0, name="ns")

--- a/tests/test_ansatz.py
+++ b/tests/test_ansatz.py
@@ -1,0 +1,703 @@
+"""Ansatz families and coefficient fitting (``alkahest.ansatz``).
+
+Covers the properties a conjecture-generation loop depends on: a known
+polynomial round-trips exactly, an underdetermined family reports its free
+parameters instead of picking a member, an inconsistent family raises
+``E-ANSATZ-003`` (a *result* — the branch is closed), an oversized family is
+refused before anything is materialised, the Padé/rational transform keeps the
+solve linear, sample points are reproducible from a seed, and a fitted solution
+drops into a :class:`~alkahest.research.ClaimGraph` unchanged.
+
+The honesty contract is the point of most of these: :func:`alkahest.ansatz.fit`
+may solve heuristically, but it grades itself by exact back-substitution, and
+``"exactly_verified"`` is reachable only when the residual provably normalises
+to zero.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import alkahest as ak
+import pytest
+from alkahest.ansatz import (
+    DEFAULT_SEED,
+    Ansatz,
+    AnsatzSolution,
+    certify_nonneg,
+    enumerate_family,
+    exponential_polynomial,
+    fit,
+    linear_combination,
+    polynomial,
+    quadratic_form,
+    rational,
+)
+from alkahest.exceptions import AnsatzError
+from alkahest.research import MACHINE_CHECKED_STATUSES, STATUS_BADGES
+
+
+@pytest.fixture
+def pool():
+    return ak.ExprPool()
+
+
+@pytest.fixture
+def x(pool):
+    return pool.symbol("x")
+
+
+@pytest.fixture
+def y(pool):
+    return pool.symbol("y")
+
+
+def assert_identical(left, right) -> None:
+    """Assert ``left - right`` is identically zero.
+
+    The kernel has several normalisers with different strengths (``simplify``
+    does not collect like terms with rational coefficients; ``cancel`` refuses
+    non-integer coefficients outright), so a round-trip check tries each of the
+    public ones and passes if any of them closes.
+    """
+    difference = left - right
+    for normalise in (ak.simplify_expanded, ak.cancel, ak.simplify, ak.together):
+        try:
+            candidate = normalise(difference)
+        except Exception:
+            continue
+        candidate = getattr(candidate, "value", candidate)
+        if str(candidate).strip() == "0":
+            return
+    raise AssertionError(f"{left} is not identical to {right}")
+
+
+def _fit_code(*args, **kwargs) -> str:
+    """Return the ``E-ANSATZ-*`` code raised by a call, failing if none is."""
+    with pytest.raises(AnsatzError) as excinfo:
+        fit(*args, **kwargs)
+    return excinfo.value.code
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_reachable_from_package_root():
+    assert "ansatz" in ak.__all__
+    assert ak.ansatz.fit is fit
+
+
+def test_public_names_are_exported():
+    for name in (
+        "Ansatz",
+        "AnsatzSolution",
+        "certify_nonneg",
+        "enumerate_family",
+        "exponential_polynomial",
+        "fit",
+        "linear_combination",
+        "polynomial",
+        "quadratic_form",
+        "rational",
+    ):
+        assert name in ak.ansatz.__all__, f"{name} missing from alkahest.ansatz.__all__"
+        assert hasattr(ak.ansatz, name)
+
+
+# ---------------------------------------------------------------------------
+# Family construction
+# ---------------------------------------------------------------------------
+
+
+def test_polynomial_names_are_predictable_and_graded(pool, x, y):
+    univariate = polynomial(pool, [x], degree=3)
+    assert univariate.names == ("c_0", "c_1", "c_2", "c_3")
+
+    bivariate = polynomial(pool, [x, y], degree=2, name="a")
+    # Graded, then lexicographic with the first variable heaviest.
+    assert bivariate.names == ("a_0_0", "a_1_0", "a_0_1", "a_2_0", "a_1_1", "a_0_2")
+    assert len(bivariate) == len(bivariate.unknowns) == len(bivariate.basis) == 6
+    assert bivariate.vars == (x, y)
+    assert set(bivariate.symbols) == set(bivariate.names)
+
+
+def test_polynomial_min_degree_gives_homogeneous_forms(pool, x, y):
+    homogeneous = polynomial(pool, [x, y], degree=2, min_degree=2, name="h")
+    assert homogeneous.names == ("h_2_0", "h_1_1", "h_0_2")
+
+
+def test_unknowns_and_vars_stay_disjoint(pool, x):
+    family = polynomial(pool, [x], degree=2)
+    assert set(map(str, family.unknowns)).isdisjoint(map(str, family.vars))
+
+
+def test_coefficient_name_collision_is_refused(pool, x):
+    # The pool already has a symbol c_0 reachable from the variables handed in,
+    # so a family prefixed "c" would silently fit the wrong thing.
+    collider = pool.symbol("c_0")
+    with pytest.raises(AnsatzError) as excinfo:
+        polynomial(pool, [x], degree=1, reserved=[collider])
+    assert excinfo.value.code == "E-ANSATZ-001"
+    assert "name" in (excinfo.value.remediation or "")
+    # ... and a different prefix is accepted rather than gensym-ed.
+    assert polynomial(pool, [x], degree=1, name="k", reserved=[collider]).names == ("k_0", "k_1")
+
+
+def test_collision_check_sees_symbols_of_the_variables(pool):
+    weird = pool.symbol("c_0")
+    with pytest.raises(AnsatzError) as excinfo:
+        polynomial(pool, [weird], degree=1)
+    assert excinfo.value.code == "E-ANSATZ-001"
+
+
+def test_with_prefix_renames_the_whole_family(pool, x):
+    family = polynomial(pool, [x], degree=2)
+    renamed = family.with_prefix("t")
+    assert renamed.names == ("t_0", "t_1", "t_2")
+    assert renamed.family == family.family
+
+
+def test_rational_denominator_is_monic_by_default(pool, x):
+    family = rational(pool, [x], num_degree=2, den_degree=2)
+    assert family.names == ("a_0", "a_1", "a_2", "b_1", "b_2")
+    assert family.metadata["numerator_terms"] == 3
+    # Without the normalisation p/q and (2p)/(2q) are the same function, so the
+    # extra denominator constant would show up as a spurious free parameter.
+    unnormalised = rational(pool, [x], 1, 1, name="u", den_name="v", monic_denominator=False)
+    assert unnormalised.names == ("u_0", "u_1", "v_0", "v_1")
+
+
+def test_exponential_polynomial_shape(pool, x):
+    family = exponential_polynomial(pool, x, [1, -1], degree=1)
+    assert family.names == ("c_0_0", "c_0_1", "c_1_0", "c_1_1")
+    assert family.metadata["degrees"] == (1, 1)
+
+
+def test_quadratic_form_carries_only_the_upper_triangle(pool, x, y):
+    family = quadratic_form(pool, [x, y])
+    assert family.names == ("q_0_0", "q_0_1", "q_1_1")
+
+
+def test_linear_combination_infers_its_variables(pool, x):
+    family = linear_combination(pool, [ak.sin(x), ak.cos(x)])
+    assert family.names == ("c_0", "c_1")
+    assert [str(v) for v in family.vars] == ["x"]
+
+
+def test_max_terms_refuses_before_materialising(pool, x, y):
+    with pytest.raises(AnsatzError) as excinfo:
+        polynomial(pool, [x, y], degree=40, max_terms=32)
+    assert excinfo.value.code == "E-ANSATZ-002"
+    assert "861" in str(excinfo.value)  # C(42, 2) — counted, never built
+    assert "max_terms" in (excinfo.value.remediation or "")
+
+
+def test_max_terms_is_checked_for_every_family(pool, x, y):
+    for call in (
+        lambda: rational(pool, [x], num_degree=20, den_degree=20, max_terms=8),
+        lambda: quadratic_form(pool, [x, y], max_terms=2),
+        lambda: exponential_polynomial(pool, x, [1, 2], degree=9, max_terms=4),
+        lambda: linear_combination(pool, [x, y, x * y], max_terms=2),
+    ):
+        with pytest.raises(AnsatzError) as excinfo:
+            call()
+        assert excinfo.value.code == "E-ANSATZ-002"
+
+
+def test_instantiate_accepts_names_and_exprs(pool, x):
+    family = polynomial(pool, [x], degree=1)
+    assert str(family.instantiate({"c_0": 2, "c_1": 0})) == "2"
+    assert str(family.instantiate({family.unknowns[0]: 0, family.unknowns[1]: 1})) == "x"
+
+
+def test_instantiate_rejects_an_unknown_name(pool, x):
+    family = polynomial(pool, [x], degree=1)
+    with pytest.raises(AnsatzError) as excinfo:
+        family.instantiate({"nope": 1})
+    assert excinfo.value.code == "E-ANSATZ-001"
+
+
+# ---------------------------------------------------------------------------
+# Enumeration (stage 2)
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_family_is_lazy_and_complete(pool, x):
+    family = polynomial(pool, [x], degree=1)
+    members = [str(m) for m in enumerate_family(family, [0, 1])]
+    assert members == ["0", "x", "1", "(x + 1)"]
+
+
+def test_enumerate_family_is_bounded_before_the_first_member(pool, x):
+    family = polynomial(pool, [x], degree=5)
+    generator = enumerate_family(family, range(100), max_members=1000)
+    with pytest.raises(AnsatzError) as excinfo:
+        next(generator)
+    assert excinfo.value.code == "E-ANSATZ-002"
+
+
+def test_enumerate_family_output_is_evaluable(pool, x):
+    family = polynomial(pool, [x], degree=2, name="e")
+    for member in enumerate_family(family, [-1, 1]):
+        assert isinstance(ak.eval_expr(member, {x: 0.5}), float)
+
+
+# ---------------------------------------------------------------------------
+# Fitting — the round trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("coefficients", "expected_terms"),
+    [
+        ((2, -3, 1), {"2", "x^2"}),
+        ((0, 0, 5), {"x^2"}),
+        ((7, 0, 0), {"7"}),
+    ],
+)
+def test_polynomial_round_trip_recovers_the_target(pool, x, coefficients, expected_terms):
+    family = polynomial(pool, [x], degree=2)
+    target = pool.integer(0)
+    for power, coefficient in enumerate(coefficients):
+        target = target + pool.integer(coefficient) * x**power
+    target = ak.simplify(target).value
+
+    solution = fit(family, family.expr - target)
+
+    assert solution.status == "exactly_verified"
+    assert solution.free == ()
+    assert solution.determined
+    assert solution.rank == len(family)
+    assert_identical(solution.expr, target)
+    assert expected_terms <= set(str(solution.expr).replace("(", " ").replace(")", " ").split())
+
+
+def test_multivariate_round_trip(pool, x, y):
+    family = polynomial(pool, [x, y], degree=2, name="m")
+    target = x * y + y**2 - pool.integer(3)
+    solution = fit(family, family.expr - target)
+    assert solution.status == "exactly_verified"
+    assert solution.rank == len(family)
+    assert_identical(solution.expr, target)
+
+
+def test_linear_combination_round_trip(pool, x):
+    family = linear_combination(pool, [ak.sin(x), ak.cos(x)], name="L")
+    target = pool.integer(3) * ak.sin(x) - pool.integer(2) * ak.cos(x)
+    solution = fit(family, family.expr - target)
+    assert solution.status == "exactly_verified"
+    assert solution.rank == 2
+
+
+def test_exponential_polynomial_round_trip(pool, x):
+    family = exponential_polynomial(pool, x, [1, -1], name="g")
+    target = pool.integer(2) * ak.exp(x) + pool.integer(3) * ak.exp(-x)
+    solution = fit(family, family.expr - target)
+    assert solution.status == "exactly_verified"
+    assert solution.rank == 2
+
+
+def test_quadratic_form_round_trip(pool, x, y):
+    family = quadratic_form(pool, [x, y], name="w")
+    target = x * x + pool.integer(2) * x * y + pool.integer(5) * y * y
+    solution = fit(family, family.expr - target)
+    assert solution.status == "exactly_verified"
+    assert solution.rank == 3
+
+
+def test_fit_result_is_an_ansatz_solution(pool, x):
+    family = polynomial(pool, [x], degree=1)
+    solution = fit(family, family.expr - x)
+    assert isinstance(solution, AnsatzSolution)
+    assert isinstance(solution.ansatz, Ansatz)
+    assert solution.value is solution.expr
+    assert solution.certificate is None
+    assert solution.points  # the points that built the system, for reproduction
+    assert "AnsatzSolution" in repr(solution)
+
+
+# ---------------------------------------------------------------------------
+# Fitting — underdetermined, inconsistent, and over-sampling
+# ---------------------------------------------------------------------------
+
+
+def test_underdetermined_family_returns_free_parameters(pool, x):
+    # d/dx of a cubic vanishing identically pins every coefficient but the
+    # constant: the members that work are a one-dimensional family.
+    family = polynomial(pool, [x], degree=3, name="d")
+    solution = fit(family, ak.diff(family.expr, x).value)
+
+    assert solution.rank == 3
+    assert [str(f) for f in solution.free] == ["d_0"]
+    assert not solution.determined
+    assert solution.status == "exactly_verified"
+    # No arbitrary member was picked: the free parameter is still symbolic.
+    assert "d_0" in str(solution.expr)
+
+
+def test_underdetermined_family_is_solved_for_any_free_value(pool, x):
+    family = polynomial(pool, [x], degree=3, name="u")
+    solution = fit(family, ak.diff(family.expr, x).value)
+    free = solution.free[0]
+    for value in (-2, 0, 7):
+        member = ak.subs(solution.expr, {free: value})
+        assert_identical(ak.diff(member, x).value, pool.integer(0))
+
+
+def test_dependent_basis_shows_up_as_a_free_parameter(pool, x):
+    # sin and 2*sin are dependent, so fitting them to sin(x) is a family.
+    family = linear_combination(pool, [ak.sin(x), pool.integer(2) * ak.sin(x)], name="p")
+    solution = fit(family, family.expr - ak.sin(x))
+    assert solution.rank == 1
+    assert len(solution.free) == 1
+
+
+def test_inconsistent_family_raises_e_ansatz_003(pool, x):
+    family = polynomial(pool, [x], degree=1, name="s")
+    with pytest.raises(AnsatzError) as excinfo:
+        fit(family, family.expr - x**2)
+    error = excinfo.value
+    assert error.code == "E-ANSATZ-003"
+    # Worded as a result, not a malfunction.
+    assert "no member of this" in str(error)
+    assert "result, not a malfunction" in (error.remediation or "")
+
+
+def test_inconsistency_survives_enlarging_only_by_enlarging(pool, x):
+    small = polynomial(pool, [x], degree=1, name="v")
+    assert _fit_code(small, small.expr - x**3) == "E-ANSATZ-003"
+    big = polynomial(pool, [x], degree=3, name="V")
+    assert fit(big, big.expr - x**3).status == "exactly_verified"
+
+
+def test_rank_is_read_off_the_reduction_not_the_point_count(pool, x):
+    # 4 unknowns, and fit() draws strictly more equations than that; a family
+    # that is only rank 3 must still report 3.
+    family = polynomial(pool, [x], degree=3, name="r")
+    solution = fit(family, ak.diff(family.expr, x).value)
+    assert solution.rank == 3 < len(family)
+
+
+def test_oversample_can_be_tightened(pool, x):
+    family = polynomial(pool, [x], degree=2, name="o")
+    solution = fit(family, family.expr - x**2, oversample=0)
+    assert solution.rank == 3
+    assert len(solution.points) == 3
+
+
+def test_points_with_a_vanishing_denominator_are_skipped(pool, x):
+    # Put a removable singularity exactly where the sampler looks first: the
+    # fit must skip that point rather than build a row out of 0/0.
+    probe = fit(polynomial(pool, [x], degree=1, name="pp"), pool.symbol("pp_1") * pool.integer(0))
+    pole = Fraction(probe.points[0][0])
+    pole_expr = pool.rational(pole.numerator, pole.denominator)
+
+    family = polynomial(pool, [x], degree=1, name="q")
+    target = (x * x - pole_expr * pole_expr) / (x - pole_expr)  # = x + pole, undefined at x = pole
+    solution = fit(family, family.expr - target)
+
+    assert all(point[0] != str(pole) for point in solution.points)
+    assert solution.rank == 2
+    assert_identical(solution.expr, x + pole_expr)
+
+
+# ---------------------------------------------------------------------------
+# Fitting — the rational / Padé transform
+# ---------------------------------------------------------------------------
+
+
+def test_rational_fit_recovers_a_rational_target(pool, x):
+    family = rational(pool, [x], num_degree=1, den_degree=1)
+    target = (x + pool.integer(2)) / (x - pool.integer(1))
+    solution = fit(family, family.expr - target)
+    assert solution.status == "exactly_verified"
+    assert_identical(solution.expr, target)
+
+
+def test_rational_fit_clears_the_denominator_automatically(pool, x):
+    family = rational(pool, [x], num_degree=1, den_degree=1, name="n", den_name="m")
+    target = pool.integer(1) / (pool.integer(1) + x)
+    solution = fit(family, family.expr - target)
+    rules = [step["rule"] for step in solution.steps]
+    assert "ansatz_clear_denominator" in rules
+    assert solution.status == "exactly_verified"
+
+
+def test_ansatz_residual_states_the_denominator_clearing(pool, x):
+    family = rational(pool, [x], num_degree=1, den_degree=1, name="p", den_name="r")
+    residual = family.residual(pool.integer(1))
+    # p - 1*q is affine in the unknowns; p/q - 1 is not.
+    assert "^-1" not in str(residual)
+    solution = fit(family, residual)
+    assert solution.status == "exactly_verified"
+
+
+def test_pade_of_exp_matches_the_taylor_coefficients(pool, x):
+    # A Padé approximant is a *local* match, not an identity, so this is the
+    # exact-system route with an explicit degree bound.
+    family = rational(pool, [x], num_degree=2, den_degree=2, name="u", den_name="v")
+    solution = fit(family, family.residual(ak.exp(x)), certify="exact", degree_bound=4)
+
+    # The (2,2) Pade approximant of exp: (1 + x/2 + x^2/12) / (1 - x/2 + x^2/12).
+    by_name = {str(k): str(v) for k, v in solution.assignment.items()}
+    assert by_name == {
+        "u_0": "1",
+        "u_1": "1/2",
+        "u_2": "1/12",
+        "v_1": "-1/2",
+        "v_2": "1/12",
+    }
+
+    # ... and the honesty gate correctly refuses to call it an identity.
+    assert solution.status == "numerically_checked"
+    assert solution.verification["residual"] != "0"
+
+
+def test_fitting_a_rational_family_to_exp_as_an_identity_is_inconsistent(pool, x):
+    family = rational(pool, [x], num_degree=2, den_degree=2, name="i", den_name="j")
+    assert _fit_code(family, family.residual(ak.exp(x))) == "E-ANSATZ-003"
+
+
+# ---------------------------------------------------------------------------
+# Fitting — the honesty contract
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_verified_only_when_the_residual_normalises_to_zero(pool, x):
+    family = polynomial(pool, [x], degree=2, name="hv")
+    solution = fit(family, family.expr - (x**2 + pool.integer(1)))
+    assert solution.verification["status"] == "exactly_verified"
+    assert solution.verification["residual"] == "0"
+    assert solution.verification["externally_verified"] is False
+    assert solution.status in MACHINE_CHECKED_STATUSES
+
+
+def test_status_strings_come_from_the_existing_vocabulary(pool, x):
+    family = polynomial(pool, [x], degree=1, name="sv")
+    for certify, expected in (("residual", "exactly_verified"), ("none", "unverified")):
+        solution = fit(family, family.expr - x, certify=certify)
+        assert solution.status == expected
+        assert solution.status in STATUS_BADGES
+        assert solution.badge == STATUS_BADGES[expected]
+
+
+def test_certify_none_records_no_verification_and_no_recheck_recipe(pool, x):
+    family = polynomial(pool, [x], degree=1, name="cn")
+    solution = fit(family, family.expr - x, certify="none")
+    assert solution.verification["evidence"] == "none"
+    assert solution.check == {}
+
+
+def test_certify_rejects_an_unknown_mode(pool, x):
+    family = polynomial(pool, [x], degree=1, name="cr")
+    with pytest.raises(ValueError, match="certify"):
+        fit(family, family.expr - x, certify="wishful")
+
+
+def test_derivation_log_uses_the_step_schema(pool, x):
+    family = polynomial(pool, [x], degree=2, name="dl")
+    solution = fit(family, family.expr - x**2)
+    assert solution.steps
+    for step in solution.steps:
+        assert set(ak.STEP_FIELDS) <= set(step)
+        assert isinstance(step["side_conditions"], list)
+    assert [s["rule"] for s in solution.steps][-1] == "ansatz_back_substitution"
+
+
+def test_collocation_and_derivative_extraction_agree(pool, x, y):
+    for family, target in (
+        (polynomial(pool, [x], degree=3, name="A1"), x**3 - pool.integer(2) * x),
+        (polynomial(pool, [x, y], degree=2, name="A2"), x * y + pool.integer(4)),
+    ):
+        by_points = fit(family, family.expr - target)
+        by_taylor = fit(family, family.expr - target, certify="exact")
+        assert by_points.rank == by_taylor.rank
+        assert by_points.status == by_taylor.status == "exactly_verified"
+        assert_identical(by_points.expr, by_taylor.expr)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_sample_points_are_reproducible_without_a_budget(pool, x):
+    family = polynomial(pool, [x], degree=2, name="D1")
+    first = fit(family, family.expr - x**2)
+    second = fit(family, family.expr - x**2)
+    assert first.points == second.points
+
+
+def test_budget_seed_drives_the_sample_points(pool, x):
+    family = polynomial(pool, [x], degree=2, name="D2")
+    residual = family.expr - x**2
+
+    with ak.context(budget=ak.Budget(seed=7)):
+        seven_a = fit(family, residual)
+    with ak.context(budget=ak.Budget(seed=7)):
+        seven_b = fit(family, residual)
+    with ak.context(budget=ak.Budget(seed=99)):
+        ninety_nine = fit(family, residual)
+
+    assert seven_a.points == seven_b.points
+    assert seven_a.points != ninety_nine.points
+    # Different points, same mathematics.
+    assert_identical(seven_a.expr, ninety_nine.expr)
+
+
+def test_explicit_seed_overrides_the_budget(pool, x):
+    family = polynomial(pool, [x], degree=2, name="D3")
+    residual = family.expr - x**2
+    with ak.context(budget=ak.Budget(seed=7)):
+        overridden = fit(family, residual, seed=DEFAULT_SEED)
+    assert overridden.points == fit(family, residual).points
+
+
+def test_the_default_seed_is_a_fixed_constant():
+    # Two machines with no budget active must draw the same points.
+    assert isinstance(DEFAULT_SEED, int)
+
+
+# ---------------------------------------------------------------------------
+# Nonlinear escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not ak.capabilities()["groebner"], reason="needs a groebner build")
+def test_nonlinear_residual_escalates_to_solve(pool, x):
+    family = polynomial(pool, [x], degree=0, name="nl")
+    unknown = family.unknowns[0]
+    solution = fit(family, unknown * unknown - pool.integer(4) + pool.integer(0) * x)
+    assert "ansatz_nonlinear_escalation" in [s["rule"] for s in solution.steps]
+    assert str(solution.expr) in {"2", "-2"}
+    assert solution.status == "exactly_verified"
+
+
+@pytest.mark.skipif(ak.capabilities()["groebner"], reason="only meaningful without groebner")
+def test_nonlinear_residual_refuses_without_groebner(pool, x):  # pragma: no cover - build gated
+    family = polynomial(pool, [x], degree=0, name="nl")
+    unknown = family.unknowns[0]
+    assert _fit_code(family, unknown * unknown - pool.integer(4)) == "E-ANSATZ-004"
+
+
+@pytest.mark.skipif(not ak.capabilities()["groebner"], reason="needs a groebner build")
+def test_unsatisfiable_nonlinear_residual_is_also_e_ansatz_003(pool, x):
+    # c^2 * x = 1 cannot hold at two different sample points at once.
+    family = polynomial(pool, [x], degree=0, name="ns")
+    unknown = family.unknowns[0]
+    assert _fit_code(family, unknown * unknown * x - pool.integer(1)) == "E-ANSATZ-003"
+
+
+# ---------------------------------------------------------------------------
+# Hand-off to positivity
+# ---------------------------------------------------------------------------
+
+
+def test_certify_nonneg_hands_a_lyapunov_candidate_to_prove_nonneg(pool, x, y):
+    family = quadratic_form(pool, [x, y], name="P")
+    target = x * x + pool.integer(2) * x * y + pool.integer(5) * y * y
+    solution = fit(family, family.expr - target)
+
+    certificate = certify_nonneg(solution)
+    # Returned verbatim from alkahest.prove_nonneg — nothing reinterpreted here.
+    assert isinstance(certificate, ak.PositivityCertificate)
+    assert certificate.verify()
+
+
+def test_certify_nonneg_passes_a_refutation_through(pool, x, y):
+    family = quadratic_form(pool, [x, y], name="N")
+    target = x * x - pool.integer(4) * y * y
+    solution = fit(family, family.expr - target)
+    with pytest.raises(ak.SosError) as excinfo:
+        certify_nonneg(solution)
+    # The positivity subsystem's own three-valued outcome, unmodified.
+    assert excinfo.value.code.startswith("E-SOS-")
+
+
+def test_certify_nonneg_refuses_an_undetermined_family(pool, x, y):
+    family = quadratic_form(pool, [x, y], name="U")
+    solution = fit(family, pool.integer(0) * family.expr)
+    assert solution.free
+    with pytest.raises(AnsatzError) as excinfo:
+        certify_nonneg(solution)
+    assert excinfo.value.code == "E-ANSATZ-003"
+    assert "family, not a candidate" in str(excinfo.value)
+
+
+def test_certify_nonneg_accepts_a_bare_expression(pool, x):
+    assert certify_nonneg(x * x, [x]).verify()
+
+
+# ---------------------------------------------------------------------------
+# Claim-graph integration
+# ---------------------------------------------------------------------------
+
+
+def test_solution_records_into_a_claim_graph_unchanged(pool, x):
+    family = polynomial(pool, [x], degree=2, name="cg")
+    with ak.research.session(title="ansatz", pool=pool) as session:
+        solution = fit(family, family.expr - (x**2 + pool.integer(1)))
+        claim = session.record(
+            solution,
+            method="ansatz.fit",
+            label="degree-2 fit",
+            check=solution.check,
+        )
+
+    assert claim.status == "exactly_verified"
+    assert claim.machine_checked
+    assert claim.badge == STATUS_BADGES["exactly_verified"]
+    assert claim.derivation  # the fit's own steps travelled with it
+    assert claim.certificate is None
+    assert len(session.graph) == 1
+    assert session.graph.summary() == {"exactly_verified": 1}
+
+
+def test_recorded_solution_survives_a_json_round_trip(pool, x):
+    family = polynomial(pool, [x], degree=1, name="js")
+    with ak.research.session(title="ansatz", pool=pool) as session:
+        session.record(fit(family, family.expr - x), method="ansatz.fit")
+    restored = ak.research.ClaimGraph.from_json(session.graph.to_json())
+    assert restored.digest() == session.graph.digest()
+
+
+def test_recheck_recipe_does_not_refute_a_good_fit(pool, x):
+    family = polynomial(pool, [x], degree=2, name="rc")
+    with ak.research.session(title="ansatz", pool=pool) as session:
+        solution = fit(family, family.expr - (x**2 - pool.integer(1)))
+        session.record(solution, method="ansatz.fit", check=solution.check)
+    report = session.graph.verify()
+    assert report.ok
+    assert report.failed == ()
+
+
+def test_an_unverified_fit_is_recorded_as_unverified(pool, x):
+    family = polynomial(pool, [x], degree=1, name="uv")
+    with ak.research.session(title="ansatz", pool=pool) as session:
+        claim = session.record(fit(family, family.expr - x, certify="none"), method="ansatz.fit")
+    assert claim.status == "unverified"
+    assert not claim.machine_checked
+
+
+# ---------------------------------------------------------------------------
+# Composition with the rest of the loop plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_fit_composes_with_batch_map(pool, x):
+    families = [polynomial(pool, [x], degree=d, name=f"b{d}") for d in (1, 2, 3)]
+    target = x**2
+
+    outcomes = ak.batch_map(lambda f: fit(f, f.expr - target), families)
+    assert [o.ok for o in outcomes] == [False, True, True]
+    # The failing candidate carries the ansatz code, not a generic batch code.
+    assert (outcomes[0].error or {})["code"] == "E-ANSATZ-003"
+
+
+def test_enumerated_members_compile(pool, x):
+    family = polynomial(pool, [x], degree=1, name="jt")
+    for member in enumerate_family(family, [0, 1]):
+        compiled = ak.compile_expr(member, [x])
+        assert isinstance(compiled([0.5]), float)

--- a/tests/test_certificate_ledger.py
+++ b/tests/test_certificate_ledger.py
@@ -334,11 +334,14 @@ def test_capabilities_advertises_only_statuses_it_can_emit(pool):
     assert verification["statuses"] == [
         "certificate_available",
         "exactly_verified",
+        # `smt.solve` emits this for an external `unsat`; see
+        # tests/test_smt.py::test_unsat_is_externally_asserted_and_never_machine_checked
+        "externally_asserted",
         "numerically_checked",
         "unverified",
     ]
     assert "lean_checked" not in verification["statuses"]
-    assert verification["checkers"] == {"lean4": "external"}
+    assert verification["checkers"] == {"lean4": "external", "smt": "external"}
 
     x = pool.symbol("x")
     for result in (

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -874,12 +874,17 @@ def test_all_exports_exist():
     assert len(module.__all__) == len(set(module.__all__))
 
 
-def test_error_codes_used_are_the_registered_three():
-    """Only ``E-XCHECK-001/002/003`` may be raised from this module."""
+def test_error_codes_used_are_the_registered_four():
+    """Only ``E-XCHECK-001/002/003/004`` may be raised from this module.
+
+    003 and 004 are separate on purpose: 003 is the caller error "this operation
+    has no comparison rung", raised before any oracle is consulted, and 004 is
+    "the oracle declined". Sharing one code left a caller unable to tell the two
+    apart.
+    """
     source = (REPO / "python" / "alkahest" / "crosscheck.py").read_text(encoding="utf-8")
     used = set(re.findall(r'"(E-XCHECK-\d+)"', source))
-    assert used <= {"E-XCHECK-001", "E-XCHECK-002", "E-XCHECK-003"}
-    assert used == {"E-XCHECK-001", "E-XCHECK-002", "E-XCHECK-003"}
+    assert used == {"E-XCHECK-001", "E-XCHECK-002", "E-XCHECK-003", "E-XCHECK-004"}
 
 
 def test_doc_page_exists_and_covers_the_surface():
@@ -894,8 +899,17 @@ def test_module_is_importable_without_touching_sympy():
     """Importing ``alkahest`` must not pull SymPy in — it is an optional dep."""
     source = (REPO / "python" / "alkahest" / "crosscheck.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
+
+    def _is_sympy(name: str | None) -> bool:
+        # Submodules count: `import sympy.abc` and `from sympy.functions import sin`
+        # both import SymPy at module-import time, and an exact == "sympy"
+        # comparison would wave them through.
+        return name is not None and (name == "sympy" or name.startswith("sympy."))
+
     for node in tree.body:  # module level only; lazy imports live inside functions
         assert not isinstance(node, ast.Import) or all(
-            alias.name != "sympy" for alias in node.names
+            not _is_sympy(alias.name) for alias in node.names
         )
-        assert not (isinstance(node, ast.ImportFrom) and node.module == "sympy")
+        # `node.level == 0` keeps a relative `from .sympy_helpers import ...` out
+        # of scope; only absolute imports can reach the real SymPy.
+        assert not (isinstance(node, ast.ImportFrom) and node.level == 0 and _is_sympy(node.module))

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -1,0 +1,901 @@
+"""Cross-CAS differential testing — the harness's own tests.
+
+A tool whose job is detecting disagreement has an unusual failure mode: it can
+be *quietly useless*. Every test here is aimed at one of the three ways that
+happens, rather than at "the happy path works":
+
+* **Silent non-coverage.** The translator grows a hole when a new node kind
+  lands, and expressions containing it stop being checked at all.
+  ``test_dispatch_table_covers_every_node_tag`` re-derives the tag set from the
+  Rust binding source, so the table cannot drift.
+* **Silent unavailability.** SymPy is not installed, ``check`` answers
+  something falsy-but-not-alarming, and a loop believes it is cross-checking.
+  ``test_absent_oracle_*`` simulates the missing oracle and pins
+  ``outcome="unavailable"``.
+* **Silent collapse.** ``incomparable`` gets folded into ``agree`` somewhere in
+  the ladder. ``test_incomparable_never_reports_agreement`` and the refusal
+  tests pin every route that can produce it.
+
+Oracle-dependent tests use ``pytest.importorskip``, matching ``test_oracle.py``:
+without SymPy this file skips cleanly rather than failing.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import alkahest as ak
+import pytest
+from alkahest.crosscheck import (
+    FROZEN_CORPUS,
+    FUNCTION_MAP,
+    NODE_TAGS,
+    OPERATIONS,
+    OUTCOMES,
+    PREDICATE_KINDS,
+    REFUSED_FUNCTIONS,
+    RUNG_NAMES,
+    CrossCheck,
+    Divergence,
+    FrozenCase,
+    Oracle,
+    SweepReport,
+    SymPyOracle,
+    SymPyTranslator,
+    Translator,
+    check,
+    oracles,
+    run_frozen_corpus,
+    sweep,
+    to_sympy,
+)
+from alkahest.exceptions import CrossCheckError
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def pool():
+    return ak.ExprPool()
+
+
+@pytest.fixture
+def x(pool):
+    return pool.symbol("x")
+
+
+def _sympy():
+    return pytest.importorskip("sympy")
+
+
+# ---------------------------------------------------------------------------
+# The translation table must not drift
+# ---------------------------------------------------------------------------
+
+
+def _tags_from_binding_source() -> set[str] | None:
+    """Re-derive the node tags from ``alkahest-py/src/lib.rs``.
+
+    The tags are emitted by one exhaustive ``match`` over ``ExprData`` inside
+    ``PyExpr::node``; Rust's exhaustiveness check guarantees a new variant
+    cannot be added without an arm, and this reads the string literal each arm
+    produces. Returns ``None`` when the source is not present (an installed
+    wheel rather than a checkout), so the test degrades to a skip.
+    """
+    source_path = REPO / "alkahest-py" / "src" / "lib.rs"
+    if not source_path.is_file():
+        return None
+    text = source_path.read_text(encoding="utf-8")
+    start = text.find("fn node(")
+    if start == -1:
+        return None
+    # Brace-match the function body rather than guessing at an end marker.
+    open_index = text.find("{", start)
+    depth = 0
+    end = open_index
+    for index in range(open_index, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    body = text[open_index : end + 1]
+    return set(re.findall(r'"([a-z_0-9]+)"\.into_py\(py\)', body))
+
+
+def test_dispatch_table_covers_every_node_tag():
+    """The translator's table must be total over what ``node()`` can emit.
+
+    This is the anti-drift ratchet. A partial table does not fail loudly — it
+    silently stops cross-checking every expression containing the new node,
+    which is the worst possible outcome for a tool whose entire job is
+    detecting disagreement.
+    """
+    emitted = _tags_from_binding_source()
+    if emitted is None:
+        pytest.skip("alkahest-py/src/lib.rs is not present in this environment")
+    assert emitted == set(NODE_TAGS), (
+        "alkahest.crosscheck.NODE_TAGS has drifted from the tags PyExpr::node emits.\n"
+        f"  only in lib.rs:    {sorted(emitted - set(NODE_TAGS))}\n"
+        f"  only in NODE_TAGS: {sorted(set(NODE_TAGS) - emitted)}\n"
+        "Add the new tag to Translator._DISPATCH with a mapping you can defend, or "
+        "to the refusal path — but it must appear explicitly."
+    )
+    assert set(Translator._DISPATCH) == set(NODE_TAGS)
+
+
+def test_every_dispatch_handler_exists_on_the_sympy_translator():
+    for tag, handler in Translator._DISPATCH.items():
+        assert hasattr(SymPyTranslator, handler), f"{tag} -> missing handler {handler}"
+
+
+def test_predicate_kinds_match_the_binding_source():
+    """``PREDICATE_KINDS`` must track the Rust ``PredicateKind`` match."""
+    source_path = REPO / "alkahest-py" / "src" / "lib.rs"
+    if not source_path.is_file():
+        pytest.skip("alkahest-py/src/lib.rs is not present in this environment")
+    text = source_path.read_text(encoding="utf-8")
+    emitted = set(re.findall(r'PredicateKind::\w+ => "(\w+)"', text))
+    assert emitted == set(PREDICATE_KINDS)
+
+
+def test_unknown_tag_refuses_rather_than_guessing():
+    """A tag absent from the table raises ``E-XCHECK-001``, never a best effort."""
+    _sympy()
+
+    class Fake:
+        @staticmethod
+        def node():
+            return ["quaternion", 1]
+
+    with pytest.raises(CrossCheckError) as info:
+        SymPyOracle().translate(Fake())
+    assert info.value.code == "E-XCHECK-001"
+    assert "quaternion" in str(info.value)
+
+
+def test_function_map_and_refusals_are_disjoint():
+    assert not set(FUNCTION_MAP) & set(REFUSED_FUNCTIONS)
+
+
+def test_every_mapped_primitive_resolves_in_sympy():
+    """A name in ``FUNCTION_MAP`` that SymPy does not have is a latent refusal."""
+    sympy = _sympy()
+    missing = [name for name in FUNCTION_MAP.values() if not hasattr(sympy, name)]
+    assert not missing, f"FUNCTION_MAP targets absent from SymPy: {missing}"
+
+
+def test_registry_primitives_are_classified(pool, x):
+    """Every registered primitive is either mapped or explicitly refused.
+
+    "Not in either table" is the state that produces a surprise refusal in the
+    middle of a sweep; forcing a decision per primitive is what keeps the
+    refusals *documented* rather than accidental.
+    """
+    _sympy()
+    names = {row["name"] for row in ak.capabilities()["primitives"]}
+    classified = set(FUNCTION_MAP) | set(REFUSED_FUNCTIONS) | {"bessel_j0", "bessel_j1"}
+    unclassified = sorted(names - classified)
+    assert not unclassified, (
+        f"primitives with no entry in FUNCTION_MAP or REFUSED_FUNCTIONS: {unclassified}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(REFUSED_FUNCTIONS))
+def test_refused_primitives_refuse_with_a_reason(pool, name):
+    _sympy()
+    x = pool.symbol("x")
+    with pytest.raises(CrossCheckError) as info:
+        to_sympy(pool.func(name, [x]))
+    assert info.value.code == "E-XCHECK-001"
+    assert REFUSED_FUNCTIONS[name] in str(info.value)
+
+
+# ---------------------------------------------------------------------------
+# Translation is faithful
+# ---------------------------------------------------------------------------
+
+
+def test_translates_the_arithmetic_core(pool, x):
+    sympy = _sympy()
+    sx = sympy.Symbol("x")
+    cases = [
+        (pool.integer(-3), sympy.Integer(-3)),
+        (pool.rational(2, 5), sympy.Rational(2, 5)),
+        (x + pool.integer(1), sx + 1),
+        (x * pool.integer(3), 3 * sx),
+        (x ** pool.integer(2), sx**2),
+        (ak.sin(x) ** pool.integer(2), sympy.sin(sx) ** 2),
+        (ak.log(ak.exp(x)), sympy.log(sympy.exp(sx))),
+    ]
+    for expr, expected in cases:
+        assert sympy.simplify(to_sympy(expr) - expected) == 0, str(expr)
+
+
+def test_translates_reserved_symbols(pool):
+    """``∞`` and ``I`` are interned as ordinary symbols and must not stay free."""
+    sympy = _sympy()
+    assert to_sympy(pool.pos_infinity()) is sympy.oo
+    assert to_sympy(pool.imaginary_unit()) is sympy.I
+    assert to_sympy(-pool.pos_infinity()) == -sympy.oo
+
+
+def test_translates_predicates_and_piecewise(pool, x):
+    sympy = _sympy()
+    sx = sympy.Symbol("x")
+    zero = pool.integer(0)
+    assert to_sympy(pool.lt(x, zero)) == sympy.StrictLessThan(sx, 0)
+    assert to_sympy(pool.pred_and([pool.gt(x, zero), pool.pred_ne(x, zero)])).func is sympy.And
+    assert to_sympy(pool.pred_true()) is sympy.true
+    branch = ak.piecewise([(pool.lt(x, zero), pool.integer(1))], pool.integer(2))
+    assert to_sympy(branch) == sympy.Piecewise((1, sx < 0), (2, True))
+
+
+def test_translates_big_o(pool, x):
+    sympy = _sympy()
+    assert to_sympy(pool.big_o(x ** pool.integer(3))) == sympy.O(sympy.Symbol("x") ** 3)
+
+
+def test_translates_root_sum(pool, x):
+    """``RootSum`` maps onto SymPy's ``RootSum``, which is genuinely the same object."""
+    sympy = _sympy()
+    antiderivative = ak.integrate(x / (x ** pool.integer(4) + pool.integer(1)), x).value
+    assert antiderivative.node()[0] == "root_sum"
+    assert isinstance(to_sympy(antiderivative), sympy.RootSum)
+
+
+def test_quantifiers_refuse(pool, x):
+    """SymPy has no term-level quantifier, so translating one would be a fiction."""
+    _sympy()
+    body = pool.gt(x, pool.integer(0))
+    for quantified in (pool.forall(x, body), pool.exists(x, body)):
+        with pytest.raises(CrossCheckError) as info:
+            to_sympy(quantified)
+        assert info.value.code == "E-XCHECK-001"
+
+
+# ---------------------------------------------------------------------------
+# Assumptions
+# ---------------------------------------------------------------------------
+
+
+def test_mappable_assumptions_travel_with_the_expression(pool, x):
+    """``x > 0`` must reach SymPy, or the oracle is asked a weaker question."""
+    sympy = _sympy()
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    translated = to_sympy(ak.sqrt(x ** pool.integer(2)), assumptions=assumptions)
+    # Under x > 0 SymPy folds sqrt(x**2) to x; without the assumption it cannot.
+    assert translated == sympy.Symbol("x", positive=True)
+    assert to_sympy(ak.sqrt(x ** pool.integer(2))) != sympy.Symbol("x")
+
+
+@pytest.mark.parametrize(
+    ("build", "flag"),
+    [
+        (lambda p, s: p.gt(s, p.integer(0)), "positive"),
+        (lambda p, s: p.ge(s, p.integer(0)), "nonnegative"),
+        (lambda p, s: p.lt(s, p.integer(0)), "negative"),
+        (lambda p, s: p.le(s, p.integer(0)), "nonpositive"),
+        (lambda p, s: p.pred_ne(s, p.integer(0)), "nonzero"),
+    ],
+)
+def test_each_sign_assumption_maps_to_its_flag(pool, x, build, flag):
+    _sympy()
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(build(pool, x))
+    flags = SymPyTranslator(pytest.importorskip("sympy")).assumption_flags(assumptions)
+    assert flags == {"x": {flag: True}}
+
+
+def test_unmappable_assumption_refuses(pool, x):
+    """A relation between two symbols has no per-symbol flag; refuse, do not drop it."""
+    _sympy()
+    y = pool.symbol("y")
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, y))
+    with pytest.raises(CrossCheckError) as info:
+        to_sympy(x, assumptions=assumptions)
+    assert info.value.code == "E-XCHECK-001"
+
+
+def test_unmappable_assumption_yields_incomparable_not_agree(pool, x):
+    _sympy()
+    y = pool.symbol("y")
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, y))
+    out = check("diff", ak.sin(x), x, assumptions=assumptions)
+    assert out.outcome == "incomparable"
+    assert out.reason == "untranslatable"
+    assert not out.checked
+
+
+def test_ambient_assumption_context_is_picked_up(pool, x):
+    _sympy()
+    assumptions = ak.Assumptions(pool)
+    assumptions.refine(pool.gt(x, pool.integer(0)))
+    with ak.context(pool=pool, assumptions=assumptions):
+        flags = SymPyTranslator(pytest.importorskip("sympy"))
+        assert flags.assumption_flags(ak.active_assumptions()) == {"x": {"positive": True}}
+
+
+# ---------------------------------------------------------------------------
+# The absent oracle must be loud
+# ---------------------------------------------------------------------------
+
+
+class _AbsentOracle(Oracle):
+    """An oracle that is never available — stands in for SymPy not installed."""
+
+    name = "absent"
+
+    @classmethod
+    def available(cls) -> bool:
+        return False
+
+    @property
+    def version(self) -> str:  # pragma: no cover - never constructed
+        raise AssertionError
+
+    def translate(self, expr, *, assumptions=None):  # pragma: no cover
+        raise AssertionError
+
+    def lift(self, obj, pool):  # pragma: no cover
+        raise AssertionError
+
+    def render(self, obj):  # pragma: no cover
+        raise AssertionError
+
+    def canonical(self, obj):  # pragma: no cover
+        raise AssertionError
+
+    def supports(self, operation):  # pragma: no cover
+        raise AssertionError
+
+    def run(self, operation, args):  # pragma: no cover
+        raise AssertionError
+
+    def is_zero(self, obj):  # pragma: no cover
+        raise AssertionError
+
+    def diff(self, obj, var):  # pragma: no cover
+        raise AssertionError
+
+    def subs(self, obj, bindings):  # pragma: no cover
+        raise AssertionError
+
+    def subs_by_name(self, obj, point):  # pragma: no cover
+        raise AssertionError
+
+    def to_float(self, obj):  # pragma: no cover
+        raise AssertionError
+
+
+@pytest.fixture
+def no_oracles(monkeypatch):
+    """Simulate an environment with no oracle installed at all."""
+    monkeypatch.setattr(
+        "alkahest.crosscheck._ORACLE_CLASSES", {"absent": _AbsentOracle}, raising=True
+    )
+
+
+def test_absent_oracle_reports_unavailable_never_agree(pool, x, no_oracles):
+    """The single easiest way for this feature to become actively harmful."""
+    out = check("diff", ak.sin(x), x)
+    assert out.outcome == "unavailable"
+    assert out.reason == "no_oracle"
+    assert out.outcome != "agree"
+    assert not out.checked
+    assert out.rung is None
+
+
+def test_absent_oracle_is_visible_in_oracles(no_oracles):
+    assert oracles() == {"absent": None}
+
+
+def test_absent_oracle_makes_the_frozen_corpus_skip_not_pass(no_oracles):
+    outcomes = run_frozen_corpus()
+    assert len(outcomes) == len(FROZEN_CORPUS)
+    assert all(result is None for _case, result in outcomes)
+
+
+def test_absent_oracle_sweep_does_not_pretend_to_have_run(no_oracles):
+    report = sweep(cases=4, seed=1)
+    assert report.oracle is None
+    assert report.counts()["unavailable"] == 4
+    assert report.counts()["agree"] == 0
+    assert report.findings == ()
+
+
+def test_sympy_import_failure_raises_e_xcheck_002(monkeypatch):
+    """``E-XCHECK-002`` must name the missing oracle, with a remediation."""
+
+    def boom():
+        raise CrossCheckError("no oracle", code="E-XCHECK-002", remediation="pip install sympy")
+
+    monkeypatch.setattr("alkahest.crosscheck._import_sympy", boom)
+    assert SymPyOracle.available() is False
+    with pytest.raises(CrossCheckError) as info:
+        SymPyOracle()
+    assert info.value.code == "E-XCHECK-002"
+    assert info.value.remediation
+
+
+def test_oracles_reports_installed_version():
+    sympy = _sympy()
+    assert oracles()["sympy"] == sympy.__version__
+
+
+# ---------------------------------------------------------------------------
+# Outcome vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_vocabulary_is_exactly_four_valued():
+    assert OUTCOMES == ("agree", "diverge", "incomparable", "unavailable")
+
+
+def test_crosscheck_has_no_truthiness():
+    """``if check(...)`` must not compile into a silent "it agreed"."""
+    assert "__bool__" not in CrossCheck.__dict__
+
+
+def test_checked_is_false_for_the_two_no_signal_outcomes():
+    for outcome in ("incomparable", "unavailable"):
+        assert not CrossCheck(operation="diff", outcome=outcome).checked
+    for outcome in ("agree", "diverge"):
+        assert CrossCheck(operation="diff", outcome=outcome).checked
+
+
+def test_unknown_operation_raises_e_xcheck_003(pool, x):
+    with pytest.raises(CrossCheckError) as info:
+        check("factor_the_universe", x)
+    assert info.value.code == "E-XCHECK-003"
+    assert "integrate" in str(info.value.remediation)
+
+
+def test_every_operation_names_a_real_alkahest_entry_point():
+    for name in OPERATIONS:
+        assert hasattr(ak, name), f"OPERATIONS[{name!r}] has no alkahest counterpart"
+
+
+def test_every_operation_declares_rungs_from_the_ladder():
+    for name, spec in OPERATIONS.items():
+        assert spec.rungs, name
+        assert all(rung in RUNG_NAMES for rung in spec.rungs), name
+
+
+def test_sweep_avoids_operations_with_a_known_non_terminating_path():
+    """``limit`` is excluded deliberately, and the exclusion must not be lost.
+
+    ``limit(sqrt(x**2 + x) - x, x, oo)`` does not terminate at this commit, and
+    the kernel holds the GIL throughout, so nothing in Python can bound it. The
+    sweep is a nightly job; one wedged candidate is one unread report.
+    """
+    from alkahest.crosscheck import SWEEP_OPERATIONS
+
+    assert "limit" not in SWEEP_OPERATIONS
+    assert set(SWEEP_OPERATIONS) <= set(OPERATIONS)
+
+
+def test_rung_four_leads_wherever_an_invariant_exists():
+    """The stated default: the invariant rung goes first when there is one."""
+    for name, spec in OPERATIONS.items():
+        if spec.invariant is not None:
+            assert spec.rungs[0] == 4, f"{name} has an invariant but does not lead with rung 4"
+
+
+# ---------------------------------------------------------------------------
+# The ladder
+# ---------------------------------------------------------------------------
+
+
+def test_integrate_settles_on_the_invariant_rung(pool, x):
+    """``sin·cos`` has three standard antiderivatives differing by constants."""
+    _sympy()
+    with ak.context(pool=pool):
+        out = check("integrate", ak.sin(x) * ak.cos(x), x)
+    assert out.outcome == "agree"
+    assert out.rung == 4
+    assert out.rung_name == "invariant"
+    assert out.conclusive
+
+
+def test_simplify_uses_the_value_preserving_invariant(pool, x):
+    """SymPy folds ``sin²+cos²`` and Alkahest may not — a strength gap, not a divergence."""
+    _sympy()
+    with ak.context(pool=pool):
+        out = check("simplify", ak.sin(x) ** pool.integer(2) + ak.cos(x) ** pool.integer(2))
+    assert out.outcome == "agree"
+    assert out.rung == 4
+
+
+def test_sum_indefinite_uses_the_telescoping_invariant(pool):
+    _sympy()
+    k = pool.symbol("k")
+    with ak.context(pool=pool):
+        out = check("sum_indefinite", k ** pool.integer(2), k)
+    assert out.outcome == "agree"
+    assert out.rung == 4
+
+
+def test_solve_substitutes_solutions_back(pool, x):
+    _sympy()
+    with ak.context(pool=pool):
+        out = check("solve", [x ** pool.integer(2) - pool.integer(4)], [x])
+    assert out.outcome == "agree"
+    assert out.rung == 4
+    assert "substituted back" in out.detail
+
+
+def test_series_strips_the_remainder_before_comparing(pool, x):
+    _sympy()
+    with ak.context(pool=pool):
+        out = check("series", ak.exp(x), x, pool.integer(0), 5)
+    assert out.outcome == "agree"
+    assert out.rung in (1, 2, 3)
+
+
+def test_diff_settles_without_an_invariant(pool, x):
+    _sympy()
+    with ak.context(pool=pool):
+        out = check("diff", ak.sin(ak.exp(x)), x)
+    assert out.outcome == "agree"
+    assert out.rung in (1, 2, 3)
+
+
+def test_rung_three_agreement_is_reported_as_inconclusive():
+    """Sampling can only fail to refute; that must show on the record."""
+    settled = CrossCheck(operation="diff", outcome="agree", rung=3, conclusive=False)
+    assert settled.rung_name == "rigorous_numeric"
+    assert not settled.conclusive
+
+
+def test_a_plus_c_difference_is_never_reported_as_a_divergence(pool, x, monkeypatch):
+    """The classic false alarm: two correct antiderivatives differing by a constant.
+
+    Rung 4 normally settles it. This forces rung 4 to come back inconclusive,
+    so rungs 1–3 are reached with two answers that genuinely differ pointwise —
+    and they must fall through to ``incomparable``, not fire.
+    """
+    _sympy()
+    real_integrate = ak.integrate
+
+    def shifted(expr, var, *bounds, **kwargs):
+        return real_integrate(expr, var, *bounds, **kwargs).value + pool.integer(7)
+
+    monkeypatch.setattr(ak, "integrate", shifted)
+    monkeypatch.setattr("alkahest.crosscheck._INVARIANTS", {})  # force rung 4 to be inconclusive
+    with ak.context(pool=pool):
+        out = check("integrate", x ** pool.integer(2), x)
+
+    assert out.outcome != "diverge", out.detail
+    assert out.divergence is None
+
+
+def test_alkahest_refusal_is_not_a_divergence(pool, x):
+    """An honest refusal must never be scored against Alkahest."""
+    _sympy()
+    with ak.context(pool=pool):
+        out = check("integrate", ak.exp(x ** pool.integer(2)), x)
+    assert out.outcome == "incomparable"
+    assert out.reason == "alkahest_refused"
+    assert out.divergence is None
+
+
+def test_oracle_refusal_is_not_a_divergence(pool, x, monkeypatch):
+    """An unevaluated ``Integral`` from SymPy is a refusal, not an answer."""
+    sympy = _sympy()
+    original = sympy.integrate
+
+    def unevaluated(expr, *args, **kwargs):
+        return sympy.Integral(expr, *args)
+
+    monkeypatch.setattr(sympy, "integrate", unevaluated)
+    try:
+        with ak.context(pool=pool):
+            out = check("integrate", x ** pool.integer(2), x)
+    finally:
+        monkeypatch.setattr(sympy, "integrate", original)
+    assert out.outcome == "incomparable"
+    assert out.reason == "oracle_refused"
+    assert out.divergence is None
+
+
+def test_incomparable_never_reports_agreement(pool, x):
+    """Sweep the routes that produce ``incomparable`` and pin every one."""
+    _sympy()
+    y = pool.symbol("y")
+    unmappable = ak.Assumptions(pool)
+    unmappable.refine(pool.gt(x, y))
+    routes = [
+        check("diff", ak.sin(x), x, assumptions=unmappable),
+        check("diff", pool.func("heaviside", [x]), x),
+        check("integrate", ak.exp(x ** pool.integer(2)), x),
+    ]
+    for out in routes:
+        assert out.outcome == "incomparable", out
+        assert out.outcome != "agree"
+        assert not out.checked
+
+
+# ---------------------------------------------------------------------------
+# Divergence records name two suspects
+# ---------------------------------------------------------------------------
+
+
+def test_a_divergence_names_two_suspects():
+    divergence = Divergence(
+        operation="integrate",
+        oracle="sympy",
+        oracle_version="1.14.0",
+        point={"x": 1.25},
+        alkahest_value="x**2",
+        oracle_value="x**3",
+    )
+    statement = divergence.statement()
+    assert "alkahest" in statement
+    assert "sympy" in statement
+    assert "x**2" in statement
+    assert "x**3" in statement
+    assert divergence.support == "unresolved"
+    assert not divergence.silent_error_candidate
+
+
+def test_divergence_wording_never_declares_alkahest_correct():
+    """The API must not editorialise; a divergence is evidence about *both*."""
+    forbidden = ("alkahest is right", "alkahest is correct", "sympy is wrong")
+    for support in ("unresolved", "alkahest_supported", "oracle_supported"):
+        divergence = Divergence(
+            operation="integrate",
+            oracle="sympy",
+            oracle_version="1.14.0",
+            support=support,
+            detail="the oracle answer fails the invariant",
+        )
+        text = divergence.statement().lower()
+        assert not any(phrase in text for phrase in forbidden)
+
+
+def test_only_a_rigorously_refuted_alkahest_side_is_a_silent_error_candidate():
+    """Routing into ``tests/silent_errors/`` must be earned, not assumed."""
+    assert not Divergence("i", "sympy", "1", support="unresolved").silent_error_candidate
+    assert not Divergence("i", "sympy", "1", support="alkahest_supported").silent_error_candidate
+    assert Divergence("i", "sympy", "1", support="oracle_supported").silent_error_candidate
+
+
+def test_a_planted_wrong_answer_is_caught_and_attributed(pool, x, monkeypatch):
+    """End-to-end: break Alkahest's integrator and the harness must say so.
+
+    Substituting a wrong antiderivative is the cheapest available model of a
+    silent error, and it exercises the whole escalation — invariant residual,
+    rigorous enclosure, ``support="oracle_supported"``, witness point.
+    """
+    _sympy()
+    real_integrate = ak.integrate
+
+    def wrong(expr, var, *bounds, **kwargs):
+        result = real_integrate(expr, var, *bounds, **kwargs)
+        return result.value + pool.integer(1) * var  # F + x: derivative is off by one
+
+    monkeypatch.setattr(ak, "integrate", wrong)
+    with ak.context(pool=pool):
+        out = check("integrate", x ** pool.integer(2), x)
+
+    assert out.outcome == "diverge"
+    assert out.rung == 4
+    assert out.divergence is not None
+    assert out.divergence.support == "oracle_supported"
+    assert out.divergence.silent_error_candidate
+    assert out.witness is not None
+    assert out.witness["point"]
+    assert out.alkahest_value
+    assert out.oracle_value
+
+
+def test_a_planted_wrong_oracle_is_attributed_to_the_oracle(pool, x, monkeypatch):
+    """The mirror image: the harness must be able to blame the oracle too."""
+    sympy = _sympy()
+    original = sympy.integrate
+
+    def wrong(expr, *args, **kwargs):
+        return original(expr, *args, **kwargs) + sympy.Symbol("x")
+
+    monkeypatch.setattr(sympy, "integrate", wrong)
+    try:
+        with ak.context(pool=pool):
+            out = check("integrate", x ** pool.integer(2), x)
+    finally:
+        monkeypatch.setattr(sympy, "integrate", original)
+
+    assert out.outcome == "diverge"
+    assert out.divergence is not None
+    assert out.divergence.support == "alkahest_supported"
+    assert not out.divergence.silent_error_candidate
+
+
+def test_a_planted_missing_solution_is_caught(pool, x, monkeypatch):
+    """``solve`` rung 4: every returned solution verifies, but one is missing."""
+    _sympy()
+    real_solve = ak.solve
+
+    def truncated(equations, variables, **kwargs):
+        return real_solve(equations, variables, **kwargs)[:1]
+
+    monkeypatch.setattr(ak, "solve", truncated)
+    with ak.context(pool=pool):
+        out = check("solve", [x ** pool.integer(2) - pool.integer(4)], [x])
+
+    assert out.outcome == "diverge"
+    assert out.reason == "solution_set_size_differs"
+    assert out.divergence is not None
+    assert out.divergence.support == "unresolved"
+
+
+# ---------------------------------------------------------------------------
+# Determinism and reproducibility
+# ---------------------------------------------------------------------------
+
+
+def test_checks_are_deterministic_under_a_fixed_seed(pool, x):
+    _sympy()
+    with ak.context(pool=pool):
+        first = check("integrate", ak.sin(x) * ak.cos(x), x, seed=99)
+        second = check("integrate", ak.sin(x) * ak.cos(x), x, seed=99)
+    assert first.as_dict() == second.as_dict()
+
+
+def test_sweeps_are_reproducible_from_their_recorded_seed():
+    _sympy()
+    first = sweep(cases=8, seed=4242)
+    second = sweep(cases=8, seed=first.seed)
+    assert first.seed == 4242
+    assert [c.as_dict() for c in first.checks] == [c.as_dict() for c in second.checks]
+
+
+def test_sweep_takes_its_seed_from_the_active_budget():
+    """D6's nightly sweep is driven by ``budget_seed``, not a private RNG."""
+    _sympy()
+    with ak.context(budget=ak.Budget(seed=31337)):
+        report = sweep(cases=2)
+    assert report.seed == 31337
+
+
+def test_sweep_report_counts_are_total_over_the_vocabulary():
+    _sympy()
+    report = sweep(cases=6, seed=11)
+    counts = report.counts()
+    assert set(counts) == set(OUTCOMES)
+    assert sum(counts.values()) == len(report.checks)
+    assert isinstance(report, SweepReport)
+    assert str(report.seed) in report.summary()
+    assert report.oracle_version in report.summary()
+
+
+def test_sweep_findings_and_candidates_are_subsets():
+    _sympy()
+    report = sweep(cases=10, seed=5)
+    assert all(c.outcome == "diverge" for c in report.findings)
+    assert set(report.silent_error_candidates) <= set(report.findings)
+
+
+# ---------------------------------------------------------------------------
+# The frozen corpus (tier 2 — the per-PR gate)
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_corpus_ids_are_unique():
+    ids = [case.id for case in FROZEN_CORPUS]
+    assert len(ids) == len(set(ids))
+
+
+def test_every_frozen_case_is_well_formed():
+    for case in FROZEN_CORPUS:
+        assert case.operation in OPERATIONS, case.id
+        assert case.expected in OUTCOMES, case.id
+        assert case.oracle_versions, case.id
+        assert case.found_by, f"{case.id} does not say where it came from"
+        assert case.note, f"{case.id} does not say what it protects"
+
+
+def test_frozen_cases_carry_an_oracle_version_range():
+    """Without a version range the corpus rots silently on an oracle upgrade."""
+    for case in FROZEN_CORPUS:
+        assert case.applies_to("1.14.0"), case.id
+        assert not case.applies_to("0.1"), case.id
+
+
+@pytest.mark.parametrize("case", FROZEN_CORPUS, ids=lambda c: c.id)
+def test_frozen_corpus_case(case):
+    _sympy()
+    results = dict(run_frozen_corpus(cases=[case]))
+    outcome = results[case]
+    if outcome is None:
+        pytest.skip(f"{case.id} does not apply to the installed oracle version")
+    assert outcome.outcome == case.expected, (
+        f"{case.id}: expected {case.expected}, got {outcome.outcome} "
+        f"({outcome.reason}: {outcome.detail})"
+    )
+    if case.expected_reason is not None:
+        assert outcome.reason == case.expected_reason, case.id
+
+
+def test_version_range_matching():
+    build = FrozenCase(id="t", operation="diff", build=lambda p: (), expected="agree")
+    for spec, version, expected in [
+        (">=1.12", "1.14.0", True),
+        (">=1.12", "1.11.1", False),
+        (">=1.12,<2", "1.99", True),
+        (">=1.12,<2", "2.0.0", False),
+        ("==1.14.0", "1.14.0", True),
+        ("!=1.14.0", "1.14.0", False),
+    ]:
+        case = FrozenCase(
+            id=build.id,
+            operation="diff",
+            build=build.build,
+            expected="agree",
+            oracle_versions=spec,
+        )
+        assert case.applies_to(version) is expected, (spec, version)
+
+
+def test_version_range_tolerates_prerelease_suffixes():
+    case = FrozenCase(
+        id="t", operation="diff", build=lambda p: (), expected="agree", oracle_versions=">=1.12"
+    )
+    assert case.applies_to("1.14.0rc1")
+
+
+# ---------------------------------------------------------------------------
+# Docs and error-code hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_module_docstrings_have_runnable_doctests():
+    """The doctests must pass with *and* without SymPy, so they are guarded."""
+    import doctest
+
+    import alkahest.crosscheck as module
+
+    failures, _tests = doctest.testmod(module, verbose=False)
+    assert failures == 0
+
+
+def test_all_exports_exist():
+    import alkahest.crosscheck as module
+
+    for name in module.__all__:
+        assert hasattr(module, name), name
+    assert len(module.__all__) == len(set(module.__all__))
+
+
+def test_error_codes_used_are_the_registered_three():
+    """Only ``E-XCHECK-001/002/003`` may be raised from this module."""
+    source = (REPO / "python" / "alkahest" / "crosscheck.py").read_text(encoding="utf-8")
+    used = set(re.findall(r'"(E-XCHECK-\d+)"', source))
+    assert used <= {"E-XCHECK-001", "E-XCHECK-002", "E-XCHECK-003"}
+    assert used == {"E-XCHECK-001", "E-XCHECK-002", "E-XCHECK-003"}
+
+
+def test_doc_page_exists_and_covers_the_surface():
+    page = REPO / "docs" / "mdbook" / "src" / "crosscheck.md"
+    assert page.is_file(), "docs/mdbook/src/crosscheck.md is listed in SUMMARY.md"
+    text = page.read_text(encoding="utf-8")
+    for token in ("unavailable", "incomparable", "E-XCHECK-001", "oracles()", "check("):
+        assert token in text, f"crosscheck.md does not mention {token!r}"
+
+
+def test_module_is_importable_without_touching_sympy():
+    """Importing ``alkahest`` must not pull SymPy in — it is an optional dep."""
+    source = (REPO / "python" / "alkahest" / "crosscheck.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:  # module level only; lazy imports live inside functions
+        assert not isinstance(node, ast.Import) or all(
+            alias.name != "sympy" for alias in node.names
+        )
+        assert not (isinstance(node, ast.ImportFrom) and node.module == "sympy")

--- a/tests/test_research_crosscheck.py
+++ b/tests/test_research_crosscheck.py
@@ -1,0 +1,91 @@
+"""D8: ResearchSession cross-check policy — evidence, never a verdict."""
+
+from __future__ import annotations
+
+import alkahest as ak
+import pytest
+
+sympy = pytest.importorskip("sympy")
+
+
+def _session(**kw):
+    pool = ak.ExprPool()
+    return pool, ak.research.session(pool=pool, capture=True, **kw)
+
+
+def test_crosscheck_off_by_default_records_nothing():
+    pool, sess = _session()
+    x = pool.symbol("x")
+    with sess as s:
+        ak.integrate(x**2, x)
+    claim = s.graph.claims[0]
+    assert "crosscheck" not in claim.verification
+    assert not any(t.startswith("crosscheck:") for t in claim.tags)
+
+
+def test_crosscheck_on_attaches_outcome_and_tag():
+    pool, sess = _session(crosscheck=True)
+    x = pool.symbol("x")
+    with sess as s:
+        ak.integrate(x**2, x)
+    claim = s.graph.claims[0]
+    rec = claim.verification["crosscheck"]
+    assert rec["outcome"] in ak.crosscheck.OUTCOMES
+    assert f"crosscheck:{rec['outcome']}" in claim.tags
+
+
+def test_agreement_never_upgrades_status():
+    """The load-bearing invariant: an oracle agreeing is not a proof."""
+    pool, sess = _session(crosscheck=True)
+    x = pool.symbol("x")
+    with sess as s:
+        result = ak.integrate(x**2, x)
+    claim = s.graph.claims[0]
+    assert claim.status == str((result.verification or {}).get("status", "unverified"))
+    assert claim.verification["crosscheck"]["outcome"] == "agree"
+    # Agreement must not make the claim machine-checked.
+    if claim.status not in ak.research.MACHINE_CHECKED_STATUSES:
+        assert claim.machine_checked is False
+
+
+def test_divergence_does_not_refute():
+    """A divergence names two suspects (D5), so it must not set 'refuted'."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    with ak.research.session(pool=pool) as s:
+        stub = (
+            ak.crosscheck.CrossCheck(operation="integrate", outcome="diverge", oracle="sympy")
+            if hasattr(ak.crosscheck, "CrossCheck")
+            else None
+        )
+        if stub is None:
+            pytest.skip("CrossCheck not constructible directly")
+        claim = s.record(x**2, statement=x**2, method="integrate", crosscheck=stub)
+    assert claim.status != "refuted"
+    assert claim.verification["crosscheck"]["outcome"] == "diverge"
+    assert "crosscheck:diverge" in claim.tags
+
+
+def test_unavailable_oracle_is_not_agreement():
+    """The one thing that must never happen: absent oracle reading as agree."""
+    rec = ak.research._crosscheck_record(
+        type("S", (), {"outcome": "unavailable", "conclusive": False, "checked": False})()
+    )
+    assert rec["outcome"] == "unavailable"
+    assert rec["checked"] is False
+
+
+def test_crosscheck_failure_degrades_to_incomparable_not_agree():
+    """A cross-check that cannot even be posed is never recorded as agreement."""
+    bad = ak.research._run_crosscheck("integrate", ("not-an-expr", "nope"), {})
+    assert bad is not None
+    assert ak.research._crosscheck_record(bad)["outcome"] == "incomparable"
+
+
+def test_claim_with_crosscheck_survives_json_round_trip():
+    pool, sess = _session(crosscheck=True)
+    x = pool.symbol("x")
+    with sess as s:
+        ak.integrate(x**2, x)
+    restored = ak.research.ClaimGraph.from_json(s.graph.to_json())
+    assert restored.claims[0].verification["crosscheck"]["outcome"] in ak.crosscheck.OUTCOMES

--- a/tests/test_research_crosscheck.py
+++ b/tests/test_research_crosscheck.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import alkahest as ak
 import pytest
 
@@ -53,13 +55,7 @@ def test_divergence_does_not_refute():
     pool = ak.ExprPool()
     x = pool.symbol("x")
     with ak.research.session(pool=pool) as s:
-        stub = (
-            ak.crosscheck.CrossCheck(operation="integrate", outcome="diverge", oracle="sympy")
-            if hasattr(ak.crosscheck, "CrossCheck")
-            else None
-        )
-        if stub is None:
-            pytest.skip("CrossCheck not constructible directly")
+        stub = ak.crosscheck.CrossCheck(operation="integrate", outcome="diverge", oracle="sympy")
         claim = s.record(x**2, statement=x**2, method="integrate", crosscheck=stub)
     assert claim.status != "refuted"
     assert claim.verification["crosscheck"]["outcome"] == "diverge"
@@ -89,3 +85,39 @@ def test_claim_with_crosscheck_survives_json_round_trip():
         ak.integrate(x**2, x)
     restored = ak.research.ClaimGraph.from_json(s.graph.to_json())
     assert restored.claims[0].verification["crosscheck"]["outcome"] in ak.crosscheck.OUTCOMES
+
+
+def test_operation_kwargs_colliding_with_check_parameters_are_refused():
+    """A collision must refuse, not silently compare a different call.
+
+    ``crosscheck.check`` owns keyword-only parameters (``oracle``, ``points``,
+    ``pool``, ...). If a captured operation is called with one of those names,
+    forwarding it blindly would let ``check`` consume it as a cross-check
+    *setting*, so the comparison would run against a different call than the one
+    recorded — and report ``agree``. An honest ``incomparable`` is the only
+    acceptable outcome.
+    """
+    reserved = {
+        p.name
+        for p in inspect.signature(ak.crosscheck.check).parameters.values()
+        if p.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+    assert reserved, "check() should have keyword-only parameters to collide with"
+
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    for name in sorted(reserved):
+        stub = ak.research._run_crosscheck("integrate", (x**2, x), {name: object()})
+        record = ak.research._crosscheck_record(stub)
+        assert record is not None, f"{name}: collision must not be silently ignored"
+        assert record["outcome"] == "incomparable", f"{name}: got {record['outcome']}"
+        assert name in record["reason"]
+
+
+def test_non_colliding_kwargs_still_cross_check():
+    """The guard must not refuse ordinary operation keyword arguments."""
+    pool = ak.ExprPool()
+    x = pool.symbol("x")
+    stub = ak.research._run_crosscheck("integrate", (x**2, x), {})
+    record = ak.research._crosscheck_record(stub)
+    assert record is None or record["outcome"] in ak.crosscheck.OUTCOMES

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -139,6 +139,30 @@ def test_golden_powers_expand_into_products(pool):
     assert "(>= (* x x x) 8)" in ak.to_smtlib(pool.ge(x**3, pool.integer(8)))
 
 
+def test_golden_negative_power_over_an_int_base_uses_real_division(pool):
+    """`/` is real division in SMT-LIB; `div` is integer division.
+
+    `n^-1` for an integer `n` means the real reciprocal, so both operands are
+    lifted with `to_real`. Emitting a bare `(/ 1 n)` under a Reals_Ints logic
+    would still be real division, but relying on mixed-sort sugar that only some
+    logics define; emitting `div` would silently change the question to integer
+    division. This pins the coercion so neither can creep in.
+    """
+    n = pool.symbol("n", "integer")
+    text = ak.to_smtlib(pool.pred_eq(n ** pool.integer(-1), pool.rational(1, 2)))
+    assert "(/ (to_real 1) (to_real n))" in text
+    assert "div" not in text
+    # Only one sort appears in the source, but the coercion needs Reals_Ints.
+    assert "(set-logic QF_NIRA)" in text
+
+
+def test_golden_negative_power_over_a_real_base_needs_no_coercion(pool):
+    x = pool.symbol("x")
+    text = ak.to_smtlib(pool.pred_eq(x ** pool.integer(-1), pool.rational(1, 2)))
+    assert "(/ 1 x)" in text
+    assert "to_real" not in text
+
+
 def test_golden_piecewise_becomes_ite(pool):
     x = pool.symbol("x")
     pw = ak.piecewise([(pool.gt(x, pool.integer(0)), pool.integer(1))], pool.integer(-1))

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -431,8 +431,15 @@ def test_quantified_formulas_are_refused_by_solve(pool):
     assert support.reason == "quantified"
 
 
+@requires_solver
 def test_uncheckable_formula_is_refused_before_the_solver_runs(pool, monkeypatch):
-    """`abs` exports fine but the kernel cannot evaluate it exactly."""
+    """`abs` exports fine but the kernel cannot evaluate it exactly.
+
+    Guarded on a solver because it is about *ordering*: that the exactness
+    probe fires before the solver is invoked. With no solver installed the
+    ``E-SMT-001`` refusal legitimately comes first, so there is no ordering
+    left to observe.
+    """
     x = pool.symbol("x")
     f = pool.gt(pool.func("abs", [x]), pool.integer(1))
     assert "(ite (>= x 0) x (- x))" in ak.to_smtlib(f)
@@ -514,8 +521,13 @@ def test_supported_prefers_the_in_tree_route_for_real_arithmetic(pool):
     x = pool.symbol("x")
     support = smt.supported(pool.ge(x * x, pool.integer(0)))
     assert support.logic in {"QF_LRA", "QF_NRA"}
+    # The recommendation is about which *route* is better, not about what
+    # happens to be installed, so it holds with or without a solver.
     assert support.recommendation == "prefer_in_tree"
-    assert "prove_nonneg" in support.detail
+    if has_solver:
+        # `detail` names the in-tree route only when SMT was actually an
+        # option; with no solver it explains the missing binary instead.
+        assert "prove_nonneg" in support.detail
 
 
 def test_supported_recommends_smt_for_mixed_arithmetic(pool):

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -1,0 +1,782 @@
+"""P2 item 3 — the SMT/SAT bridge (``alkahest.to_smtlib`` / ``alkahest.smt``).
+
+Three tiers, deliberately separated:
+
+1. **Emitter goldens.** Pure text, no solver, runnable everywhere. If these
+   drift, the artifact Alkahest hands to the outside world changed.
+2. **Coverage guards.** The emitter must stay exhaustive over ``Formula`` and
+   ``PredicateKind``. Rust's match exhaustiveness enforces that at compile time;
+   these assert it from outside so a new variant handled by a wildcard would
+   still be caught.
+3. **Round-trip against z3**, skipped when no solver is installed — including a
+   property test over generated formulas for the one invariant the whole bridge
+   rests on: every ``sat`` model survives exact back-substitution.
+"""
+
+from __future__ import annotations
+
+import re
+from fractions import Fraction
+from pathlib import Path
+
+import alkahest as ak
+import pytest
+from alkahest import research, smt
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+REPO = Path(__file__).resolve().parent.parent
+EXPR_RS = REPO / "alkahest-core" / "src" / "kernel" / "expr.rs"
+LOGIC_RS = REPO / "alkahest-core" / "src" / "logic" / "mod.rs"
+SMTLIB_RS = REPO / "alkahest-core" / "src" / "logic" / "smtlib.rs"
+
+has_solver = any(v is not None for v in smt.solvers().values())
+requires_solver = pytest.mark.skipif(has_solver is False, reason="no SMT solver installed")
+
+# A wall limit on every solver call so a pathological instance cannot stall the
+# suite; the bridge maps a trip onto BudgetExceededError, which the tests that
+# expect an answer would surface loudly rather than hang on.
+BUDGET = ak.Budget(wall_ms=5_000)
+
+
+@pytest.fixture
+def pool():
+    return ak.ExprPool()
+
+
+# ---------------------------------------------------------------------------
+# 1. Emitter goldens — no solver required
+# ---------------------------------------------------------------------------
+
+
+def test_golden_linear_real(pool):
+    x = pool.symbol("x")
+    f = ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(3)))
+    assert ak.to_smtlib(f) == (
+        "; alkahest SMT-LIB 2 export\n"
+        "(set-logic QF_LRA)\n"
+        "(set-option :produce-models true)\n"
+        "(declare-fun x () Real)\n"
+        "(assert (and (> x 0) (< x 3)))\n"
+        "(check-sat)\n"
+        "(get-model)\n"
+    )
+
+
+def test_golden_nonlinear_picks_qf_nra(pool):
+    x = pool.symbol("x")
+    f = pool.gt(x * x, pool.integer(2))
+    assert ak.to_smtlib(f) == (
+        "; alkahest SMT-LIB 2 export\n"
+        "(set-logic QF_NRA)\n"
+        "(set-option :produce-models true)\n"
+        "(declare-fun x () Real)\n"
+        "(assert (> (* x x) 2))\n"
+        "(check-sat)\n"
+        "(get-model)\n"
+    )
+
+
+def test_golden_mixed_int_real_coerces_with_to_real(pool):
+    x = pool.symbol("x")
+    n = pool.symbol("n", "integer")
+    f = ak.And(pool.gt(x, n), pool.ge(n, pool.integer(2)))
+    assert ak.to_smtlib(f) == (
+        "; alkahest SMT-LIB 2 export\n"
+        "(set-logic QF_LIRA)\n"
+        "(set-option :produce-models true)\n"
+        "(declare-fun n () Int)\n"
+        "(declare-fun x () Real)\n"
+        "(assert (and (> x (to_real n)) (>= n 2)))\n"
+        "(check-sat)\n"
+        "(get-model)\n"
+    )
+
+
+def test_golden_pure_real_never_emits_to_real(pool):
+    """``to_real`` lives in Reals_Ints; under QF_LRA it would not even parse."""
+    x = pool.symbol("x")
+    assert "to_real" not in ak.to_smtlib(pool.gt(x, pool.integer(2)))
+
+
+def test_golden_quantified_drops_the_qf_prefix(pool):
+    x = pool.symbol("x")
+    y = pool.symbol("y")
+    f = ak.Forall(x, pool.gt(x + y, pool.integer(0)))
+    text = ak.to_smtlib(f)
+    assert "(set-logic LRA)" in text
+    assert "(forall ((x Real))" in text
+    # The bound variable is *not* also declared at the top level.
+    assert "(declare-fun x () Real)" not in text
+    assert "(declare-fun y () Real)" in text
+
+
+def test_golden_refined_domain_emits_its_side_condition(pool):
+    """Dropping the guard would silently widen the question being asked."""
+    q = pool.symbol("q", "positive")
+    text = ak.to_smtlib(pool.lt(q, pool.integer(1)))
+    assert "(assert (> q 0))" in text
+
+
+@pytest.mark.parametrize(
+    ("domain", "guard"),
+    [("positive", "(> g 0)"), ("nonneg", "(>= g 0)")],
+)
+def test_golden_refined_domains(pool, domain, guard):
+    g = pool.symbol("g", domain)
+    assert f"(assert {guard})" in ak.to_smtlib(pool.lt(g, pool.integer(5)))
+
+
+def test_golden_rationals_stay_exact(pool):
+    x = pool.symbol("x")
+    text = ak.to_smtlib(pool.pred_eq(x, pool.rational(-1, 3)))
+    assert "(/ (- 1) 3)" in text
+
+
+def test_golden_powers_expand_into_products(pool):
+    x = pool.symbol("x")
+    assert "(>= (* x x x) 8)" in ak.to_smtlib(pool.ge(x**3, pool.integer(8)))
+
+
+def test_golden_piecewise_becomes_ite(pool):
+    x = pool.symbol("x")
+    pw = ak.piecewise([(pool.gt(x, pool.integer(0)), pool.integer(1))], pool.integer(-1))
+    assert "(ite (> x 0) 1 (- 1))" in ak.to_smtlib(pool.pred_eq(pw, pool.integer(1)))
+
+
+def test_golden_reserved_names_are_quoted(pool):
+    ite = pool.symbol("ite")
+    assert "(declare-fun |ite| () Real)" in ak.to_smtlib(pool.gt(ite, pool.integer(0)))
+
+
+def test_check_sat_and_get_model_are_optional(pool):
+    x = pool.symbol("x")
+    text = ak.to_smtlib(pool.gt(x, pool.integer(0)), check_sat=False, get_model=False)
+    assert "(check-sat)" not in text
+    assert "(get-model)" not in text
+    assert ":produce-models" not in text
+
+
+# ---------------------------------------------------------------------------
+# Refusals — the emitter is total-or-refuse
+# ---------------------------------------------------------------------------
+
+
+def test_float_literal_is_refused_not_approximated(pool):
+    """A float is not the exact question it looks like, so it is not exported."""
+    x = pool.symbol("x")
+    with pytest.raises(ak.SmtError) as exc:
+        ak.to_smtlib(pool.gt(x, pool.float(0.1)))
+    assert exc.value.code == "E-SMT-002"
+    assert "rational" in (exc.value.remediation or "")
+
+
+def test_transcendental_head_is_refused(pool):
+    x = pool.symbol("x")
+    with pytest.raises(ak.SmtError) as exc:
+        ak.to_smtlib(pool.gt(ak.sin(x), pool.integer(0)))
+    assert exc.value.code == "E-SMT-002"
+
+
+def test_complex_symbol_is_refused(pool):
+    z = pool.symbol("z", "complex")
+    with pytest.raises(ak.SmtError) as exc:
+        ak.to_smtlib(pool.gt(z, pool.integer(0)))
+    assert exc.value.code == "E-SMT-002"
+
+
+def test_non_predicate_is_refused(pool):
+    with pytest.raises(ak.SmtError) as exc:
+        ak.to_smtlib(pool.symbol("x"))
+    assert exc.value.code == "E-SMT-002"
+
+
+def test_huge_exponent_is_bounded_not_expanded(pool):
+    """`x**100000` must refuse, not emit a megabyte of `x`."""
+    x = pool.symbol("x")
+    with pytest.raises(ak.SmtError) as exc:
+        ak.to_smtlib(pool.ge(x**100_000, pool.integer(1)))
+    assert exc.value.code == "E-SMT-002"
+    assert "MAX_POW_EXPANSION" in (exc.value.remediation or "")
+
+
+def test_named_logic_too_weak_is_an_error_not_a_downgrade(pool):
+    x = pool.symbol("x")
+    f = pool.gt(x * x, pool.integer(2))
+    with pytest.raises(ak.SmtError) as exc:
+        ak.to_smtlib(f, "QF_LRA")
+    assert exc.value.code == "E-SMT-002"
+    assert "(set-logic QF_NRA)" in ak.to_smtlib(f, "QF_NRA")
+
+
+def test_unknown_logic_name_is_refused(pool):
+    x = pool.symbol("x")
+    with pytest.raises(ak.SmtError):
+        ak.to_smtlib(pool.gt(x, pool.integer(0)), "QF_BV")
+
+
+# ---------------------------------------------------------------------------
+# 2. Coverage guards — the emitter cannot silently drift
+# ---------------------------------------------------------------------------
+
+#: Every ``PredicateKind`` the emitter has been reviewed against. Adding one to
+#: the kernel without adding it here fails, which is the point.
+FROZEN_PREDICATE_KINDS = frozenset(
+    {"Lt", "Le", "Gt", "Ge", "Eq", "Ne", "And", "Or", "Not", "True", "False"}
+)
+
+#: Same, for ``Formula``.
+FROZEN_FORMULA_VARIANTS = frozenset(
+    {"Atom", "And", "Or", "Not", "True", "False", "Forall", "Exists"}
+)
+
+
+def _enum_variants(source: str, name: str) -> set[str]:
+    match = re.search(rf"pub enum {name} \{{(.*?)\n\}}", source, re.DOTALL)
+    assert match, f"could not find `pub enum {name}` — did it move?"
+    body = match.group(1)
+    # Strip nested braces so struct-like variants contribute only their name.
+    depth = 0
+    flat = []
+    for char in body:
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        elif depth == 0:
+            flat.append(char)
+    return set(re.findall(r"^\s*([A-Z]\w*)", "".join(flat), re.MULTILINE))
+
+
+def test_predicate_kinds_have_not_drifted():
+    found = _enum_variants(EXPR_RS.read_text(), "PredicateKind")
+    assert found == FROZEN_PREDICATE_KINDS, (
+        "PredicateKind changed. Handle the new variant in "
+        "alkahest-core/src/logic/smtlib.rs (Emitter::formula) and update "
+        "FROZEN_PREDICATE_KINDS here."
+    )
+
+
+def test_formula_variants_have_not_drifted():
+    found = _enum_variants(LOGIC_RS.read_text(), "Formula")
+    assert found == FROZEN_FORMULA_VARIANTS, (
+        "Formula changed. Handle the new variant in "
+        "alkahest-core/src/logic/smtlib.rs and update FROZEN_FORMULA_VARIANTS here."
+    )
+
+
+def test_emitter_mentions_every_predicate_kind():
+    source = SMTLIB_RS.read_text()
+    missing = [k for k in FROZEN_PREDICATE_KINDS if f"PredicateKind::{k}" not in source]
+    assert not missing, f"smtlib.rs has no arm for PredicateKind::{missing}"
+
+
+def test_emitter_mentions_every_formula_variant():
+    source = SMTLIB_RS.read_text()
+    missing = [v for v in FROZEN_FORMULA_VARIANTS if f"Formula::{v}" not in source]
+    assert not missing, f"smtlib.rs has no arm for Formula::{missing}"
+
+
+def test_emitter_has_no_wildcard_match_arm():
+    """A `_ =>` arm would let a new node emit *something* instead of failing.
+
+    Match exhaustiveness is the enforcement mechanism for this emitter; a
+    catch-all disables it silently, and silently emitting plausible-but-wrong
+    SMT-LIB is exactly the failure this subsystem exists to prevent.
+    """
+    offenders = [
+        (i, line)
+        for i, line in enumerate(SMTLIB_RS.read_text().splitlines(), 1)
+        if re.match(r"^\s*_\s*=>", line)
+    ]
+    assert not offenders, f"wildcard match arm in smtlib.rs: {offenders}"
+
+
+def test_every_predicate_kind_actually_emits(pool):
+    """The static guards above pin the arms; this pins the behaviour."""
+    x = pool.symbol("x")
+    z = pool.integer(0)
+    leaf = pool.gt(x, z)
+    formulas = {
+        "Lt": pool.lt(x, z),
+        "Le": pool.le(x, z),
+        "Gt": pool.gt(x, z),
+        "Ge": pool.ge(x, z),
+        "Eq": pool.pred_eq(x, z),
+        "Ne": pool.pred_ne(x, z),
+        "And": ak.And(leaf, leaf),
+        "Or": ak.Or(leaf, leaf),
+        "Not": ak.Not(leaf),
+        "True": pool.pred_true(),
+        "False": pool.pred_false(),
+    }
+    assert set(formulas) == FROZEN_PREDICATE_KINDS
+    for kind, formula in formulas.items():
+        assert "(assert " in ak.to_smtlib(formula), kind
+
+
+def test_every_formula_variant_actually_emits(pool):
+    x = pool.symbol("x")
+    leaf = pool.gt(x, pool.integer(0))
+    formulas = {
+        "Atom": leaf,
+        "And": ak.And(leaf, leaf),
+        "Or": ak.Or(leaf, leaf),
+        "Not": ak.Not(leaf),
+        "True": pool.pred_true(),
+        "False": pool.pred_false(),
+        "Forall": ak.Forall(x, leaf),
+        "Exists": ak.Exists(x, leaf),
+    }
+    assert set(formulas) == FROZEN_FORMULA_VARIANTS
+    for variant, formula in formulas.items():
+        assert "(assert " in ak.to_smtlib(formula), variant
+
+
+# ---------------------------------------------------------------------------
+# Model reading — exactness, tested without a solver
+# ---------------------------------------------------------------------------
+
+
+def _sexp(text):
+    return smt._parse_sexprs(text)[0]
+
+
+@pytest.mark.parametrize(
+    ("term", "expected"),
+    [
+        ("3", Fraction(3)),
+        ("(- 3)", Fraction(-3)),
+        ("(/ 1 3)", Fraction(1, 3)),
+        ("(- (/ 1 3))", Fraction(-1, 3)),
+        # SMT-LIB decimals are exact decimal rationals, parsed from the *string*.
+        ("(/ 25.0 4.0)", Fraction(25, 4)),
+        ("0.1", Fraction(1, 10)),
+    ],
+)
+def test_model_values_lift_exactly(term, expected):
+    value = smt._lift_value(_sexp(term) if term.startswith("(") else term, "x")
+    assert value == expected
+    assert isinstance(value, Fraction)
+
+
+def test_decimal_lift_is_not_a_binary_float():
+    """`0.1` must become 1/10, never the nearest double."""
+    assert smt._lift_value("0.1", "x") == Fraction(1, 10)
+    assert smt._lift_value("0.1", "x") != Fraction(0.1)
+
+
+def test_root_obj_is_refused_not_truncated():
+    """The whole point of D2: refuse the algebraic number, never round it."""
+    term = _sexp("(root-obj (+ (^ x 2) (- 2)) 2)")
+    with pytest.raises(ak.SmtError) as exc:
+        smt._lift_value(term, "x")
+    assert exc.value.code == "E-SMT-003"
+    assert "refused, not rounded" in (exc.value.remediation or "")
+
+
+def test_unknown_model_term_is_refused():
+    with pytest.raises(ak.SmtError) as exc:
+        smt._lift_value(_sexp("(_ as-array k!0)"), "x")
+    assert exc.value.code == "E-SMT-003"
+
+
+def test_model_parser_handles_both_z3_shapes():
+    modern = "(\n  (define-fun x () Real\n    (- 2.0))\n)\n"
+    legacy = "(model\n  (define-fun x () Real (- 2.0))\n)\n"
+    for text in (modern, legacy):
+        model = smt._parse_model(smt._parse_sexprs(text))
+        assert smt._lift_value(model["x"], "x") == Fraction(-2)
+
+
+# ---------------------------------------------------------------------------
+# Refusals in the driver, tested without a solver
+# ---------------------------------------------------------------------------
+
+
+def test_missing_solver_is_a_refusal_not_a_fallback(pool, monkeypatch):
+    """Never quietly degrade to the weak interval `satisfiable`.
+
+    That would answer ``Unknown`` and look exactly like a solver had run and
+    found nothing.
+    """
+    monkeypatch.setattr(smt, "_find_binary", lambda _binary: None)
+    x = pool.symbol("x")
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(pool.gt(x, pool.integer(0)))
+    assert exc.value.code == "E-SMT-001"
+    assert "refusal, not a fallback" in (exc.value.remediation or "")
+    assert smt.solvers() == dict.fromkeys(smt.SOLVERS, None)
+    assert smt.supported(pool.gt(x, pool.integer(0))).reason == "no_solver"
+
+
+def test_unknown_solver_name_is_refused(pool):
+    x = pool.symbol("x")
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(pool.gt(x, pool.integer(0)), solver="nosuchsolver")
+    assert exc.value.code == "E-SMT-001"
+
+
+def test_quantified_formulas_are_refused_by_solve(pool):
+    """`to_smtlib` exports them; `solve` will not, because it cannot check them."""
+    x = pool.symbol("x")
+    f = ak.Exists(x, pool.gt(x, pool.integer(0)))
+    assert "(exists ((x Real))" in ak.to_smtlib(f)
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(f)
+    assert exc.value.code == "E-SMT-002"
+    support = smt.supported(f)
+    assert support.exportable
+    assert not support.supported
+    assert support.reason == "quantified"
+
+
+def test_uncheckable_formula_is_refused_before_the_solver_runs(pool, monkeypatch):
+    """`abs` exports fine but the kernel cannot evaluate it exactly."""
+    x = pool.symbol("x")
+    f = pool.gt(pool.func("abs", [x]), pool.integer(1))
+    assert "(ite (>= x 0) x (- x))" in ak.to_smtlib(f)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("the solver must not be run for an uncheckable formula")
+
+    monkeypatch.setattr(smt, "_run_solver", _boom)
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(f)
+    assert exc.value.code == "E-SMT-002"
+    assert smt.supported(f).reason == "not_exactly_checkable"
+
+
+def test_bad_model_raises_loudly_rather_than_warning(pool, monkeypatch):
+    """A model that fails back-substitution means something is broken."""
+    x = pool.symbol("x")
+    monkeypatch.setattr(
+        smt,
+        "_run_solver",
+        lambda *_a, **_k: ("sat\n(\n  (define-fun x () Real\n    (- 5.0))\n)\n", 1.0),
+    )
+    monkeypatch.setattr(smt, "_resolve_solver", lambda _s: (smt._SPECS["z3"], "/nonexistent/z3"))
+    monkeypatch.setattr(smt, "_version_of", lambda *_a: "fake")
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(pool.gt(x, pool.integer(0)))
+    assert exc.value.code == "E-SMT-004"
+    assert "never warned" in (exc.value.remediation or "")
+
+
+def test_model_violating_a_refined_domain_is_caught(pool, monkeypatch):
+    """The `Positive` guard is a separate assertion, and it is checked too."""
+    q = pool.symbol("q", "positive")
+    monkeypatch.setattr(
+        smt,
+        "_run_solver",
+        lambda *_a, **_k: ("sat\n(\n  (define-fun q () Real\n    (- 5.0))\n)\n", 1.0),
+    )
+    monkeypatch.setattr(smt, "_resolve_solver", lambda _s: (smt._SPECS["z3"], "/nonexistent/z3"))
+    monkeypatch.setattr(smt, "_version_of", lambda *_a: "fake")
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(pool.lt(q, pool.integer(10)))
+    assert exc.value.code == "E-SMT-004"
+
+
+def test_non_integer_value_for_an_int_symbol_is_caught(pool, monkeypatch):
+    n = pool.symbol("n", "integer")
+    monkeypatch.setattr(
+        smt,
+        "_run_solver",
+        lambda *_a, **_k: ("sat\n(\n  (define-fun n () Int\n    (/ 1 2))\n)\n", 1.0),
+    )
+    monkeypatch.setattr(smt, "_resolve_solver", lambda _s: (smt._SPECS["z3"], "/nonexistent/z3"))
+    monkeypatch.setattr(smt, "_version_of", lambda *_a: "fake")
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(pool.gt(n, pool.integer(0)))
+    assert exc.value.code == "E-SMT-004"
+
+
+# ---------------------------------------------------------------------------
+# supported() — the plan-ahead predicate
+# ---------------------------------------------------------------------------
+
+
+def test_supported_is_truthy_and_carries_the_reason(pool):
+    n = pool.symbol("n", "integer")
+    support = smt.supported(pool.gt(n * n, pool.integer(10)))
+    assert bool(support) is support.supported
+    assert support.logic == "QF_NIA"
+    assert support.script is not None
+
+
+def test_supported_prefers_the_in_tree_route_for_real_arithmetic(pool):
+    """D4, and it cuts against the usual instinct.
+
+    For QF_NRA the in-tree route yields a certificate that composes with
+    ``to_lean``; z3's nlsat yields an answer and no artifact.
+    """
+    x = pool.symbol("x")
+    support = smt.supported(pool.ge(x * x, pool.integer(0)))
+    assert support.logic in {"QF_LRA", "QF_NRA"}
+    assert support.recommendation == "prefer_in_tree"
+    assert "prove_nonneg" in support.detail
+
+
+def test_supported_recommends_smt_for_mixed_arithmetic(pool):
+    """The genuinely new capability: mixed integer/real."""
+    x = pool.symbol("x")
+    n = pool.symbol("n", "integer")
+    support = smt.supported(ak.And(pool.gt(x, n), pool.lt(x * x, pool.integer(10))))
+    assert support.logic == "QF_NIRA"
+    assert support.recommendation == "smt"
+
+
+def test_supported_never_raises_on_an_unexportable_formula(pool):
+    x = pool.symbol("x")
+    support = smt.supported(pool.gt(ak.sin(x), pool.integer(0)))
+    assert not support
+    assert not support.exportable
+    assert support.reason == "outside_fragment"
+    assert support.error is not None
+    assert support.error.code == "E-SMT-002"
+
+
+# ---------------------------------------------------------------------------
+# Verification vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_externally_asserted_is_not_machine_checked():
+    """D3. Widening this set to include "z3 said so" would erode the one
+    guarantee ``research.py`` makes."""
+    assert smt.EXTERNALLY_ASSERTED not in research.MACHINE_CHECKED_STATUSES
+    assert frozenset({"exactly_verified", "lean_checked"}) == research.MACHINE_CHECKED_STATUSES
+
+
+def test_externally_asserted_badge_is_unflattering():
+    badge = smt.STATUS_BADGES[smt.EXTERNALLY_ASSERTED]
+    assert "no proof was checked" in badge.lower()
+    assert "prov" not in badge.replace("proof", "")
+
+
+# ---------------------------------------------------------------------------
+# 3. Round trip against a real solver
+# ---------------------------------------------------------------------------
+
+
+@requires_solver
+def test_sat_model_is_verified_and_reports_its_engine(pool):
+    x = pool.symbol("x")
+    n = pool.symbol("n", "integer")
+    f = ak.And(pool.gt(x, n), ak.And(pool.lt(x * x, pool.integer(10)), pool.gt(n, pool.integer(1))))
+    result = smt.solve(f, budget=BUDGET)
+    assert result.status == "sat"
+    assert result.engine.startswith(("z3", "cvc5"))
+    assert result.logic == "QF_NIRA"
+    assert set(result.model) == {"x", "n"}
+    assert all(isinstance(v, Fraction) for v in result.model.values())
+    assert result.model["n"].denominator == 1
+    assert result.verification["status"] == "exactly_verified"
+    assert result.machine_checked is True
+    # Independently re-verify, without going through the bridge's own check.
+    symbols = {"x": x, "n": n}
+    check = ak.evaluate(f, {symbols[k]: v for k, v in result.model.items()}, mode="exact")
+    assert check.status == "ok"
+    assert check.value == 1
+
+
+@requires_solver
+def test_unsat_is_externally_asserted_and_never_machine_checked(pool):
+    x = pool.symbol("x")
+    f = ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(0)))
+    result = smt.solve(f, budget=BUDGET)
+    assert result.status == "unsat"
+    assert result.verification["status"] == smt.EXTERNALLY_ASSERTED
+    assert result.machine_checked is False
+    assert result.model == {}
+    assert "no unsat proof" in result.verification["note"]
+
+
+@requires_solver
+def test_sat_model_lifts_into_the_pool_when_one_is_active(pool):
+    x = pool.symbol("x")
+    f = ak.And(pool.gt(x, pool.integer(1)), pool.lt(x, pool.integer(2)))
+    with ak.context(pool=pool):
+        result = smt.solve(f, budget=BUDGET)
+    assert result.status == "sat"
+    assert set(result.model_exprs) == {"x"}
+    # The lifted Expr and the Fraction agree exactly.
+    lifted = ak.evaluate(f, {x: result.model["x"]}, mode="exact")
+    assert lifted.value == 1
+    assert str(result.model_exprs["x"])
+
+
+@requires_solver
+def test_explicit_pool_argument_lifts_without_a_context(pool):
+    x = pool.symbol("x")
+    result = smt.solve(pool.gt(x, pool.integer(3)), budget=BUDGET, pool=pool)
+    assert set(result.model_exprs) == {"x"}
+
+
+@requires_solver
+def test_algebraic_witness_is_refused_rather_than_rounded(pool):
+    """`x**2 == 2, x > 0` has no rational witness; z3 answers with `root-obj`."""
+    x = pool.symbol("x")
+    f = ak.And(pool.pred_eq(x * x, pool.integer(2)), pool.gt(x, pool.integer(0)))
+    with pytest.raises(ak.SmtError) as exc:
+        smt.solve(f, budget=BUDGET)
+    assert exc.value.code == "E-SMT-003"
+
+
+@requires_solver
+def test_piecewise_round_trips(pool):
+    x = pool.symbol("x")
+    pw = ak.piecewise([(pool.gt(x, pool.integer(0)), pool.integer(1))], pool.integer(-1))
+    result = smt.solve(pool.pred_eq(pw, pool.integer(1)), budget=BUDGET)
+    assert result.status == "sat"
+    assert result.model["x"] > 0
+
+
+@requires_solver
+def test_pure_integer_problem_uses_an_integer_logic(pool):
+    a = pool.symbol("a", "integer")
+    b = pool.symbol("b", "integer")
+    f = ak.And(
+        pool.pred_eq(a * a + b * b, pool.integer(25)),
+        ak.And(pool.gt(a, pool.integer(0)), pool.gt(b, pool.integer(0))),
+    )
+    result = smt.solve(f, budget=BUDGET)
+    assert result.logic == "QF_NIA"
+    assert result.status == "sat"
+    assert {result.model["a"], result.model["b"]} == {Fraction(3), Fraction(4)}
+
+
+@requires_solver
+def test_budget_timeout_maps_onto_budget_exceeded(pool):
+    """D5: a solver timeout is a resource verdict, not a mathematical one."""
+    a, b, c, d = (pool.symbol(name) for name in "abcd")
+    f = ak.And(
+        pool.pred_eq(a**4 + b**4 + c**4 + d**4, pool.integer(1)),
+        ak.And(
+            pool.pred_eq(a**3 + b**3 + c**3 + d**3, pool.integer(0)),
+            ak.And(
+                pool.gt(a * b * c * d, pool.integer(0)),
+                pool.pred_eq(
+                    a * a * b * b + c * c * d * d + a * d + b * c, pool.rational(355, 113)
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(ak.BudgetExceededError) as exc:
+        smt.solve(f, budget=ak.Budget(wall_ms=250))
+    assert exc.value.code == "E-BUDGET-001"
+
+
+@requires_solver
+def test_result_records_into_a_claim_graph_with_an_honest_status(pool):
+    x = pool.symbol("x")
+    session = research.session(title="smt bridge")
+    with session:
+        sat = smt.solve(
+            ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(2))), budget=BUDGET
+        )
+        claim = session.record(sat, statement="0 < x < 2 is satisfiable", method="smt.solve")
+        assert claim.status == "exactly_verified"
+        assert claim.machine_checked is True
+
+        unsat = smt.solve(
+            ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(0))), budget=BUDGET
+        )
+        claim2 = session.record(unsat, statement="0 < x < 0 is unsatisfiable", method="smt.solve")
+        assert claim2.status == smt.EXTERNALLY_ASSERTED
+        # The load-bearing property: an external assertion is never counted as
+        # machine-checked, whatever the badge vocabulary says about it.
+        assert claim2.machine_checked is False
+
+
+# ---------------------------------------------------------------------------
+# The invariant the whole bridge rests on, as a property test
+# ---------------------------------------------------------------------------
+
+_COEFFS = st.integers(min_value=-4, max_value=4)
+_RELATIONS = st.sampled_from(["lt", "le", "gt", "ge", "pred_eq", "pred_ne"])
+
+
+@st.composite
+def _atoms(draw, names):
+    """A comparison between two small polynomials in the given symbols."""
+    name = draw(st.sampled_from(names))
+    other = draw(st.sampled_from(names))
+    power = draw(st.integers(min_value=1, max_value=2))
+    coeff = draw(_COEFFS)
+    constant = draw(_COEFFS)
+    return (draw(_RELATIONS), name, other, power, coeff, constant)
+
+
+@st.composite
+def _formulas(draw, names):
+    atoms = draw(st.lists(_atoms(names), min_size=1, max_size=3))
+    connectives = draw(st.lists(st.sampled_from(["and", "or"]), min_size=len(atoms) - 1))
+    negate = draw(st.booleans())
+    return atoms, connectives, negate
+
+
+def _build(pool, symbols, spec):
+    atoms, connectives, negate = spec
+    built = []
+    for relation, name, other, power, coeff, constant in atoms:
+        lhs = symbols[name] ** power * coeff + symbols[other]
+        built.append(getattr(pool, relation)(lhs, pool.integer(constant)))
+    formula = built[0]
+    for connective, atom in zip(connectives, built[1:]):
+        formula = ak.And(formula, atom) if connective == "and" else ak.Or(formula, atom)
+    return ak.Not(formula) if negate else formula
+
+
+@requires_solver
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(spec=_formulas(("x", "n")))
+def test_property_every_sat_model_survives_back_substitution(spec):
+    """The invariant the bridge rests on, over generated formulas rather than
+    a handful of examples.
+
+    ``solve`` enforces this internally and raises ``E-SMT-004`` when it fails;
+    the test additionally re-checks the model through ``evaluate`` so a bug in
+    the bridge's own checker cannot make the test vacuous.
+    """
+    pool = ak.ExprPool()
+    symbols = {"x": pool.symbol("x"), "n": pool.symbol("n", "integer")}
+    formula = _build(pool, symbols, spec)
+    try:
+        result = smt.solve(formula, budget=ak.Budget(wall_ms=2_000))
+    except ak.SmtError as exc:
+        # E-SMT-003 (no rational witness) is a legitimate refusal, not a failure.
+        refusal = exc
+        assert refusal.code == "E-SMT-003", refusal
+        return
+    except ak.BudgetExceededError:
+        return
+    assert result.status in {"sat", "unsat", "unknown"}
+    if result.status != "sat":
+        assert result.model == {}
+        assert not result.machine_checked
+        return
+    bindings = {symbols[name]: value for name, value in result.model.items() if name in symbols}
+    check = ak.evaluate(formula, bindings, mode="exact")
+    assert check.status == "ok", (ak.to_smtlib(formula), result.model, check.reason)
+    assert check.value == 1, (ak.to_smtlib(formula), result.model)
+    assert result.verification["status"] == "exactly_verified"
+
+
+@requires_solver
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(spec=_formulas(("x", "y")))
+def test_property_emitted_script_is_accepted_by_the_solver(spec):
+    """Anything `to_smtlib` emits must at least *parse*; a script Alkahest
+    produces and a solver rejects is an emitter bug, not a user error."""
+    pool = ak.ExprPool()
+    symbols = {"x": pool.symbol("x"), "y": pool.symbol("y")}
+    formula = _build(pool, symbols, spec)
+    try:
+        result = smt.solve(formula, budget=ak.Budget(wall_ms=2_000))
+    except (ak.SmtError, ak.BudgetExceededError) as exc:
+        refusal = exc
+        assert getattr(refusal, "code", "") in {"E-SMT-003", "E-BUDGET-001"}, refusal
+        return
+    assert "(error" not in result.raw_output.split(result.status)[0]

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -16,6 +16,7 @@ Three tiers, deliberately separated:
 from __future__ import annotations
 
 import re
+import subprocess
 from fractions import Fraction
 from pathlib import Path
 
@@ -562,8 +563,11 @@ def test_externally_asserted_is_not_machine_checked():
 
 
 def test_externally_asserted_badge_is_unflattering():
-    badge = smt.STATUS_BADGES[smt.EXTERNALLY_ASSERTED]
-    assert "no proof was checked" in badge.lower()
+    # One lowercased value for both checks: the badge says "NO proof", so a
+    # case-sensitive second check would let a "Proven" through the guard that
+    # exists to reject exactly that word.
+    badge = smt.STATUS_BADGES[smt.EXTERNALLY_ASSERTED].lower()
+    assert "no proof was checked" in badge
     assert "prov" not in badge.replace("proof", "")
 
 
@@ -660,8 +664,87 @@ def test_pure_integer_problem_uses_an_integer_logic(pool):
 
 
 @requires_solver
-def test_budget_timeout_maps_onto_budget_exceeded(pool):
-    """D5: a solver timeout is a resource verdict, not a mathematical one."""
+def test_the_mixed_logic_name_is_one_the_installed_solver_accepts(pool):
+    """`QF_LIRA` / `QF_NIRA` are absent from the SMT-LIB 2.7 catalog.
+
+    They are emitted anyway because they are what the solvers this bridge
+    drives use for mixed Int/Real, and because the catalog alternatives
+    (`AUFLIRA` / `AUFNIRA`) are quantified array logics that would discard the
+    `QF_` hint. That makes it a contract with the *solver*, so pin it against
+    the solver actually installed: the emitted script must be accepted outright,
+    with no "unsupported logic" complaint.
+    """
+    x = pool.symbol("x")
+    n = pool.symbol("n", "integer")
+    mixed_linear = ak.And(pool.gt(x, n), pool.lt(x, n + pool.integer(1)))
+    mixed_nonlinear = ak.And(pool.gt(x, n), pool.lt(x * x, pool.integer(10)))
+    assert "(set-logic QF_LIRA)" in ak.to_smtlib(mixed_linear)
+    assert "(set-logic QF_NIRA)" in ak.to_smtlib(mixed_nonlinear)
+
+    spec, path = smt._resolve_solver("auto")
+    for formula in (mixed_linear, mixed_nonlinear):
+        output, _elapsed = smt._run_solver(spec, path, ak.to_smtlib(formula), 5_000)
+        assert smt._extract_status(output) == "sat", output
+        assert "unsupported" not in output.lower(), output
+        assert "error" not in output.lower(), output
+
+    # Non-vacuity: the same runner *does* complain about a name the solver has
+    # never heard of, so the assertions above are testing something.
+    bogus, _elapsed = smt._run_solver(spec, path, "(set-logic QF_BOGUS)\n(check-sat)\n", 5_000)
+    assert "unsupported" in bogus.lower() or "error" in bogus.lower(), bogus
+
+    # And a consumer that will only take catalog names has one available.
+    catalog = ak.to_smtlib(mixed_linear, "AUFLIRA")
+    assert "(set-logic AUFLIRA)" in catalog
+    output, _elapsed = smt._run_solver(spec, path, catalog, 5_000)
+    assert smt._extract_status(output) == "sat", output
+
+
+def test_parent_deadline_maps_onto_budget_exceeded(monkeypatch):
+    """D5: a solver timeout is a resource verdict, not a mathematical one.
+
+    Driven directly rather than by racing a real solver against a small wall
+    clock: what is under test is the *mapping*, and a faster machine or a
+    smarter z3 answering first would fail this for an unrelated reason.
+    """
+
+    def never_answers(args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs.get("timeout") or 0.0)
+
+    monkeypatch.setattr(smt.subprocess, "run", never_answers)
+    with pytest.raises(ak.BudgetExceededError) as exc:
+        smt._run_solver(smt._SPECS["z3"], "/nonexistent/z3", "(check-sat)\n", 250)
+    assert exc.value.code == "E-BUDGET-001"
+    assert "250" in str(exc.value)
+
+
+def test_solver_reported_timeout_maps_onto_budget_exceeded(pool, monkeypatch):
+    """The other half of D5: `unknown` with `:reason-unknown timeout` is a
+    resource verdict too, and must not surface as a bare `unknown` result."""
+    x = pool.symbol("x")
+    f = ak.And(pool.gt(x, pool.integer(0)), pool.lt(x, pool.integer(2)))
+    monkeypatch.setattr(smt, "_resolve_solver", lambda name: (smt._SPECS["z3"], "/nonexistent/z3"))
+    monkeypatch.setattr(
+        smt,
+        "_run_solver",
+        lambda spec, path, script, wall_ms: ('unknown\n(:reason-unknown "timeout")\n', 250.0),
+    )
+    with pytest.raises(ak.BudgetExceededError) as exc:
+        smt.solve(f, budget=ak.Budget(wall_ms=250))
+    assert exc.value.code == "E-BUDGET-001"
+    # Without a budget the same output is a result, not a resource refusal.
+    result = smt.solve(f)
+    assert result.status == "unknown"
+    assert result.reason_unknown == "timeout"
+
+
+@requires_solver
+def test_a_real_solver_timeout_produces_a_verdict_or_a_budget_error(pool):
+    """The wiring the mocks cannot cover: the solver's own timeout flag.
+
+    Deliberately tolerant about *which* outcome — the point is that a tiny wall
+    clock never produces a third thing (a crash, or a bare `unknown` that a
+    loop would mistake for a mathematical answer)."""
     a, b, c, d = (pool.symbol(name) for name in "abcd")
     f = ak.And(
         pool.pred_eq(a**4 + b**4 + c**4 + d**4, pool.integer(1)),
@@ -675,9 +758,11 @@ def test_budget_timeout_maps_onto_budget_exceeded(pool):
             ),
         ),
     )
-    with pytest.raises(ak.BudgetExceededError) as exc:
-        smt.solve(f, budget=ak.Budget(wall_ms=250))
-    assert exc.value.code == "E-BUDGET-001"
+    try:
+        outcome = smt.solve(f, budget=ak.Budget(wall_ms=250)).status
+    except ak.BudgetExceededError as exc:
+        outcome = exc.code
+    assert outcome in {"sat", "unsat", "unknown", "E-BUDGET-001"}
 
 
 @requires_solver


### PR DESCRIPTION
Implements the three **P2** items from `temp-alkahest/planning/autoresearch.md`, following the design addendum at the bottom of that note. P0 and P1 have all landed; this is the remaining list.

A theme worth stating once: each of these adds a *new way for Alkahest to be wrong* — a fitted ansatz nobody checked, an oracle that wasn't installed, an external solver whose `unsat` nobody verified. Each is arranged so the **unavailable** and **unchecked** cases are structurally impossible to confuse with success. That constraint drove more of the design than the mathematics did.

## `alkahest.ansatz` — conjecture generation (P2-1)

Families (`polynomial`, `rational`, `linear_combination`, `exponential_polynomial`, `quadratic_form`), `fit`, `enumerate_family`.

- **Exact linear algebra by default, not Gröbner.** The system is built by affine probing with `subs` and solved via `Matrix.rref` over ℚ, so it works in a build without the `groebner` feature. Rational families clear the denominator, keeping `p − f·q = 0` linear — the trick that keeps Padé on the fast path.
- **Solving is heuristic; checking is exact.** `fit` back-substitutes and reports `exactly_verified` only when the residual provably normalises to zero, otherwise `numerically_checked` with the surviving residual stated plainly.
- Underdetermined returns the free parameters; inconsistent raises `E-ANSATZ-003`, worded as a *closed branch* — a result a search loop wants to record.

## `alkahest.crosscheck` — differential testing (P2-2)

- **One total-or-refuse translator** over `Expr.node()`. An unmapped tag or assumption refuses rather than approximating: false divergences are worse than no signal, because they train everyone to ignore the alarm.
- **Four outcomes** — `agree` / `diverge` / `incomparable` / `unavailable`. A missing oracle can never read as agreement. `CrossCheck` has no `__bool__`, pinned by a test, so `if check(...)` can't compile into a silent "it agreed".
- **The operation-specific invariant rung leads wherever it exists** (differentiate the antiderivative, substitute solutions back), sidestepping equal-up-to-a-constant entirely.
- Found **zero divergences** over 2400 seeded checks plus ~90 adversarial probes — every non-agreement was an honest coded refusal. Since a comparator that finds nothing is indistinguishable from one that doesn't work, the detection path is proven by **fault injection**: tests break Alkahest's integrator, then SymPy's, and assert the divergence is caught *and attributed to the correct side*.

## `alkahest.smt` — SMT/SAT bridge (P2-3)

- **Export, don't embed.** SMT-LIB 2 text, mirroring `to_lean`. Emitter in Rust next to `Formula` so match exhaustiveness enforces coverage (no `_ =>` arms, greped by a test); discovery, model parsing and lifting in Python.
- **`sat` and `unsat` are trusted asymmetrically.** A `sat` model is *always* back-substituted and checked exactly in-process — twice, against the original formula and against the script actually sent, so an emitter mistranslation must fool both. `unsat` becomes the new `externally_asserted` status, deliberately **absent** from `research.MACHINE_CHECKED_STATUSES`.
- Algebraic-number (`root-obj`) model values are **refused**, not truncated to a float: a float witness recorded as exact is the exact silent-error shape this subsystem exists to prevent.
- `dpll_sat` was deliberately *not* wired in as a fallback — abstracting arithmetic atoms to propositions is sound only for `unsat`, and would hand back meaningless models under a bridge whose premise is that every model is checked.

## Integration

- `ResearchSession(crosscheck=True)` — a **recording-time** policy (D8), at stage-5 frequency rather than stage-2. It attaches evidence and never raises a claim's confidence; a divergence does not set `refuted`, because it names two suspects. Runs under `_suppress_capture` — a cross-check drives captured operations itself, which otherwise recurses without terminating.
- `capabilities()["verification"]` now reports `oracles` and `smt_solvers`, **including negatively**, so an absent checker is distinguishable from one that agreed.

## Verification

All CI gates run locally with the lockfile-pinned tooling (ruff 0.15.14, ty 0.0.39):

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets -D warnings` (default, egraph, parallel, groebner-cuda) | pass |
| `cargo test --all` | pass, incl. doctests |
| `ruff check` / `ruff format --check` | pass |
| `ty check python/alkahest/` | 0 errors, 42 diagnostics — **exactly the pristine-HEAD baseline** |
| certificate ledger drift | up to date |
| silent-error gate | 149 passed, rate 0.0% |
| `pytest tests/` | **2411 passed**, 61 skipped, 0 failed |

`clippy --features jit` is the one gate not run locally (needs LLVM 15); CI covers it.

## Pre-existing issues found, deliberately NOT fixed here

Filing these rather than folding them in, so this PR stays reviewable and doesn't turn a gate red for unrelated reasons:

1. **Silent error in symbolic linear algebra.** For a matrix whose second row is exactly `exp(a)` times the first, `Matrix.rank()` returns 2 (true rank 1) and `rref` emits the `[0, 0, 1]` inconsistency signature for a *consistent* system. Root cause is a simplifier gap — no route proves `exp(a)·exp(a) − exp(a+a) = 0`, and `simplify_log_exp` reduces it to `X + (−1)·X` and still fails to collect. This is a genuine `tests/silent_errors/` candidate; adding it now would turn that gate red.
2. **`limit(sqrt(x²+x) − x, x, ∞)` does not terminate** (SIGKILLed at 30s; SymPy answers `1/2` instantly). It sits in Rust holding the GIL, so it ignores signals *and* cooperative cancellation — `Budget(wall_ms=…)` cannot bound it. The Gruntz path appears to have no budget checkpoint.
3. **`scripts/check_error_codes.py` already fails on `main`** (8 errors, verified against a pristine tree). It is referenced by no workflow. This PR removes one line from its output and adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMT-LIB export, external solver support, capability reporting, and exact model verification.
  * Added ansatz construction, family enumeration, coefficient fitting, and certification tools.
  * Added cross-CAS differential checking and research-session evidence capture.
  * Added structured error reporting for ansatz, cross-check, and SMT operations.
* **Documentation**
  * Added guides for ansatz workflows, cross-checking, SMT/SAT usage, limitations, and new error types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->