### PR TITLE
fix(research): refuse claim-graph edges that would close a cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Fixed
 
+- **Claim graphs: a merge could close a dependency cycle, making the graph
+  unreadable.** Claim IDs are content-addressed over the *normalised*
+  statement, so two textually different statements (`"a"` and `" a"`) share an
+  ID. Re-adding one took `ClaimGraph.add`'s merge path, which unions in its
+  dependency edges — and those can point at claims recorded later, including
+  ones that already depend on it. The resulting graph served fine in memory and
+  serialised fine, then could never be read back: `from_json` topologically
+  sorts and raised `CycleError`. `add` now refuses an edge that would close a
+  cycle, naming both claims, so "a `ClaimGraph` is acyclic" is a real invariant
+  and a JSON round-trip is total. Legitimate acyclic merging is unaffected.
+  Found by the `test_json_round_trip_is_lossless` property test.
+
 - **Sparse interpolation: Zippel oracle cost is now polynomial, not
   multiplicative.** `sparse_interp` was formulated recursively — interpolate the
   coefficients of `x₁` as polynomials in the remaining variables, recursively —

--- a/python/alkahest/research.py
+++ b/python/alkahest/research.py
@@ -890,6 +890,8 @@ class ClaimGraph:
         ------
         MissingClaimError
             If any dependency is absent from the graph.
