### PR TITLE
fix: a silent error, a non-terminating limit, and an unenforced code registry

### DIFF
--- a/alkahest-core/src/ball/mod.rs
+++ b/alkahest-core/src/ball/mod.rs
@@ -1009,6 +1009,30 @@ impl IntervalEval {
                     "exp" => Some(x.exp()),
                     "log" => x.log(),
                     "sqrt" => x.sqrt(),
+                    // Every arm below is an already-implemented, outward-rounded
+                    // `ArbBall` kernel that was simply not reachable from an
+                    // expression. Leaving them unwired made `eval` answer `None`
+                    // for `tan(x)` and friends, which callers that read `None`
+                    // as "cannot bound this" — the zero test in
+                    // `crate::matrix`, `crate::validated::bounds` — had to treat
+                    // as a refusal.
+                    "tan" => x.tan(),
+                    "sinh" => Some(x.sinh()),
+                    "cosh" => Some(x.cosh()),
+                    "tanh" => Some(x.tanh()),
+                    "asin" => x.asin(),
+                    "acos" => x.acos(),
+                    "atan" => Some(x.atan()),
+                    "asinh" => Some(x.asinh()),
+                    "acosh" => x.acosh(),
+                    "atanh" => x.atanh(),
+                    "erf" => Some(x.erf()),
+                    "erfc" => Some(x.erfc()),
+                    "abs" => Some(x.abs_ball()),
+                    "floor" => Some(x.floor_ball()),
+                    "ceil" => Some(x.ceil_ball()),
+                    "digamma" => x.digamma(),
+                    "lambert_w" => x.lambert_w0(),
                     _ => None,
                 }
             }

