### PR TITLE
fix(cuda): reach every GPU from Python, and a racecheck gate that printed nothing

### DIFF
--- a/.github/workflows/cuda_nightly.yml
+++ b/.github/workflows/cuda_nightly.yml
@@ -29,6 +29,16 @@ jobs:
           ALKAHEST_GPU_TESTS: "1"
         run: cargo test --features cuda,groebner-cuda --no-fail-fast
 
+      # Both sanitizer steps are scoped to the two integration targets that
+      # actually launch kernels. Wrapping the whole `cargo test` instead drags
+      # rustdoc's doc-test runner under the sanitizer, where it segfaults
+      # (SIGSEGV, exit 139) *after* the CUDA suites have passed but *before*
+      # the summary is printed — so racecheck produced no RACECHECK SUMMARY at
+      # all, and with `continue-on-error: true` that looked like a pass.
+      # Scoping costs no coverage: the only GPU work in the workspace lives in
+      # these two targets. The in-`src` unit tests reach `compile_cuda` for PTX
+      # generation only, and `compute_groebner_basis_gpu(.., None)` takes the
+      # `reduce_cpu` path, so neither issues a CUDA API call.
       - name: Run compute-sanitizer memcheck
         env:
           ALKAHEST_GPU_TESTS: "1"
@@ -38,7 +48,8 @@ jobs:
           # no CUDA calls whatsoever. Without it this step emits a banner, no
           # ERROR SUMMARY, and a green tick while checking nothing.
           compute-sanitizer --target-processes all --tool memcheck \
-            cargo test --features cuda,groebner-cuda --no-fail-fast
+            cargo test --features cuda,groebner-cuda --no-fail-fast \
+              --test nvptx_gpu --test groebner_cuda
         continue-on-error: false
 
       - name: Run compute-sanitizer racecheck
@@ -46,7 +57,8 @@ jobs:
           ALKAHEST_GPU_TESTS: "1"
         run: |
           compute-sanitizer --target-processes all --tool racecheck \