+        CycleError
+            If the edge would make the graph cyclic.
         """
         deps = tuple(dict.fromkeys(d for d in claim.depends_on if d != claim.id))
         for dep in deps:
@@ -897,6 +899,7 @@ class ClaimGraph:
                 raise MissingClaimError(
                     f"claim {claim.id!r} depends on {dep!r}, which is not in this graph"
                 )
+        self._reject_cycles(claim.id, deps)
         existing = self._claims.get(claim.id)
         if existing is None:
             stored = replace(claim, depends_on=deps)
@@ -919,6 +922,35 @@ class ClaimGraph:
         for dep in merged_deps:
             self._dependents.setdefault(dep, set()).add(claim.id)
         return stored
+
+    def _reject_cycles(self, claim_id_: str, deps: Sequence[str]) -> None:
+        """Refuse an edge set that would make the graph cyclic.
+
+        A first insertion cannot create a cycle: every dependency must already
+        be present, and nothing depends on the new claim yet. The *merge* path
+        can, though. IDs are content-addressed over the **normalised**
+        statement, so two textually different statements (``"a"`` and ``" a"``)
+        share an ID; re-adding one of them merges its edges into the stored
+        claim, and those edges may point at claims recorded later — including
+        ones that already depend on it.
+
+        The result used to be a graph that served fine in memory, serialised
+        fine, and then could never be read back: :meth:`from_json` topologically
+        sorts and raised :class:`CycleError`. Rejecting the edge here keeps
+        "a ClaimGraph is acyclic" a real invariant, so a round-trip is total.
+        """
+        if claim_id_ not in self._claims:
+            # Fresh insertion: dependencies pre-exist and nothing points here yet.
+            return
+        for dep in deps:
+            if dep == claim_id_:
+                continue
+            # Does `dep` already (transitively) depend on this claim?
+            if claim_id_ in self._walk(dep, lambda i: self._claims[i].depends_on):
+                raise CycleError(
+                    f"claim {claim_id_!r} cannot depend on {dep!r}: "
+                    f"{dep!r} already depends on it, so the edge would close a cycle"
+                )
 
     def _replace_claim(self, claim: Claim) -> None:
         """Overwrite an existing claim in place (edges unchanged)."""

--- a/tests/test_research_claim_graph.py
+++ b/tests/test_research_claim_graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import threading
+from dataclasses import replace
 
 import alkahest as ak
 import pytest
@@ -347,6 +348,94 @@ def _graphs(draw):
         graph.add(claim)
         placed.append(claim.id)
     return graph
+
+
+def test_merge_cannot_close_a_cycle():
+    """Re-adding a claim must not be able to make the graph cyclic.
+
+    Claim IDs are content-addressed over the *normalised* statement, so "a" and
+    " a" are different strings with the same ID. Re-adding one takes the merge
+    path, which unions in its dependency edges -- and those can point at claims
+    recorded later, including ones that already depend on it.
+
+    That produced a graph which served fine in memory and serialised fine, but
+    could never be read back: `from_json` topologically sorts and raised
+    CycleError. Found by the round-trip property test below.
+    """
+    graph = ClaimGraph()
+    a = Claim(
+        id=claim_id("a", (), "test"),
+        statement="a",
+        kind="text",
+        method="test",
+        status="unverified",
+    )
+    graph.add(a)
+    b = Claim(
+        id=claim_id("b", (), "test"),
+        statement="b",
+        kind="text",
+        method="test",
+        status="unverified",
+        depends_on=(a.id,),
+    )
+    graph.add(b)
+
+    # " a" normalises to "a", so this merges into `a` and would add a -> b.
+    colliding = Claim(
+        id=claim_id(" a", (), "test"),
+        statement=" a",
+        kind="text",
+        method="test",
+        status="unverified",
+        depends_on=(b.id,),
+    )
+    assert colliding.id == a.id, "precondition: normalisation collapses the IDs"
+
+    with pytest.raises(CycleError) as excinfo:
+        graph.add(colliding)
+    assert a.id in str(excinfo.value)
+    assert b.id in str(excinfo.value)
+
+    # The graph is untouched and still round-trips.
+    assert graph.ids == (a.id, b.id)
+    assert ClaimGraph.from_json(graph.to_json()).to_dict() == graph.to_dict()
+
+
+def test_merge_still_unions_edges_when_acyclic():
+    """The cycle guard must not break legitimate merging."""
+    graph = ClaimGraph()
+    base = Claim(
+        id=claim_id("base", (), "test"),
+        statement="base",
+        kind="text",
+        method="test",
+        status="unverified",
+    )
+    other = Claim(
+        id=claim_id("other", (), "test"),
+        statement="other",
+        kind="text",
+        method="test",
+        status="unverified",
+    )
+    graph.add(base)
+    graph.add(other)
+
+    dependent = Claim(
+        id=claim_id("dependent", (), "test"),
+        statement="dependent",
+        kind="text",
+        method="test",
+        status="unverified",
+        depends_on=(base.id,),
+    )
+    graph.add(dependent)
+    # Re-derive the same claim, now also citing `other` -- acyclic, so allowed.
+    graph.add(replace(dependent, depends_on=(other.id,)))
+
+    assert set(graph[dependent.id].depends_on) == {base.id, other.id}
+    assert ClaimGraph.from_json(graph.to_json()).to_dict() == graph.to_dict()
 
 
 @settings(max_examples=60, deadline=None)


### PR DESCRIPTION
A `ClaimGraph` could be put into a state it could not be read back from. Found by the `test_json_round_trip_is_lossless` property test, which had been failing intermittently — it only reproduced where Hypothesis's local example database happened to hold the counterexample, which is why it looked like a flake.

## The bug

Claim IDs are content-addressed over the **normalised** statement, so two textually different statements share an ID:

```python
claim_id("a", (), "test") == claim_id(" a", (), "test")   # True
```

Re-adding one takes `add`'s **merge** path, which unions in its dependency edges — and those can point at claims recorded *later*, including ones that already depend on it. Three lines reproduce it:

```python
g.add(mk("a"))          # id X
g.add(mk("b", [X]))     # id Y, depends on X
g.add(mk(" a", [Y]))    # normalises to X, merges, closing X -> Y -> X
```

The graph then serves fine in memory and serialises fine — and can never be read back, because `from_json` topologically sorts and raises `CycleError`.

A *first insertion* cannot do this: dependencies must already exist, and nothing points at the new claim yet. Only the merge path was exposed, which is why this survived.

## The fix

`add` now rejects an edge whose target already (transitively) depends on the claim, naming both claims in the message. That makes "a `ClaimGraph` is acyclic" a real invariant rather than something only `from_json` checks, so the round-trip is total.

Legitimate acyclic merging — re-deriving a claim that picks up new citations — is unaffected, and `test_merge_still_unions_edges_when_acyclic` pins that so the guard can't be tightened into a regression later.

## Tests

- `test_merge_cannot_close_a_cycle` — the deterministic three-line reproducer, asserting the refusal names both claims and that the graph is left untouched and still round-trips.
- `test_merge_still_unions_edges_when_acyclic` — the legitimate case keeps working.
- The property test now passes across repeated fresh runs (I cleared the Hypothesis database and re-ran).

## Gates

`ruff check` / `ruff format --check` clean; `ty check` 44 diagnostics — identical to unmodified `main`, none in `research.py`; full `pytest` 1834 passed, 94 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented claim dependency cycles from being added to the graph.
  - Invalid merges now fail safely without altering existing graph data.
  - Valid claim merges continue to combine dependency information correctly.
  - Preserved accurate JSON export and re-import behavior for claim graphs.

- **Tests**
  - Added coverage for cycle prevention, safe failed merges, valid acyclic merges, and JSON round trips.

- **Documentation**
  - Documented the fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->