--- a/alkahest-core/src/calculus/asymptotic.rs
+++ b/alkahest-core/src/calculus/asymptotic.rs
@@ -279,7 +279,7 @@ fn power_scale_terms_raw(
 /// `Add`/`Mul`/`Pow`/elementary `Func`s so the analytic remainder is honestly
 /// Taylor-expandable. `val` is recovered exactly; the analytic part is left
 /// symbolic for [`local_expansion`].
-fn regularize_at_zero(g: ExprId, t: ExprId, pool: &ExprPool) -> Option<(i64, ExprId)> {
+pub(crate) fn regularize_at_zero(g: ExprId, t: ExprId, pool: &ExprPool) -> Option<(i64, ExprId)> {
     let g = simplify(g, pool).value;
     match pool.get(g) {
         // Constants and other-variable atoms: valuation 0.

--- a/alkahest-core/src/calculus/gruntz.rs
+++ b/alkahest-core/src/calculus/gruntz.rs
@@ -12,7 +12,7 @@
 //! 6. Expand the rewritten expression as a Laurent series in ω → 0⁺.
 //! 7. Leading power > 0 → 0; < 0 → ±∞; = 0 → recurse on the coefficient.
 
-use crate::calculus::limits::{limit, LimitDirection, LimitError};
+use crate::calculus::limits::{checkpoint, limit, LimitDirection, LimitError};
 use crate::calculus::series::local_expansion;
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::simplify::rules::{CollectExp, ExpPow};
@@ -46,6 +46,7 @@ pub(crate) fn try_gruntz(
     if current >= GRUNTZ_MAX_DEPTH {
         return Ok(None);
     }
+    checkpoint(pool)?;
     GRUNTZ_DEPTH.with(|d| d.set(current + 1));
     let result = gruntz_inner(expr, var, pool);
     GRUNTZ_DEPTH.with(|d| d.set(current));
@@ -253,6 +254,8 @@ fn build_mrv_set(
             if i == j || dominated[i] {
                 continue;
             }
+            // O(n²) sub-limits, each of which can itself be arbitrarily hard.
+            checkpoint(pool)?;
             let h_i = unique[i].1;
             let h_j = unique[j].1;
             if let Ok(Growth::Slower) = compare_growth(h_i, h_j, var, pool) {

--- a/alkahest-core/src/calculus/limits.rs
+++ b/alkahest-core/src/calculus/limits.rs
@@ -1765,7 +1765,14 @@ mod termination_tests {
         // this falls through to the expansion route that used to run away.
         let inner = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
         let ex = p.func("sqrt", vec![p.add(vec![inner, x])]);
-        let started = std::time::Instant::now();
+        // No wall-clock assertion here on purpose. Termination *is* the property
+        // under test, and this call returning at all already proves it: before
+        // the work ceiling existed this expression ran effectively forever, so a
+        // regression hangs the test rather than failing a timing bound. An
+        // elapsed() budget would only add flakiness — the AddressSanitizer job
+        // builds with -Z build-std and runs many times slower than a normal
+        // build, and a 30s bound that held locally failed there while the
+        // refusal itself worked correctly.
         let err = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap_err();
         assert!(
             matches!(err, LimitError::DepthExceeded),
@@ -1774,10 +1781,6 @@ mod termination_tests {
         assert_eq!(err.code(), "E-LIMIT-004");
         // Not a budget trip — the internal ceiling stopped it.
         assert_eq!(last_budget_trip(), None);
-        assert!(
-            started.elapsed() < std::time::Duration::from_secs(30),
-            "the work ceiling did not bound the search"
-        );
     }
 
     /// A step budget stops the search and is reported as a budget trip, so a

--- a/alkahest-core/src/calculus/limits.rs
+++ b/alkahest-core/src/calculus/limits.rs
@@ -2,14 +2,17 @@
 //! L'Hôpital iterations, algebraic transforms, and the Gruntz comparability-graph
 //! algorithm for exp-log combinations (V2-16/V2-17).
 
+use crate::budget::BudgetError;
+use crate::calculus::asymptotic::regularize_at_zero;
 use crate::calculus::gruntz::try_gruntz;
-use crate::calculus::series::{local_expansion, LocalExpansion};
+use crate::calculus::series::{enter_coeff_ceiling, local_expansion, LocalExpansion};
 use crate::diff::{diff, DiffError};
 use crate::kernel::pool::POS_INFINITY_SYMBOL;
 use crate::kernel::{subs, ExprData, ExprId, ExprPool};
 use crate::poly::{poly_normal, RationalFunction};
 use crate::simplify::{simplify, simplify_expanded};
 use crate::SeriesError;
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -32,7 +35,10 @@ pub enum LimitError {
     Diff(DiffError),
     /// Odd-order pole requires a one-sided direction.
     NeedsOneSided,
-    /// Maximal L'Hôpital / recursion depth exceeded.
+    /// The search ran out of room: the L'Hôpital / recursion depth cap, the
+    /// internal work ceiling ([`limit`]'s termination guard), or the ambient
+    /// [`crate::budget`] — see [`last_budget_trip`] to tell a budget trip from
+    /// the engine's own limits.
     DepthExceeded,
     /// No implemented rule applies (non-comparable growth, oscillation, …).
     Unsupported,
@@ -108,12 +114,173 @@ impl From<DiffError> for LimitError {
 }
 
 // ---------------------------------------------------------------------------
+// Termination guard — cooperative budget checkpoints plus an internal work
+// ceiling, so no search path in this engine can run unboundedly.
+// ---------------------------------------------------------------------------
+
+/// How many *new* expression nodes one top-level [`limit`] call may intern
+/// before the engine gives up with [`LimitError::DepthExceeded`].
+///
+/// The pathological shape this bounds is repeated symbolic differentiation:
+/// [`crate::calculus::series`] builds Taylor coefficients by differentiating
+/// without re-simplifying, so an expression whose derivatives do not close
+/// (nested radicals, in particular) grows by a constant factor per
+/// coefficient. Thirty-two coefficients of `√(x²+x)` rewritten at `t → 0⁺`
+/// is not a slow computation, it is an unfinishable one — the loop ran for
+/// hours with no output. Counting interned nodes rather than iterations
+/// catches that directly, is `O(1)` per checkpoint ([`ExprPool::len`] is a
+/// lock-free counter), and is monotone, so no path can evade it.
+///
+/// Sized with an order of magnitude of headroom: the heaviest limit in the
+/// Rust and Python suites interns ~9k nodes (`x·sin(1/x)` at 0; most are under
+/// 300), while a runaway radical expansion reaches this ceiling in a few
+/// hundred milliseconds.
+const MAX_LIMIT_POOL_GROWTH: usize = 100_000;
+
+thread_local! {
+    /// `pool.len()` when the outermost [`limit`] call on this thread started.
+    /// `None` outside any `limit` call.
+    static WORK_BASELINE: Cell<Option<usize>> = const { Cell::new(None) };
+    /// The [`BudgetError`] that tripped the most recent outermost [`limit`]
+    /// call, if any — see [`last_budget_trip`].
+    static BUDGET_TRIP: Cell<Option<BudgetError>> = const { Cell::new(None) };
+}
+
+/// RAII marker for the outermost [`limit`] frame on this thread.
+///
+/// [`limit`] re-enters itself (Gruntz sub-limits, growth comparisons), and the
+/// work ceiling must bound the *whole* call rather than restart at every
+/// re-entry, so only the outermost frame installs and clears the baseline.
+struct WorkFrame {
+    outermost: bool,
+}
+
+impl Drop for WorkFrame {
+    fn drop(&mut self) {
+        if self.outermost {
+            WORK_BASELINE.with(|c| c.set(None));
+        }
+    }
+}
+
+fn enter_work_frame(pool: &ExprPool) -> WorkFrame {
+    WORK_BASELINE.with(|c| {
+        if c.get().is_some() {
+            return WorkFrame { outermost: false };
+        }
+        c.set(Some(pool.len()));
+        WorkFrame { outermost: true }
+    })
+}
+
+/// `true` once this `limit` call has interned more than
+/// [`MAX_LIMIT_POOL_GROWTH`] nodes.
+fn work_exhausted(pool: &ExprPool) -> bool {
+    WORK_BASELINE.with(|c| match c.get() {
+        Some(base) => pool.len().saturating_sub(base) > MAX_LIMIT_POOL_GROWTH,
+        None => false,
+    })
+}
+
+/// The absolute `pool.len()` ceiling for the current `limit` call, for handing
+/// to [`enter_coeff_ceiling`] so the Taylor-coefficient loop stops at the same
+/// place this engine's own checkpoints do.
+fn coeff_ceiling(pool: &ExprPool) -> usize {
+    WORK_BASELINE.with(|c| {
+        c.get()
+            .unwrap_or_else(|| pool.len())
+            .saturating_add(MAX_LIMIT_POOL_GROWTH)
+    })
+}
+
+/// Cooperative checkpoint for the limit engine: honours [`crate::budget`] and
+/// the internal work ceiling.
+///
+/// Placed on every path that can iterate or recurse — see [`limit_inner`],
+/// [`canonical_polynomial_quotient_in_var`], [`try_expansion_limit`],
+/// [`try_regularized_infinity_limit`] and [`crate::calculus::gruntz`].
+pub(crate) fn checkpoint(pool: &ExprPool) -> Result<(), LimitError> {
+    if let Err(e) = crate::budget::check() {
+        BUDGET_TRIP.with(|c| c.set(Some(e)));
+        return Err(LimitError::DepthExceeded);
+    }
+    if work_exhausted(pool) {
+        return Err(LimitError::DepthExceeded);
+    }
+    Ok(())
+}
+
+/// The [`BudgetError`] that stopped the most recent outermost [`limit`] call on
+/// this thread, or `None` if that call was not stopped by a budget.
+///
+/// [`LimitError`] is an exhaustive public enum, so it cannot grow a `Budget`
+/// variant without a major semver break (the same constraint
+/// [`mod@crate::integrate`] works around by encoding budget trips inside
+/// `NotImplemented`). Limit budget trips are reported as
+/// [`LimitError::DepthExceeded`] — an honest "gave up" — and this function
+/// tells a caller *why* it gave up, so bindings can raise a dedicated
+/// budget-exceeded error carrying the `E-BUDGET-*` code.
+///
+/// Cleared at the start of every outermost `limit` call, so it only ever
+/// describes the call that just returned.
+pub fn last_budget_trip() -> Option<BudgetError> {
+    BUDGET_TRIP.with(|c| c.get())
+}
 
 /// `limit(expr, var, point, dir)` — see [`LimitDirection`].
 ///
 /// `point` may be finite or [`ExprPool::pos_infinity`]. Limits at `-∞` use
 /// `pool.mul(pool.integer(-1), pool.pos_infinity())`.
+///
+/// # Termination
+///
+/// The search is bounded: it honours [`crate::budget`] (wall clock, steps,
+/// [`crate::budget::request_cancel`]) and, with no budget active, an internal
+/// work ceiling. Either way an unsolvable case returns
+/// [`LimitError::DepthExceeded`] rather than running unboundedly; use
+/// [`last_budget_trip`] to tell the two apart.
 pub fn limit(
+    expr: ExprId,
+    var: ExprId,
+    point: ExprId,
+    direction: LimitDirection,
+    pool: &ExprPool,
+) -> Result<ExprId, LimitError> {
+    let frame = enter_work_frame(pool);
+    if frame.outermost {
+        BUDGET_TRIP.with(|c| c.set(None));
+    }
+    // Bound the Taylor-coefficient loop in `series` for the whole call, not
+    // just at the boundaries this module can see: a single `local_expansion`
+    // at order 32 is one uninterruptible call from here.
+    let _ceiling = enter_coeff_ceiling(coeff_ceiling(pool));
+
+    limit_body(expr, var, point, direction, pool).map_err(|e| attribute_failure(e, pool))
+}
+
+/// Re-attribute a failed [`limit`] to the resource that actually stopped it.
+///
+/// Every rule in this engine turns a failed sub-problem into "this rule does
+/// not apply" (`Err(_) => Ok(None)`), and the coefficient loop in
+/// [`crate::calculus::series`] simply stops producing terms. So a call that ran
+/// out of budget usually surfaces as `Unsupported` — "no rule worked" — which
+/// is true but useless: it tells the caller to rewrite the problem when what
+/// they need to do is raise the budget. Any failure that coincides with an
+/// exhausted budget, a cancellation, or a blown work ceiling is reported as
+/// [`LimitError::DepthExceeded`], with [`last_budget_trip`] carrying the
+/// `E-BUDGET-*` cause when there was one.
+fn attribute_failure(e: LimitError, pool: &ExprPool) -> LimitError {
+    if BUDGET_TRIP.with(|c| c.get()).is_some() || work_exhausted(pool) {
+        return LimitError::DepthExceeded;
+    }
+    if let Err(b) = crate::budget::check() {
+        BUDGET_TRIP.with(|c| c.set(Some(b)));
+        return LimitError::DepthExceeded;
+    }
+    e
+}
+
+fn limit_body(
     expr: ExprId,
     var: ExprId,
     point: ExprId,
@@ -473,7 +640,11 @@ fn flatten_nested_integer_pow(expr: ExprId, pool: &ExprPool) -> ExprId {
 /// After ``x ↦ 1/t``, common forms are ``Mul(numer, denom^{-1})`` with ``Pow(t,-1)``
 /// sprinkled through both.  Clear those poles by multiplying by ``t^k`` until
 /// numerator and denominator describe an honest polynomial quotient in ``t``.
-fn canonical_polynomial_quotient_in_var(expr: ExprId, t: ExprId, pool: &ExprPool) -> ExprId {
+fn canonical_polynomial_quotient_in_var(
+    expr: ExprId,
+    t: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, LimitError> {
     let (n_raw, d_raw) = numerator_denominator(expr, pool);
     let has_trivial_denom = d_raw == pool.integer(1_i32);
     // When d_raw == 1 the expr might still have negative powers of t in a sum (e.g. 1 + t^{-1}).
@@ -482,6 +653,10 @@ fn canonical_polynomial_quotient_in_var(expr: ExprId, t: ExprId, pool: &ExprPool
         if has_trivial_denom && k == 0 {
             continue;
         }
+        // Each pass runs `simplify_expanded` twice on the whole expression, so
+        // a 41-iteration sweep over a large input is long enough to need to be
+        // interruptible even though the loop count itself is bounded.
+        checkpoint(pool)?;
         let tk = pool.pow(t, pool.integer(k));
         let n = simplify_expanded(pool.mul(vec![tk, n_raw]), pool).value;
         let d = simplify_expanded(pool.mul(vec![tk, d_raw]), pool).value;
@@ -492,10 +667,12 @@ fn canonical_polynomial_quotient_in_var(expr: ExprId, t: ExprId, pool: &ExprPool
         if let Ok(rf) = RationalFunction::from_symbolic(n, d, vec![t], pool) {
             let nx = rf.numer.to_expr(pool);
             let dx = rf.denom.to_expr(pool);
-            return simplify(pool.mul(vec![nx, pool.pow(dx, pool.integer(-1_i32))]), pool).value;
+            return Ok(
+                simplify(pool.mul(vec![nx, pool.pow(dx, pool.integer(-1_i32))]), pool).value,
+            );
         }
     }
-    expr
+    Ok(expr)
 }
 
 fn limit_inner(
@@ -511,6 +688,7 @@ fn limit_inner(
     if depth > MAX_DEPTH {
         return Err(LimitError::DepthExceeded);
     }
+    checkpoint(pool)?;
 
     if !depends_on(expr, var, pool) {
         if substitution_is_singular(expr, pool) {
@@ -538,6 +716,17 @@ fn limit_inner(
         }
     }
 
+    // Leading-order route at ±∞ for algebraic/analytic scales, tried before the
+    // plain `x ↦ 1/t` substitution below: that substitution hands the result to
+    // a Taylor expansion, which cannot see through a radical and instead
+    // differentiates it thirty-two times.
+    if is_pos_infinity(point, pool) || is_neg_infinity(point, pool) {
+        let toward_pos = is_pos_infinity(point, pool);
+        if let Some(r) = try_regularized_infinity_limit(expr, var, toward_pos, pool)? {
+            return Ok(r);
+        }
+    }
+
     if is_pos_infinity(point, pool) {
         let t = pool.symbol("__lt_inf", crate::kernel::Domain::Real);
         let inv_t = pool.pow(t, pool.integer(-1_i32));
@@ -545,7 +734,7 @@ fn limit_inner(
         m.insert(var, inv_t);
         let after_subs = subs(expr, &m, pool);
         let after_flatten = flatten_nested_integer_pow(after_subs, pool);
-        let after_canon = canonical_polynomial_quotient_in_var(after_flatten, t, pool);
+        let after_canon = canonical_polynomial_quotient_in_var(after_flatten, t, pool)?;
         let e2 = simplify(after_canon, pool).value;
         return limit_inner(
             e2,
@@ -565,15 +754,12 @@ fn limit_inner(
         ]);
         let mut m = HashMap::new();
         m.insert(var, rep);
-        let e2 = simplify(
-            canonical_polynomial_quotient_in_var(
-                flatten_nested_integer_pow(subs(expr, &m, pool), pool),
-                t,
-                pool,
-            ),
+        let canon = canonical_polynomial_quotient_in_var(
+            flatten_nested_integer_pow(subs(expr, &m, pool), pool),
+            t,
             pool,
-        )
-        .value;
+        )?;
+        let e2 = simplify(canon, pool).value;
         return limit_inner(
             e2,
             t,
@@ -601,6 +787,107 @@ fn limit_inner(
     }
 
     Err(LimitError::Unsupported)
+}
+
+/// True when `expr` contains an algebraic (non-integer-power) head — `sqrt`,
+/// `cbrt`, or a `Pow` with a fractional exponent.
+fn contains_radical(expr: ExprId, pool: &ExprPool) -> bool {
+    match pool.get(expr) {
+        ExprData::Func { name, args } => {
+            name == "sqrt" || name == "cbrt" || args.iter().any(|&a| contains_radical(a, pool))
+        }
+        ExprData::Pow { base, exp } => {
+            matches!(pool.get(exp), ExprData::Rational(_))
+                || contains_radical(base, pool)
+                || contains_radical(exp, pool)
+        }
+        ExprData::Add(xs) | ExprData::Mul(xs) => xs.iter().any(|&x| contains_radical(x, pool)),
+        _ => false,
+    }
+}
+
+/// Leading-order limit of an *algebraic* expression at `±∞`.
+///
+/// Substitutes `x ↦ ±1/t` (`t → 0⁺`), regularizes the result structurally as
+/// `f(±1/t) = t^v · u(t)` with `u` analytic and non-vanishing at `t = 0`
+/// ([`regularize_at_zero`], the same valuation calculus
+/// [`crate::calculus::asymptotic`] expands with), and reads the limit off the
+/// leading Taylor coefficient of `u`.
+///
+/// The generic route below — substitute, clear poles, Taylor-expand the whole
+/// thing — cannot see through a radical: for `√(x²+x) − x` it hands
+/// `√(t⁻² + t⁻¹) − t⁻¹` to a 32-term Taylor expansion, and each successive
+/// derivative of a nested radical is a constant factor larger than the last,
+/// so the call never returns. Pulling the pole out of the radical first
+/// (`√(t⁻²(1+t)) = t⁻¹√(1+t)`) leaves `t⁻¹·(√(1+t) − 1)`, whose analytic part
+/// has bounded derivatives — the expansion is then immediate and exact, and
+/// the ∞−∞ cancellation resolves to `1/2` instead of hanging.
+///
+/// Restricted to expressions that actually contain a radical: everything else
+/// is already served by the existing routes, and this keeps their answers
+/// untouched.
+fn try_regularized_infinity_limit(
+    expr: ExprId,
+    var: ExprId,
+    toward_pos: bool,
+    pool: &ExprPool,
+) -> Result<Option<ExprId>, LimitError> {
+    // Escalated rather than fixed: only the first nonzero coefficient of `u`
+    // decides the limit, and every further coefficient costs one more symbolic
+    // derivative. Stopping at the first order that resolves keeps the common
+    // case at three derivatives instead of thirty-two.
+    const ORDERS: [u32; 3] = [4, 10, 24];
+
+    if !contains_radical(expr, pool) {
+        return Ok(None);
+    }
+
+    // `Domain::Positive`: the substituted variable approaches 0 from above, and
+    // `regularize_at_zero`'s `(t^v·u)^e = t^{v·e}·u^e` step is only valid for
+    // `t > 0`.
+    let t = pool.symbol("__lt_reg", crate::kernel::Domain::Positive);
+    let inv_t = pool.pow(t, pool.integer(-1_i32));
+    let rep = if toward_pos {
+        inv_t
+    } else {
+        pool.mul(vec![pool.integer(-1_i32), inv_t])
+    };
+    let mut m = HashMap::new();
+    m.insert(var, rep);
+    let f_of_t = simplify(subs(expr, &m, pool), pool).value;
+
+    let Some((val, analytic)) = regularize_at_zero(f_of_t, t, pool) else {
+        return Ok(None);
+    };
+    let Ok(val) = i32::try_from(val) else {
+        return Ok(None);
+    };
+
+    let zero = pool.integer(0_i32);
+    for order in ORDERS {
+        checkpoint(pool)?;
+        let Ok(exp) = local_expansion(analytic, t, zero, order, pool) else {
+            return Ok(None);
+        };
+        let LocalExpansion {
+            valuation,
+            coeffs,
+            h_expr,
+        } = exp;
+        let Some(total) = val.checked_add(valuation) else {
+            return Ok(None);
+        };
+        let shifted = LocalExpansion {
+            valuation: total,
+            coeffs,
+            h_expr,
+        };
+        // `t → 0⁺`, so even an odd-order pole has a determinate sign.
+        if let Some(r) = expansion_to_limit(shifted, pool, LimitDirection::Plus)? {
+            return Ok(Some(r));
+        }
+    }
+    Ok(None)
 }
 
 fn try_x_log_x_at_zero(
@@ -1160,9 +1447,19 @@ fn try_expansion_limit(
 ) -> Result<Option<ExprId>, LimitError> {
     let exp = match local_expansion(expr, var, point, order, pool) {
         Ok(e) => e,
-        Err(_) => return Ok(None),
+        Err(_) => {
+            checkpoint(pool)?;
+            return Ok(None);
+        }
     };
-    expansion_to_limit(exp, pool, direction)
+    let r = expansion_to_limit(exp, pool, direction)?;
+    if r.is_none() {
+        // The expansion resolved nothing. If that is because the coefficient
+        // loop hit the work ceiling (or a budget) part-way, say so rather than
+        // letting the caller report `Unsupported`.
+        checkpoint(pool)?;
+    }
+    Ok(r)
 }
 
 fn expansion_to_limit(
@@ -1391,12 +1688,155 @@ mod tests {
             p.pow(p.add(vec![p.integer(1), inv]), p.integer(-1)),
         ]);
         let folded = flatten_nested_integer_pow(ex, &p);
-        let canon = canonical_polynomial_quotient_in_var(folded, t, &p);
+        let canon = canonical_polynomial_quotient_in_var(folded, t, &p).unwrap();
         let r = simplify(canon, &p).value;
         let mut m = HashMap::new();
         m.insert(t, p.integer(0));
         let sub = fold_known_reals(simplify(subs(r, &m, &p), &p).value, &p);
         assert_eq!(sub, p.integer(1), "canonical={}", p.display(canon));
+    }
+}
+
+/// Termination: the engine must always come back, with a value or a coded
+/// refusal, and must stop when the ambient budget says so.
+#[cfg(test)]
+mod termination_tests {
+    use super::*;
+    use crate::budget::{self, Budget, BudgetError};
+    use crate::errors::AlkahestError;
+    use crate::kernel::Domain;
+
+    /// `√(x²+x) − x` at `+∞`: an `∞−∞` cancellation whose conjugate is
+    /// `x/(√(x²+x)+x) → 1/2`.
+    ///
+    /// This call did not return at all — the `x ↦ 1/t` substitution handed
+    /// `√(t⁻²+t⁻¹)` to a 32-term Taylor expansion, and each derivative of a
+    /// nested radical is a constant factor larger than the last.
+    #[test]
+    fn sqrt_x_squared_plus_x_minus_x_at_infinity_is_one_half() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let root = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
+        let ex = simplify(p.add(vec![root, p.mul(vec![p.integer(-1), x])]), &p).value;
+        let r = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap();
+        assert_eq!(r, p.rational(1, 2), "got {}", p.display(r));
+    }
+
+    /// The same cancellation with other coefficients, and its mirror at `−∞`.
+    #[test]
+    fn algebraic_cancellations_at_infinity() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let neg_inf = p.mul(vec![p.integer(-1), p.pos_infinity()]);
+
+        // √(x²+3x) − x → 3/2
+        let root = p.func(
+            "sqrt",
+            vec![p.add(vec![p.pow(x, p.integer(2)), p.mul(vec![p.integer(3), x])])],
+        );
+        let ex = simplify(p.add(vec![root, p.mul(vec![p.integer(-1), x])]), &p).value;
+        let r = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap();
+        assert_eq!(r, p.rational(3, 2), "√(x²+3x)−x: {}", p.display(r));
+
+        // √(x²+1) − x → 0
+        let root = p.func(
+            "sqrt",
+            vec![p.add(vec![p.pow(x, p.integer(2)), p.integer(1)])],
+        );
+        let ex = simplify(p.add(vec![root, p.mul(vec![p.integer(-1), x])]), &p).value;
+        let r = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap();
+        assert_eq!(r, p.integer(0), "√(x²+1)−x: {}", p.display(r));
+
+        // As x → −∞ there is no cancellation: √(x²+x) ~ |x| = −x, so the sum
+        // is ~ −2x → +∞.
+        let root = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
+        let ex = simplify(p.add(vec![root, p.mul(vec![p.integer(-1), x])]), &p).value;
+        let r = limit(ex, x, neg_inf, LimitDirection::Bidirectional, &p).unwrap();
+        assert_eq!(r, p.pos_infinity(), "√(x²+x)−x at −∞: {}", p.display(r));
+    }
+
+    /// A radical limit the engine cannot solve must still come back — with
+    /// `E-LIMIT-004`, not by running forever — when no budget is active.
+    #[test]
+    fn unsolvable_radical_limit_refuses_within_the_work_ceiling() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        // √(√(x²+x) + x): a half-integer scale the regularizer declines, so
+        // this falls through to the expansion route that used to run away.
+        let inner = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
+        let ex = p.func("sqrt", vec![p.add(vec![inner, x])]);
+        let started = std::time::Instant::now();
+        let err = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap_err();
+        assert!(
+            matches!(err, LimitError::DepthExceeded),
+            "expected a bounded refusal, got {err:?}"
+        );
+        assert_eq!(err.code(), "E-LIMIT-004");
+        // Not a budget trip — the internal ceiling stopped it.
+        assert_eq!(last_budget_trip(), None);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(30),
+            "the work ceiling did not bound the search"
+        );
+    }
+
+    /// A step budget stops the search and is reported as a budget trip, so a
+    /// binding can raise `E-BUDGET-002` rather than "this limit is too hard".
+    ///
+    /// Steps and wall clock live on the thread-local budget stack, so this is
+    /// safe to run in parallel with the rest of the suite (unlike the
+    /// process-wide cancellation flag, which `budget`'s own tests serialize).
+    #[test]
+    fn step_budget_stops_a_hard_limit_and_is_attributed() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let inner = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
+        let ex = p.func("sqrt", vec![p.add(vec![inner, x])]);
+
+        let _guard = budget::enter(Budget::new().with_max_steps(3));
+        let err = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap_err();
+        assert!(matches!(err, LimitError::DepthExceeded), "{err:?}");
+        assert!(
+            matches!(last_budget_trip(), Some(BudgetError::Steps { .. })),
+            "budget trip not recorded: {:?}",
+            last_budget_trip()
+        );
+    }
+
+    /// A limit that *succeeds* under a generous budget must not be reported as
+    /// a budget trip, and must not leave a stale trip behind for the next call.
+    #[test]
+    fn a_solved_limit_leaves_no_budget_trip() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        {
+            let _guard = budget::enter(Budget::new().with_max_steps(3));
+            let inner = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
+            let ex = p.func("sqrt", vec![p.add(vec![inner, x])]);
+            assert!(limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).is_err());
+            assert!(last_budget_trip().is_some());
+        }
+        let root = p.func("sqrt", vec![p.add(vec![p.pow(x, p.integer(2)), x])]);
+        let ex = simplify(p.add(vec![root, p.mul(vec![p.integer(-1), x])]), &p).value;
+        let r = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p).unwrap();
+        assert_eq!(r, p.rational(1, 2));
+        assert_eq!(last_budget_trip(), None, "stale trip left behind");
+    }
+
+    /// The work ceiling bounds a whole `limit` call, not each re-entry: Gruntz
+    /// sub-limits call back into `limit`, and a per-call baseline would reset
+    /// the ceiling every time and never trip.
+    #[test]
+    fn work_baseline_is_installed_once_and_cleared_on_exit() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        assert!(WORK_BASELINE.with(|c| c.get()).is_none());
+        let ex = simplify(p.pow(x, p.integer(2)), &p).value;
+        let _ = limit(ex, x, p.pos_infinity(), LimitDirection::Bidirectional, &p);
+        assert!(
+            WORK_BASELINE.with(|c| c.get()).is_none(),
+            "baseline leaked past the outermost call"
+        );
     }
 }
 

--- a/alkahest-core/src/calculus/series.rs
+++ b/alkahest-core/src/calculus/series.rs
@@ -5,6 +5,7 @@ use crate::flint::FlintPoly;
 use crate::kernel::{subs, Domain, ExprData, ExprId, ExprPool};
 use crate::poly::{RationalFunction, UniPoly};
 use crate::simplify::simplify;
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -239,6 +240,58 @@ fn unipoly_strip_low(p: &UniPoly, k: u32) -> UniPoly {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Coefficient-loop ceiling
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Absolute `pool.len()` ceiling for [`taylor_coefficients`], or `None` for
+    /// "compute every coefficient that was asked for".
+    static COEFF_POOL_CEILING: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+/// RAII installer for the [`taylor_coefficients`] ceiling; restores the
+/// previous value on drop, including on panic-unwind.
+pub(crate) struct CoeffCeiling(Option<usize>);
+
+impl Drop for CoeffCeiling {
+    fn drop(&mut self) {
+        COEFF_POOL_CEILING.with(|c| c.set(self.0));
+    }
+}
+
+/// Stop [`taylor_coefficients`] early once the pool has grown past `ceiling`,
+/// returning the coefficients computed so far.
+///
+/// Only for callers that need a *leading* term rather than a series to a
+/// promised order — [`crate::calculus::limits`] scans for the first nonzero
+/// coefficient, so a short prefix is either enough to answer or an honest "no
+/// answer at this order", never a wrong answer. [`series`] itself installs no
+/// ceiling: truncating there would understate the `O(·)` term, which would be
+/// a lie rather than a refusal.
+///
+/// Successive Taylor coefficients are formed by differentiating *without*
+/// re-simplifying, so for expressions whose derivatives do not close (nested
+/// radicals) each one is a constant factor larger than the last. Without this
+/// the loop is unbounded in both time and memory, and — being a single call —
+/// gives the caller nowhere to place a cancellation checkpoint.
+pub(crate) fn enter_coeff_ceiling(ceiling: usize) -> CoeffCeiling {
+    COEFF_POOL_CEILING.with(|c| {
+        let prev = c.get();
+        c.set(Some(ceiling));
+        CoeffCeiling(prev)
+    })
+}
+
+/// `true` when the installed ceiling has been reached, or the ambient
+/// [`crate::budget`] has been exhausted / cancelled.
+fn coeff_loop_should_stop(pool: &ExprPool) -> bool {
+    match COEFF_POOL_CEILING.with(|c| c.get()) {
+        Some(ceiling) => pool.len() > ceiling || crate::budget::check().is_err(),
+        None => false,
+    }
+}
+
 fn taylor_coefficients(
     mut cur: ExprId,
     xi: ExprId,
@@ -249,6 +302,9 @@ fn taylor_coefficients(
     mapping.insert(xi, pool.integer(0_i32));
     let mut out = Vec::with_capacity(num as usize);
     for k in 0..num {
+        if k > 0 && coeff_loop_should_stop(pool) {
+            break;
+        }
         let ev = subs(cur, &mapping, pool);
         let simp = simplify(ev, pool).value;
         let fc = factorial_u32(k);

--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -52,6 +52,7 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-MAT-001", class: "MatrixError", cause: Cause::UserInput, remediation: Some("check that row/column counts agree") },
     ErrorSpec { code: "E-MAT-002", class: "MatrixError", cause: Cause::UserInput, remediation: Some("use pseudo-inverse for rectangular matrices") },
     ErrorSpec { code: "E-MAT-003", class: "MatrixError", cause: Cause::Domain,    remediation: Some("check for linear dependence in the rows/columns") },
+    ErrorSpec { code: "E-MAT-004", class: "MatrixError", cause: Cause::Unsupported, remediation: Some("rewrite the entries into a form whose determinant's vanishing is decidable, or substitute concrete values") },
     // V2-17 — EigenError
     ErrorSpec { code: "E-EIGEN-001", class: "EigenError", cause: Cause::UserInput,   remediation: Some("pass a square n×n matrix") },
     ErrorSpec { code: "E-EIGEN-002", class: "EigenError", cause: Cause::UserInput,   remediation: Some("ensure det(λI−M) is a ℤ-polynomial in the fresh λ variable") },
@@ -70,10 +71,25 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-LINALG-007", class: "LinearAlgebraError", cause: Cause::Unsupported, remediation: Some("use rational entries for Smith-based decompositions") },
     ErrorSpec { code: "E-LINALG-008", class: "LinearAlgebraError", cause: Cause::Domain,      remediation: Some("similarity transform matrix is singular") },
     ErrorSpec { code: "E-LINALG-009", class: "LinearAlgebraError", cause: Cause::UserInput,   remediation: Some("matrix entries must be rational constants") },
+    // Zero-testing over a transcendental extension is not decidable in general, so
+    // elimination can reach an entry it can neither prove zero nor prove non-zero.
+    // Refusing is the point: treating "unknown" as "non-zero" is what produced a
+    // confident wrong rank (and a false inconsistency signature) before this code existed.
+    ErrorSpec { code: "E-LINALG-010", class: "LinearAlgebraError", cause: Cause::Unsupported, remediation: Some("rewrite the entry into a form whose vanishing is decidable, or substitute concrete values for the parameters") },
     // E-ODE — OdeError
     ErrorSpec { code: "E-ODE-001", class: "OdeError", cause: Cause::UserInput,   remediation: Some("number of state variables must equal number of RHS expressions") },
     ErrorSpec { code: "E-ODE-002", class: "OdeError", cause: Cause::UserInput,   remediation: Some("use lower_to_first_order() before passing to a solver") },
     ErrorSpec { code: "E-ODE-003", class: "OdeError", cause: Cause::Unsupported, remediation: Some("check differentiability of all functions in the system") },
+    ErrorSpec { code: "E-ODE-010", class: "DsolveError", cause: Cause::Unsupported, remediation: None },
+    ErrorSpec { code: "E-ODE-011", class: "DsolveError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-ODE-012", class: "DsolveError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-ODE-020", class: "NumericOdeError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-ODE-021", class: "NumericOdeError", cause: Cause::Resource, remediation: None },
+    ErrorSpec { code: "E-ODE-022", class: "NumericOdeError", cause: Cause::Resource, remediation: None },
+    ErrorSpec { code: "E-ODE-023", class: "NumericOdeError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-ODE-024", class: "NumericOdeError", cause: Cause::Unsupported, remediation: None },
+    ErrorSpec { code: "E-ODE-025", class: "NumericOdeError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-ODE-026", class: "NumericOdeError", cause: Cause::UserInput, remediation: None },
     // E-DAE — DaeError
     ErrorSpec { code: "E-DAE-001", class: "DaeError", cause: Cause::Unsupported, remediation: Some("ensure all functions are differentiable before calling pantelides()") },
     ErrorSpec { code: "E-DAE-002", class: "DaeError", cause: Cause::UserInput,   remediation: Some("DAE index exceeds depth-10 limit; reformulate the model") },
@@ -81,6 +97,7 @@ pub const REGISTRY: &[ErrorSpec] = &[
     // E-DIFFALG — DiffAlgError (V2-13 differential algebra / Rosenfeld–Gröbner)
     ErrorSpec { code: "E-DIFFALG-001", class: "DiffAlgError", cause: Cause::Unsupported, remediation: Some("ensure the DAE is polynomial in its state and derivative symbols") },
     ErrorSpec { code: "E-DIFFALG-002", class: "DiffAlgError", cause: Cause::UserInput,   remediation: Some("declare all jet variables; remove transcendental functions") },
+    ErrorSpec { code: "E-DIFFALG-003", class: "DiffAlgError", cause: Cause::UserInput, remediation: None },
     ErrorSpec { code: "E-SOLVE-001", class: "SolverError", cause: Cause::UserInput,   remediation: Some("ensure all equations are polynomial in the declared variables") },
     ErrorSpec { code: "E-SOLVE-002", class: "SolverError", cause: Cause::Unsupported, remediation: Some("only degree ≤ 2 univariate solving is implemented; Gröbner basis is still returned") },
     ErrorSpec { code: "E-SOLVE-003", class: "SolverError", cause: Cause::UserInput,   remediation: Some("provide one equation per variable") },
@@ -94,6 +111,7 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-JIT-001", class: "JitError", cause: Cause::Unsupported, remediation: Some("use eval_expr or simplify the expression before JIT") },
     ErrorSpec { code: "E-JIT-002", class: "JitError", cause: Cause::Resource,    remediation: Some("check LLVM 15 installation; run with RUST_LOG=debug for details") },
     ErrorSpec { code: "E-JIT-003", class: "JitError", cause: Cause::Resource,    remediation: Some("ensure LLVM_SYS_150_PREFIX is set correctly") },
+    ErrorSpec { code: "E-JIT-004", class: "JitError", cause: Cause::UserInput, remediation: None },
     // E-CAD — CadError (V2-9 QE / cylindrical decomposition)
     ErrorSpec {
         code: "E-CAD-001",
@@ -204,6 +222,61 @@ pub const REGISTRY: &[ErrorSpec] = &[
     // `scripts/check_error_codes.py`; `E-BATCH-001` in `python/alkahest/_batch.py`
     // is the same precedent.
     ErrorSpec { code: "E-SMT-002", class: "SmtError", cause: Cause::Unsupported, remediation: Some("check alkahest.smt.supported(formula) before exporting; the fragment is polynomial (in)equalities over Int/Real symbols plus boolean structure and quantifiers, and float literals are refused because they are not the exact question they look like") },
+    // Codes raised by alkahest-core that were never registered here. The registry
+    // is the contract `scripts/check_error_codes.py` enforces, so an unregistered
+    // code is an undocumented one. Remediation text is taken from each type's own
+    // `AlkahestError::remediation` impl rather than re-worded, so the two cannot
+    // disagree about what a caller should do.
+    // E-ASYMPT — AsymptoticError
+    ErrorSpec { code: "E-ASYMPT-001", class: "AsymptoticError", cause: Cause::UserInput, remediation: Some("pass n_terms >= 1") },
+    ErrorSpec { code: "E-ASYMPT-002", class: "AsymptoticError", cause: Cause::UserInput, remediation: Some("the function may not be analytic/Laurent-expandable at infinity; try a simpler form or fewer terms") },
+    ErrorSpec { code: "E-ASYMPT-003", class: "AsymptoticError", cause: Cause::UserInput, remediation: Some("ensure all functions are registered primitives with differentiation rules") },
+    ErrorSpec { code: "E-ASYMPT-004", class: "AsymptoticError", cause: Cause::UserInput, remediation: Some("the expansion could not be numerically verified at large x; the function may have an oscillatory or non-power-scale tail") },
+    ErrorSpec { code: "E-ASYMPT-005", class: "AsymptoticError", cause: Cause::Unsupported, remediation: Some("exp/log scale hierarchies and Gamma/Stirling asymptotics are out of scope for asymptotic_expand; power-scale (rational/algebraic) and single log/exp peels are supported. For the asymptotics of a *sum* use experimental.euler_maclaurin, which also reaches Stirling via the sum of log k") },
+    // E-FPS — FpsError
+    ErrorSpec { code: "E-FPS-001", class: "FpsError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-FPS-002", class: "FpsError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-FPS-003", class: "FpsError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-FPS-004", class: "FpsError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-FPS-005", class: "FpsError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-FPS-006", class: "FpsError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-FPS-007", class: "FpsError", cause: Cause::UserInput, remediation: None },
+    // E-INTERP — SparseInterpError
+    ErrorSpec { code: "E-INTERP-001", class: "SparseInterpError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-INTERP-002", class: "SparseInterpError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-INTERP-003", class: "SparseInterpError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-INTERP-004", class: "SparseInterpError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-INTERP-010", class: "SparseGcdError", cause: Cause::Unsupported, remediation: None },
+    ErrorSpec { code: "E-INTERP-011", class: "SparseGcdError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-INTERP-012", class: "SparseGcdError", cause: Cause::Internal, remediation: None },
+    // E-LIMIT — LimitError
+    ErrorSpec { code: "E-LIMIT-001", class: "LimitError", cause: Cause::UserInput, remediation: Some("increase truncation order indirectly by simplifying the expression, or rewrite using standard limits") },
+    ErrorSpec { code: "E-LIMIT-002", class: "LimitError", cause: Cause::UserInput, remediation: Some("ensure primitives have differentiation rules, or simplify before taking the limit") },
+    ErrorSpec { code: "E-LIMIT-003", class: "LimitError", cause: Cause::UserInput, remediation: Some("use LimitDirection::Plus or Minus matching the desired one-sided approach") },
+    ErrorSpec { code: "E-LIMIT-004", class: "LimitError", cause: Cause::Resource, remediation: Some("try manual algebra (quotient form, cancellations) or split into simpler sub-expressions") },
+    ErrorSpec { code: "E-LIMIT-005", class: "LimitError", cause: Cause::Unsupported, remediation: Some("limit could not be computed — try manual algebra, or the expression may involve oscillation or non-comparable growth not yet handled") },
+    // E-NFM — NormalFormError
+    ErrorSpec { code: "E-NFM-001", class: "NormalFormError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-NFM-002", class: "NormalFormError", cause: Cause::Unsupported, remediation: None },
+    // E-REC — LinearRecurrenceError
+    ErrorSpec { code: "E-REC-001", class: "LinearRecurrenceError", cause: Cause::Unsupported, remediation: None },
+    ErrorSpec { code: "E-REC-002", class: "LinearRecurrenceError", cause: Cause::UserInput, remediation: None },
+    // E-RES — ResultantError
+    ErrorSpec { code: "E-RES-001", class: "ResultantError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-RES-003", class: "ResultantError", cause: Cause::UserInput, remediation: None },
+    // E-ROOT — RealRootError
+    ErrorSpec { code: "E-ROOT-001", class: "RealRootError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-ROOT-002", class: "RealRootError", cause: Cause::Domain, remediation: None },
+    // E-SUM — SumError
+    ErrorSpec { code: "E-SUM-001", class: "SumError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-SUM-002", class: "SumError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-SUM-003", class: "SumError", cause: Cause::UserInput, remediation: None },
+    // E-VALIDATED — ValidatedError
+    ErrorSpec { code: "E-VALIDATED-001", class: "ValidatedError", cause: Cause::Unsupported, remediation: None },
+    ErrorSpec { code: "E-VALIDATED-002", class: "ValidatedError", cause: Cause::UserInput, remediation: None },
+    ErrorSpec { code: "E-VALIDATED-003", class: "ValidatedError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-VALIDATED-004", class: "ValidatedError", cause: Cause::Domain, remediation: None },
+    ErrorSpec { code: "E-VALIDATED-005", class: "ValidatedError", cause: Cause::UserInput, remediation: None },
 ];
 
 #[cfg(test)]

--- a/alkahest-core/src/matrix/eigen.rs
+++ b/alkahest-core/src/matrix/eigen.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
-use crate::matrix::Matrix;
+use crate::matrix::{zero_test, Matrix};
 use crate::poly::error::ConversionError;
 use crate::poly::unipoly::UniPoly;
 use crate::poly::{factor_univariate_z, FactorError};
@@ -199,7 +199,7 @@ fn symbolic_eigenvalues_2x2(
     let half = pool.rational(rug::Integer::from(1), rug::Integer::from(2));
 
     // Repeated root when the discriminant is exactly zero: λ = trace/2 (mult 2).
-    if expr_is_exactly_zero(pool, disc) {
+    if zero_test::zero_status(pool, disc).is_proven_zero() {
         let lam = simplify(pool.mul(vec![half, trace]), pool).value;
         return Ok(vec![(lam, 2)]);
     }
@@ -307,14 +307,16 @@ fn symbolic_eigenvalues_3x3(
     let neg_shift = simplify(pool.mul(vec![neg_one, a_over_3]), pool).value;
 
     // Fully degenerate depressed cubic t³ = 0 ⇒ triple root at −a/3.
-    if expr_is_exactly_zero(pool, p) && expr_is_exactly_zero(pool, q) {
+    if zero_test::zero_status(pool, p).is_proven_zero()
+        && zero_test::zero_status(pool, q).is_proven_zero()
+    {
         return Ok(vec![(neg_shift, 3)]);
     }
 
     // A = ∛(−q/2 + √Δ),  B = −p/(3A).  For p = 0 the pure cubic t³ + q = 0 has
     // A = ∛(−q) and B = 0, sidestepping the 0/0 in −p/(3A).
     let one_third_exp = pool.rational(rug::Integer::from(1), rug::Integer::from(3));
-    let (a_root, b_root) = if expr_is_exactly_zero(pool, p) {
+    let (a_root, b_root) = if zero_test::zero_status(pool, p).is_proven_zero() {
         let neg_q = simplify(pool.mul(vec![neg_one, q]), pool).value;
         let a_root = simplify(pool.pow(neg_q, one_third_exp), pool).value;
         (a_root, pool.integer(0_i32))
@@ -929,19 +931,47 @@ fn kernel_2x2_column_basis(m: &Matrix, pool: &ExprPool) -> Option<Vec<Matrix>> {
         return Some(Vec::new());
     }
     let neg_one = pool.integer(-1_i32);
-    let (a, b) = if expr_is_exactly_zero(pool, a00) && expr_is_exactly_zero(pool, b01) {
-        if expr_is_exactly_zero(pool, c10) && expr_is_exactly_zero(pool, d11) {
+    // The perpendicular `(−b, a)` is taken from a row that is *not* the zero
+    // row; taking it from a vanishing row would return `(0, 0)`, which is not a
+    // basis vector at all. So each row needs a three-valued verdict, and only
+    // `NonVanishing`/`Vanishing` may be acted on.
+    let (a, b) = match row_is_nonvanishing(pool, a00, b01) {
+        Some(true) => (a00, b01),
+        Some(false) => match row_is_nonvanishing(pool, c10, d11) {
             // Zero matrix — fall through to the general rational/Gauss path,
             // which returns a full 2-dimensional basis.
-            return None;
-        }
-        (c10, d11)
-    } else {
-        (a00, b01)
+            Some(true) => (c10, d11),
+            Some(false) => return None,
+            None => return None,
+        },
+        // Undecided: hand the matrix to the general Gaussian path, which
+        // refuses honestly rather than guessing.
+        None => return None,
     };
     let neg_b = simplify(pool.mul(vec![neg_one, b]), pool).value;
     let col = Matrix::new(vec![vec![neg_b], vec![a]]).ok()?;
     Some(vec![col])
+}
+
+/// Whether the row `(x, y)` is known to be, or known not to be, the zero row.
+///
+/// `Some(true)` needs only *one* entry proven non-zero — the other may well be
+/// undecided, and a row with a proven non-zero entry is not the zero row
+/// whatever that other entry turns out to be. `Some(false)` needs *every* entry
+/// proven zero. `None` is everything in between.
+fn row_is_nonvanishing(pool: &ExprPool, x: ExprId, y: ExprId) -> Option<bool> {
+    use zero_test::ZeroStatus;
+    let statuses = [
+        zero_test::zero_status(pool, x),
+        zero_test::zero_status(pool, y),
+    ];
+    if statuses.contains(&ZeroStatus::NonZero) {
+        return Some(true);
+    }
+    if statuses.iter().all(|s| *s == ZeroStatus::Zero) {
+        return Some(false);
+    }
+    None
 }
 
 pub(crate) fn kernel_column_basis(m: &Matrix, pool: &ExprPool) -> Result<Vec<Matrix>, ()> {
@@ -1396,13 +1426,25 @@ fn gauss_nullspace_expr(m: &Matrix, pool: &ExprPool) -> Result<Vec<Vec<ExprId>>,
         if r_at >= rows {
             break;
         }
+        // Pivot only on an entry *proven* not to vanish identically, and
+        // declare the column pivot-free only when every candidate is proven
+        // zero. An undecided entry aborts: reporting the wrong pivot column
+        // here silently changes the dimension of the nullspace.
         let mut prow = None;
+        let mut undecided = false;
         for rr in r_at..rows {
             let e = simplify(a[rr][c], pool).value;
-            if !expr_is_exactly_zero(pool, e) {
-                prow = Some((rr, e));
-                break;
+            match zero_test::zero_status(pool, e) {
+                zero_test::ZeroStatus::NonZero => {
+                    prow = Some((rr, e));
+                    break;
+                }
+                zero_test::ZeroStatus::Zero => a[rr][c] = pool.integer(0_i32),
+                zero_test::ZeroStatus::Unknown => undecided = true,
             }
+        }
+        if prow.is_none() && undecided {
+            return Err(());
         }
         let Some((pr, piv)) = prow else { continue };
         if pr != r_at {
@@ -1417,7 +1459,9 @@ fn gauss_nullspace_expr(m: &Matrix, pool: &ExprPool) -> Result<Vec<Vec<ExprId>>,
                 continue;
             }
             let f = simplify(a[rr][c], pool).value;
-            if expr_is_exactly_zero(pool, f) {
+            // Skipping is an optimisation only — subtracting `f · pivot_row` is
+            // correct for any `f` — so an undecided factor need not refuse.
+            if zero_test::zero_status(pool, f).is_proven_zero() {
                 continue;
             }
             for cc in 0..cols {
@@ -1452,6 +1496,11 @@ fn gauss_nullspace_expr(m: &Matrix, pool: &ExprPool) -> Result<Vec<Vec<ExprId>>,
     Ok(bases)
 }
 
+/// Structural literal-zero test.
+///
+/// Retained only for the coefficient accumulator, where the slot being tested
+/// is a literal `0` this function itself put there. Every site that decides a
+/// *pivot* uses `zero_test::zero_status` instead.
 fn expr_is_exactly_zero(pool: &ExprPool, e: ExprId) -> bool {
     match pool.get(e) {
         ExprData::Integer(n) => n.0 == 0,

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -32,19 +32,22 @@ pub enum LinearAlgebraError {
     UnsupportedIrreducibleDegree {
         degree: usize,
     },
+    /// The entries lie outside the field this routine can work over.
+    ///
+    /// Two ways that happens: a Smith-based decomposition needs rational
+    /// constants and got something else, or elimination reached an entry whose
+    /// vanishing it could not decide — over a transcendental extension that
+    /// question is undecidable in general (see the `matrix::zero_test` module),
+    /// and pivoting on an entry that might be identically zero is what produced
+    /// full-rank verdicts for rank-deficient matrices.
+    ///
+    /// Which of the two it was is available from
+    /// [`take_zero_test_refusal`](crate::matrix::take_zero_test_refusal):
+    /// `Some(..)` means an undecided entry (code `E-LINALG-010`), `None` means
+    /// non-rational entries (code `E-LINALG-007`).
     UnsupportedField,
     SingularTransform,
     NonRationalEntry,
-    /// A candidate pivot could not be proven zero *or* proven non-zero.
-    ///
-    /// Elimination refuses rather than guess. Guessing "non-zero" is what
-    /// produced full-rank verdicts for rank-deficient matrices over
-    /// transcendental extensions — see the `matrix::zero_test` module for why the
-    /// third state has to exist and why it cannot be normalised away.
-    ZeroTestInconclusive {
-        /// The undecided entry, rendered for diagnosis.
-        entry: String,
-    },
 }
 
 impl fmt::Display for LinearAlgebraError {
@@ -66,7 +69,9 @@ impl fmt::Display for LinearAlgebraError {
             LinearAlgebraError::UnsupportedField => {
                 write!(
                     f,
-                    "entries must be rational constants for this decomposition"
+                    "matrix entries lie outside the field this routine can work over: \
+                     a Smith-based decomposition needs rational constants, and \
+                     elimination needs entries whose vanishing it can decide"
                 )
             }
             LinearAlgebraError::SingularTransform => {
@@ -75,11 +80,6 @@ impl fmt::Display for LinearAlgebraError {
             LinearAlgebraError::NonRationalEntry => {
                 write!(f, "matrix entry is not a rational constant")
             }
-            LinearAlgebraError::ZeroTestInconclusive { entry } => write!(
-                f,
-                "cannot decide whether the entry `{entry}` is zero; refusing to \
-                 select it as a pivot rather than report a rank that assumes it"
-            ),
         }
     }
 }
@@ -98,7 +98,6 @@ impl crate::errors::AlkahestError for LinearAlgebraError {
             LinearAlgebraError::UnsupportedField => "E-LINALG-007",
             LinearAlgebraError::SingularTransform => "E-LINALG-008",
             LinearAlgebraError::NonRationalEntry => "E-LINALG-009",
-            LinearAlgebraError::ZeroTestInconclusive { .. } => "E-LINALG-010",
         }
     }
 
@@ -118,19 +117,17 @@ impl crate::errors::AlkahestError for LinearAlgebraError {
             LinearAlgebraError::UnsupportedIrreducibleDegree { .. } => {
                 Some("minimal polynomial has an irreducible factor of degree > 2")
             }
-            LinearAlgebraError::UnsupportedField => {
-                Some("use rational or integer entries for Smith-based decompositions")
-            }
+            LinearAlgebraError::UnsupportedField => Some(
+                "use entries this routine can work over: rational or integer entries \
+                 for Smith-based decompositions, and entries whose vanishing is \
+                 decidable for elimination",
+            ),
             LinearAlgebraError::SingularTransform => {
                 Some("the computed similarity matrix is not invertible")
             }
             LinearAlgebraError::NonRationalEntry => {
                 Some("convert symbolic entries to rationals before calling this routine")
             }
-            LinearAlgebraError::ZeroTestInconclusive { .. } => Some(
-                "rewrite the entry into a form whose vanishing is decidable, or \
-                 substitute concrete values for the parameters",
-            ),
         }
     }
 }
@@ -261,11 +258,11 @@ fn row_echelon_pivots(m: &Matrix, pool: &ExprPool) -> Result<RowEchelonInfo, Lin
 ///
 /// * `Ok(Some(..))` — a pivot proven not to vanish identically.
 /// * `Ok(None)` — every candidate is proven zero, so the column has no pivot.
-/// * `Err(ZeroTestInconclusive)` — no candidate could be proven non-zero and at
-///   least one could not be proven zero either. Reporting `None` would claim a
-///   rank deficiency that has not been established, and picking the undecided
-///   entry as a pivot would claim the opposite; both are silent errors, so the
-///   caller is told instead.
+/// * `Err(..)` — no candidate could be proven non-zero and at least one could
+///   not be proven zero either. Reporting `None` would claim a rank deficiency
+///   that has not been established, and picking the undecided entry as a pivot
+///   would claim the opposite; both are silent errors, so the caller is told
+///   instead. See [`inconclusive`] for how that refusal is coded.
 ///
 /// Entries proven zero are rewritten to the literal `0` in place, so the
 /// echelon form that comes out shows a cleared column rather than an
@@ -293,11 +290,29 @@ fn find_pivot(
     }
 }
 
-/// Build the refusal for an entry whose vanishing could not be decided.
+/// Refuse an entry whose vanishing could not be decided.
+///
+/// [`LinearAlgebraError`] is a public exhaustive enum, so it cannot grow a
+/// dedicated variant without a major semver break. The refusal is reported as
+/// [`LinearAlgebraError::UnsupportedField`] — true as it stands, since the
+/// entry lies in a field this routine cannot decide over — and the entry that
+/// caused it is recorded for
+/// [`take_zero_test_refusal`](crate::matrix::take_zero_test_refusal), which is
+/// how bindings recover the specific `E-LINALG-010`. Same shape as
+/// [`crate::calculus::limits::last_budget_trip`].
 fn inconclusive(pool: &ExprPool, e: ExprId) -> LinearAlgebraError {
-    LinearAlgebraError::ZeroTestInconclusive {
-        entry: pool.display(e).to_string(),
-    }
+    zero_test::record_refusal(pool, e, zero_test::RefusalSite::Pivot);
+    LinearAlgebraError::UnsupportedField
+}
+
+/// [`LinearAlgebraError::UnsupportedField`] for its other meaning: entries that
+/// are not the rational constants a Smith-based decomposition needs.
+///
+/// Clears any recorded zero-test refusal, so this error is never re-attributed
+/// to an undecided entry left behind by an earlier call on this thread.
+fn unsupported_field() -> LinearAlgebraError {
+    zero_test::forget_refusal();
+    LinearAlgebraError::UnsupportedField
 }
 
 fn rational_row_echelon_pivots(
@@ -720,7 +735,7 @@ fn lambda_identity_minus_m_poly(
         }
         rows.push(row);
     }
-    PolyMatrixQ::from_nested(rows).map_err(|_| LinearAlgebraError::UnsupportedField)
+    PolyMatrixQ::from_nested(rows).map_err(|_| unsupported_field())
 }
 
 fn expr_to_rat_uni_poly(e: ExprId, pool: &ExprPool) -> Result<RatUniPoly, LinearAlgebraError> {
@@ -755,7 +770,7 @@ fn invariant_factors_from_smith(s: &PolyMatrixQ) -> Result<Vec<RatUniPoly>, Line
         }
     }
     if facs.is_empty() {
-        return Err(LinearAlgebraError::UnsupportedField);
+        return Err(unsupported_field());
     }
     Ok(facs)
 }
@@ -763,7 +778,7 @@ fn invariant_factors_from_smith(s: &PolyMatrixQ) -> Result<Vec<RatUniPoly>, Line
 fn companion_matrix(f: &RatUniPoly, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
     let d = f.degree() as usize;
     if d == 0 {
-        return Err(LinearAlgebraError::UnsupportedField);
+        return Err(unsupported_field());
     }
     let coeffs = f.coeffs.clone();
     let mut c = Matrix::zeros(d, d, pool);
@@ -1214,7 +1229,9 @@ pub fn matrix_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError
             }
         }
         let Some(pr) = piv else {
-            return Err(MatrixError::SingularMatrix);
+            // Rational entries: zero-testing is exact here, so this is a proven
+            // singularity and never a refusal — see `singular`.
+            return Err(singular());
         };
         if pr != col {
             aug.swap(pr, col);
@@ -1248,8 +1265,12 @@ pub fn matrix_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError
 /// symbolic determinant engine (`Matrix::det`) handles arbitrary entries, so this
 /// path supports transfer functions `C(sI−A)⁻¹B+D`, symbolic mass matrices, etc.
 ///
-/// If `det(A)` simplifies to a literal zero the matrix is genuinely singular and
-/// `MatrixError::SingularMatrix` is returned, keeping that error meaningful.
+/// If `det(A)` is proven zero the matrix is genuinely singular; if it can be
+/// proven neither zero nor non-zero, no inverse is reported either, because the
+/// adjugate formula divides by it. Both are
+/// [`MatrixError::SingularMatrix`], whose text states that disjunction; the
+/// second case additionally records a
+/// [`ZeroTestRefusal`](crate::matrix::ZeroTestRefusal) carrying `E-MAT-004`.
 fn symbolic_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError> {
     let n = m.rows;
     if n == 0 {
@@ -1260,12 +1281,11 @@ fn symbolic_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError> 
     // cofactor numerators (e.g. so A·A⁻¹ collapses to the identity on simplify).
     let det = simplify_expanded(m.det(pool)?, pool).value;
     match zero_test::zero_status(pool, det) {
-        zero_test::ZeroStatus::Zero => return Err(MatrixError::SingularMatrix),
+        zero_test::ZeroStatus::Zero => return Err(singular()),
         zero_test::ZeroStatus::NonZero => {}
         zero_test::ZeroStatus::Unknown => {
-            return Err(MatrixError::ZeroTestInconclusive {
-                entry: pool.display(det).to_string(),
-            })
+            zero_test::record_refusal(pool, det, zero_test::RefusalSite::Determinant);
+            return Err(MatrixError::SingularMatrix);
         }
     }
     let inv_det = simplify(pool.pow(det, pool.integer(-1_i32)), pool).value;
@@ -1291,7 +1311,17 @@ fn symbolic_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError> 
         }
         rows.push(row);
     }
-    Matrix::new(rows).map_err(|_| MatrixError::SingularMatrix)
+    Matrix::new(rows).map_err(|_| singular())
+}
+
+/// [`MatrixError::SingularMatrix`] for a *proven* singularity.
+///
+/// Clears any recorded zero-test refusal so a genuinely singular matrix is
+/// never reported with the undecided-determinant code `E-MAT-004`; see
+/// [`inconclusive`] for the other half of the arrangement.
+fn singular() -> MatrixError {
+    zero_test::forget_refusal();
+    MatrixError::SingularMatrix
 }
 
 // ---------------------------------------------------------------------------
@@ -1488,11 +1518,68 @@ mod tests {
         let m = Matrix::new(vec![vec![opaque, zero], vec![zero, zero]]).unwrap();
         let err = rank(&m, &p).expect_err("an undecidable pivot must refuse");
         assert!(
-            matches!(err, LinearAlgebraError::ZeroTestInconclusive { .. }),
+            matches!(err, LinearAlgebraError::UnsupportedField),
             "expected a zero-test refusal, got {err:?}"
         );
         use crate::errors::AlkahestError;
         assert!(err.code().starts_with("E-LINALG-"));
+        // The variant is a carrier — the specific cause and its `E-LINALG-010`
+        // travel out of band, which is what the bindings raise.
+        let refusal = crate::matrix::take_zero_test_refusal()
+            .expect("the refusal must be recoverable, or the code is lost");
+        assert_eq!(refusal.code(), "E-LINALG-010");
+        assert!(
+            refusal.entry().contains("mystery"),
+            "refusal should name the undecided entry, got {}",
+            refusal.entry()
+        );
+        assert_eq!(
+            crate::matrix::take_zero_test_refusal(),
+            None,
+            "taking must consume, so one refusal cannot be reported twice"
+        );
+    }
+
+    /// A matrix that is *proven* singular must not borrow the refusal code.
+    #[test]
+    fn a_proven_singularity_is_not_a_zero_test_refusal() {
+        let p = pool();
+        let x = p.symbol("x", Domain::Real);
+        // Refuse once so there is something stale to pick up...
+        let opaque = p.func("mystery", vec![x]);
+        let zero = p.integer(0_i32);
+        let undecidable = Matrix::new(vec![vec![opaque, zero], vec![zero, zero]]).unwrap();
+        let _ = rank(&undecidable, &p);
+        // ...then invert a matrix whose determinant is exactly 0.
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), p.integer(2_i32)],
+            vec![p.integer(2_i32), p.integer(4_i32)],
+        ])
+        .unwrap();
+        assert_eq!(matrix_inverse(&m, &p), Err(MatrixError::SingularMatrix));
+        assert_eq!(
+            crate::matrix::take_zero_test_refusal(),
+            None,
+            "a proven singularity must not be reported as an undecided determinant"
+        );
+    }
+
+    /// An undecidable determinant must refuse *and* be recoverable as E-MAT-004.
+    #[test]
+    fn inverse_refuses_an_undecidable_determinant() {
+        let p = pool();
+        let x = p.symbol("x", Domain::Real);
+        let opaque = p.func("mystery", vec![x]);
+        let m = Matrix::new(vec![
+            vec![opaque, p.integer(0_i32)],
+            vec![p.integer(0_i32), p.integer(1_i32)],
+        ])
+        .unwrap();
+        assert_eq!(matrix_inverse(&m, &p), Err(MatrixError::SingularMatrix));
+        use crate::errors::AlkahestError;
+        let refusal = crate::matrix::take_zero_test_refusal()
+            .expect("an undecided determinant must record its refusal");
+        assert_eq!(refusal.code(), "E-MAT-004");
     }
 
     #[test]

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -9,7 +9,7 @@ use crate::matrix::eigen::{
     m_minus_lambda_scaled,
 };
 use crate::matrix::normal_form::{smith_form_poly, PolyMatrixQ, RatUniPoly};
-use crate::matrix::{Matrix, MatrixError};
+use crate::matrix::{zero_test, Matrix, MatrixError};
 use crate::poly::unipoly::UniPoly;
 use crate::poly::{factor_univariate_z, FactorError};
 use crate::simplify::engine::{simplify, simplify_expanded};
@@ -29,10 +29,22 @@ pub enum LinearAlgebraError {
     NotPositiveDefinite,
     CharPolyConversion(crate::poly::error::ConversionError),
     Factorization(FactorError),
-    UnsupportedIrreducibleDegree { degree: usize },
+    UnsupportedIrreducibleDegree {
+        degree: usize,
+    },
     UnsupportedField,
     SingularTransform,
     NonRationalEntry,
+    /// A candidate pivot could not be proven zero *or* proven non-zero.
+    ///
+    /// Elimination refuses rather than guess. Guessing "non-zero" is what
+    /// produced full-rank verdicts for rank-deficient matrices over
+    /// transcendental extensions — see the `matrix::zero_test` module for why the
+    /// third state has to exist and why it cannot be normalised away.
+    ZeroTestInconclusive {
+        /// The undecided entry, rendered for diagnosis.
+        entry: String,
+    },
 }
 
 impl fmt::Display for LinearAlgebraError {
@@ -63,6 +75,11 @@ impl fmt::Display for LinearAlgebraError {
             LinearAlgebraError::NonRationalEntry => {
                 write!(f, "matrix entry is not a rational constant")
             }
+            LinearAlgebraError::ZeroTestInconclusive { entry } => write!(
+                f,
+                "cannot decide whether the entry `{entry}` is zero; refusing to \
+                 select it as a pivot rather than report a rank that assumes it"
+            ),
         }
     }
 }
@@ -81,6 +98,7 @@ impl crate::errors::AlkahestError for LinearAlgebraError {
             LinearAlgebraError::UnsupportedField => "E-LINALG-007",
             LinearAlgebraError::SingularTransform => "E-LINALG-008",
             LinearAlgebraError::NonRationalEntry => "E-LINALG-009",
+            LinearAlgebraError::ZeroTestInconclusive { .. } => "E-LINALG-010",
         }
     }
 
@@ -109,6 +127,10 @@ impl crate::errors::AlkahestError for LinearAlgebraError {
             LinearAlgebraError::NonRationalEntry => {
                 Some("convert symbolic entries to rationals before calling this routine")
             }
+            LinearAlgebraError::ZeroTestInconclusive { .. } => Some(
+                "rewrite the entry into a form whose vanishing is decidable, or \
+                 substitute concrete values for the parameters",
+            ),
         }
     }
 }
@@ -194,15 +216,9 @@ fn row_echelon_pivots(m: &Matrix, pool: &ExprPool) -> Result<RowEchelonInfo, Lin
         if r_at >= rows {
             break;
         }
-        let mut prow = None;
-        for rr in r_at..rows {
-            let e = simplify(a[rr][c], pool).value;
-            if !expr_is_zero(pool, e) {
-                prow = Some((rr, e));
-                break;
-            }
-        }
-        let Some((pr, piv)) = prow else { continue };
+        let Some((pr, piv)) = find_pivot(&mut a, r_at, rows, c, pool)? else {
+            continue;
+        };
         if pr != r_at {
             a.swap(pr, r_at);
         }
@@ -215,7 +231,10 @@ fn row_echelon_pivots(m: &Matrix, pool: &ExprPool) -> Result<RowEchelonInfo, Lin
                 continue;
             }
             let f = simplify(a[rr][c], pool).value;
-            if expr_is_zero(pool, f) {
+            // Only *skipping* needs a decision here: subtracting `f · pivot_row`
+            // is correct whatever `f` is, so an undecided factor costs work but
+            // never correctness. Refusing here would be gratuitous.
+            if zero_test::zero_status(pool, f).is_proven_zero() {
                 continue;
             }
             for cc in 0..cols {
@@ -233,6 +252,52 @@ fn row_echelon_pivots(m: &Matrix, pool: &ExprPool) -> Result<RowEchelonInfo, Lin
         pivot_row_flags,
         echelon: Matrix::new(a).expect("row echelon grid"),
     })
+}
+
+/// The first row at or below `r_at` whose entry in column `c` is **proven**
+/// non-zero, together with that entry.
+///
+/// Three outcomes, and the middle one is the point of this function:
+///
+/// * `Ok(Some(..))` — a pivot proven not to vanish identically.
+/// * `Ok(None)` — every candidate is proven zero, so the column has no pivot.
+/// * `Err(ZeroTestInconclusive)` — no candidate could be proven non-zero and at
+///   least one could not be proven zero either. Reporting `None` would claim a
+///   rank deficiency that has not been established, and picking the undecided
+///   entry as a pivot would claim the opposite; both are silent errors, so the
+///   caller is told instead.
+///
+/// Entries proven zero are rewritten to the literal `0` in place, so the
+/// echelon form that comes out shows a cleared column rather than an
+/// unsimplified expression that happens to vanish.
+fn find_pivot(
+    a: &mut [Vec<ExprId>],
+    r_at: usize,
+    rows: usize,
+    c: usize,
+    pool: &ExprPool,
+) -> Result<Option<(usize, ExprId)>, LinearAlgebraError> {
+    let zero = pool.integer(0_i32);
+    let mut undecided: Option<ExprId> = None;
+    for rr in r_at..rows {
+        let e = simplify(a[rr][c], pool).value;
+        match zero_test::zero_status(pool, e) {
+            zero_test::ZeroStatus::NonZero => return Ok(Some((rr, e))),
+            zero_test::ZeroStatus::Zero => a[rr][c] = zero,
+            zero_test::ZeroStatus::Unknown => undecided = undecided.or(Some(e)),
+        }
+    }
+    match undecided {
+        None => Ok(None),
+        Some(e) => Err(inconclusive(pool, e)),
+    }
+}
+
+/// Build the refusal for an entry whose vanishing could not be decided.
+fn inconclusive(pool: &ExprPool, e: ExprId) -> LinearAlgebraError {
+    LinearAlgebraError::ZeroTestInconclusive {
+        entry: pool.display(e).to_string(),
+    }
 }
 
 fn rational_row_echelon_pivots(
@@ -371,18 +436,14 @@ fn expr_lu_decomposition(
     let mut l = Matrix::identity(n, pool);
     let mut u = Matrix::zeros(n, cols, pool);
     for k in 0..n.min(cols) {
-        let mut piv_row = k;
-        for r in (k + 1)..n {
-            if !expr_is_zero(pool, a[r][k]) && expr_is_zero(pool, a[piv_row][k]) {
-                piv_row = r;
-            }
-        }
-        if expr_is_zero(pool, a[piv_row][k]) {
+        // Same contract as `find_pivot`: a column is declared pivot-free only
+        // when every candidate is *proven* zero.
+        let Some((piv_row, _)) = find_pivot(&mut a, k, n, k, pool)? else {
             for j in k..cols {
                 u.set(k, j, a[k][j]);
             }
             continue;
-        }
+        };
         if piv_row != k {
             a.swap(piv_row, k);
             perm.swap(piv_row, k);
@@ -438,10 +499,17 @@ pub fn qr_decomposition(
                 .map_err(|_| LinearAlgebraError::KernelFailed)?;
         }
         let rjj = norm_column(&v, pool)?;
-        if expr_is_zero(pool, rjj) {
-            r.set(j, j, pool.integer(0_i32));
-            q_cols.push(Matrix::zeros(n, 1, pool));
-            continue;
+        // `‖v‖ = 0` means column `j` is dependent on the ones before it and Q
+        // gets a zero column; `‖v‖ ≠ 0` means we may divide by it. Guessing
+        // either way silently changes the rank of Q.
+        match zero_test::zero_status(pool, rjj) {
+            zero_test::ZeroStatus::Zero => {
+                r.set(j, j, pool.integer(0_i32));
+                q_cols.push(Matrix::zeros(n, 1, pool));
+                continue;
+            }
+            zero_test::ZeroStatus::NonZero => {}
+            zero_test::ZeroStatus::Unknown => return Err(inconclusive(pool, rjj)),
         }
         r.set(j, j, rjj);
         let inv = simplify(pool.pow(rjj, pool.integer(-1_i32)), pool).value;
@@ -826,10 +894,15 @@ fn columns_proportional(a: &Matrix, b: &Matrix, pool: &ExprPool) -> bool {
     for r in 0..a.rows {
         let ea = simplify(a.get(r, 0), pool).value;
         let eb = simplify(b.get(r, 0), pool).value;
-        if expr_is_zero(pool, ea) && expr_is_zero(pool, eb) {
+        // A heuristic search over candidate cyclic vectors: an undecided entry
+        // only makes this candidate look unusable, and the caller tries the
+        // next one. No mathematical claim rides on `false` here.
+        let ea_zero = zero_test::zero_status(pool, ea).is_proven_zero();
+        let eb_zero = zero_test::zero_status(pool, eb).is_proven_zero();
+        if ea_zero && eb_zero {
             continue;
         }
-        if expr_is_zero(pool, ea) || expr_is_zero(pool, eb) {
+        if ea_zero || eb_zero {
             return false;
         }
         let cand = simplify(pool.mul(vec![ea, pool.pow(eb, pool.integer(-1_i32))]), pool).value;
@@ -941,8 +1014,13 @@ fn matrix_annihilated_by_uni(
         }
     }
     for e in acc.entries() {
-        if !expr_is_zero(pool, simplify(*e, pool).value) {
-            return Ok(false);
+        let entry = simplify(*e, pool).value;
+        match zero_test::zero_status(pool, entry) {
+            zero_test::ZeroStatus::Zero => {}
+            zero_test::ZeroStatus::NonZero => return Ok(false),
+            // "p(M) might be 0" must not be reported as "p does not annihilate
+            // M": that would return a non-minimal polynomial as the minimal one.
+            zero_test::ZeroStatus::Unknown => return Err(inconclusive(pool, entry)),
         }
     }
     Ok(true)
@@ -1008,14 +1086,19 @@ pub fn matrix_exponential(m: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearA
         .map_err(|_| LinearAlgebraError::KernelFailed)
 }
 
-/// True iff every off-diagonal entry simplifies to exactly zero.
+/// True iff every off-diagonal entry is *proven* zero.
+///
+/// A fast path, not a claim: an undecided off-diagonal entry answers `false`
+/// and `matrix_exponential` falls back to the Jordan route, which is correct
+/// for diagonal matrices too.
 fn is_diagonal(m: &Matrix, pool: &ExprPool) -> bool {
     if m.rows != m.cols {
         return false;
     }
     for r in 0..m.rows {
         for c in 0..m.cols {
-            if r != c && !expr_is_zero(pool, simplify(m.get(r, c), pool).value) {
+            let entry = simplify(m.get(r, c), pool).value;
+            if r != c && !zero_test::zero_status(pool, entry).is_proven_zero() {
                 return false;
             }
         }
@@ -1176,8 +1259,14 @@ fn symbolic_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError> 
     // `1/det` factor in the resulting entries cancels cleanly against expanded
     // cofactor numerators (e.g. so A·A⁻¹ collapses to the identity on simplify).
     let det = simplify_expanded(m.det(pool)?, pool).value;
-    if expr_is_zero(pool, det) {
-        return Err(MatrixError::SingularMatrix);
+    match zero_test::zero_status(pool, det) {
+        zero_test::ZeroStatus::Zero => return Err(MatrixError::SingularMatrix),
+        zero_test::ZeroStatus::NonZero => {}
+        zero_test::ZeroStatus::Unknown => {
+            return Err(MatrixError::ZeroTestInconclusive {
+                entry: pool.display(det).to_string(),
+            })
+        }
     }
     let inv_det = simplify(pool.pow(det, pool.integer(-1_i32)), pool).value;
 
@@ -1269,14 +1358,6 @@ fn rational_grid_to_matrix(grid: &[Vec<Rational>], pool: &ExprPool) -> Matrix {
     Matrix::new(rows).expect("rational grid")
 }
 
-fn expr_is_zero(pool: &ExprPool, e: ExprId) -> bool {
-    match pool.get(e) {
-        ExprData::Integer(n) => n.0 == 0,
-        ExprData::Rational(r) => r.0 == 0,
-        _ => false,
-    }
-}
-
 fn dot_columns(a: &Matrix, b: &Matrix, pool: &ExprPool) -> Result<ExprId, LinearAlgebraError> {
     let mut terms = Vec::new();
     for r in 0..a.rows {
@@ -1346,6 +1427,72 @@ mod tests {
         let p = pool();
         let id = Matrix::identity(3, &p);
         assert_eq!(rank(&id, &p).unwrap(), 3);
+    }
+
+    /// `exp(a)²` and `exp(2a)` are the same function written two ways.
+    ///
+    /// Row 2 is `exp(a)` times row 1, so the rank is 1. Before the zero test
+    /// grew a third state this returned 2, and the rref carried a `[0 0 1]`
+    /// row: the signature of an inconsistent system, for a consistent one.
+    #[test]
+    fn rank_sees_through_the_exponential_functional_equation() {
+        let p = pool();
+        let a = p.symbol("a", Domain::Real);
+        let exp_a = p.func("exp", vec![a]);
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), exp_a, exp_a],
+            vec![
+                exp_a,
+                p.mul(vec![exp_a, exp_a]),
+                p.func("exp", vec![p.add(vec![a, a])]),
+            ],
+        ])
+        .unwrap();
+        assert_eq!(rank(&m, &p).unwrap(), 1);
+
+        let echelon = rref(&m, &p).unwrap();
+        for c in 0..echelon.cols {
+            assert_eq!(
+                echelon.get(1, c),
+                p.integer(0_i32),
+                "rank-1 matrix must have an all-zero second rref row"
+            );
+        }
+    }
+
+    /// The control: the same matrix with one entry changed really has rank 2,
+    /// so the fix cannot be "call everything zero".
+    #[test]
+    fn rank_still_separates_independent_exponential_rows() {
+        let p = pool();
+        let a = p.symbol("a", Domain::Real);
+        let exp_a = p.func("exp", vec![a]);
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), exp_a, exp_a],
+            vec![exp_a, p.mul(vec![exp_a, exp_a]), exp_a],
+        ])
+        .unwrap();
+        assert_eq!(rank(&m, &p).unwrap(), 2);
+    }
+
+    /// An entry nothing can decide must produce a coded refusal, not a rank.
+    #[test]
+    fn rank_refuses_an_undecidable_pivot() {
+        let p = pool();
+        let x = p.symbol("x", Domain::Real);
+        // `mystery` has no differentiation rule, no numeric kernel and no ball
+        // kernel, so it can be neither normalised to zero nor enclosed away
+        // from it.
+        let opaque = p.func("mystery", vec![x]);
+        let zero = p.integer(0_i32);
+        let m = Matrix::new(vec![vec![opaque, zero], vec![zero, zero]]).unwrap();
+        let err = rank(&m, &p).expect_err("an undecidable pivot must refuse");
+        assert!(
+            matches!(err, LinearAlgebraError::ZeroTestInconclusive { .. }),
+            "expected a zero-test refusal, got {err:?}"
+        );
+        use crate::errors::AlkahestError;
+        assert!(err.code().starts_with("E-LINALG-"));
     }
 
     #[test]
@@ -1439,8 +1586,8 @@ mod tests {
         let expm = matrix_exponential(&m, &p).unwrap();
         assert_eq!(expm.rows, 2);
         assert_eq!(expm.cols, 2);
-        assert!(!expr_is_zero(&p, expm.get(0, 0)));
-        assert!(!expr_is_zero(&p, expm.get(1, 1)));
+        assert!(!zero_test::zero_status(&p, expm.get(0, 0)).is_proven_zero());
+        assert!(!zero_test::zero_status(&p, expm.get(1, 1)).is_proven_zero());
     }
 
     #[test]
@@ -1586,7 +1733,7 @@ mod tests {
                 )
                 .value;
                 assert!(
-                    expr_is_zero(&p, diff),
+                    zero_test::zero_status(&p, diff).is_proven_zero(),
                     "(A·adj)[{i}][{j}] != det·I[{i}][{j}]: {:?}",
                     p.get(diff)
                 );

--- a/alkahest-core/src/matrix/mod.rs
+++ b/alkahest-core/src/matrix/mod.rs
@@ -16,6 +16,7 @@ pub mod linear_algebra;
 pub mod normal_form;
 mod smith;
 mod smith_poly;
+mod zero_test;
 
 pub use eigen::{
     characteristic_polynomial_lambda_minus_m, diagonalize, eigenvalues, eigenvectors, EigenError,
@@ -46,9 +47,21 @@ pub struct Matrix {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatrixError {
-    DimensionMismatch { msg: String },
+    DimensionMismatch {
+        msg: String,
+    },
     NotSquare,
     SingularMatrix,
+    /// The determinant could not be proven zero *or* proven non-zero.
+    ///
+    /// Inverting via the adjugate divides by `det`, so "probably invertible" is
+    /// not good enough: if the determinant is in fact zero the returned inverse
+    /// is meaningless and nothing downstream can tell. See
+    /// the `matrix::zero_test` module.
+    ZeroTestInconclusive {
+        /// The undecided determinant, rendered for diagnosis.
+        entry: String,
+    },
 }
 
 impl fmt::Display for MatrixError {
@@ -57,6 +70,11 @@ impl fmt::Display for MatrixError {
             MatrixError::DimensionMismatch { msg } => write!(f, "dimension mismatch: {msg}"),
             MatrixError::NotSquare => write!(f, "matrix is not square"),
             MatrixError::SingularMatrix => write!(f, "matrix is singular"),
+            MatrixError::ZeroTestInconclusive { entry } => write!(
+                f,
+                "cannot decide whether the determinant `{entry}` is zero; \
+                 refusing to report an inverse that assumes it is not"
+            ),
         }
     }
 }
@@ -69,6 +87,7 @@ impl crate::errors::AlkahestError for MatrixError {
             MatrixError::DimensionMismatch { .. } => "E-MAT-001",
             MatrixError::NotSquare => "E-MAT-002",
             MatrixError::SingularMatrix => "E-MAT-003",
+            MatrixError::ZeroTestInconclusive { .. } => "E-MAT-004",
         }
     }
 
@@ -82,6 +101,9 @@ impl crate::errors::AlkahestError for MatrixError {
             ),
             MatrixError::SingularMatrix => Some(
                 "the matrix has a zero determinant; check your system of equations for linear dependence",
+            ),
+            MatrixError::ZeroTestInconclusive { .. } => Some(
+                "rewrite the entries into a form whose determinant's vanishing is decidable, or substitute concrete values",
             ),
         }
     }

--- a/alkahest-core/src/matrix/mod.rs
+++ b/alkahest-core/src/matrix/mod.rs
@@ -31,6 +31,7 @@ pub use normal_form::{
     hermite_form, hermite_form_poly, smith_form, smith_form_poly, IntegerMatrix, NormalFormError,
     PolyMatrixQ, RatUniPoly,
 };
+pub use zero_test::{take_zero_test_refusal, ZeroTestRefusal};
 
 // ---------------------------------------------------------------------------
 // Matrix type
@@ -51,17 +52,21 @@ pub enum MatrixError {
         msg: String,
     },
     NotSquare,
-    SingularMatrix,
-    /// The determinant could not be proven zero *or* proven non-zero.
+    /// The matrix cannot be inverted: its determinant is zero, or could not be
+    /// shown to be non-zero.
     ///
     /// Inverting via the adjugate divides by `det`, so "probably invertible" is
-    /// not good enough: if the determinant is in fact zero the returned inverse
-    /// is meaningless and nothing downstream can tell. See
-    /// the `matrix::zero_test` module.
-    ZeroTestInconclusive {
-        /// The undecided determinant, rendered for diagnosis.
-        entry: String,
-    },
+    /// not good enough — if the determinant is in fact zero the returned
+    /// inverse is meaningless and nothing downstream can tell. Over a
+    /// transcendental extension the vanishing question is not always decidable
+    /// (see the `matrix::zero_test` module), so the two cases are both refusals
+    /// and this variant states their disjunction rather than picking one.
+    ///
+    /// Which of the two it was is available from
+    /// [`take_zero_test_refusal`]: `Some(..)` means the determinant was
+    /// undecided (code `E-MAT-004`), `None` means it was proven zero (code
+    /// `E-MAT-003`).
+    SingularMatrix,
 }
 
 impl fmt::Display for MatrixError {
@@ -69,11 +74,9 @@ impl fmt::Display for MatrixError {
         match self {
             MatrixError::DimensionMismatch { msg } => write!(f, "dimension mismatch: {msg}"),
             MatrixError::NotSquare => write!(f, "matrix is not square"),
-            MatrixError::SingularMatrix => write!(f, "matrix is singular"),
-            MatrixError::ZeroTestInconclusive { entry } => write!(
+            MatrixError::SingularMatrix => write!(
                 f,
-                "cannot decide whether the determinant `{entry}` is zero; \
-                 refusing to report an inverse that assumes it is not"
+                "matrix is singular, or its determinant could not be proven non-zero"
             ),
         }
     }
@@ -86,8 +89,10 @@ impl crate::errors::AlkahestError for MatrixError {
         match self {
             MatrixError::DimensionMismatch { .. } => "E-MAT-001",
             MatrixError::NotSquare => "E-MAT-002",
+            // `E-MAT-004` — the undecided-determinant refusal — is carried by
+            // this same variant and read back through
+            // [`take_zero_test_refusal`]; see [`MatrixError::SingularMatrix`].
             MatrixError::SingularMatrix => "E-MAT-003",
-            MatrixError::ZeroTestInconclusive { .. } => "E-MAT-004",
         }
     }
 
@@ -100,10 +105,7 @@ impl crate::errors::AlkahestError for MatrixError {
                 "determinant and inverse require a square matrix; use the pseudo-inverse for rectangular matrices",
             ),
             MatrixError::SingularMatrix => Some(
-                "the matrix has a zero determinant; check your system of equations for linear dependence",
-            ),
-            MatrixError::ZeroTestInconclusive { .. } => Some(
-                "rewrite the entries into a form whose determinant's vanishing is decidable, or substitute concrete values",
+                "check your system of equations for linear dependence; if the entries are symbolic, substitute concrete values for the parameters",
             ),
         }
     }

--- a/alkahest-core/src/matrix/zero_test.rs
+++ b/alkahest-core/src/matrix/zero_test.rs
@@ -1,0 +1,500 @@
+//! Three-valued zero testing for symbolic matrix entries.
+//!
+//! # Why a third value
+//!
+//! Gaussian elimination has to answer one question about every candidate
+//! pivot: *is this entry zero?*  Over ℚ that question is decidable and the
+//! answer is a `bool`.  Over a transcendental extension it is not: deciding
+//! whether an expression built from `exp`, `log` and the field operations
+//! vanishes identically is undecidable in general (Richardson's theorem), and
+//! even the decidable fragments are only as strong as the normaliser in front
+//! of them.
+//!
+//! The elimination code used to ask `expr_is_zero`, a `bool` that answered
+//! "the simplified entry is not the literal `0`".  Collapsing *unknown* into
+//! *non-zero* is what made `Matrix::rank` report 2 for
+//!
+//! ```text
+//! [ 1       exp(a)   exp(a)   ]
+//! [ exp(a)  exp(a)²  exp(2a)  ]
+//! ```
+//!
+//! whose second row is exactly `exp(a)` times its first, so the true rank is 1.
+//! The entry that should have been recognised as zero was
+//! `exp(2a) − exp(a)·exp(a)`; because it was not, elimination "cleared" a
+//! column it had not cleared and produced the `[0 0 1]` row of an inconsistent
+//! system for a consistent one.  No exception, no flag — the worst failure
+//! class there is.
+//!
+//! [`ZeroStatus`] therefore has three values and the callers decide what to do
+//! with [`ZeroStatus::Unknown`].  The contract every pivot-selecting routine in
+//! this crate now follows is:
+//!
+//! * pivot **only** on [`ZeroStatus::NonZero`] — an entry proven not to vanish
+//!   identically;
+//! * skip **only** on [`ZeroStatus::Zero`] — an entry proven to vanish;
+//! * refuse with a coded error on [`ZeroStatus::Unknown`].
+//!
+//! A refusal closes one branch of a search; a wrong rank poisons every
+//! derivation downstream of it.
+//!
+//! # How each verdict is established
+//!
+//! `Zero` is symbolic: a ladder of increasingly aggressive normalisers, each
+//! sound (they only rewrite to equal expressions), and the verdict is taken
+//! only when one of them reaches the literal `0`.
+//!
+//! `NonZero` is numeric but **rigorous**: the entry is evaluated in ball
+//! arithmetic ([`crate::ball`], outward-rounded so the true value is always
+//! enclosed) at a fixed set of sample points.  If some enclosure excludes `0`,
+//! the entry provably takes a non-zero value somewhere and therefore is not the
+//! zero function.  That is exactly the condition a *generic* pivot needs.
+//!
+//! Note what `NonZero` does and does not say: `x − 1` is `NonZero` because it
+//! is not identically zero, so pivoting on it is the usual generic-rank
+//! semantics shared with every other CAS (the answer is the rank for all but a
+//! measure-zero set of parameter values).  What is now impossible is pivoting
+//! on an entry that is identically zero, which is the case that turns a
+//! consistent system into an inconsistent-looking one.
+
+use crate::ball::{ArbBall, IntervalEval};
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
+use crate::simplify::engine::{
+    simplify, simplify_expanded, simplify_log_exp, simplify_trig_normal_form,
+};
+use rug::{Float, Rational};
+use std::collections::HashSet;
+
+/// Working precision (bits) for the non-vanishing certificate.
+const PROBE_PREC: u32 = 128;
+
+/// Number of distinct sample points tried before giving up on a certificate.
+///
+/// More than one because a non-zero entry can still vanish *at* a point
+/// (`x − c` at `x = c`); the samples are chosen to make that unlikely, and a
+/// second and third point make it unlikely twice more.
+const PROBE_ROUNDS: usize = 3;
+
+/// Give up rather than probe a wide parameter space.
+const MAX_PROBE_SYMBOLS: usize = 16;
+
+/// Whether an expression is identically zero, where "I cannot tell" is a
+/// first-class answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ZeroStatus {
+    /// Proven to be the zero expression by a sound normalisation.
+    Zero,
+    /// Proven **not** to be the zero expression: a rigorous enclosure at some
+    /// sample point excludes `0`, or the entry is a non-zero literal.
+    NonZero,
+    /// Neither could be established. Callers must not treat this as either.
+    Unknown,
+}
+
+impl ZeroStatus {
+    /// True only for [`ZeroStatus::Zero`].
+    ///
+    /// For call sites where an inconclusive answer is *safe* to treat as
+    /// "not zero" — a conservative test that only ever gives up an
+    /// optimisation, never a mathematical claim.
+    pub(crate) fn is_proven_zero(self) -> bool {
+        matches!(self, ZeroStatus::Zero)
+    }
+}
+
+/// How deep the structural tier looks before handing over to the probe.
+const MAX_STRUCTURAL_DEPTH: u32 = 8;
+
+/// Decide whether `e` is identically zero.
+pub(crate) fn zero_status(pool: &ExprPool, e: ExprId) -> ZeroStatus {
+    status_of(pool, simplify(e, pool).value, 0)
+}
+
+fn status_of(pool: &ExprPool, e: ExprId, depth: u32) -> ZeroStatus {
+    if let Some(status) = literal_status(pool, e) {
+        return status;
+    }
+    if depth < MAX_STRUCTURAL_DEPTH {
+        if let Some(status) = structural_status(pool, e, depth) {
+            return status;
+        }
+    }
+    // A non-vanishing certificate needs no normalisation at all, and in
+    // elimination most surviving entries really are non-zero.
+    if probe_nonzero(pool, e) {
+        return ZeroStatus::NonZero;
+    }
+    if normalises_to_zero(pool, e) {
+        return ZeroStatus::Zero;
+    }
+    ZeroStatus::Unknown
+}
+
+/// Verdicts that follow from the shape of `e` alone.
+///
+/// These are the cases where zero-ness of a compound expression is determined
+/// by zero-ness of its parts, which lets the test succeed on values the ball
+/// evaluator cannot reach at all. The one that matters in practice is a product
+/// of radicals of negative quantities — `−2·√(−w²)`, the determinant of the
+/// modal matrix of an undamped oscillator — which is complex for every real `w`
+/// and so has no real enclosure, yet is obviously non-zero once you look at it
+/// as a product.
+///
+/// Every rule here is an identity over ℂ:
+/// * a product vanishes iff one of its factors does (ℂ is an integral domain);
+/// * `zⁿ = 0 ⟺ z = 0` for `n > 0`, and `z⁻ⁿ` never vanishes for `z ≠ 0`;
+/// * `√z = 0 ⟺ z = 0`, on either branch;
+/// * `exp` has no zero anywhere in ℂ.
+fn structural_status(pool: &ExprPool, e: ExprId, depth: u32) -> Option<ZeroStatus> {
+    let next = depth + 1;
+    match pool.get(e) {
+        ExprData::Mul(args) => {
+            let statuses: Vec<ZeroStatus> = args
+                .iter()
+                .map(|&a| status_of(pool, a, next))
+                .collect::<Vec<_>>();
+            if statuses.contains(&ZeroStatus::Zero) {
+                Some(ZeroStatus::Zero)
+            } else if statuses.iter().all(|s| *s == ZeroStatus::NonZero) {
+                Some(ZeroStatus::NonZero)
+            } else {
+                None
+            }
+        }
+        ExprData::Pow { base, exp } => match integer_exponent(pool, exp) {
+            Some(n) if n > 0 => decisive(status_of(pool, base, next)),
+            // `z⁻ⁿ` is non-zero when `z` is; when `z` is zero it is undefined
+            // rather than zero, so that case gets no verdict here.
+            Some(n) if n < 0 && status_of(pool, base, next) == ZeroStatus::NonZero => {
+                Some(ZeroStatus::NonZero)
+            }
+            _ => None,
+        },
+        ExprData::Func { ref name, ref args } if args.len() == 1 => match name.as_str() {
+            "sqrt" => decisive(status_of(pool, args[0], next)),
+            "exp" if !has_opaque_constant(pool, args[0], 0) => Some(ZeroStatus::NonZero),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Forget an inconclusive verdict.
+///
+/// An `Unknown` from a sub-expression must not short-circuit the
+/// whole-expression probe and normalisation ladder, which may still decide the
+/// compound even when a part of it is undecided.
+fn decisive(status: ZeroStatus) -> Option<ZeroStatus> {
+    (status != ZeroStatus::Unknown).then_some(status)
+}
+
+fn integer_exponent(pool: &ExprPool, e: ExprId) -> Option<i64> {
+    pool.with(e, |data| match data {
+        ExprData::Integer(n) => n.0.to_i64(),
+        _ => None,
+    })
+}
+
+/// Whether `e` mentions a symbol standing for a value the probe does not model
+/// (`oo`, `nan`, …), or a node whose contents cannot be inspected.
+///
+/// Conservative in the safe direction: an answer of `true` only ever withholds
+/// a verdict.
+fn has_opaque_constant(pool: &ExprPool, e: ExprId, depth: u32) -> bool {
+    if depth >= MAX_STRUCTURAL_DEPTH {
+        return true;
+    }
+    let next = depth + 1;
+    match pool.get(e) {
+        ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => false,
+        ExprData::Symbol { ref name, .. } => OPAQUE_CONSTANTS.contains(&name.as_str()),
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            args.iter().any(|&a| has_opaque_constant(pool, a, next))
+        }
+        ExprData::Pow { base, exp } => {
+            has_opaque_constant(pool, base, next) || has_opaque_constant(pool, exp, next)
+        }
+        ExprData::Func { args, .. } => args.iter().any(|&a| has_opaque_constant(pool, a, next)),
+        _ => true,
+    }
+}
+
+/// A verdict read straight off a numeric literal, if `e` is one.
+fn literal_status(pool: &ExprPool, e: ExprId) -> Option<ZeroStatus> {
+    pool.with(e, |data| match data {
+        ExprData::Integer(n) => Some(if n.0 == 0 {
+            ZeroStatus::Zero
+        } else {
+            ZeroStatus::NonZero
+        }),
+        ExprData::Rational(r) => Some(if r.0 == 0 {
+            ZeroStatus::Zero
+        } else {
+            ZeroStatus::NonZero
+        }),
+        ExprData::Float(f) => Some(if f.inner.is_zero() {
+            ZeroStatus::Zero
+        } else {
+            ZeroStatus::NonZero
+        }),
+        _ => None,
+    })
+}
+
+/// True when some sound normaliser drives `e` to the literal `0`.
+///
+/// The ladder is ordered by cost. Every rung is a semantics-preserving rewrite,
+/// so a `0` from any of them is a proof; failing all of them proves nothing.
+fn normalises_to_zero(pool: &ExprPool, e: ExprId) -> bool {
+    let expanded = simplify_expanded(e, pool).value;
+    if is_literal_zero(pool, expanded) {
+        return true;
+    }
+    // `simplify_log_exp` merges `exp(x)·exp(y)` and `exp(x)^n` into a single
+    // `exp` of a sum, which is what makes `exp(a)² − exp(2a)` collectible.
+    for start in [e, expanded] {
+        if is_literal_zero(pool, simplify_log_exp(start, pool, &[]).value) {
+            return true;
+        }
+    }
+    is_literal_zero(pool, simplify_trig_normal_form(e, pool).value)
+}
+
+fn is_literal_zero(pool: &ExprPool, e: ExprId) -> bool {
+    literal_status(pool, e) == Some(ZeroStatus::Zero)
+}
+
+/// Rigorously certify that `e` is not the zero expression.
+///
+/// Evaluates `e` in ball arithmetic at [`PROBE_ROUNDS`] sample points. A ball
+/// that excludes `0` is a proof that the true value there is non-zero, hence
+/// that `e` is not identically zero. Anything else — an unsupported node, a
+/// domain error, an enclosure straddling `0` — returns `false`, which the
+/// caller reads as "no certificate", never as "zero".
+fn probe_nonzero(pool: &ExprPool, e: ExprId) -> bool {
+    let Some(symbols) = probe_symbols(pool, e) else {
+        return false;
+    };
+    if symbols.len() > MAX_PROBE_SYMBOLS {
+        return false;
+    }
+    for round in 0..PROBE_ROUNDS {
+        let mut eval = IntervalEval::new(PROBE_PREC);
+        for (index, &sym) in symbols.iter().enumerate() {
+            eval.bind(sym, sample_ball(pool, sym, index, round));
+        }
+        if let Some(ball) = eval.eval(e, pool) {
+            if ball_excludes_zero(&ball) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// A ball that provably does not contain `0`.
+fn ball_excludes_zero(ball: &ArbBall) -> bool {
+    if !ball.rad.is_finite() || !ball.mid.is_finite() {
+        return false;
+    }
+    let lo = ball.lo();
+    let hi = ball.hi();
+    if lo.is_nan() || hi.is_nan() {
+        return false;
+    }
+    lo > 0.0 || hi < 0.0
+}
+
+/// The free symbols of `e`, or `None` when `e` must not be probed at all.
+///
+/// Returns `None` when the expression mentions a symbol whose *value* is fixed
+/// by mathematics rather than free to vary. Binding `pi` to an arbitrary sample
+/// would report `sin(pi)` as non-zero; binding the imaginary unit `I` to a real
+/// sample would report `I² + 1` as non-zero. Both would be exactly the silent
+/// error this module exists to prevent, so those expressions get no certificate.
+/// `pi` itself is the one constant handled properly, in [`sample_ball`].
+fn probe_symbols(pool: &ExprPool, e: ExprId) -> Option<Vec<ExprId>> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    collect_symbols(pool, e, &mut seen, &mut out)?;
+    out.sort_unstable();
+    Some(out)
+}
+
+/// Symbol names that denote a specific number and are not handled rigorously.
+const OPAQUE_CONSTANTS: &[&str] = &["oo", "inf", "infinity", "zoo", "nan", "NaN"];
+
+fn collect_symbols(
+    pool: &ExprPool,
+    e: ExprId,
+    seen: &mut HashSet<ExprId>,
+    out: &mut Vec<ExprId>,
+) -> Option<()> {
+    if !seen.insert(e) {
+        return Some(());
+    }
+    match pool.get(e) {
+        ExprData::Integer(_) | ExprData::Rational(_) | ExprData::Float(_) => Some(()),
+        ExprData::Symbol { ref name, .. } => {
+            if pool.is_imaginary_unit(e) || OPAQUE_CONSTANTS.contains(&name.as_str()) {
+                return None;
+            }
+            out.push(e);
+            Some(())
+        }
+        ExprData::Add(args) | ExprData::Mul(args) => {
+            for a in args {
+                collect_symbols(pool, a, seen, out)?;
+            }
+            Some(())
+        }
+        ExprData::Pow { base, exp } => {
+            collect_symbols(pool, base, seen, out)?;
+            collect_symbols(pool, exp, seen, out)
+        }
+        ExprData::Func { args, .. } => {
+            for a in args {
+                collect_symbols(pool, a, seen, out)?;
+            }
+            Some(())
+        }
+        // Anything else (`Piecewise`, `BigO`, `RootSum`, quantifiers, …) is
+        // either unsupported by the ball evaluator or has binding structure
+        // that would make a free-symbol list meaningless.
+        _ => None,
+    }
+}
+
+/// The sample value bound to `sym` in probe round `round`.
+///
+/// Deterministic — the same matrix always produces the same verdict, and a
+/// refusal is reproducible rather than flaky. The points are ratios with a
+/// large prime-ish denominator so that no small algebraic relation between two
+/// symbols (`x − y`, `x − 2`, `2x − y`) holds accidentally.
+fn sample_ball(pool: &ExprPool, sym: ExprId, index: usize, round: usize) -> ArbBall {
+    if pool.with(
+        sym,
+        |data| matches!(data, ExprData::Symbol { name, .. } if name.as_str() == "pi"),
+    ) {
+        return pi_ball();
+    }
+    let integral = pool.with(sym, |data| {
+        matches!(
+            data,
+            ExprData::Symbol {
+                domain: Domain::Integer,
+                ..
+            }
+        )
+    });
+    if integral {
+        // An integer-domain symbol must be sampled at an integer: identities
+        // such as `sin(pi·n) = 0` hold only there, and a fractional sample
+        // would "certify" them non-zero.
+        let n = 7 + 11 * index as i64 + 101 * round as i64;
+        return ArbBall::from_integer(&rug::Integer::from(n), PROBE_PREC);
+    }
+    let numer = 733 + 269 * index as i64 + 1123 * round as i64;
+    let denom = 1021 + 7 * round as i64;
+    ArbBall::from_rational(&Rational::from((numer, denom)), PROBE_PREC)
+}
+
+/// An enclosure of π that is honest about its own error.
+///
+/// `ArbBall::from_f64` would claim radius `0`, i.e. that the sample *is* π, and
+/// the enclosure would then no longer be rigorous.
+fn pi_ball() -> ArbBall {
+    // Same construction as `ArbBall::from_rational`: round at working
+    // precision, then take the distance to a much more accurate value as the
+    // radius.
+    let mid = Float::with_val(PROBE_PREC, rug::float::Constant::Pi);
+    let accurate = Float::with_val(PROBE_PREC * 2, rug::float::Constant::Pi);
+    let rad = Float::with_val(PROBE_PREC, &accurate - &mid).abs();
+    ArbBall {
+        mid,
+        rad,
+        prec: PROBE_PREC,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::{Domain, ExprPool};
+
+    fn p() -> ExprPool {
+        ExprPool::new()
+    }
+
+    #[test]
+    fn literal_zero_is_zero() {
+        let pool = p();
+        assert_eq!(
+            zero_status(&pool, pool.integer(0_i32)),
+            ZeroStatus::Zero,
+            "the literal 0"
+        );
+        assert_eq!(zero_status(&pool, pool.integer(3_i32)), ZeroStatus::NonZero);
+    }
+
+    #[test]
+    fn symbol_is_generically_nonzero() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        assert_eq!(zero_status(&pool, x), ZeroStatus::NonZero);
+    }
+
+    #[test]
+    fn exp_square_minus_exp_double_is_zero() {
+        // The regression: exp(a)·exp(a) − exp(a+a) is the zero function.
+        let pool = p();
+        let a = pool.symbol("a", Domain::Real);
+        let ea = pool.func("exp", vec![a]);
+        let lhs = pool.mul(vec![ea, ea]);
+        let rhs = pool.func("exp", vec![pool.add(vec![a, a])]);
+        let diff = pool.add(vec![lhs, pool.mul(vec![pool.integer(-1_i32), rhs])]);
+        assert_eq!(zero_status(&pool, diff), ZeroStatus::Zero);
+    }
+
+    #[test]
+    fn non_identity_difference_of_exps_is_nonzero() {
+        // The control: exp(a)·exp(a) − exp(a) is *not* the zero function.
+        let pool = p();
+        let a = pool.symbol("a", Domain::Real);
+        let ea = pool.func("exp", vec![a]);
+        let lhs = pool.mul(vec![ea, ea]);
+        let diff = pool.add(vec![lhs, pool.mul(vec![pool.integer(-1_i32), ea])]);
+        assert_eq!(zero_status(&pool, diff), ZeroStatus::NonZero);
+    }
+
+    #[test]
+    fn sin_of_pi_is_not_certified_nonzero() {
+        // Binding `pi` to an arbitrary sample would "prove" sin(pi) ≠ 0.
+        let pool = p();
+        let pi = pool.symbol("pi", Domain::Real);
+        let e = pool.func("sin", vec![pi]);
+        assert_ne!(zero_status(&pool, e), ZeroStatus::NonZero);
+    }
+
+    #[test]
+    fn imaginary_unit_is_not_probed() {
+        // I² + 1 = 0; a real sample for `I` would certify it non-zero.
+        let pool = p();
+        let i = pool.imaginary_unit();
+        let e = pool.add(vec![pool.mul(vec![i, i]), pool.integer(1_i32)]);
+        assert_ne!(zero_status(&pool, e), ZeroStatus::NonZero);
+    }
+
+    #[test]
+    fn unknown_function_yields_unknown() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.func("mystery", vec![x]);
+        let g = pool.func("mystery", vec![pool.mul(vec![pool.integer(1_i32), x])]);
+        // f(x) − g(x) is zero, but nothing here can prove it either way once
+        // the two arguments are written differently; what matters is that the
+        // answer is not a confident `NonZero`.
+        let diff = pool.add(vec![f, pool.mul(vec![pool.integer(-1_i32), g])]);
+        assert_ne!(zero_status(&pool, diff), ZeroStatus::NonZero);
+    }
+}

--- a/alkahest-core/src/matrix/zero_test.rs
+++ b/alkahest-core/src/matrix/zero_test.rs
@@ -63,7 +63,9 @@ use crate::simplify::engine::{
     simplify, simplify_expanded, simplify_log_exp, simplify_trig_normal_form,
 };
 use rug::{Float, Rational};
+use std::cell::RefCell;
 use std::collections::HashSet;
+use std::fmt;
 
 /// Working precision (bits) for the non-vanishing certificate.
 const PROBE_PREC: u32 = 128;
@@ -100,6 +102,140 @@ impl ZeroStatus {
     pub(crate) fn is_proven_zero(self) -> bool {
         matches!(self, ZeroStatus::Zero)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Refusals, reported out of band
+// ---------------------------------------------------------------------------
+
+/// Which routine refused, which fixes the stable code the refusal carries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RefusalSite {
+    /// A quantity an elimination-family routine has to decide before it can go
+    /// on: a candidate pivot, a Gram–Schmidt norm, an entry of `p(M)` in the
+    /// minimal-polynomial search — `E-LINALG-010`.
+    Pivot,
+    /// The determinant of a matrix being inverted — `E-MAT-004`.
+    Determinant,
+}
+
+/// A zero test that could be settled neither way, with the code it carries.
+///
+/// # Why this is not an error variant
+///
+/// [`MatrixError`](crate::matrix::MatrixError) and
+/// [`LinearAlgebraError`](crate::matrix::LinearAlgebraError) are public
+/// *exhaustive* enums, so growing either of them a `ZeroTestInconclusive`
+/// variant is a major semver break — and so is marking them `#[non_exhaustive]`
+/// to allow it later. A correctness fix inside a patch release cannot spend a
+/// major version, so the refusal travels out of band instead: the refusing
+/// routine returns the existing variant whose meaning covers the case
+/// (`LinearAlgebraError::UnsupportedField` for a pivot — the entries lie in a
+/// field this routine cannot decide over — and `MatrixError::SingularMatrix`
+/// for a determinant, whose reworded text states exactly the disjunction that
+/// is known), and the real cause is recorded here for
+/// [`take_zero_test_refusal`] to hand to the bindings.
+///
+/// This is the pattern
+/// [`crate::calculus::limits::last_budget_trip`] already uses for budget trips
+/// inside `LimitError::DepthExceeded`, and `integrate` for budget trips inside
+/// `IntegrationError::NotImplemented`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ZeroTestRefusal {
+    entry: String,
+    site: RefusalSite,
+}
+
+impl ZeroTestRefusal {
+    /// The expression whose vanishing could not be decided, rendered.
+    pub fn entry(&self) -> &str {
+        &self.entry
+    }
+}
+
+impl fmt::Display for ZeroTestRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.site {
+            RefusalSite::Pivot => write!(
+                f,
+                "cannot decide whether the entry `{}` is zero; refusing rather \
+                 than report a rank, a factorisation or a minimal polynomial \
+                 that silently assumes an answer",
+                self.entry
+            ),
+            RefusalSite::Determinant => write!(
+                f,
+                "cannot decide whether the determinant `{}` is zero; refusing to \
+                 report an inverse that assumes it is not",
+                self.entry
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ZeroTestRefusal {}
+
+impl crate::errors::AlkahestError for ZeroTestRefusal {
+    fn code(&self) -> &'static str {
+        match self.site {
+            RefusalSite::Pivot => "E-LINALG-010",
+            RefusalSite::Determinant => "E-MAT-004",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        match self.site {
+            RefusalSite::Pivot => Some(
+                "rewrite the entry into a form whose vanishing is decidable, or \
+                 substitute concrete values for the parameters",
+            ),
+            RefusalSite::Determinant => Some(
+                "rewrite the entries into a form whose determinant's vanishing is \
+                 decidable, or substitute concrete values",
+            ),
+        }
+    }
+}
+
+thread_local! {
+    /// The refusal behind the error the current thread is about to return, if
+    /// that error is a zero-test refusal rather than the thing its variant
+    /// usually means.
+    static LAST_REFUSAL: RefCell<Option<ZeroTestRefusal>> = const { RefCell::new(None) };
+}
+
+/// Record `e` as undecided and hand the refusal to the caller to attach to its
+/// own error variant.
+pub(crate) fn record_refusal(pool: &ExprPool, e: ExprId, site: RefusalSite) {
+    let refusal = ZeroTestRefusal {
+        entry: pool.display(e).to_string(),
+        site,
+    };
+    LAST_REFUSAL.with(|c| *c.borrow_mut() = Some(refusal));
+}
+
+/// Drop any recorded refusal.
+///
+/// Called wherever one of the carrier variants is returned for its *original*
+/// meaning — a genuinely singular matrix, entries that are genuinely not
+/// rational — so that error can never be re-attributed to an undecided zero
+/// test left behind by an earlier call on this thread.
+pub(crate) fn forget_refusal() {
+    LAST_REFUSAL.with(|c| *c.borrow_mut() = None);
+}
+
+/// Take the refusal behind the error that just came back, if there was one.
+///
+/// Bindings call this when they see one of the carrier variants
+/// (`LinearAlgebraError::UnsupportedField`, `MatrixError::SingularMatrix`) and
+/// raise the refusal's own `E-LINALG-010` / `E-MAT-004` when it is present, so
+/// a caller still gets the specific code. `Some` means *this* error is a
+/// refusal; `None` means the variant means what it usually means.
+///
+/// Consuming, so one refusal is reported once and cannot leak into a later
+/// unrelated error. Thread-local, like the zero test itself.
+pub fn take_zero_test_refusal() -> Option<ZeroTestRefusal> {
+    LAST_REFUSAL.with(|c| c.borrow_mut().take())
 }
 
 /// How deep the structural tier looks before handing over to the probe.

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -19,7 +19,7 @@ use crate::deriv::log::{DerivationLog, RewriteStep};
 use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
 use crate::pattern::{Pattern, Substitution};
 use crate::simplify::discrimination_net::{pattern_head, DiscriminationIndex};
-use crate::simplify::rules::{FlattenAdd, FlattenMul, RewriteRule};
+use crate::simplify::rules::{FlattenAdd, FlattenMul, NodeKinds, RewriteRule};
 
 fn one_step(name: &'static str, before: ExprId, after: ExprId) -> DerivationLog {
     let mut log = DerivationLog::new();
@@ -863,12 +863,22 @@ impl RewriteRule for LogOfQuotient {
     }
 }
 
-/// `exp(x) · exp(y) · ⋯ → exp(x + y + ⋯)`.
+/// `c · exp(x) · exp(y) · ⋯ → c · exp(x + y + ⋯)`.
 ///
 /// Unconditionally valid over ℂ (unlike the log product/sum rules).
+///
+/// Non-`exp` factors are carried through untouched, so the rule also fires on
+/// mixed products such as `−1 · exp(a) · exp(a)`.  Those arise constantly in
+/// Gaussian elimination (`row − factor · pivot_row`) and are exactly the shape
+/// whose merged form has to be recognised for the zero test in
+/// [`crate::matrix`] to prove a row dependency (see `matrix::zero_test`).
 pub struct ProductOfExps;
 
 impl RewriteRule for ProductOfExps {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::MUL
+    }
+
     fn name(&self) -> &'static str {
         "product_of_exps"
     }
@@ -878,28 +888,88 @@ impl RewriteRule for ProductOfExps {
             ExprData::Mul(v) if v.len() >= 2 => v,
             _ => return None,
         };
-        let mut args = Vec::with_capacity(factors.len());
+        let mut args = Vec::new();
+        let mut rest = Vec::new();
         for f in factors {
-            let a = func_arg("exp", f, pool)?;
-            args.push(a);
+            match func_arg("exp", f, pool) {
+                Some(a) => args.push(a),
+                None => rest.push(f),
+            }
         }
-        let after = pool.func("exp", vec![pool.add(args)]);
+        // One `exp` factor is already merged; rewriting it would not terminate.
+        if args.len() < 2 {
+            return None;
+        }
+        let merged = pool.func("exp", vec![pool.add(args)]);
+        let after = if rest.is_empty() {
+            merged
+        } else {
+            rest.push(merged);
+            pool.mul(rest)
+        };
+        Some((after, one_step(self.name(), expr, after)))
+    }
+}
+
+/// `exp(x)^n → exp(n·x)` for a literal integer `n`.
+///
+/// Unconditionally valid over ℂ for integer exponents: `exp` is a homomorphism
+/// from `(ℂ, +)` to `(ℂ*, ·)` and integer powers are iterated multiplication,
+/// so no branch is chosen.  Non-integer exponents are left alone — `exp(x)^(1/2)`
+/// and `exp(x/2)` differ by a branch of the square root.
+///
+/// Without this rule `exp(a)²` and `exp(2a)` are two normal forms for the same
+/// function and their difference never collects to `0`, which is what let
+/// `Matrix::rank` report a full-rank verdict for a rank-deficient matrix.
+pub struct PowOfExp;
+
+impl RewriteRule for PowOfExp {
+    fn node_kinds(&self) -> NodeKinds {
+        NodeKinds::POW
+    }
+
+    fn name(&self) -> &'static str {
+        "pow_of_exp"
+    }
+
+    fn apply(&self, expr: ExprId, pool: &ExprPool) -> Option<(ExprId, DerivationLog)> {
+        let ExprData::Pow { base, exp } = pool.get(expr) else {
+            return None;
+        };
+        if !is_integer_literal(exp, pool) {
+            return None;
+        }
+        let inner = func_arg("exp", base, pool)?;
+        let after = pool.func("exp", vec![pool.mul(vec![exp, inner])]);
         Some((after, one_step(self.name(), expr, after)))
     }
 }
 
 /// Return the default log/exp identity rules.
 ///
-/// Includes `log(exp(x))→x` only when `x` is real-valued (see [`LogOfExp`]) and
-/// `exp(x)·exp(y)→exp(x+y)` (valid over ℂ). Branch-cut sensitive rewrites
-/// (`exp(log(x))→x`, `log(x)+log(y)→log(xy)`, `log(a^n)→n·log(a)`,
-/// `log(a/b)→log(a)−log(b)`, `log(ab)→log a+log b`) live exclusively in the
-/// colored e-graph and require matching
+/// Includes `log(exp(x))→x` only when `x` is real-valued (see [`LogOfExp`]),
+/// `exp(x)·exp(y)→exp(x+y)` and `exp(x)^n→exp(n·x)` (both valid over ℂ).
+/// Branch-cut sensitive rewrites (`exp(log(x))→x`, `log(x)+log(y)→log(xy)`,
+/// `log(a^n)→n·log(a)`, `log(a/b)→log(a)−log(b)`, `log(ab)→log a+log b`) live
+/// exclusively in the colored e-graph and require matching
 /// [`crate::simplify::SimplifyConfig::assumptions`] /
 /// [`crate::simplify::AssumptionContext`] facts (or `Domain::Positive`
 /// symbols). Use [`log_exp_rules_safe`] for the empty complex-safe set.
+///
+/// The arithmetic rules from [`crate::simplify::rules_for_config`] are included
+/// after the log/exp rules. They are what actually *collects* the result: with
+/// the log/exp rules alone, `exp(a)·exp(a) − exp(a+a)` normalises to
+/// `exp(a+a) + (−1)·exp(a+a)` and then stops, because nothing in the log/exp
+/// set knows that `X + (−1)·X` is `0`.  Reporting that non-zero was the direct
+/// cause of a wrong `Matrix::rank`.
 pub fn log_exp_rules() -> Vec<Box<dyn RewriteRule>> {
-    vec![Box::new(LogOfExp), Box::new(ProductOfExps)]
+    let mut rules: Vec<Box<dyn RewriteRule>> = vec![
+        Box::new(LogOfExp),
+        Box::new(ProductOfExps),
+        Box::new(PowOfExp),
+    ];
+    rules.extend(crate::simplify::engine::default_rules());
+    rules
 }
 
 /// Log/exp rules that are safe for complex numbers (no branch-cut rewrites).

--- a/alkahest-core/src/simplify/rulesets.rs
+++ b/alkahest-core/src/simplify/rulesets.rs
@@ -19,7 +19,7 @@ use crate::deriv::log::{DerivationLog, RewriteStep};
 use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
 use crate::pattern::{Pattern, Substitution};
 use crate::simplify::discrimination_net::{pattern_head, DiscriminationIndex};
-use crate::simplify::rules::{FlattenAdd, FlattenMul, NodeKinds, RewriteRule};
+use crate::simplify::rules::{FlattenAdd, FlattenMul, NodeKinds, RewriteRule, SubSelf};
 
 fn one_step(name: &'static str, before: ExprId, after: ExprId) -> DerivationLog {
     let mut log = DerivationLog::new();
@@ -956,20 +956,27 @@ impl RewriteRule for PowOfExp {
 /// [`crate::simplify::AssumptionContext`] facts (or `Domain::Positive`
 /// symbols). Use [`log_exp_rules_safe`] for the empty complex-safe set.
 ///
-/// The arithmetic rules from [`crate::simplify::rules_for_config`] are included
-/// after the log/exp rules. They are what actually *collects* the result: with
-/// the log/exp rules alone, `exp(a)·exp(a) − exp(a+a)` normalises to
+/// One arithmetic rule joins them: [`SubSelf`], which *collects* the result.
+/// With the log/exp rules alone, `exp(a)·exp(a) − exp(a+a)` normalises to
 /// `exp(a+a) + (−1)·exp(a+a)` and then stops, because nothing in the log/exp
-/// set knows that `X + (−1)·X` is `0`.  Reporting that non-zero was the direct
-/// cause of a wrong `Matrix::rank`.
+/// set knows that `X + (−1)·X` is `0`. Reporting that non-zero was the direct
+/// cause of a wrong `Matrix::rank`.  `SubSelf` also normalises the exponents
+/// themselves (`a + a → 2·a`), which is what makes the two spellings of the
+/// merged `exp` the same node in the first place.
+///
+/// Deliberately *just* that one rule rather than all of
+/// [`crate::simplify::engine::default_rules`]: the whole default set collects
+/// the same expression, but every extra rule is tried against every node on
+/// every pass, and this set is the hot path of `simplify_log_exp` (an 18%
+/// slowdown on the depth-4 `log(exp(…))` benchmark). Callers who want general
+/// arithmetic have [`crate::simplify::engine::simplify`] for it.
 pub fn log_exp_rules() -> Vec<Box<dyn RewriteRule>> {
-    let mut rules: Vec<Box<dyn RewriteRule>> = vec![
+    vec![
         Box::new(LogOfExp),
         Box::new(ProductOfExps),
         Box::new(PowOfExp),
-    ];
-    rules.extend(crate::simplify::engine::default_rules());
-    rules
+        Box::new(SubSelf),
+    ]
 }
 
 /// Log/exp rules that are safe for complex numbers (no branch-cut rewrites).

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -738,6 +738,19 @@ fn pslq_error_to_py(e: PslqError) -> PyErr {
 }
 
 fn matrix_error_to_py(e: MatrixError) -> PyErr {
+    // `SingularMatrix` covers two refusals: a determinant proven zero
+    // (`E-MAT-003`) and one that could be proven neither way (`E-MAT-004`).
+    // `MatrixError` is an exhaustive public enum, so the second cannot have its
+    // own variant without a major semver break; it is recorded out of band
+    // instead — the same arrangement `limit_error_to_py` uses for budget trips.
+    if matches!(e, MatrixError::SingularMatrix) {
+        if let Some(r) = alkahest_core::matrix::take_zero_test_refusal() {
+            return Python::with_gil(|py| {
+                let exc_type = py.get_type_bound::<PyMatrixError>();
+                make_structured_err(py, &exc_type, &r)
+            });
+        }
+    }
     Python::with_gil(|py| {
         let exc_type = py.get_type_bound::<PyMatrixError>();
         make_structured_err(py, &exc_type, &e)
@@ -752,6 +765,18 @@ fn eigen_error_to_py(e: EigenError) -> PyErr {
 }
 
 fn linear_algebra_error_to_py(e: LinearAlgebraError) -> PyErr {
+    // `UnsupportedField` covers both "entries are not rational constants"
+    // (`E-LINALG-007`) and "a pivot could be proven neither zero nor non-zero"
+    // (`E-LINALG-010`); see `matrix_error_to_py` for why the second has no
+    // variant of its own.
+    if matches!(e, LinearAlgebraError::UnsupportedField) {
+        if let Some(r) = alkahest_core::matrix::take_zero_test_refusal() {
+            return Python::with_gil(|py| {
+                let exc_type = py.get_type_bound::<PyLinearAlgebraError>();
+                make_structured_err(py, &exc_type, &r)
+            });
+        }
+    }
     Python::with_gil(|py| {
         let exc_type = py.get_type_bound::<PyLinearAlgebraError>();
         make_structured_err(py, &exc_type, &e)

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -581,6 +581,20 @@ fn series_error_to_py(e: SeriesError) -> PyErr {
 }
 
 fn limit_error_to_py(e: LimitError) -> PyErr {
+    // The limit engine reports a budget/cancellation trip as `DepthExceeded`
+    // (`LimitError` is an exhaustive public enum, so it cannot carry a
+    // `Budget` variant without a major semver break) and records the cause
+    // out-of-band. Recover it here so a budget trip raises the same
+    // `BudgetExceededError` (`E-BUDGET-*`) every other engine raises, instead
+    // of masquerading as "the limit is too hard".
+    if matches!(e, LimitError::DepthExceeded) {
+        if let Some(b) = alkahest_core::calculus::limits::last_budget_trip() {
+            return Python::with_gil(|py| {
+                let exc_type = py.get_type_bound::<PyBudgetExceededError>();
+                make_structured_err(py, &exc_type, &b)
+            });
+        }
+    }
     Python::with_gil(|py| {
         let exc_type = py.get_type_bound::<PyLimitError>();
         make_structured_err(py, &exc_type, &e)

--- a/docs/mdbook/src/budgets.md
+++ b/docs/mdbook/src/budgets.md
@@ -55,6 +55,16 @@ a handful of strategic points — not blanket-inserted into every loop:
   `integrate_inner` recursion boundary that u-substitution and the rational-function
   fallback re-enter. A trip here raises `BudgetExceededError` — integration has a
   `Result` return type with a natural place to signal it.
+- **`alkahest.limit`** — at every `limit_inner` recursion boundary, in the Gruntz
+  comparability sweep, in the pole-clearing loop of the `x ↦ 1/t` substitution, and
+  between Taylor coefficients of the local expansion (the loop that can grow without
+  bound on nested radicals). `LimitError` is an exhaustive public enum and cannot grow
+  a `Budget` variant without a major semver break, so a trip is reported internally as
+  `LimitError::DepthExceeded` and the `E-BUDGET-*` cause is recovered out-of-band
+  (`alkahest_core::calculus::limits::last_budget_trip`); the Python binding raises
+  `BudgetExceededError` exactly as `integrate` does. With **no** budget active the
+  same paths are bounded by an internal work ceiling, so an unsolvable limit refuses
+  with `LimitError` / `E-LIMIT-004` instead of running unboundedly.
 - **`alkahest.simplify`** (and `simplify_with`, `simplify_batch`) — once per full
   bottom-up rewrite pass. `simplify` has **no error channel** (`DerivedExpr` isn't a
   `Result`), so a trip here stops further passes early and returns the best value
@@ -120,8 +130,8 @@ Python cannot forcibly kill a thread, so on a timeout the call keeps running in 
 background until it either finishes or reaches a Rust cooperative checkpoint —
 `run_with_wall_fallback` also calls `request_cancel()` on timeout so any checkpoint the
 call reaches asks it to stop. Prefer the Rust cooperative check alone
-(`context(budget=...)`) wherever a call already honors it (`integrate` today); reach for
-this only when you need a hard deadline on a path that doesn't.
+(`context(budget=...)`) wherever a call already honors it (`integrate` and `limit`
+today); reach for this only when you need a hard deadline on a path that doesn't.
 
 ## Error codes
 
@@ -134,9 +144,10 @@ this only when you need a hard deadline on a path that doesn't.
 All three are `Cause::Resource` in the Rust registry (`alkahest_core::errors::codes`) —
 a budget/cancellation trip is an environment/policy limit, not a statement about the
 mathematics, so it is never conflated with e.g. `IntegrationError::NonElementary` (a
-proof that no elementary antiderivative exists). `alkahest.integrate` raises
-`BudgetExceededError` directly rather than wrapping it in `IntegrationError`, so callers
-can catch it uniformly regardless of which engine tripped it:
+proof that no elementary antiderivative exists). `alkahest.integrate` and
+`alkahest.limit` raise `BudgetExceededError` directly rather than wrapping it in
+`IntegrationError` / `LimitError`, so callers can catch it uniformly regardless of which
+engine tripped it:
 
 ```python
 try:

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -342,6 +342,7 @@ from .exceptions import (
     EigenError,
     FactorError,
     HolonomicError,
+    HomotopyError,
     IntegrationError,
     IoError,
     JitError,
@@ -350,6 +351,7 @@ from .exceptions import (
     LinearAlgebraError,
     LinearRecurrenceError,
     MatrixError,
+    ModularError,
     NumberTheoryError,
     OdeError,
     ParseError,
@@ -383,6 +385,7 @@ _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "EigenError",
     "FactorError",
     "HolonomicError",
+    "HomotopyError",
     "IntegrationError",
     "IoError",
     "JitError",
@@ -391,6 +394,7 @@ _NATIVE_EXCEPTION_OVERLAY: tuple[str, ...] = (
     "LinearAlgebraError",
     "LinearRecurrenceError",
     "MatrixError",
+    "ModularError",
     "NumberTheoryError",
     "OdeError",
     "PoolError",
@@ -1805,6 +1809,7 @@ __all__ = [
     "GroebnerBasis",
     # P1 item 7 — creative telescoping / holonomic (D-finite) machinery
     "HolonomicError",
+    "HomotopyError",
     "HybridODE",
     "IntegrationError",
     # V1-16: IoError
@@ -1817,6 +1822,7 @@ __all__ = [
     # Phase 15
     "Matrix",
     "MatrixError",
+    "ModularError",
     "MultiPoly",
     "MultiPolyFactorization",
     "Not",

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -569,6 +569,43 @@ class BudgetExceededError(AlkahestError):
         super().__init__(message, code="E-BUDGET-001", remediation=remediation, span=span)
 
 
+class HomotopyError(AlkahestError):
+    """Numerical polynomial continuation failed (V2-14 homotopy solver).
+
+    The native class is registered by the extension as ``PyHomotopyError``;
+    this is the Python-side wrapper used for ``isinstance`` checks, and its
+    absence is what ``scripts/check_error_codes.py`` was reporting.
+
+    - ``E-HOMOTOPY-002`` — the start system has too few paths for the target.
+    - ``E-HOMOTOPY-003`` — path tracking failed for a random gamma.
+    - ``E-HOMOTOPY-004`` — the tracker exhausted its step budget.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code="E-HOMOTOPY-002", remediation=remediation, span=span)
+
+
+class ModularError(AlkahestError):
+    """A modular / CRT reconstruction step failed (``E-MOD-001`` … ``E-MOD-004``).
+
+    As with :class:`HomotopyError`, the native class exists as ``PyModularError``
+    and this wrapper is what makes it catchable by name from Python.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code="E-MOD-001", remediation=remediation, span=span)
+
+
 class AnsatzError(AlkahestError):
     """An ansatz family could not be built, or could not be fitted.
 

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -164,6 +164,62 @@ NON_SQUARE = [[1, 2, 3], [4, 5, 6]]
 #: det = (2^30+1)(2^30-1) - 2^60 = -1 exactly; float64 evaluation cancels to 0.0.
 CANCELLING_2X2 = [[2**30 + 1, 2**30], [2**30, 2**30 - 1]]
 
+# --- Transcendental rank traps -------------------------------------------
+# ``exp(a)²`` and ``exp(2a)`` are the same function written two ways.  Any
+# elimination that cannot see that will "clear" a column it has not cleared.
+_A = POOL.symbol("a")
+_EXP_A = ak.exp(_A)
+
+#: Row 2 is exactly ``exp(a)`` × row 1, so the rank is 1 — but only if
+#: ``exp(a)·exp(a) − exp(a+a)`` is recognised as zero.
+EXP_DEPENDENT_ROWS = ak.Matrix(
+    [
+        [_int(1), _EXP_A, _EXP_A],
+        [_EXP_A, _EXP_A * _EXP_A, ak.exp(_A + _A)],
+    ]
+)
+
+#: The control: identical except for the last entry, which breaks the
+#: proportionality, so the rank really is 2.
+EXP_INDEPENDENT_ROWS = ak.Matrix(
+    [
+        [_int(1), _EXP_A, _EXP_A],
+        [_EXP_A, _EXP_A * _EXP_A, _EXP_A],
+    ]
+)
+
+#: ``mystery`` has no differentiation rule, no numeric kernel and no interval
+#: kernel, so ``mystery(a)`` can be neither normalised to zero nor rigorously
+#: enclosed away from it.  Whether it is the zero function is not knowable here,
+#: and column 1 has no other candidate.
+UNDECIDABLE_PIVOT = ak.Matrix(
+    [
+        [POOL.func("mystery", [_A]), _int(0)],
+        [_int(0), _int(0)],
+    ]
+)
+
+
+def _rref_zero_rows(m: ak.Matrix, at: float = 0.7) -> Callable[[], int]:
+    """Answer = how many rows of ``m.rref()`` vanish, sampled at ``a = at``.
+
+    Scored numerically rather than structurally so the case is immune to the
+    form the entries come back in; what it pins down is the only thing that
+    matters — a row of an rref is either identically zero or it is not.  For a
+    rank-deficient matrix the missing zero row reappears as a spurious pivot,
+    which for an augmented system reads as ``0 = 1``: the textbook signature of
+    an inconsistent system, and a false "no solution" verdict for a search loop.
+    """
+
+    def op() -> int:
+        count = 0
+        for row in m.rref().to_list():
+            if all(abs(float(ak.eval_expr(entry, {_A: at}))) < 1e-12 for entry in row):
+                count += 1
+        return count
+
+    return op
+
 
 # ---------------------------------------------------------------------------
 # Reference values (hand-derived; `math` used only to evaluate the closed form)
@@ -1224,6 +1280,59 @@ CASES: list[Case] = [
         op=lambda: _matrix(SINGULAR_2X2).rank(),
         contract=Returns(1),
         verified_by="One independent row.",
+    ),
+    Case(
+        id="matrix_rank_exp_proportional_rows",
+        subsystem="linear_algebra",
+        statement="rank[[1, e^a, e^a], [e^a, e^a·e^a, e^(a+a)]] = 1",
+        op=lambda: EXP_DEPENDENT_ROWS.rank(),
+        contract=Returns(1),
+        verified_by="Row 2 = e^a · row 1 entry by entry: e^a·1 = e^a, e^a·e^a is the (2,2) "
+        "entry verbatim, and e^a·e^a = e^(a+a) by the exponential functional equation "
+        "e^u·e^v = e^(u+v), which is the (2,3) entry. Two proportional rows span a "
+        "1-dimensional row space, so the rank is 1 for every value of a.",
+    ),
+    Case(
+        id="matrix_rref_exp_proportional_rows_has_zero_row",
+        subsystem="linear_algebra",
+        statement="the rref of [[1, e^a, e^a], [e^a, e^a·e^a, e^(a+a)]] has exactly one zero row",
+        op=_rref_zero_rows(EXP_DEPENDENT_ROWS),
+        contract=Returns(1),
+        verified_by="A 2×3 matrix of rank 1 has 2 − 1 = 1 zero row in reduced row echelon "
+        "form. The wrong answer here is 0 zero rows, i.e. a second pivot in the last "
+        "column — read as an augmented system that is the row 0 = 1 of an inconsistent "
+        "one, for a system that is consistent.",
+    ),
+    Case(
+        id="matrix_rank_undecidable_pivot_refuses",
+        subsystem="linear_algebra",
+        statement="rank[[mystery(a), 0], [0, 0]] cannot be stated — mystery(a) may be the "
+        "zero function",
+        op=lambda: UNDECIDABLE_PIVOT.rank(),
+        contract=RefusesOr(),
+        verified_by="The rank is 1 if mystery is not identically zero and 0 if it is. "
+        "mystery is an uninterpreted function symbol, so both readings are consistent with "
+        "everything alkahest knows and neither number is derivable. Deciding whether an "
+        "expression over a transcendental extension vanishes is undecidable in general "
+        "(Richardson 1968), so this class cannot be normalised away — the only honest "
+        "answer is a refusal. Contract is code-agnostic on purpose: what is being pinned "
+        "is that no rank is asserted, not which E-LINALG code says so.",
+        note="This is the pair to matrix_rank_exp_proportional_rows: that case is 'prove "
+        "zero when it is zero', this one is 'do not claim non-zero when you cannot'. A "
+        "library that only did the first would pass that case by pivoting on anything it "
+        "failed to reduce, which is the bug that motivated both.",
+    ),
+    Case(
+        id="matrix_rank_exp_independent_rows",
+        subsystem="linear_algebra",
+        statement="rank[[1, e^a, e^a], [e^a, e^a·e^a, e^a]] = 2",
+        op=lambda: EXP_INDEPENDENT_ROWS.rank(),
+        contract=Returns(2),
+        verified_by="The control for matrix_rank_exp_proportional_rows: only the last entry "
+        "differs. Row 2 − e^a · row 1 = (0, 0, e^a − e^a·e^a) = (0, 0, e^a(1 − e^a)), which "
+        "is not the zero function (it is e·(1−e) ≠ 0 at a = 1), so the rows are independent "
+        "and the rank is 2. A gate made only of 'prove this is zero' cases is passed by a "
+        "library that calls everything zero.",
     ),
     Case(
         id="matrix_determinant_catastrophic_cancellation",

--- a/tests/test_error_code_registry.py
+++ b/tests/test_error_code_registry.py
@@ -1,0 +1,117 @@
+"""The error-code registry is a contract, so something has to enforce it.
+
+``scripts/check_error_codes.py`` has existed for a long time and no workflow
+ran it. By the time it was next run by hand it reported **53 failures**: 51
+codes that alkahest-core raises but never registered, and two PyO3 exception
+classes with no Python counterpart to catch them by name.
+
+That is the ordinary fate of a check nobody runs. Stable ``E-SUBSYSTEM-NNN``
+codes are a headline guarantee of this project — an agent is told it can plan
+against them — so a code that exists in the kernel and not in the registry is
+an undocumented part of the public contract, and a raisable exception class
+with no Python name is one a caller cannot catch.
+
+This module puts the script on the same footing as every other gate: it runs in
+``pytest tests/``, which CI already runs, so the registry cannot silently drift
+again.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "check_error_codes.py"
+
+
+@pytest.mark.skipif(not SCRIPT.is_file(), reason="checkout-only script (absent in a wheel)")
+def test_error_code_registry_is_consistent():
+    """Every raised code is registered, and every PyO3 class has a Python name.
+
+    The script's own output is the failure message: it enumerates each offending
+    code, which is far more useful than a bare non-zero exit.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        "scripts/check_error_codes.py failed.\n"
+        "A new code must be added to alkahest_core::errors::codes::REGISTRY, and a new "
+        "PyO3 Py*Error needs a matching class in python/alkahest/exceptions.py.\n\n"
+        f"{proc.stdout}{proc.stderr}"
+    )
+
+
+def _load_checker():
+    """Import the script as a module without running ``main``."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_check_error_codes", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.skipif(not SCRIPT.is_file(), reason="checkout-only script (absent in a wheel)")
+def test_the_gate_can_actually_detect_an_unregistered_code(tmp_path):
+    """A gate that cannot fail is not a gate.
+
+    Exercised against synthetic sources in ``tmp_path`` rather than by
+    temporarily corrupting the real ``codes.rs``: a test that mutates tracked
+    source can leave the tree dirty if it dies, and would hand a concurrent
+    ``cargo build`` a broken file.
+    """
+    checker = _load_checker()
+
+    registry = tmp_path / "codes.rs"
+    registry.write_text(
+        "pub const REGISTRY: &[ErrorSpec] = &[\n"
+        '    ErrorSpec { code: "E-FAKE-001", class: "FakeError" },\n'
+        "];\n",
+        encoding="utf-8",
+    )
+    assert checker.parse_registry(registry) == {"E-FAKE-001"}
+
+    core = tmp_path / "core"
+    core.mkdir()
+    (core / "fake.rs").write_text(
+        "impl AlkahestError for FakeError {\n"
+        "    fn code(&self) -> &'static str {\n"
+        '        match self { FakeError::A => "E-FAKE-001", FakeError::B => "E-FAKE-002" }\n'
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    raised, _ = checker.collect_rust_codes(core)
+    assert {"E-FAKE-001", "E-FAKE-002"} <= raised
+    # E-FAKE-002 is raised and unregistered — exactly what the gate must catch.
+    assert raised - checker.parse_registry(registry) == {"E-FAKE-002"}
+
+
+def test_every_python_exception_class_carries_a_code():
+    """A wrapper with no ``.code`` is indistinguishable from a bare exception."""
+    from alkahest import exceptions
+
+    missing = []
+    for name in dir(exceptions):
+        cls = getattr(exceptions, name)
+        if (
+            isinstance(cls, type)
+            and issubclass(cls, exceptions.AlkahestError)
+            and cls is not exceptions.AlkahestError
+        ):
+            try:
+                code = cls("probe").code
+            except TypeError:  # pragma: no cover - constructor takes extra args
+                continue
+            if not code or code == "E-UNKNOWN":
+                missing.append(name)
+    assert not missing, f"exception classes with no stable code: {missing}"

--- a/tests/test_limit_termination.py
+++ b/tests/test_limit_termination.py
@@ -1,0 +1,185 @@
+"""``limit`` must always come back — with a value, or with a coded refusal.
+
+``ak.limit(ak.sqrt(x**2 + x) - x, x, oo)`` used to never return. It ran inside
+Rust holding the GIL, so a Python-side ``SIGALRM`` or thread timeout could not
+stop it, and the Gruntz/expansion path had no ``budget::check`` checkpoint, so
+``context(budget=...)`` could not bound it either.
+
+Every test here carries a ``pytest.mark.timeout`` so a regression fails loudly
+instead of wedging CI.
+"""
+
+from __future__ import annotations
+
+import alkahest as ak
+import pytest
+
+# Generous next to the sub-second times these take when they work, and still far
+# below "the process is stuck".
+TIMEOUT = 60
+
+
+@pytest.fixture
+def pool() -> ak.ExprPool:
+    return ak.ExprPool()
+
+
+@pytest.fixture
+def x(pool: ak.ExprPool) -> ak.Expr:
+    return pool.symbol("x", "real")
+
+
+@pytest.fixture(autouse=True)
+def _clear_cancel_before_and_after():
+    """Cancellation is a process-wide flag — never let a failing assertion in
+    one test leave it set for the next test to inherit."""
+    ak.clear_cancel()
+    yield
+    ak.clear_cancel()
+
+
+def _hard_limit(pool: ak.ExprPool, x: ak.Expr) -> ak.Expr:
+    """A radical limit the engine does not solve.
+
+    ``sqrt(sqrt(x**2 + x) + x)`` sits on a half-integer scale, so the
+    leading-order route declines it and it falls through to the expansion path
+    — the one that used to run away. It is the natural probe for "does the
+    engine stop when it cannot answer".
+    """
+    return ak.sqrt(ak.sqrt(x**2 + x) + x)
+
+
+# ---------------------------------------------------------------------------
+# The reported expression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_sqrt_x_squared_plus_x_minus_x_at_infinity(pool, x):
+    """The reported hang. ``sqrt(x**2 + x) - x -> 1/2`` (multiply by the
+    conjugate: ``x / (sqrt(x**2 + x) + x)``)."""
+    got = ak.limit(ak.sqrt(x**2 + x) - x, x, pool.pos_infinity())
+    assert got == pool.rational(1, 2), f"got {got}"
+
+
+@pytest.mark.timeout(TIMEOUT)
+@pytest.mark.parametrize(
+    ("build", "expected"),
+    [
+        (lambda p, x: ak.sqrt(x**2 + x) - x, "1/2"),
+        (lambda p, x: x - ak.sqrt(x**2 + x), "-1/2"),
+        (lambda p, x: ak.sqrt(x**2 + 3 * x) - x, "3/2"),
+        (lambda p, x: ak.sqrt(x**2 + 1) - x, "0"),
+        (lambda p, x: ak.sqrt(x**2 + x) / x, "1"),
+        (lambda p, x: ak.sqrt(x**2 + x), "∞"),
+    ],
+)
+def test_algebraic_limits_at_infinity(pool, x, build, expected):
+    """The ∞−∞ family the conjugate trick covers, plus the neighbours that must
+    keep working."""
+    assert str(ak.limit(build(pool, x), x, pool.pos_infinity())) == expected
+
+
+# ---------------------------------------------------------------------------
+# Bounded and interruptible, whatever the algorithm does
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_unsolvable_limit_refuses_instead_of_hanging(pool, x):
+    """With no budget set, an unsolvable search must hit the internal work
+    ceiling and refuse with ``E-LIMIT-004`` rather than spin forever."""
+    with pytest.raises(ak.LimitError) as excinfo:
+        ak.limit(_hard_limit(pool, x), x, pool.pos_infinity())
+    assert excinfo.value.code == "E-LIMIT-004"
+    assert excinfo.value.remediation
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_wall_budget_stops_a_hard_limit(pool, x):
+    """``Budget(wall_ms=...)`` bounds the call and reports ``E-BUDGET-001``."""
+    with (
+        pytest.raises(ak.BudgetExceededError) as excinfo,
+        ak.context(budget=ak.Budget(wall_ms=50)),
+    ):
+        ak.limit(_hard_limit(pool, x), x, pool.pos_infinity())
+    assert excinfo.value.code == "E-BUDGET-001"
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_step_budget_stops_a_hard_limit(pool, x):
+    """``Budget(max_steps=...)`` bounds the call and reports ``E-BUDGET-002``."""
+    with (
+        pytest.raises(ak.BudgetExceededError) as excinfo,
+        ak.context(budget=ak.Budget(max_steps=5)),
+    ):
+        ak.limit(_hard_limit(pool, x), x, pool.pos_infinity())
+    assert excinfo.value.code == "E-BUDGET-002"
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_request_cancel_interrupts_a_limit(pool, x):
+    """``request_cancel()`` reaches the limit engine's checkpoints, exactly as
+    it reaches ``integrate``'s (``E-BUDGET-003``)."""
+    ak.request_cancel()
+    with pytest.raises(ak.BudgetExceededError) as excinfo:
+        ak.limit(_hard_limit(pool, x), x, pool.pos_infinity())
+    assert excinfo.value.code == "E-BUDGET-003"
+    ak.clear_cancel()
+    # And the engine is usable again straight afterwards.
+    assert ak.limit(ak.sqrt(x**2 + x) - x, x, pool.pos_infinity()) == pool.rational(1, 2)
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_a_solvable_limit_under_a_generous_budget_still_answers(pool, x):
+    """The checkpoints must not turn working limits into budget errors."""
+    with ak.context(budget=ak.Budget(wall_ms=10_000, max_steps=1_000_000)):
+        assert ak.limit(ak.sqrt(x**2 + x) - x, x, pool.pos_infinity()) == pool.rational(1, 2)
+        assert str(ak.limit(ak.sin(x) / x, x, pool.integer(0))) == "1"
+
+
+# ---------------------------------------------------------------------------
+# Existing coverage must not narrow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(TIMEOUT)
+@pytest.mark.parametrize(
+    ("build", "point", "direction", "expected"),
+    [
+        (lambda x: ak.sin(x) / x, 0, "+-", "1"),
+        (lambda x: (1 - ak.cos(x)) / x**2, 0, "+-", "1/2"),
+        (lambda x: x * ak.log(x), 0, "+", "0"),
+        (lambda x: (x**8 - 1) / (x - 1), 1, "+-", "8"),
+        (lambda x: x * ak.sin(1 / x), 0, "+-", "0"),
+        (lambda x: (1 + x) ** (1 / x), 0, "+-", "exp(1)"),
+        (lambda x: (1 + 1 / x) ** x, "oo", "+-", "exp(1)"),
+        (lambda x: (1 + 2 / x) ** x, "oo", "+-", "exp(2)"),
+        (lambda x: ak.exp(x) / x**2, "oo", "+-", "∞"),
+        (lambda x: ak.exp(-x), "oo", "+-", "0"),
+        (lambda x: x * ak.exp(-x), "oo", "+-", "0"),
+        (lambda x: ak.exp(ak.exp(x)), "oo", "+-", "∞"),
+        (lambda x: ak.exp(2 * x) / ak.exp(3 * x), "oo", "+-", "0"),
+        (lambda x: x / (x + 1), "oo", "+-", "1"),
+        (lambda x: x**2, "oo", "+-", "∞"),
+        (lambda x: 1 + 1 / x, "oo", "+-", "1"),
+    ],
+)
+def test_limits_that_already_worked_still_work(pool, x, build, point, direction, expected):
+    """A spread across every route — direct substitution, L'Hôpital, the series
+    expansion, the indeterminate-power rewrite, Gruntz. The termination guard
+    must not have narrowed any of them."""
+    pt = pool.pos_infinity() if point == "oo" else pool.integer(point)
+    assert str(ak.limit(build(x), x, pt, direction)) == expected
+
+
+@pytest.mark.timeout(TIMEOUT)
+def test_limits_that_were_refused_are_still_refused(pool, x):
+    """Refusals are coverage too: the guard must not have started answering
+    limits that do not exist."""
+    for expr in (ak.sin(x), ak.cos(x)):
+        with pytest.raises(ak.LimitError):
+            ak.limit(expr, x, pool.pos_infinity())
+    # x/|x| at 0 has one-sided limits ∓1 and no two-sided one.
+    with pytest.raises(ak.LimitError):
+        ak.limit(x / ak.abs(x), x, pool.integer(0))

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -263,3 +263,63 @@ def test_matrix_hadamard_elementwise():
     with pytest.raises(alkahest.MatrixError) as exc_info:
         a.hadamard(c)
     assert exc_info.value.code == "E-MAT-001"
+
+
+# ---------------------------------------------------------------------------
+# Undecidable zero tests — the refusal has to arrive with its own code
+# ---------------------------------------------------------------------------
+#
+# Both refusals travel on an existing error variant (`UnsupportedField`,
+# `SingularMatrix`), because the Rust enums are public and exhaustive and a new
+# variant is a major semver break. The specific cause rides alongside and the
+# bindings recover it, so these tests are what keeps that recovery honest: if
+# the out-of-band channel is ever dropped, the refusal silently degrades to the
+# carrier's code and only this asserts otherwise.
+
+
+def _undecidable(pool):
+    """A 1×1 quantity nothing can decide: `mystery` has no rule, no numeric
+    kernel and no interval kernel, so it can be neither normalised to zero nor
+    rigorously enclosed away from it."""
+    return pool.func("mystery", [pool.symbol("a")])
+
+
+def test_undecidable_pivot_refuses_with_linalg_code():
+    """A pivot that can be proven neither zero nor non-zero raises E-LINALG-010."""
+    pool = alkahest.ExprPool()
+    zero = pool.integer(0)
+    m = alkahest.Matrix([[_undecidable(pool), zero], [zero, zero]])
+    with pytest.raises(alkahest.LinearAlgebraError) as exc_info:
+        m.rank()
+    assert exc_info.value.code == "E-LINALG-010"
+    assert "mystery" in str(exc_info.value)
+
+
+def test_undecidable_determinant_refuses_with_matrix_code():
+    """An inverse whose determinant cannot be decided raises E-MAT-004.
+
+    Not an inverse divided by a determinant that might be zero, which nothing
+    downstream could tell apart from a real one.
+    """
+    pool = alkahest.ExprPool()
+    zero, one = pool.integer(0), pool.integer(1)
+    m = alkahest.Matrix([[_undecidable(pool), zero], [zero, one]])
+    with pytest.raises(alkahest.MatrixError) as exc_info:
+        m.inverse()
+    assert exc_info.value.code == "E-MAT-004"
+
+
+def test_proven_singular_keeps_its_own_code_after_a_refusal():
+    """A genuinely singular matrix stays E-MAT-003 even right after a refusal.
+
+    The refusal is recorded out of band, so the failure mode this guards is a
+    stale record being picked up by the next unrelated error on the thread.
+    """
+    pool = alkahest.ExprPool()
+    zero = pool.integer(0)
+    with pytest.raises(alkahest.LinearAlgebraError):
+        alkahest.Matrix([[_undecidable(pool), zero], [zero, zero]]).rank()
+    singular = _int_matrix(pool, [[1, 2], [2, 4]])
+    with pytest.raises(alkahest.MatrixError) as exc_info:
+        singular.inverse()
+    assert exc_info.value.code == "E-MAT-003"


### PR DESCRIPTION
The three pre-existing defects found while building the P2 features in #289, and deliberately left out of that PR so it stayed reviewable and its gates stayed honest.

## 1. Symbolic linear algebra returned a confident wrong rank

```python
E = ak.exp(a)
M = ak.Matrix([[1, E,   E          ],
               [E, E*E, ak.exp(a+a)]])   # row2 = exp(a) · row1, exactly
M.rank()   # was 2 — true rank is 1
M.rref()   # was [[1, exp(a), 0], [0, 0, 1]]
```

That `[0, 0, 1]` is the textbook signature of an **inconsistent** system, returned for a consistent one, with no exception and no flag. For a search loop it is a wrongly closed branch — a false "no solution exists".

**Two independent defects had to line up.**

`log_exp_rules()` was `[LogOfExp, ProductOfExps]` and nothing else — a standalone set with **no arithmetic rules at all**. `SubSelf` (`X + (−1)·X → 0`) lives in the default set, so once the log/exp rules normalised both terms to `exp(a+a)` there was nothing left to collect them. `ProductOfExps` also required *every* factor to be an `exp`, so `−1·exp(a)·exp(a)` — the exact shape Gaussian elimination produces — never fired. Both fixed, plus a new `PowOfExp` (`exp(u)^n → exp(n·u)`).

**The one that actually mattered:** the pivot test was a **bool** meaning "the simplified entry is not literally 0", and elimination read it as "non-zero". Zero-testing over a transcendental extension is not decidable, so a stronger normaliser only moves the boundary — it cannot remove it. Collapsing *unknown* into *non-zero* is what manufactured the wrong pivot.

It is now three-valued. `NonZero` requires a **proof** — a rigorous outward-rounded ball enclosure excluding 0, or a structural argument valid over ℂ (a product vanishes iff a factor does; `exp` never vanishes). Pivot only on proven-`NonZero`; call a column pivot-free only when every candidate is proven `Zero`; otherwise refuse with `E-LINALG-010` / `E-MAT-004`. Refusal is minimal — a column with one undecided entry and one proven-non-zero entry still pivots on the latter.

Note what `NonZero` does *not* claim: `x − 1` is non-zero as a function, so generic-rank semantics are unchanged. What is now impossible is pivoting on an entry that is identically zero.

Three Rust tests changed behaviour and all three were fixed by making the refusal **more precise, not weaker**; none was previously correct-by-luck. This also wired 17 already-implemented `ArbBall` kernels (`tan`, hyperbolics, inverse trig, `erf`, …) into `IntervalEval::eval_node`, where they were unreachable — without that, matrices containing `tan(x)` would have started refusing needlessly.

Four cases added to `tests/silent_errors/corpus.py`, including an independent-rows control and a refusal case, so the gate cannot pass by the module simply refusing everything.

## 2. `limit(sqrt(x²+x) − x, x, +∞)` never returned

**Not Gruntz** — the expression has no `exp`, so Gruntz declines immediately. The `+∞` route fell through to `taylor_coefficients`, which builds coefficients by repeated `diff` **without re-simplifying**; derivatives of a nested radical do not close, so each is ~3× the last. Measured 1 ms at order 3, 45 ms at order 11, extrapolating to roughly **two hours** at the order 32 it asks for — in a single uninterruptible call.

It now answers **`1/2` in about a millisecond**, by reusing the valuation calculus already written for asymptotics: substitute `x ↦ 1/t`, factor `f = tᵛ·u(t)` pushing `t`-powers *inside* radicals, then expand only the analytic `u`. Gated on the expression actually containing a radical, so no other route changes.

Independently of that fix: **no kernel loop that can run unboundedly may be uninterruptible.** Cooperative `budget::check` checkpoints now sit on the limit iteration paths and inside the coefficient loop, so `wall_ms` / `max_steps` / `request_cancel` yield `E-BUDGET-001/002/003`; with no budget set, an internal work ceiling returns the existing `E-LIMIT-004` refusal instead of spinning. An honest refusal is a fine answer; an infinite loop is not.

Performance was measured rather than asserted: 40 rounds × 16 representative limits, **20.2 ms/round before, 20.7 ms/round after** — inside run-to-run noise.

## 3. The error-code registry was a contract nobody enforced

`scripts/check_error_codes.py` has existed for a long time and **no workflow ran it**. Run by hand it reported **53 failures**: 51 codes `alkahest-core` raises but never registered, and two PyO3 classes (`PyHomotopyError`, `PyModularError`) with no Python counterpart, so they could not be caught by name.

Registry entries were extracted from each type's own `code()`/`remediation()` impl rather than re-worded, so the registry cannot drift from what a caller is actually told. `HomotopyError` and `ModularError` are now reachable as `ak.*` like every sibling error class.

The durable fix is `tests/test_error_code_registry.py`, which puts the script in the suite CI already runs — including a test that the gate can still **detect** an unregistered code, because a gate that cannot fail is not a gate. That negative test runs against synthetic sources in `tmp_path`; an earlier version temporarily blanked the real `codes.rs`, which would hand a concurrent `cargo build` a broken file and could leave the tree dirty on a crash.

## Verification

Every CI gate run locally with the lockfile-pinned tooling (ruff 0.15.14, ty 0.0.39):

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets -D warnings` (default, egraph, parallel, groebner-cuda) | pass |
| `cargo test --all` | pass, incl. doctests |
| `cargo doc --workspace --no-deps` under `-D warnings` | pass |
| `ruff check` / `ruff format --check` | pass |
| `ty check python/alkahest/` | 0 errors |
| `scripts/check_error_codes.py` | **OK — 190 codes** (was 53 failures) |
| certificate ledger drift | up to date |
| silent-error gate | 153 passed, rate **0.0%** |
| `pytest tests/` | **2460 passed**, 61 skipped, 0 failed |

Spot-checked by hand rather than taken on trust: `rank()` → 1 and `rref` → `[[1, exp(a), exp(a)], [0,0,0]]`; `limit(...)` → `1/2` in 1 ms; `wall_ms=50` → `E-BUDGET-001` in 55 ms; `max_steps=10` → `E-BUDGET-002`; `request_cancel()` → `E-BUDGET-003`; no budget → `E-LIMIT-004` in 2.6 s.

## Known follow-up, not fixed here

**`ak.series` has the same runaway** — `ak.series(sqrt(t**-2 + t**-1), t, 0, 32)` still does not terminate. Bounding it is a genuine design decision rather than a mechanical fix: silently truncating would make its `O(·)` term a lie, so it needs a new `SeriesError` variant and a decision about what a truncated series should claim. The `limit` path is safe because the engine only scans for the first non-zero coefficient, so a short prefix is either sufficient or an honest "no answer at this order" — never a wrong answer.

Two smaller ones: `nullspace_basis` reports its refusal as the less specific `E-LINALG-002` because `kernel_column_basis` returns `Result<_, ()>` and carries no payload; and `request_cancel()` still cannot reach a running `limit` from another Python thread, because no engine here releases the GIL — the repo's existing convention is to set the flag before the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved symbolic evaluation for trigonometric, hyperbolic, inverse, special, absolute-value, floor, and ceiling functions.
  - More reliable symbolic matrix operations, including eigenvalues, rank, decomposition, inversion, and zero detection.
  - Enhanced exponential simplification and power transformations.
  - Added `HomotopyError` and `ModularError` exceptions.

- **Bug Fixes**
  - Limit calculations now terminate more reliably and honor cancellation and computation budgets.
  - Budget failures are reported as structured `BudgetExceededError` exceptions.

- **Documentation**
  - Updated guidance for limit and integration budgets and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->