-            cargo test --features cuda,groebner-cuda
+            cargo test --features cuda,groebner-cuda \
+              --test nvptx_gpu --test groebner_cuda
         continue-on-error: true  # racecheck may have false positives
 
       - name: Upload sanitizer logs

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -9327,8 +9327,39 @@ impl PyCudaCompiledFn {
     /// ``inputs`` is a list of length ``n_inputs``.  Each entry is a 1-D sequence
     /// of ``N`` values for that variable (column-major / SoA: one array per
     /// symbolic input).  Returns a Python ``list`` of ``N`` outputs.
+    ///
+    /// Equivalent to ``call_batch_on(0, inputs)``.
     #[pyo3(name = "call_batch")]
     fn call_batch_py(&self, inputs: &Bound<'_, PyList>) -> PyResult<Vec<f64>> {
+        self.eval_on_device(0, inputs)
+    }
+
+    /// Evaluate the compiled kernel on a specific CUDA device ordinal.
+    ///
+    /// Same contract as :meth:`call_batch`, which is this method with
+    /// ``device = 0``. The PTX is device-independent — it is generated once and
+    /// each device gets its own lazily-loaded module — so the same
+    /// ``CudaCompiledFn`` can be driven across every device on the host.
+    ///
+    /// `alkahest-core` has always been able to target a chosen device
+    /// (`CudaCompiledFn::call_batch_on`, exercised by
+    /// `nvptx_gpu::nvptx_multi_device_both_3090s`), but the binding only ever
+    /// exposed device 0, so on a multi-GPU host every device but the first was
+    /// unreachable from Python.
+    ///
+    /// Raises :class:`CudaError` if *device* is not a valid ordinal on this
+    /// host.
+    #[pyo3(name = "call_batch_on")]
+    fn call_batch_on_py(&self, device: usize, inputs: &Bound<'_, PyList>) -> PyResult<Vec<f64>> {
+        self.eval_on_device(device, inputs)
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl PyCudaCompiledFn {
+    /// Shared body of `call_batch` / `call_batch_on`: validate the SoA input
+    /// columns, then dispatch to the requested device ordinal.
+    fn eval_on_device(&self, device: usize, inputs: &Bound<'_, PyList>) -> PyResult<Vec<f64>> {
         if inputs.len() != self.inner.n_inputs {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "expected {} input columns, got {}",
@@ -9349,12 +9380,14 @@ impl PyCudaCompiledFn {
         }
         let col_refs: Vec<&[f64]> = cols.iter().map(|c| c.as_slice()).collect();
         let mut out = vec![0.0f64; n_pts];
-        self.inner.call_batch(&col_refs, &mut out).map_err(|e| {
-            Python::with_gil(|py2| {
-                let exc_type = py2.get_type_bound::<PyCudaError>();
-                make_structured_err(py2, &exc_type, &e)
-            })
-        })?;
+        self.inner
+            .call_batch_on(device, &col_refs, &mut out)
+            .map_err(|e| {
+                Python::with_gil(|py2| {
+                    let exc_type = py2.get_type_bound::<PyCudaError>();
+                    make_structured_err(py2, &exc_type, &e)
+                })
+            })?;
         Ok(out)
     }
 }

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -190,3 +190,43 @@ def test_llvm_jit_bit_tracks_what_is_linked_not_which_flag_was_named():
             'cuda = ["jit", ...]), so llvm_jit cannot be False'
         )
         assert features["jit"]
+
+
+def test_cuda_kernels_are_reachable_on_every_device_not_just_zero():
+    """Device selection must be reachable from Python, not only from Rust.
+
+    `alkahest-core` has always had `CudaCompiledFn::call_batch_on(ordinal, ..)`
+    — `nvptx_gpu::nvptx_multi_device_both_3090s` drives both cards through it —
+    but the binding exposed only `call_batch`, hardwired to device 0. On a
+    multi-GPU host every device but the first was therefore unreachable from
+    Python, which is the same shape of gap as `cuda` advertising an entry point
+    the public namespace could not reach.
+
+    Asserts agreement rather than mere reachability: the PTX is
+    device-independent, so the same kernel on a different card must return the
+    identical bit pattern, not merely a close one.
+    """
+    if not alkahest.capabilities()["features"]["cuda"]:
+        import pytest
+
+        pytest.skip("not a cuda build")
+
+    pool = alkahest.ExprPool()
+    x = pool.symbol("x")
+    fn = alkahest.compile_cuda(x * x + pool.integer(1), [x])
+
+    assert hasattr(fn, "call_batch_on"), "no way to select a CUDA device from Python"
+
+    pts = [0.0, 1.0, -2.5, 1e8, 1e-8]
+    on_zero = fn.call_batch_on(0, [pts])
+    assert on_zero == fn.call_batch([pts]), "call_batch must equal call_batch_on(0, ..)"
+
+    # Second device only if the host has one; single-GPU CI must still pass.
+    try:
+        on_one = fn.call_batch_on(1, [pts])
+    except alkahest.CudaError:
+        return
+    assert on_one == on_zero, (
+        "identical PTX on a second device returned different values: "
+        f"{on_one} vs {on_zero}"
+    )


### PR DESCRIPTION
Verified on dual RTX 3090 hardware against `release/3.8.0` @ `d139a46` — the only configuration any of this is observable in, since CI builds the `cuda` feature nowhere and the shipped wheel does not carry it.

## Verification of d139a46 (the reason this branch exists)

| Claim | Result |
|---|---|
| `llvm_jit` / `jit` true on a `--features cuda` build | PASS — `jit_is_available()` agrees |
| `compile_cuda` / `CudaCompiledFn` / `CudaError` public | PASS — reachable, in `__all__`, `cuda == hasattr(ak, "compile_cuda")` |
| memcheck emits a real `ERROR SUMMARY` | PASS |
| racecheck emits a real summary | **FAIL — fixed here** |

The memcheck summary was confirmed to be evidence rather than decoration: a control run with the GPU tests filtered out prints `Target application terminated before first instrumented API call` and **no** summary, so the line only appears when kernels actually ran.

## What this changes

**Racecheck was still checking nothing.** `--target-processes all` fixed memcheck but not racecheck: wrapping the whole `cargo test` pulls rustdoc's doc-test runner under the sanitizer, where it segfaults (exit 139) *after* the CUDA suites pass but *before* the summary prints. With `continue-on-error: true` that renders as a green tick with no `RACECHECK SUMMARY` anywhere in the log — the same failure mode d139a46 set out to remove, one step further down the file. Both steps are now scoped to the two integration targets that launch kernels, which yields `RACECHECK SUMMARY: 0 hazards displayed` and costs no coverage: the in-`src` unit tests only generate PTX, and `compute_groebner_basis_gpu(.., None)` takes the `reduce_cpu` path, so neither issues a CUDA API call.

**`CudaCompiledFn` could only run on device 0 from Python.** The core has had `call_batch_on(ordinal, ..)` all along — `nvptx_gpu::nvptx_multi_device_both_3090s` drives both cards through it — but the binding exposed only `call_batch`, so on a multi-GPU host every device but the first was unreachable. Same shape as `cuda` advertising an entry point the public namespace could not reach. `call_batch_on` is now bound, `call_batch` delegates to it with ordinal 0, and both share one input-validation body.

## GPU/CPU numerical agreement — checked, not a problem

`numpy_eval` delegates to the same Cranelift `CompiledFn`, so it is not an independent oracle. Against numpy's own ufuncs (5011 points, no shared code with the codegen) every lowered primitive agrees to **0–2 ulp**.

The largest discrepancy anywhere, **6.17e-15** on `x**3 - 2*x`, is exactly one ulp of `x**3` (4.441e-16) divided by a result that cancels 40.8×. The 1.13e-13 on `tan(x)*exp(x**2)` is `exp`'s condition number (|u| = 585) amplifying a last-place difference in its argument. Both are what floating point does, not what the backend got wrong.

Both cards return **bit-identical** results across 6028 points on six expressions; an out-of-range ordinal raises a structured `CudaError [E-CUDA-003]` rather than aborting.

## Known gaps left alone (in protected paths)

- `capabilities()["features"]["groebner_cuda"]` is `True` but has **no** Python-reachable path — not even a private one, unlike the `cuda` case d139a46 fixed. Implementation lives in `alkahest-core/src/poly/groebner/cuda.rs`.
- `compute_groebner_basis_gpu(polys, order, None)` silently runs entirely on CPU (`device_id: None` → `reduce_cpu()`), with nothing in the return value saying so.
- No way to query CUDA device count from Python; the valid ordinal range must be discovered by catching `CudaError`.

## Gates

Run with rustc 1.97.1 / clippy 0.1.97 to match CI:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features cuda,groebner-cuda -- -D warnings` — exit 0
- `cargo test --features cuda,groebner-cuda` — 2027 passed, 0 failed
- `pytest -q` — 2611 passed, 57 skipped, 3 xfailed, 0 failed (on a `--release` extension; a debug build fails an unrelated perf-sanity test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)