### PR TITLE
feat(holonomic): continuous creative telescoping — Almkvist–Zeilberger with a boundary verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 ## Unreleased
 
+- **Continuous creative telescoping — Almkvist–Zeilberger, the differential
+  twin of Zeilberger's algorithm** (`alkahest_cas::experimental::almkvist_zeilberger`,
+  `dgosper`, `integral_boundary_status`; Rust-only, no PyO3 binding yet). The
+  holonomic subsystem had a complete discrete stack — proper hypergeometric
+  recognition, Zeilberger, the q-analogue, multi-sum Apagodu–Zeilberger, a
+  three-valued boundary verdict — and nothing on the `∫ F(n,x) dx` side.
+  `holonomic::azeil` is that side: given `F(n,x)` hyperexponential in `x` and
+  hypergeometric in `n`, it finds an order `J`, polynomial coefficients
+  `a_0(n) … a_J(n)` and an exact rational certificate `R ∈ Q(n)(x)` with
+
+  ```
+  Σ_i a_i(n)·F(n+i,x) = D_x( R(n,x)·F(n,x) ),
+  ```
+
+  which is a recurrence for `f(n) = ∫_a^b F(n,x) dx` **once the boundary term
+  `[R·F]_a^b` is discharged** — a separate question the certificate says
+  nothing about, decided three-valued by `integral_boundary_status`. This is
+  the principled replacement for a Meijer-G engine on definite integrals of
+  special functions: more general, and it produces a certificate.
+
+  Worked end to end, with the certificate checked against the classical
+  recurrence rather than against the machinery that produced it:
+  `∫_0^∞ xⁿe^{−x} dx = n!` (order 1, `R = x`), `∫_0^1 xⁿ(1−x)^{1/2} dx` and
+  `∫_0^1 xⁿ(1−x)ⁿ dx` (order 1), `∫_{−∞}^{∞} x^{2n}e^{−x²} dx` (order 1,
+  `R = x`), `∫_0^∞ xⁿe^{−x²} dx` (order **2**, middle coefficient zero),
+  Bessel `J_n(2)` via the Schläfli contour (order 2, `R = 1`, recovering
+  `J_n + J_{n+2} = (n+1)J_{n+1}`) and Legendre `P_n(3)` likewise (order 2,
+  recovering `(n+1)P_n − 3(2n+3)P_{n+1} + (n+2)P_{n+2} = 0`).
+
+  **One solver, not two.** Dividing the identity through by `F` turns it into
+  the parametric Risch differential equation `R′ + θ·R = Σ_i a_i·r_i` with
+  `θ = ∂_xF/F`; indefinite integration (`dgosper`, the differential mirror of
+  Gosper's algorithm) is the same equation at `J = 0`, `a_0 = 1`.
+  `integrate::risch::rational_rde::solve_rational_rde_generalized` is
+  deliberately **not** reused for that, and the reason is correctness rather
+  than style: its denominator bound `E = gcd(D, D′)` is taken from the
+  right-hand side alone, which is Bronstein-exact only when `f` is a
+  polynomial. Probed directly, it returns `None` for `R′ + (1/x+1)R = 1` and
+  `R′ + (2/x+1)R = 1` — the equations behind `∫x·eˣ dx` and `∫x²·eˣ dx`, both
+  of which do have rational solutions. Both are regression tests here. (That
+  gap is in the generalized entry point, not in the exponential tower that is
+  its main caller, where `f = k·η′` is a polynomial; it is worth its own
+  investigation for the callers in `simple_radical`, `genus_zero` and the
+  fractional-exponent `exp_case` paths, which do pass rational `f`.) The `Q(n)`
+  Gaussian elimination *is* shared with `zeilberger`.
+
+  **Honest limitations.** The certificate ansatz is `R = P(x)/(D(x)^κ·B(x))`
+  with `D` the denominator of `θ` and `B` a common denominator of the shift
+  ratios. That denominator's *support* is derived, not guessed — a pole of `R`
+  must lie over a pole of `θ` or of the right-hand side — but its
+  *multiplicity* `κ` is a bounded search, because at a simple pole of `θ` with
+  residue `ρ` the certificate may have a pole of order `ρ` whenever `ρ` is a
+  positive integer, and with `ρ ∈ Q(n)` symbolic (the usual case, `θ = n/x + …`)
+  that is not decidable at all. The search is order-major ascending, so a
+  returned order is the least one reachable within the degree bounds — the
+  claim `zeilberger`'s cost-ordered plan trades away. `B(x)^β` for non-integer
+  `β` is treated formally, so reading a certificate as an identity of
+  *functions* needs a consistent branch on the interval. Only `n`-independent
+  integration limits are analysed; an `n`-dependent one is not representable
+  rather than mishandled. Out-of-class inputs get typed refusals under a new
+  `E-HOLO-06x` sub-block — with `NotHypergeometricInN` (`E-HOLO-061`)
+  deliberately distinct from a shape failure, because `exp(n·x)` closes the
+  branch for every algorithm in this family and raising search bounds cannot
+  help.
+
 - **`telescope2d` generalizes from two bound indices to an arbitrary `m ≥ 1`:
   `experimental.telescope_md`** (M4 extension). `telescope2d(term, n, j, k)`
   only ever reached exactly two bound indices; the underlying ansatz search

--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -269,6 +269,16 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-HOLO-040", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("rewrite the term as R(n,j,k)*z1**j*z2**k*w**n*prod(gamma(a*n+b*j+c*k+d)**e) with integer a, b, c; supported function heads are gamma, factorial, binomial, pochhammer") },
     ErrorSpec { code: "E-HOLO-041", class: "HolonomicError", cause: Cause::Resource,    remediation: Some("raise max_order, max_a_degree and/or max_cert_degree in Telescoping2dOpts; if the term genuinely has no such double-sum certificate within reach — or needs a certificate denominator this module's fixed-denominator ansatz cannot represent — this method does not apply") },
     ErrorSpec { code: "E-HOLO-042", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("n, j and k must be three distinct symbols") },
+    // E-HOLO-06x — DiffTelescopingError (continuous creative telescoping /
+    // Almkvist-Zeilberger, the differential twin of the classical engine). Its
+    // own sub-block for the same reason the q- and multi-sum engines have one:
+    // a caller can tell which engine refused, and the refusals differ in kind
+    // (061 in particular closes the branch rather than suggesting new bounds).
+    ErrorSpec { code: "E-HOLO-060", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("write the integrand as R(n,x)*w**n*exp(eta(x))*prod(B(x)**(a*n + b)) with integer a and rational b; supported function heads are exp and sqrt, and a sum of two hyperexponential terms is not itself hyperexponential") },
+    ErrorSpec { code: "E-HOLO-061", class: "HolonomicError", cause: Cause::Unsupported, remediation: Some("the x-side is fine but F(n+1,x)/F(n,x) is not rational in x - e.g. exp(n*x), whose ratio is exp(x). No algorithm in this family applies; close the branch") },
+    ErrorSpec { code: "E-HOLO-062", class: "HolonomicError", cause: Cause::Resource,    remediation: Some("raise max_order, max_degree and/or max_den_power in AzOpts; if the integrand genuinely has no such certificate within reach - or needs a certificate denominator this module's D**kappa * B ansatz cannot represent - this method does not apply") },
+    ErrorSpec { code: "E-HOLO-063", class: "HolonomicError", cause: Cause::Internal,    remediation: Some("internal: report the integrand as a minimal failing example") },
+    ErrorSpec { code: "E-HOLO-064", class: "HolonomicError", cause: Cause::UserInput,   remediation: Some("n and x must be distinct symbols; the max_order, max_degree and max_den_power bounds must be within the documented ranges") },
     // E-SMT — SmtError (P2 item 3: SMT/SAT bridge).
     //
     // Only the code Rust actually raises is registered here.  The rest of the

--- a/alkahest-core/src/holonomic/azeil/boundary.rs
+++ b/alkahest-core/src/holonomic/azeil/boundary.rs
@@ -1,0 +1,862 @@
+//! Deciding the boundary hypothesis an Almkvist–Zeilberger certificate rests on.
+//!
+//! [`super::almkvist_zeilberger`] proves an identity about the *integrand*:
+//!
+//! ```text
+//! Σ_i a_i(n)·F(n+i, x) = D_x( G(n,x) ),    G(n,x) = R(n,x)·F(n,x)
+//! ```
+//!
+//! Turning that into a statement about `f(n) = ∫_a^b F(n,x) dx` is a second,
+//! separate step, and it is where a valid certificate can produce a false
+//! theorem. This module takes it, three-valued, in the same discipline as
+//! [`mod@super::super::boundary`]:
+//!
+//! | [`IntegralBoundaryStatus`] | claim |
+//! |---|---|
+//! | [`Vanishes`](IntegralBoundaryStatus::Vanishes) | proved `[G]_a^b = 0`; the homogeneous recurrence `Σ_i a_i(n)·f(n+i) = 0` holds |
+//! | [`Nonzero`](IntegralBoundaryStatus::Nonzero) | `[G]_a^b` computed exactly and proved `≢ 0`; the *inhomogeneous* recurrence holds, with the right-hand side explicit |
+//! | [`Unknown`](IntegralBoundaryStatus::Unknown) | neither was established; **nothing** may be claimed about the integral |
+//!
+//! Only the first two are results. `Unknown` carries a reason, so a caller can
+//! tell "the boundary term diverges" from "both endpoints are finite and their
+//! difference could not be decided" and act differently. `Unknown` is never
+//! collapsed into `Vanishes`.
+//!
+//! # Why this is simpler than the discrete case, and where it is not
+//!
+//! Simpler: the limits do not move with `n`, so `∫_a^b F(n+i,x) dx` *is*
+//! `f(n+i)` and the whole inhomogeneity is the endpoint difference. The
+//! discrete module's `D_i(n)` correction terms — the reason
+//! `Σ_{k=0}^{n} C(n,k)` comes out right — have no analogue here, because a
+//! continuous integration range that moved with `n` would not be a
+//! creative-telescoping problem in the first place (it would need a Leibniz
+//! rule term this module does not model, which is why `n`-dependent limits are
+//! refused rather than mishandled).
+//!
+//! Harder: an endpoint is a *limit*, not an evaluation, and it can diverge. The
+//! order of `G` at an endpoint is generally an element of `Q(n)` — `n + 1` for
+//! `G = x^(n+1)·e^(−x)` at `0` — so "does it vanish" is a question about `n`,
+//! not a yes/no. That is reported, never assumed: see
+//! [`IntegralBoundaryStatus::conditions`].
+//!
+//! # How a verdict is reached
+//!
+//! Nothing here is numeric. Write `G = r(n,x)·wⁿ·exp(η(x))·∏_j B_j(x)^(e_j)`
+//! with `e_j = α_j·n + β_j`, which is what [`super::hyperexp`] already parses,
+//! with `r` the certificate times the integrand's own rational part.
+//!
+//! **At a finite rational endpoint `c`.** If `η` has a pole at `c`, the verdict
+//! is `Unknown` — `exp` of a pole is `0` on one side and `∞` on the other, and
+//! deciding which needs an interval this module is not given. Otherwise `exp(η)`
+//! contributes a finite nonzero factor, and the order of `G` at `c` is
+//!
+//! ```text
+//! ν = ord_c(r) + Σ_j e_j·ord_c(B_j)   ∈ Q(n), affine in n,
+//! ```
+//!
+//! computed by exact deflation of the root `c` over `Q(n)`. `G → 0` exactly
+//! when `ν > 0`; when `ν` is a concrete positive rational that is
+//! unconditional, and when it carries `n` it becomes a stated condition. `ν = 0`
+//! with nothing vanishing or blowing up gives the endpoint value by direct
+//! substitution — a product of a nonzero `Q(n)` element, `wⁿ`, `exp` of a
+//! finite value and nonzero powers, hence *provably* nonzero. Anything else
+//! (`ν < 0`, or `ν = 0` reached by cancellation between a zero of `r` and a pole
+//! of some `B_j`) is `Unknown`.
+//!
+//! **At `±∞`.** If `deg η ≥ 1` with a leading coefficient that is a concrete
+//! rational, `exp(η)` decides everything: it beats every power of `x`, so the
+//! endpoint contributes `0` unconditionally when `η → −∞` and `Unknown`
+//! (divergence) when `η → +∞`. Otherwise `exp(η)` tends to a finite nonzero
+//! constant and the endpoint is decided by the algebraic degree
+//! `δ = deg(r) + Σ_j e_j·deg(B_j) ∈ Q(n)`, with `G → 0` exactly when `δ < 0`.
+//!
+//! # The residual hypothesis
+//!
+//! Orders and degrees are computed over `Q(n)`, so a coefficient that is a
+//! nonzero element of `Q(n)` is nonzero for all but finitely many `n`. A verdict
+//! is therefore a statement about the `n` at which the integrand, the
+//! certificate and the integral are all defined and the integral converges —
+//! stated rather than hidden, in [`IntegralBoundaryStatus::side_conditions`].
+//! Convergence in particular is *not* established here: this module decides the
+//! boundary term of an identity, not the existence of `f(n)`.
+
+use super::hyperexp::HyperExpTerm;
+use super::search::AzResult;
+use super::DiffTelescopingError;
+use crate::holonomic::hyperterm::{as_ratk, rn_to_expr};
+use crate::holonomic::qfield::{
+    rn_add, rn_int, rn_is_zero, rn_mul, rn_rat, rn_var, rn_zero, PolyK, RatK, Rn,
+};
+use crate::kernel::{ExprId, ExprPool};
+use rug::Rational;
+
+/// One end of the integration range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegrationLimit {
+    /// A finite rational endpoint.
+    Finite(Rational),
+    /// `−∞`.
+    NegInfinity,
+    /// `+∞`.
+    PosInfinity,
+}
+
+impl IntegrationLimit {
+    /// A finite endpoint from an integer, for the common cases `0` and `1`.
+    pub fn at(v: i64) -> IntegrationLimit {
+        IntegrationLimit::Finite(Rational::from(v))
+    }
+
+    fn describe(&self) -> String {
+        match self {
+            IntegrationLimit::Finite(q) => q.to_string(),
+            IntegrationLimit::NegInfinity => "-oo".into(),
+            IntegrationLimit::PosInfinity => "+oo".into(),
+        }
+    }
+}
+
+/// The verdict on `[G]_a^b`, the inhomogeneity of the recurrence for the
+/// *integral*.
+///
+/// See the [module documentation](self) for what each variant is allowed to
+/// mean and why.
+#[derive(Debug, Clone)]
+pub enum IntegralBoundaryStatus {
+    /// Proved `[G]_a^b = 0`: the homogeneous recurrence
+    /// `Σ_i a_i(n)·f(n+i) = 0` holds over the range that was supplied, for
+    /// every `n` satisfying `conditions`.
+    Vanishes {
+        /// Each entry is an expression in `n` that must be **strictly
+        /// positive** for the proof to apply. Empty means unconditional.
+        ///
+        /// These are not caveats bolted on afterwards: they are the exact
+        /// inequalities the order computation produced, e.g. `n + 1 > 0` for
+        /// `x^(n+1)·e^(−x)` at `0`.
+        conditions: Vec<ExprId>,
+    },
+    /// `[G]_a^b` was computed exactly and proved not identically zero. The
+    /// **inhomogeneous** recurrence `Σ_i a_i(n)·f(n+i) = rhs(n)` holds — still a
+    /// theorem about the integral, just not the homogeneous one.
+    Nonzero {
+        /// `[G]_a^b`, as an expression in `n` alone.
+        rhs: ExprId,
+        /// Conditions on `n`, as in [`Vanishes`](IntegralBoundaryStatus::Vanishes).
+        conditions: Vec<ExprId>,
+    },
+    /// Neither could be established. **No** recurrence for the integral
+    /// follows; the certificate remains a true statement about the integrand
+    /// and nothing more.
+    Unknown {
+        /// Why the verdict could not be reached.
+        reason: String,
+    },
+}
+
+impl IntegralBoundaryStatus {
+    /// `"vanishes"`, `"nonzero"` or `"unknown"` — the stable tag to record.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            IntegralBoundaryStatus::Vanishes { .. } => "vanishes",
+            IntegralBoundaryStatus::Nonzero { .. } => "nonzero",
+            IntegralBoundaryStatus::Unknown { .. } => "unknown",
+        }
+    }
+
+    /// Whether a recurrence for the *integral* may be read off at all — true
+    /// for [`Vanishes`](IntegralBoundaryStatus::Vanishes) (homogeneous) and
+    /// [`Nonzero`](IntegralBoundaryStatus::Nonzero) (inhomogeneous), false for
+    /// [`Unknown`](IntegralBoundaryStatus::Unknown).
+    pub fn implies_integral_recurrence(&self) -> bool {
+        !matches!(self, IntegralBoundaryStatus::Unknown { .. })
+    }
+
+    /// The positivity conditions on `n` this verdict is conditional on, or an
+    /// empty slice.
+    pub fn conditions(&self) -> &[ExprId] {
+        match self {
+            IntegralBoundaryStatus::Vanishes { conditions }
+            | IntegralBoundaryStatus::Nonzero { conditions, .. } => conditions,
+            IntegralBoundaryStatus::Unknown { .. } => &[],
+        }
+    }
+
+    /// What is still assumed after this verdict, as plain strings — the same
+    /// shape as the discrete module's
+    /// [`side_conditions`](super::super::boundary::BoundaryStatus::side_conditions).
+    ///
+    /// This is *not* a fixed string: a discharged hypothesis and an open one
+    /// read differently, which is the whole point of computing a verdict rather
+    /// than restating the caveat.
+    pub fn side_conditions(&self, range: &str, pool: &ExprPool) -> Vec<String> {
+        let render = |conds: &[ExprId]| -> Vec<String> {
+            conds
+                .iter()
+                .map(|c| format!("{} > 0", pool.display(*c)))
+                .collect()
+        };
+        match self {
+            IntegralBoundaryStatus::Vanishes { conditions } => {
+                let mut out = vec![format!(
+                    "the boundary term [R*F] over {range} was proved to vanish in exact \
+                     arithmetic, so the homogeneous recurrence sum_i a_i(n)*f(n+i) = 0 holds \
+                     for the integral"
+                )];
+                out.extend(render(conditions));
+                out.push(
+                    "the verdict is a statement about the n at which the integrand, the \
+                     certificate and the integral are all defined; convergence of the \
+                     integral itself is assumed, not proved here"
+                        .into(),
+                );
+                out
+            }
+            IntegralBoundaryStatus::Nonzero { conditions, .. } => {
+                let mut out = vec![format!(
+                    "the boundary term [R*F] over {range} was computed exactly and is not \
+                     identically zero, so the recurrence for the integral is inhomogeneous: \
+                     sum_i a_i(n)*f(n+i) = rhs(n)"
+                )];
+                out.extend(render(conditions));
+                out.push(
+                    "the verdict is a statement about the n at which the integrand, the \
+                     certificate and the integral are all defined; convergence of the \
+                     integral itself is assumed, not proved here"
+                        .into(),
+                );
+                out
+            }
+            IntegralBoundaryStatus::Unknown { reason } => vec![format!(
+                "no recurrence for the integral over {range} may be claimed: {reason}. The \
+                 certificate remains a true identity about the integrand"
+            )],
+        }
+    }
+}
+
+/// Decide the boundary hypothesis for `f(n) = ∫_lower^upper F(n,x) dx`.
+///
+/// `term` must be the same `F(n,x)` that produced `result`, and `n`, `x` the
+/// same symbols. The limits must not depend on `n` — an `n`-dependent limit
+/// would add a Leibniz term this module does not model, so the type does not
+/// admit one.
+///
+/// Never panics on user input; an input it cannot analyse becomes
+/// [`IntegralBoundaryStatus::Unknown`], and a `term` that is not the parsed
+/// integrand is a [`DiffTelescopingError`].
+pub fn integral_boundary_status(
+    result: &AzResult,
+    term: ExprId,
+    n: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+    lower: &IntegrationLimit,
+    upper: &IntegrationLimit,
+) -> Result<IntegralBoundaryStatus, DiffTelescopingError> {
+    let f = HyperExpTerm::parse(term, n, x, pool)?;
+    let r = as_ratk(result.certificate, n, x, pool, 0).ok_or_else(|| {
+        DiffTelescopingError::InvalidInput(
+            "the certificate is not a rational function of the two symbols supplied; it must \
+             come from the same almkvist_zeilberger call as `term`"
+                .into(),
+        )
+    })?;
+    // G = R·F: the certificate folds into the rational prefactor and nothing
+    // else changes, which is exactly why the endpoint analysis below can be
+    // written once for the whole class.
+    let g = HyperExpTerm {
+        rat: f.rat.mul(&r),
+        w: f.w.clone(),
+        eta: f.eta.clone(),
+        powers: f.powers.clone(),
+    };
+    if g.rat.is_zero() {
+        // R·F ≡ 0 is a perfectly good (if degenerate) antiderivative.
+        return Ok(IntegralBoundaryStatus::Vanishes { conditions: vec![] });
+    }
+
+    let hi = endpoint_limit(&g, upper, n, pool);
+    let lo = endpoint_limit(&g, lower, n, pool);
+    Ok(combine(hi, lo, lower, upper, pool))
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint analysis
+// ---------------------------------------------------------------------------
+
+/// What `G` does at one endpoint. `Finite` is *provably nonzero*: it is only
+/// produced when every factor's value is a nonzero element of its own field.
+enum EndpointLimit {
+    Zero { conditions: Vec<ExprId> },
+    Finite(ExprId),
+    Unknown(String),
+}
+
+fn endpoint_limit(
+    g: &HyperExpTerm,
+    limit: &IntegrationLimit,
+    n: ExprId,
+    pool: &ExprPool,
+) -> EndpointLimit {
+    match limit {
+        IntegrationLimit::Finite(c) => finite_endpoint(g, c, n, pool),
+        IntegrationLimit::PosInfinity => infinite_endpoint(g, true, n, pool),
+        IntegrationLimit::NegInfinity => infinite_endpoint(g, false, n, pool),
+    }
+}
+
+fn finite_endpoint(g: &HyperExpTerm, c: &Rational, n: ExprId, pool: &ExprPool) -> EndpointLimit {
+    // exp(η): a pole at the endpoint makes the limit direction-dependent (0 on
+    // one side, ∞ on the other), which this module refuses to guess at.
+    let Some(eta_val) = ratk_eval(&g.eta, c) else {
+        return EndpointLimit::Unknown(format!(
+            "the exponential argument has a pole at x = {c}, so exp(eta) has no two-sided limit \
+             there"
+        ));
+    };
+
+    let Some((rat_ord, rat_val)) = ratk_order_and_value(&g.rat, c) else {
+        return EndpointLimit::Unknown(format!("the rational part of R*F degenerates at x = {c}"));
+    };
+
+    // ν = ord(r) + Σ_j e_j·ord(B_j), an element of Q(n) affine in n.
+    let mut nu = rn_int(rat_ord);
+    let mut any_power_singular = false;
+    let mut power_vals: Vec<(Rn, Rn)> = Vec::with_capacity(g.powers.len());
+    for p in &g.powers {
+        let Some((ord, val)) = ratk_order_and_value(&p.base, c) else {
+            return EndpointLimit::Unknown(format!("a power factor's base degenerates at x = {c}"));
+        };
+        let e = rn_add(
+            &rn_mul(&rn_int(p.alpha), &rn_var()),
+            &rn_rat(p.beta.clone()),
+        );
+        if ord != 0 {
+            any_power_singular = true;
+            nu = rn_add(&nu, &rn_mul(&e, &rn_int(ord)));
+        }
+        power_vals.push((e, val));
+    }
+
+    match positivity(&nu, n, pool) {
+        Positivity::Positive => EndpointLimit::Zero { conditions: vec![] },
+        Positivity::Conditional(cond) => EndpointLimit::Zero {
+            conditions: vec![cond],
+        },
+        Positivity::Zero => {
+            if any_power_singular || rat_ord != 0 {
+                // ν = 0 reached by cancellation: the leading coefficient is a
+                // product of *limits* of vanishing factors raised to symbolic
+                // powers, which is not something to guess at.
+                return EndpointLimit::Unknown(format!(
+                    "the order of R*F at x = {c} is zero only through cancellation between a \
+                     vanishing rational part and a vanishing power factor; the limiting value \
+                     is not determined by this analysis"
+                ));
+            }
+            EndpointLimit::Finite(endpoint_value(g, &rat_val, &eta_val, &power_vals, n, pool))
+        }
+        Positivity::Negative => EndpointLimit::Unknown(format!(
+            "R*F is unbounded as x -> {c} (order {}), so the boundary term does not exist",
+            pool.display(rn_to_expr(pool, n, &nu))
+        )),
+        Positivity::Undecided => EndpointLimit::Unknown(format!(
+            "the order of R*F at x = {c} is {}, whose sign is not an affine condition on n",
+            pool.display(rn_to_expr(pool, n, &nu))
+        )),
+    }
+}
+
+fn infinite_endpoint(g: &HyperExpTerm, at_plus: bool, n: ExprId, pool: &ExprPool) -> EndpointLimit {
+    let where_ = if at_plus { "+oo" } else { "-oo" };
+    // exp(η) dominates every power of x, so when η has a genuine polynomial
+    // part its sign decides the endpoint outright.
+    let eta_deg = ratk_degree(&g.eta);
+    if eta_deg >= 1 {
+        let Some(lead) = ratk_leading_rational(&g.eta) else {
+            return EndpointLimit::Unknown(format!(
+                "the exponential argument grows at {where_} with a leading coefficient that \
+                 depends on n, so the direction of exp(eta) is not decided"
+            ));
+        };
+        let sign_at_end = if at_plus || eta_deg % 2 == 0 {
+            lead.clone()
+        } else {
+            -lead.clone()
+        };
+        return if sign_at_end < 0 {
+            // exp of something tending to −∞ beats any power of x, for every n.
+            EndpointLimit::Zero { conditions: vec![] }
+        } else {
+            EndpointLimit::Unknown(format!(
+                "R*F is unbounded as x -> {where_}: the exponential argument tends to +oo"
+            ))
+        };
+    }
+
+    // η tends to a finite value, so exp(η) is a nonzero constant and the
+    // algebraic degree decides.
+    let mut delta = rn_int(ratk_degree(&g.rat));
+    for p in &g.powers {
+        let e = rn_add(
+            &rn_mul(&rn_int(p.alpha), &rn_var()),
+            &rn_rat(p.beta.clone()),
+        );
+        delta = rn_add(&delta, &rn_mul(&e, &rn_int(ratk_degree(&p.base))));
+    }
+    // G → 0 at infinity exactly when δ < 0, i.e. when −δ > 0.
+    let neg_delta = rn_mul(&delta, &rn_int(-1));
+    match positivity(&neg_delta, n, pool) {
+        Positivity::Positive => EndpointLimit::Zero { conditions: vec![] },
+        Positivity::Conditional(cond) => EndpointLimit::Zero {
+            conditions: vec![cond],
+        },
+        Positivity::Zero | Positivity::Negative => EndpointLimit::Unknown(format!(
+            "R*F does not tend to 0 as x -> {where_}: its algebraic degree there is {}",
+            pool.display(rn_to_expr(pool, n, &delta))
+        )),
+        Positivity::Undecided => EndpointLimit::Unknown(format!(
+            "the degree of R*F at {where_} is {}, whose sign is not an affine condition on n",
+            pool.display(rn_to_expr(pool, n, &delta))
+        )),
+    }
+}
+
+/// `G(c)` when nothing vanishes or blows up there: a product of a nonzero
+/// `Q(n)` element, `wⁿ`, `exp` of a finite value and nonzero powers.
+fn endpoint_value(
+    g: &HyperExpTerm,
+    rat_val: &Rn,
+    eta_val: &Rn,
+    power_vals: &[(Rn, Rn)],
+    n: ExprId,
+    pool: &ExprPool,
+) -> ExprId {
+    let mut factors = vec![rn_to_expr(pool, n, rat_val)];
+    if g.w != 1 {
+        factors.push(pool.pow(rational_expr(pool, &g.w), n));
+    }
+    if !rn_is_zero(eta_val) {
+        factors.push(pool.func("exp", vec![rn_to_expr(pool, n, eta_val)]));
+    }
+    for (e, val) in power_vals {
+        // A zero exponent or a base of 1 contributes nothing; dropping them
+        // keeps `rhs` readable rather than littered with `1**n`.
+        if rn_is_zero(e) || val.eq(&crate::holonomic::qfield::rn_one()) {
+            continue;
+        }
+        factors.push(pool.pow(rn_to_expr(pool, n, val), rn_to_expr(pool, n, e)));
+    }
+    crate::simplify::simplify(pool.mul(factors), pool).value
+}
+
+fn combine(
+    hi: EndpointLimit,
+    lo: EndpointLimit,
+    lower: &IntegrationLimit,
+    upper: &IntegrationLimit,
+    pool: &ExprPool,
+) -> IntegralBoundaryStatus {
+    let range = format!("x = {}..{}", lower.describe(), upper.describe());
+    match (hi, lo) {
+        (EndpointLimit::Unknown(r), _) => IntegralBoundaryStatus::Unknown {
+            reason: format!("at the upper limit of {range}: {r}"),
+        },
+        (_, EndpointLimit::Unknown(r)) => IntegralBoundaryStatus::Unknown {
+            reason: format!("at the lower limit of {range}: {r}"),
+        },
+        (EndpointLimit::Zero { conditions: mut a }, EndpointLimit::Zero { conditions: b }) => {
+            for c in b {
+                if !a.contains(&c) {
+                    a.push(c);
+                }
+            }
+            IntegralBoundaryStatus::Vanishes { conditions: a }
+        }
+        (EndpointLimit::Finite(v), EndpointLimit::Zero { conditions }) => {
+            IntegralBoundaryStatus::Nonzero { rhs: v, conditions }
+        }
+        (EndpointLimit::Zero { conditions }, EndpointLimit::Finite(v)) => {
+            IntegralBoundaryStatus::Nonzero {
+                rhs: crate::simplify::simplify(pool.mul(vec![pool.integer(-1_i32), v]), pool).value,
+                conditions,
+            }
+        }
+        (EndpointLimit::Finite(u), EndpointLimit::Finite(l)) => {
+            if u == l {
+                // Structurally the same value at both ends: the difference is
+                // exactly zero, no numerics involved.
+                IntegralBoundaryStatus::Vanishes { conditions: vec![] }
+            } else {
+                IntegralBoundaryStatus::Unknown {
+                    reason: format!(
+                        "both endpoints of {range} are finite and nonzero ({} and {}), and their \
+                         difference could not be shown to be nonzero without leaving exact \
+                         arithmetic",
+                        pool.display(u),
+                        pool.display(l)
+                    ),
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exact `Q(n)` helpers
+// ---------------------------------------------------------------------------
+
+/// The sign of an element of `Q(n)` that is affine in `n`, as far as it can be
+/// decided without knowing `n`.
+enum Positivity {
+    Positive,
+    Zero,
+    Negative,
+    /// Positive exactly when the carried expression is `> 0`.
+    Conditional(ExprId),
+    /// Not an affine condition in `n` — nothing is claimed.
+    Undecided,
+}
+
+fn positivity(v: &Rn, n: ExprId, pool: &ExprPool) -> Positivity {
+    if v.den.degree() != 0 {
+        return Positivity::Undecided;
+    }
+    match v.num.degree() {
+        d if d < 0 => Positivity::Zero,
+        0 => {
+            let Some(q) = rn_as_rational(v) else {
+                return Positivity::Undecided;
+            };
+            if q > 0 {
+                Positivity::Positive
+            } else if q == 0 {
+                Positivity::Zero
+            } else {
+                Positivity::Negative
+            }
+        }
+        1 => Positivity::Conditional(rn_to_expr(pool, n, v)),
+        _ => Positivity::Undecided,
+    }
+}
+
+fn rn_as_rational(v: &Rn) -> Option<Rational> {
+    if v.num.degree() > 0 || v.den.degree() > 0 {
+        return None;
+    }
+    let a = v
+        .num
+        .coeffs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Rational::from(0));
+    let b = v.den.coeffs.first().cloned()?;
+    if b == 0 {
+        return None;
+    }
+    Some(a / b)
+}
+
+fn rational_expr(pool: &ExprPool, q: &Rational) -> ExprId {
+    if *q.clone().denom() == 1 {
+        pool.integer(q.numer().clone())
+    } else {
+        pool.mul(vec![
+            pool.integer(q.numer().clone()),
+            pool.pow(pool.integer(q.denom().clone()), pool.integer(-1_i32)),
+        ])
+    }
+}
+
+/// `p(c)` for `p ∈ Q(n)[x]` at a rational `c`, by Horner over `Q(n)`.
+fn polyk_eval(p: &PolyK, c: &Rational) -> Rn {
+    let cc = rn_rat(c.clone());
+    let mut acc = rn_zero();
+    for coeff in p.coeffs.iter().rev() {
+        acc = rn_add(&rn_mul(&acc, &cc), coeff);
+    }
+    acc
+}
+
+/// `p(x)/(x − c)` when `p(c) = 0`, by synthetic division over `Q(n)`.
+fn polyk_deflate(p: &PolyK, c: &Rational) -> PolyK {
+    let d = p.degree();
+    if d <= 0 {
+        return PolyK::zero();
+    }
+    let d = d as usize;
+    let cc = rn_rat(c.clone());
+    let mut q = vec![rn_zero(); d];
+    q[d - 1] = p.coeff(d);
+    for i in (1..d).rev() {
+        q[i - 1] = rn_add(&p.coeff(i), &rn_mul(&cc, &q[i]));
+    }
+    PolyK::from_coeffs(q)
+}
+
+/// `(multiplicity of the root c, value of p/(x−c)^mult at c)`.
+///
+/// `None` for the zero polynomial, which has no well-defined order.
+fn polyk_order_and_value(p: &PolyK, c: &Rational) -> Option<(i64, Rn)> {
+    if p.is_zero() {
+        return None;
+    }
+    let mut cur = p.clone();
+    let mut m = 0i64;
+    loop {
+        let val = polyk_eval(&cur, c);
+        if !rn_is_zero(&val) {
+            return Some((m, val));
+        }
+        if cur.degree() <= 0 {
+            return None;
+        }
+        cur = polyk_deflate(&cur, c);
+        m += 1;
+    }
+}
+
+/// `(ord_c(r), lim_{x→c} r(x)/(x−c)^ord)` for `r ∈ Q(n)(x)`.
+fn ratk_order_and_value(r: &RatK, c: &Rational) -> Option<(i64, Rn)> {
+    let (mn, vn) = polyk_order_and_value(&r.num, c)?;
+    let (md, vd) = polyk_order_and_value(&r.den, c)?;
+    let v = crate::holonomic::qfield::rn_div(&vn, &vd)?;
+    Some((mn - md, v))
+}
+
+/// `r(c)`, or `None` when `c` is a pole.
+fn ratk_eval(r: &RatK, c: &Rational) -> Option<Rn> {
+    let den = polyk_eval(&r.den, c);
+    if rn_is_zero(&den) {
+        return None;
+    }
+    crate::holonomic::qfield::rn_div(&polyk_eval(&r.num, c), &den)
+}
+
+/// `deg num − deg den`, the growth exponent at infinity.
+fn ratk_degree(r: &RatK) -> i64 {
+    (r.num.degree() as i64) - (r.den.degree() as i64)
+}
+
+/// The leading coefficient ratio at infinity, when it is a concrete rational.
+fn ratk_leading_rational(r: &RatK) -> Option<Rational> {
+    let lead = crate::holonomic::qfield::rn_div(&r.num.leading_coeff(), &r.den.leading_coeff())?;
+    rn_as_rational(&lead)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::holonomic::azeil::{almkvist_zeilberger, AzOpts};
+    use crate::kernel::Domain;
+
+    fn nx(pool: &ExprPool) -> (ExprId, ExprId) {
+        (
+            pool.symbol("n", Domain::Real),
+            pool.symbol("x", Domain::Real),
+        )
+    }
+
+    fn verdict(
+        f: ExprId,
+        n: ExprId,
+        x: ExprId,
+        pool: &ExprPool,
+        lo: IntegrationLimit,
+        hi: IntegrationLimit,
+    ) -> (AzResult, IntegralBoundaryStatus) {
+        let out = almkvist_zeilberger(f, n, x, pool, &AzOpts::default()).expect("certificate");
+        let status = integral_boundary_status(&out.value, f, n, x, pool, &lo, &hi)
+            .expect("boundary analysis");
+        (out.value, status)
+    }
+
+    /// `∫_0^∞ xⁿ·e^(−x) dx = n!`: the boundary term vanishes at both ends, the
+    /// lower one conditionally on `n + 1 > 0`.
+    #[test]
+    fn gamma_boundary_vanishes() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+        ]);
+        let (r, status) = verdict(
+            f,
+            n,
+            x,
+            &pool,
+            IntegrationLimit::at(0),
+            IntegrationLimit::PosInfinity,
+        );
+        assert_eq!(r.order, 1);
+        assert_eq!(status.tag(), "vanishes");
+        assert!(status.implies_integral_recurrence());
+        assert_eq!(
+            status.conditions().len(),
+            1,
+            "x^(n+1) -> 0 at the origin only for n + 1 > 0"
+        );
+        let conds = status.side_conditions("x = 0..+oo", &pool);
+        assert!(
+            conds.iter().any(|c| c.contains("> 0")),
+            "the positivity condition must be reported: {conds:?}"
+        );
+    }
+
+    /// `∫_{−∞}^{∞} x^(2n)·e^(−x²) dx`: `e^(−x²)` kills both ends
+    /// unconditionally.
+    #[test]
+    fn gaussian_boundary_vanishes_unconditionally() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, pool.mul(vec![pool.integer(2_i32), n])),
+            pool.func(
+                "exp",
+                vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+            ),
+        ]);
+        let (_, status) = verdict(
+            f,
+            n,
+            x,
+            &pool,
+            IntegrationLimit::NegInfinity,
+            IntegrationLimit::PosInfinity,
+        );
+        assert_eq!(status.tag(), "vanishes");
+        assert!(
+            status.conditions().is_empty(),
+            "exp(-x^2) needs no condition on n at either end"
+        );
+    }
+
+    /// `∫_0^1 xⁿ dx = 1/(n+1)`: the boundary term genuinely does **not**
+    /// vanish, and the verdict must say so rather than quietly claim the
+    /// homogeneous relation `f(n) = 0`.
+    #[test]
+    fn nonvanishing_boundary_is_reported_as_nonzero() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.pow(x, n);
+        let (r, status) = verdict(
+            f,
+            n,
+            x,
+            &pool,
+            IntegrationLimit::at(0),
+            IntegrationLimit::at(1),
+        );
+        assert_eq!(r.order, 0, "F = D_x(x/(n+1) * F)");
+        match &status {
+            IntegralBoundaryStatus::Nonzero { rhs, conditions } => {
+                // rhs must be 1/(n+1): check at a couple of integer n.
+                for ni in [2.0_f64, 7.0] {
+                    let env = std::collections::HashMap::from([(n, ni)]);
+                    let got = crate::eval_f64(*rhs, &pool, &env).expect("rhs evaluates");
+                    assert!(
+                        (got - 1.0 / (ni + 1.0)).abs() < 1e-12,
+                        "boundary term at n={ni}: got {got}, want {}",
+                        1.0 / (ni + 1.0)
+                    );
+                }
+                assert_eq!(conditions.len(), 1, "x^(n+1) -> 0 at 0 needs n + 1 > 0");
+            }
+            other => panic!("expected Nonzero, got {other:?}"),
+        }
+        assert!(status.implies_integral_recurrence());
+    }
+
+    /// A divergent integral must be `Unknown`, not `Vanishes`.
+    #[test]
+    fn divergent_upper_limit_is_unknown() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        // ∫_0^∞ xⁿ·eˣ dx diverges; the boundary term at +∞ is unbounded.
+        let f = pool.mul(vec![pool.pow(x, n), pool.func("exp", vec![x])]);
+        let (_, status) = verdict(
+            f,
+            n,
+            x,
+            &pool,
+            IntegrationLimit::at(0),
+            IntegrationLimit::PosInfinity,
+        );
+        assert_eq!(status.tag(), "unknown");
+        assert!(
+            !status.implies_integral_recurrence(),
+            "nothing may be claimed about a divergent integral"
+        );
+    }
+
+    /// `∫_0^1 xⁿ(1−x)ⁿ dx`: vanishes at both ends, conditionally.
+    #[test]
+    fn central_beta_boundary_vanishes() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let one_minus = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let f = pool.mul(vec![pool.pow(x, n), pool.pow(one_minus, n)]);
+        let (r, status) = verdict(
+            f,
+            n,
+            x,
+            &pool,
+            IntegrationLimit::at(0),
+            IntegrationLimit::at(1),
+        );
+        assert_eq!(r.order, 1);
+        assert_eq!(status.tag(), "vanishes", "got {status:?}");
+        assert!(
+            !status.conditions().is_empty(),
+            "the endpoints vanish only for n large enough"
+        );
+    }
+
+    /// An `Unknown` verdict must never be readable as a vanishing boundary, and
+    /// `side_conditions` must say so in words.
+    #[test]
+    fn unknown_reads_as_unknown() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![pool.pow(x, n), pool.func("exp", vec![x])]);
+        let (_, status) = verdict(
+            f,
+            n,
+            x,
+            &pool,
+            IntegrationLimit::at(0),
+            IntegrationLimit::PosInfinity,
+        );
+        let sc = status.side_conditions("x = 0..+oo", &pool);
+        assert!(
+            sc.iter().any(|s| s.contains("may be claimed")),
+            "an Unknown verdict must state that nothing follows: {sc:?}"
+        );
+    }
+
+    #[test]
+    fn certificate_from_a_different_call_is_refused() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.pow(x, n);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let mut bogus = out.value.clone();
+        bogus.certificate = pool.func("exp", vec![x]);
+        let err = integral_boundary_status(
+            &bogus,
+            f,
+            n,
+            x,
+            &pool,
+            &IntegrationLimit::at(0),
+            &IntegrationLimit::at(1),
+        )
+        .expect_err("a non-rational certificate is not from this engine");
+        assert!(matches!(err, DiffTelescopingError::InvalidInput(_)));
+    }
+}

--- a/alkahest-core/src/holonomic/azeil/dgosper.rs
+++ b/alkahest-core/src/holonomic/azeil/dgosper.rs
@@ -1,0 +1,276 @@
+//! **Differential Gosper**: indefinite integration in the hyperexponential
+//! class.
+//!
+//! Given a hyperexponential `F`, decide whether
+//!
+//! ```text
+//! ∫ F dx = R·F     for some rational R,
+//! ```
+//!
+//! and return `R` when it exists. This is the exact differential mirror of
+//! Gosper's algorithm — "is the antiderivative of a hyperexponential term again
+//! a *rational multiple* of that term" plays the same role as "is the
+//! antidifference of a hypergeometric term again a rational multiple of it" —
+//! and it is the inner loop `super::search` runs at every order.
+//!
+//! # It is one equation
+//!
+//! `D_x(R·F) = (R′ + θ·R)·F` with `θ = ∂_x F/F`, so the question is exactly
+//! whether the Risch differential equation
+//!
+//! ```text
+//! R′ + θ·R = 1
+//! ```
+//!
+//! has a rational solution. That is [`super::rde`] with `J = 0` and `a_0 = 1`,
+//! and it is solved there — including the reason
+//! `integrate::risch::rational_rde` is not called instead, which is a
+//! correctness reason and not a stylistic one.
+//!
+//! # What a returned `R` is and is not
+//!
+//! It is a proof: `R` is re-differentiated and `R′ + θ·R = 1` is checked as an
+//! exact identity in `Q(n)(x)` before [`dgosper`] returns. It is not a claim
+//! about *convergence* or about branches — `∫ x^(−1/2) dx = 2·x^(1/2)` comes
+//! back as `R = 2x`, which is the correct formal antiderivative on either side
+//! of `0` and says nothing about `∫_{−1}^{1}`.
+//!
+//! A refusal is a refusal of *this* method, not a proof that no elementary
+//! antiderivative exists. `∫ eˣ/x dx` has none in the hyperexponential class
+//! (it is `Ei(x)`), and `∫ e^(x²) dx` likewise, so both are genuine
+//! Liouville-theoretic non-existence — but [`dgosper`] reports both the same
+//! way it reports "the `κ`/`d` bounds ran out", as
+//! [`super::DiffTelescopingError::SearchExhausted`]. Do not read it as a
+//! non-existence theorem.
+
+use super::hyperexp::{fresh_outer_index, HyperExpTerm};
+use super::rde::{solve_probe, verify, RdeSetup};
+use super::{AzOpts, DiffTelescopingError};
+use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
+use crate::holonomic::hyperterm::ratk_to_expr;
+use crate::holonomic::qfield::RatK;
+use crate::kernel::{ExprId, ExprPool};
+
+/// `∫ F dx = R·F` with `R` rational, or a typed refusal.
+///
+/// `f` must be hyperexponential in `x` (see [`super::hyperexp`]); it may not
+/// contain any other free symbol, since `Q(x)` is the field the certificate
+/// lives in. The returned expression is `R`, exactly, in lowest terms.
+///
+/// `opts.max_order` is ignored — the order is `0` by definition here. Only
+/// `max_degree` and `max_den_power` bound the search.
+///
+/// ```
+/// use alkahest_cas::kernel::{Domain, ExprPool};
+/// use alkahest_cas::holonomic::azeil::{dgosper, AzOpts};
+///
+/// let pool = ExprPool::new();
+/// let x = pool.symbol("x", Domain::Real);
+/// // ∫ x·eˣ dx = (x−1)·eˣ, so R = (x−1)/x.
+/// let f = pool.mul(vec![x, pool.func("exp", vec![x])]);
+/// let r = dgosper(f, x, &pool, &AzOpts::default()).expect("hyperexponential antiderivative");
+/// // The certificate is verified as an exact identity before it is returned.
+/// assert!(format!("{}", pool.display(r.value)).contains('x'));
+/// ```
+pub fn dgosper(
+    f: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+    opts: &AzOpts,
+) -> Result<DerivedExpr<ExprId>, DiffTelescopingError> {
+    let n = fresh_outer_index(pool);
+    if n == x {
+        return Err(DiffTelescopingError::InvalidInput(
+            "the integration variable collides with the internal outer index".into(),
+        ));
+    }
+    let term = HyperExpTerm::parse(f, n, x, pool)?;
+    let r = dgosper_term(&term, opts)?;
+    let expr = ratk_to_expr(pool, n, x, &r);
+
+    let mut log = DerivationLog::new();
+    log.push(RewriteStep::simple("dgosper_certificate", f, expr));
+    Ok(DerivedExpr::with_log(expr, log))
+}
+
+/// [`dgosper`] on an already-parsed term, returning the certificate as an exact
+/// `Q(n)(x)` element.
+///
+/// Split out because `super::search` and the boundary analysis both want the
+/// exact object rather than an expression, and because a caller who already has
+/// a [`HyperExpTerm`] should not have to round-trip it through the parser.
+pub fn dgosper_term(term: &HyperExpTerm, opts: &AzOpts) -> Result<RatK, DiffTelescopingError> {
+    let theta = term.theta()?;
+    let setup = RdeSetup::new(&theta, vec![RatK::one()]).ok_or_else(|| {
+        DiffTelescopingError::SearchExhausted(
+            "the logarithmic derivative has a degenerate denominator".into(),
+        )
+    })?;
+
+    let mut saw_candidate = false;
+    for kappa in 0..=opts.max_den_power {
+        for d in 0..=opts.max_degree {
+            let Some(cand) = solve_probe(&setup, kappa, d) else {
+                continue;
+            };
+            saw_candidate = true;
+            // The only acceptance test: an exact identity in Q(n)(x).
+            if verify(&setup, &cand.a, &cand.r) {
+                return Ok(cand.r);
+            }
+        }
+    }
+    Err(if saw_candidate {
+        DiffTelescopingError::CertificateVerificationFailed(
+            "every candidate R found by the ansatz search failed the exact R' + theta*R = 1 \
+             check in Q(n)(x)"
+                .into(),
+        )
+    } else {
+        DiffTelescopingError::SearchExhausted(format!(
+            "no rational R with (R*F)' = F was found with deg R numerator <= {} and \
+             certificate denominator power <= {}; this is a limit of the search, not a proof \
+             that no elementary antiderivative exists",
+            opts.max_degree, opts.max_den_power
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::holonomic::azeil::hyperexp::hyperexp_log_derivative;
+    use crate::holonomic::hyperterm::as_ratk;
+    use crate::kernel::Domain;
+
+    fn pool_x() -> (ExprPool, ExprId) {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        (pool, x)
+    }
+
+    /// Independent check: parse `R` back and confirm `(R·F)' = F` by testing
+    /// `R' + θ·R = 1` in exact `Q(x)` arithmetic, using nothing the search
+    /// produced beyond `R` itself.
+    fn assert_is_antiderivative(f: ExprId, r: ExprId, x: ExprId, pool: &ExprPool) {
+        let n = fresh_outer_index(pool);
+        let theta_expr = hyperexp_log_derivative(f, x, pool).expect("hyperexponential");
+        let theta = as_ratk(theta_expr, n, x, pool, 0).expect("theta is rational");
+        let rr = as_ratk(r, n, x, pool, 0).expect("R is rational");
+        let lhs = crate::holonomic::qfield::ratk_deriv_k(&rr).add(&theta.mul(&rr));
+        assert!(
+            lhs.eq_ratk(&RatK::one()),
+            "R' + theta*R must be 1; got {} for R = {}",
+            pool.display(ratk_to_expr(pool, n, x, &lhs)),
+            pool.display(r)
+        );
+    }
+
+    #[test]
+    fn exp_is_its_own_antiderivative() {
+        let (pool, x) = pool_x();
+        let f = pool.func("exp", vec![x]);
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("R = 1");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+
+    #[test]
+    fn x_times_exp_x() {
+        // ∫ x·eˣ = (x−1)·eˣ ⇒ R = (x−1)/x, a simple pole at a simple pole of θ
+        // with residue 1: the κ = 1 case.
+        let (pool, x) = pool_x();
+        let f = pool.mul(vec![x, pool.func("exp", vec![x])]);
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+
+    #[test]
+    fn x_squared_times_exp_x_needs_a_double_pole() {
+        // ∫ x²·eˣ = (x²−2x+2)·eˣ ⇒ R = (x²−2x+2)/x². This is the case the
+        // `E = gcd(D, D')` denominator bound in `integrate::risch::rational_rde`
+        // misses, and the reason this module does not delegate to it.
+        let (pool, x) = pool_x();
+        let f = pool.mul(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.func("exp", vec![x]),
+        ]);
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+
+    #[test]
+    fn gaussian_derivative() {
+        // ∫ x·e^(−x²) dx = −e^(−x²)/2 ⇒ R = −1/(2x).
+        let (pool, x) = pool_x();
+        let f = pool.mul(vec![
+            x,
+            pool.func(
+                "exp",
+                vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+            ),
+        ]);
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+
+    #[test]
+    fn rational_power() {
+        // ∫ x^(−1/2) dx = 2·x^(1/2) ⇒ R = 2x. Formal: says nothing about x < 0.
+        let (pool, x) = pool_x();
+        let f = pool.pow(x, pool.rational(-1, 2));
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+
+    #[test]
+    fn a_polynomial_is_hyperexponential_too() {
+        // θ = 3/(x+1) for F = (x+1)³; ∫F = (x+1)⁴/4 ⇒ R = (x+1)/4.
+        let (pool, x) = pool_x();
+        let base = pool.add(vec![x, pool.integer(1_i32)]);
+        let f = pool.pow(base, pool.integer(3_i32));
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+
+    #[test]
+    fn exp_over_x_has_no_hyperexponential_antiderivative() {
+        // ∫ eˣ/x dx = Ei(x): genuinely not of the form R·F. Must refuse, not
+        // return something wrong.
+        let (pool, x) = pool_x();
+        let f = pool.mul(vec![
+            pool.func("exp", vec![x]),
+            pool.pow(x, pool.integer(-1_i32)),
+        ]);
+        let err = dgosper(f, x, &pool, &AzOpts::default()).expect_err("Ei is not R*F");
+        assert!(
+            matches!(err, DiffTelescopingError::SearchExhausted(_)),
+            "expected a search refusal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn erf_has_no_hyperexponential_antiderivative() {
+        // ∫ e^(x²) dx is not elementary at all.
+        let (pool, x) = pool_x();
+        let f = pool.func("exp", vec![pool.pow(x, pool.integer(2_i32))]);
+        let err = dgosper(f, x, &pool, &AzOpts::default()).expect_err("erfi is not R*F");
+        assert!(matches!(err, DiffTelescopingError::SearchExhausted(_)));
+    }
+
+    #[test]
+    fn non_hyperexponential_input_is_refused_cleanly() {
+        let (pool, x) = pool_x();
+        let f = pool.func("log", vec![x]);
+        let err = dgosper(f, x, &pool, &AzOpts::default()).expect_err("log is out of class");
+        assert!(matches!(err, DiffTelescopingError::NotHyperexponential(_)));
+    }
+
+    #[test]
+    fn certificate_is_exact_for_a_rational_integrand() {
+        // ∫ 1/x² dx = −1/x: F = x^(−2), R = −x.
+        let (pool, x) = pool_x();
+        let f = pool.pow(x, pool.integer(-2_i32));
+        let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_is_antiderivative(f, r.value, x, &pool);
+    }
+}

--- a/alkahest-core/src/holonomic/azeil/hyperexp.rs
+++ b/alkahest-core/src/holonomic/azeil/hyperexp.rs
@@ -1,0 +1,838 @@
+//! Recognising *hyperexponential* terms and computing their exact logarithmic
+//! derivative and shift ratios.
+//!
+//! `F` is **hyperexponential** in `x` when `F'/F` is a rational function —
+//! equivalently `F = exp(∫ r)` for a rational `r`. That logarithmic derivative
+//! is the whole content of `F` as far as differential creative telescoping is
+//! concerned, the way `F(n,k+1)/F(n,k)` is in the discrete case.
+//!
+//! The class this module parses, the differential mirror of
+//! [`super::super::hyperterm::ProperTerm`], is
+//!
+//! ```text
+//! F(n, x) = R(n, x) · wⁿ · exp(η(n, x)) · ∏_j B_j(n, x)^(α_j·n + β_j)
+//! ```
+//!
+//! with `R, η, B_j ∈ Q(n)(x)`, `w ∈ Q \ {0}`, `α_j ∈ Z`, `β_j ∈ Q`. Its two
+//! certificates are:
+//!
+//! - [`HyperExpTerm::theta`] — `∂_x F / F ∈ Q(n)(x)`, always available:
+//!   ```text
+//!   θ = R'/R + ∂_x η + Σ_j (α_j·n + β_j)·B_j'/B_j
+//!   ```
+//! - [`HyperExpTerm::ratio_n`] — `F(n+i, x)/F(n, x) ∈ Q(n)(x)`, available only
+//!   when `F` is *also* hypergeometric in `n`:
+//!   ```text
+//!   F(n+i,x)/F(n,x) = (R(n+i,x)/R(n,x)) · wⁱ · ∏_j B_j^(α_j·i)
+//!   ```
+//!
+//! The two are deliberately split, and the split is not cosmetic. `exp(n·x)` is
+//! hyperexponential in `x` (`θ = n`) and its `n`-ratio is `eˣ`, which is not
+//! rational: [`HyperExpTerm::theta`] succeeds and [`HyperExpTerm::ratio_n`]
+//! refuses with [`DiffTelescopingError::NotHypergeometricInN`]. A caller doing
+//! indefinite integration (`super::dgosper`) only needs the first; creative
+//! telescoping (`super::search`) needs both, and gets a *specific* refusal
+//! rather than "not hyperexponential" when only the second is missing.
+//!
+//! # Why `η` and the `B_j` may carry `n` for `theta` but not for `ratio_n`
+//!
+//! `∂_x` is `Q(n)`-linear, so any `n`-dependence is inert for the logarithmic
+//! derivative. The `n`-shift is a different matter: `exp(η(n+i,x) − η(n,x))` is
+//! rational only when `η(n+i,·) = η(n,·)`, and `B(n+i,x)^(…)/B(n,x)^(…)` only
+//! when the base is `n`-free (or the exponent is an `n`-free integer, in which
+//! case the parser has already folded the factor into `R`). Both conditions are
+//! *checked* by [`HyperExpTerm::ratio_n`] rather than assumed at parse time,
+//! which is what lets the parser accept the wider `x`-only class.
+//!
+//! # Branches
+//!
+//! `B^β` for non-integer `β` is a formal symbol here, with `(B^β)' = β·B'/B·B^β`
+//! by fiat. Every identity this module underwrites is therefore an identity of
+//! formal hyperexponential expressions; turning it into an identity of
+//! *functions* needs a consistent branch of `B^β` on the domain in question.
+//! See the [module docs](super) — this is stated, not silently assumed.
+
+use super::DiffTelescopingError;
+use crate::holonomic::hyperterm::{affine_parts, as_ratk, ratk_to_expr};
+use crate::holonomic::qfield::{ratk_deriv_k, rn_add, rn_int, rn_mul, rn_rat, rn_var, RatK};
+use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
+use rug::Rational;
+
+/// Largest integer exponent accepted on a sub-term (guards against blow-up).
+const MAX_POW: i32 = 32;
+/// Largest `|α·i|` accepted when forming an `n`-shift ratio.
+const MAX_SHIFT_POW: i64 = 512;
+/// Largest nesting depth the parser will descend.
+const MAX_PARSE_DEPTH: usize = 64;
+
+/// One `B(n,x)^(α·n + β)` factor.
+///
+/// `α = 0` with `β ∈ Z` never reaches here: the parser folds an integer power
+/// into the rational prefactor instead, which is what keeps
+/// [`HyperExpTerm::ratio_n`]'s "the base must be `n`-free" check from rejecting
+/// perfectly ordinary rational integrands.
+#[derive(Clone, Debug)]
+pub struct PowerFactor {
+    /// The base `B`, an exact element of `Q(n)(x)`.
+    pub base: RatK,
+    /// Coefficient of `n` in the exponent.
+    pub alpha: i64,
+    /// Constant part of the exponent.
+    pub beta: Rational,
+}
+
+/// A parsed hyperexponential term
+/// `F = rat · w^n · exp(eta) · ∏ powers[j].base ^ (α_j·n + β_j)`.
+#[derive(Clone, Debug)]
+pub struct HyperExpTerm {
+    /// Rational-function prefactor `R(n, x)`.
+    pub rat: RatK,
+    /// Base of the `wⁿ` factor.
+    pub w: Rational,
+    /// Exponent of the `exp(η)` factor.
+    pub eta: RatK,
+    /// The `B^(α·n + β)` factors.
+    pub powers: Vec<PowerFactor>,
+}
+
+impl HyperExpTerm {
+    fn one() -> Self {
+        HyperExpTerm {
+            rat: RatK::one(),
+            w: Rational::from(1),
+            eta: RatK::zero(),
+            powers: Vec::new(),
+        }
+    }
+
+    fn from_ratk(r: RatK) -> Self {
+        HyperExpTerm {
+            rat: r,
+            w: Rational::from(1),
+            eta: RatK::zero(),
+            powers: Vec::new(),
+        }
+    }
+
+    fn mul(&self, other: &HyperExpTerm) -> HyperExpTerm {
+        let mut powers = self.powers.clone();
+        powers.extend(other.powers.iter().cloned());
+        HyperExpTerm {
+            rat: self.rat.mul(&other.rat),
+            w: self.w.clone() * other.w.clone(),
+            eta: self.eta.add(&other.eta),
+            powers,
+        }
+    }
+
+    fn pow(&self, e: i32) -> Result<HyperExpTerm, DiffTelescopingError> {
+        if e.unsigned_abs() > MAX_POW as u32 {
+            return Err(DiffTelescopingError::NotHyperexponential(format!(
+                "exponent {e} is outside the supported range (|e| ≤ {MAX_POW})"
+            )));
+        }
+        let rat = self.rat.pow_i32(e).ok_or_else(|| {
+            DiffTelescopingError::NotHyperexponential(
+                "a factor raised to a negative power is identically zero".into(),
+            )
+        })?;
+        let scale = RatK::from_rn(rn_int(e as i64));
+        let powers = self
+            .powers
+            .iter()
+            .map(|p| {
+                Ok(PowerFactor {
+                    base: p.base.clone(),
+                    alpha: p.alpha.checked_mul(e as i64).ok_or_else(|| {
+                        DiffTelescopingError::NotHyperexponential(
+                            "exponent overflow in a power factor".into(),
+                        )
+                    })?,
+                    beta: p.beta.clone() * Rational::from(e),
+                })
+            })
+            .collect::<Result<Vec<_>, DiffTelescopingError>>()?;
+        Ok(HyperExpTerm {
+            rat,
+            w: rat_pow(&self.w, e as i64)?,
+            eta: self.eta.mul(&scale),
+            powers,
+        })
+    }
+
+    /// `∂_x F / F` as an exact element of `Q(n)(x)`.
+    ///
+    /// This is the stage-1 certificate: it *is* the statement that `F` is
+    /// hyperexponential, written down exactly.
+    pub fn theta(&self) -> Result<RatK, DiffTelescopingError> {
+        if self.rat.is_zero() {
+            return Err(DiffTelescopingError::NotHyperexponential(
+                "the term is identically zero, so F'/F is undefined".into(),
+            ));
+        }
+        let mut acc = log_deriv(&self.rat)?;
+        acc = acc.add(&ratk_deriv_k(&self.eta));
+        for p in &self.powers {
+            let e = RatK::from_rn(rn_add(
+                &rn_mul(&rn_int(p.alpha), &rn_var()),
+                &rn_rat(p.beta.clone()),
+            ));
+            acc = acc.add(&e.mul(&log_deriv(&p.base)?));
+        }
+        Ok(acc)
+    }
+
+    /// `F(n+i, x) / F(n, x)` as an exact element of `Q(n)(x)`.
+    ///
+    /// Refuses with [`DiffTelescopingError::NotHypergeometricInN`] when the
+    /// ratio is not rational — which is a statement about `F`, not about this
+    /// parser's reach, and closes the branch for every algorithm in this
+    /// family.
+    pub fn ratio_n(&self, i: i64) -> Result<RatK, DiffTelescopingError> {
+        if i == 0 {
+            return Ok(RatK::one());
+        }
+        if self.rat.is_zero() {
+            return Err(DiffTelescopingError::NotHyperexponential(
+                "the term is identically zero".into(),
+            ));
+        }
+        if !self.eta.shift_n(i).eq_ratk(&self.eta) {
+            return Err(DiffTelescopingError::NotHypergeometricInN(
+                "the argument of exp depends on n, so F(n+i,x)/F(n,x) contains \
+                 exp(eta(n+i,x) - eta(n,x)), which is not a rational function of x"
+                    .into(),
+            ));
+        }
+        let mut acc = self.rat.shift_n(i).div(&self.rat).ok_or_else(|| {
+            DiffTelescopingError::NotHyperexponential("the term is identically zero".into())
+        })?;
+        acc = acc.mul(&RatK::from_rn(rn_rat(rat_pow(&self.w, i)?)));
+        for p in &self.powers {
+            if !p.base.shift_n(i).eq_ratk(&p.base) {
+                return Err(DiffTelescopingError::NotHypergeometricInN(
+                    "the base of a symbolic power depends on n, so the n-shift ratio is not \
+                     a rational function of x"
+                        .into(),
+                ));
+            }
+            let shift = p.alpha.checked_mul(i).ok_or_else(|| {
+                DiffTelescopingError::NotHypergeometricInN("exponent overflow".into())
+            })?;
+            if shift == 0 {
+                continue;
+            }
+            if shift.abs() > MAX_SHIFT_POW {
+                return Err(DiffTelescopingError::SearchExhausted(format!(
+                    "n-shift exponent {shift} exceeds the supported limit of {MAX_SHIFT_POW}"
+                )));
+            }
+            let step = p.base.pow_i32(shift as i32).ok_or_else(|| {
+                DiffTelescopingError::NotHyperexponential(
+                    "a power factor's base is identically zero".into(),
+                )
+            })?;
+            acc = acc.mul(&step);
+        }
+        Ok(acc)
+    }
+
+    /// Parse an expression into the hyperexponential class in `(n, x)`.
+    ///
+    /// `n` may be any symbol that does not occur in `expr` when only the
+    /// `x`-side is wanted; see [`hyperexp_log_derivative`].
+    pub fn parse(
+        expr: ExprId,
+        n: ExprId,
+        x: ExprId,
+        pool: &ExprPool,
+    ) -> Result<HyperExpTerm, DiffTelescopingError> {
+        if n == x {
+            return Err(DiffTelescopingError::InvalidInput(
+                "the outer index n and the integration variable x must be distinct symbols".into(),
+            ));
+        }
+        parse_rec(expr, n, x, pool, 0)
+    }
+}
+
+/// `p'/p` for a nonzero `p ∈ Q(n)(x)`.
+fn log_deriv(p: &RatK) -> Result<RatK, DiffTelescopingError> {
+    ratk_deriv_k(p).div(p).ok_or_else(|| {
+        DiffTelescopingError::NotHyperexponential(
+            "a factor of the term is identically zero, so its logarithmic derivative is \
+             undefined"
+                .into(),
+        )
+    })
+}
+
+fn rat_pow(q: &Rational, e: i64) -> Result<Rational, DiffTelescopingError> {
+    if e == 0 {
+        return Ok(Rational::from(1));
+    }
+    if e.unsigned_abs() > 1024 {
+        return Err(DiffTelescopingError::NotHyperexponential(
+            "exponential factor exponent exceeds the supported limit".into(),
+        ));
+    }
+    if *q == 0 {
+        if e < 0 {
+            return Err(DiffTelescopingError::NotHyperexponential(
+                "zero base raised to a negative power".into(),
+            ));
+        }
+        return Ok(Rational::from(0));
+    }
+    let base = if e < 0 { q.clone().recip() } else { q.clone() };
+    let mut acc = Rational::from(1);
+    for _ in 0..e.unsigned_abs() {
+        acc *= base.clone();
+    }
+    Ok(acc)
+}
+
+fn parse_rec(
+    expr: ExprId,
+    n: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<HyperExpTerm, DiffTelescopingError> {
+    if depth > MAX_PARSE_DEPTH {
+        return Err(DiffTelescopingError::NotHyperexponential(
+            "expression nests deeper than the parser supports".into(),
+        ));
+    }
+    // Fast path: a purely rational sub-expression contributes only to `R`.
+    if let Some(r) = as_ratk(expr, n, x, pool, 0) {
+        return Ok(HyperExpTerm::from_ratk(r));
+    }
+    match pool.get(expr) {
+        ExprData::Mul(args) => {
+            let mut acc = HyperExpTerm::one();
+            for a in args {
+                acc = acc.mul(&parse_rec(a, n, x, pool, depth + 1)?);
+            }
+            Ok(acc)
+        }
+        ExprData::Pow { base, exp } => parse_pow(base, exp, n, x, pool, depth),
+        ExprData::Func { name, args } => parse_func(&name, &args, n, x, pool, depth),
+        ExprData::Add(_) => Err(DiffTelescopingError::NotHyperexponential(format!(
+            "a sum of hyperexponential terms is not itself hyperexponential (unless it is \
+             rational, which {} is not)",
+            pool.display(expr)
+        ))),
+        other => Err(DiffTelescopingError::NotHyperexponential(format!(
+            "unsupported node {other:?} in {}",
+            pool.display(expr)
+        ))),
+    }
+}
+
+fn parse_pow(
+    base: ExprId,
+    exp: ExprId,
+    n: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<HyperExpTerm, DiffTelescopingError> {
+    // An integer literal exponent is a plain power of whatever the base parses to.
+    if let ExprData::Integer(i) = pool.get(exp) {
+        let Some(e) = i.0.to_i32() else {
+            return Err(DiffTelescopingError::NotHyperexponential(
+                "integer exponent does not fit in i32".into(),
+            ));
+        };
+        return parse_rec(base, n, x, pool, depth + 1)?.pow(e);
+    }
+
+    // Otherwise the exponent must be `α·n + β` with `α ∈ Z`, `β ∈ Q`, and in
+    // particular free of `x`: `B(x)^x` is not hyperexponential (its logarithmic
+    // derivative contains `log B`).
+    let (alpha, x_coeff, beta) = affine_parts(exp, n, x, pool).ok_or_else(|| {
+        DiffTelescopingError::NotHyperexponential(format!(
+            "exponent {} is not of the form a*n + b with integer a and rational b",
+            pool.display(exp)
+        ))
+    })?;
+    if x_coeff != 0 {
+        return Err(DiffTelescopingError::NotHyperexponential(format!(
+            "exponent {} depends on the integration variable; c**x is hyperexponential only \
+             over a field containing log(c), which Q(n)(x) is not",
+            pool.display(exp)
+        )));
+    }
+
+    // `α = 0` and `β ∈ Z`: an ordinary rational power. Fold it into `R` so that
+    // `ratio_n`'s "the base must be n-free" check never sees it.
+    if alpha == 0 {
+        if let Some(b) = rational_to_i32(&beta) {
+            let inner = parse_rec(base, n, x, pool, depth + 1)?;
+            return inner.pow(b);
+        }
+    }
+
+    let b = as_ratk(base, n, x, pool, 0).ok_or_else(|| {
+        DiffTelescopingError::NotHyperexponential(format!(
+            "a symbolic power needs a rational-function base, got {}",
+            pool.display(base)
+        ))
+    })?;
+    if b.is_zero() {
+        return Err(DiffTelescopingError::NotHyperexponential(
+            "zero raised to a symbolic power".into(),
+        ));
+    }
+    // A base that is a nonzero `x`-free constant is a `wⁿ` factor, not a power
+    // factor: it contributes nothing to `θ` and `w^i` to the shift ratio.
+    if let Some(c) = ratk_as_rational(&b) {
+        let bi = rational_to_i32(&beta).ok_or_else(|| {
+            DiffTelescopingError::NotHyperexponential(
+                "a rational base raised to a non-integer constant power leaves Q (e.g. 2**(1/2))"
+                    .into(),
+            )
+        })?;
+        return Ok(HyperExpTerm {
+            rat: RatK::from_rn(rn_rat(rat_pow(&c, bi as i64)?)),
+            w: rat_pow(&c, alpha)?,
+            eta: RatK::zero(),
+            powers: Vec::new(),
+        });
+    }
+    Ok(HyperExpTerm {
+        rat: RatK::one(),
+        w: Rational::from(1),
+        eta: RatK::zero(),
+        powers: vec![PowerFactor {
+            base: b,
+            alpha,
+            beta,
+        }],
+    })
+}
+
+fn parse_func(
+    name: &str,
+    args: &[ExprId],
+    n: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+    depth: usize,
+) -> Result<HyperExpTerm, DiffTelescopingError> {
+    match (name, args.len()) {
+        ("exp", 1) => {
+            let eta = as_ratk(args[0], n, x, pool, 0).ok_or_else(|| {
+                DiffTelescopingError::NotHyperexponential(format!(
+                    "exp(...) is hyperexponential only when its argument is a rational \
+                     function of the indices; got exp({})",
+                    pool.display(args[0])
+                ))
+            })?;
+            Ok(HyperExpTerm {
+                rat: RatK::one(),
+                w: Rational::from(1),
+                eta,
+                powers: Vec::new(),
+            })
+        }
+        ("sqrt", 1) => {
+            let inner = parse_rec(args[0], n, x, pool, depth + 1)?;
+            // sqrt(F) is hyperexponential whenever F is, with every exponent
+            // halved — but only the rational-power part can be halved exactly,
+            // so a non-square rational prefactor becomes a power factor.
+            let mut out = HyperExpTerm {
+                rat: RatK::one(),
+                w: Rational::from(1),
+                eta: inner
+                    .eta
+                    .mul(&RatK::from_rn(rn_rat(Rational::from((1, 2))))),
+                powers: inner
+                    .powers
+                    .iter()
+                    .map(|p| {
+                        if p.alpha % 2 != 0 {
+                            return Err(DiffTelescopingError::NotHyperexponential(
+                                "sqrt of a factor with an odd n-exponent leaves the class \
+                                 (its n-shift ratio would be a square root)"
+                                    .into(),
+                            ));
+                        }
+                        Ok(PowerFactor {
+                            base: p.base.clone(),
+                            alpha: p.alpha / 2,
+                            beta: p.beta.clone() / Rational::from(2),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            };
+            if inner.w != 1 {
+                return Err(DiffTelescopingError::NotHyperexponential(
+                    "sqrt of a w**n factor leaves Q".into(),
+                ));
+            }
+            if !inner.rat.eq_ratk(&RatK::one()) {
+                out.powers.push(PowerFactor {
+                    base: inner.rat.clone(),
+                    alpha: 0,
+                    beta: Rational::from((1, 2)),
+                });
+            }
+            Ok(out)
+        }
+        _ => Err(DiffTelescopingError::NotHyperexponential(format!(
+            "function `{name}/{}` is not part of the hyperexponential class \
+             (supported heads: exp, sqrt)",
+            args.len()
+        ))),
+    }
+}
+
+fn rational_to_i32(q: &Rational) -> Option<i32> {
+    if *q.clone().denom() != 1 {
+        return None;
+    }
+    q.numer().to_i32()
+}
+
+/// A `Q(n)(x)` element that is a plain rational number, or `None`.
+fn ratk_as_rational(r: &RatK) -> Option<Rational> {
+    if r.num.degree() > 0 || r.den.degree() > 0 {
+        return None;
+    }
+    let num = r.num.coeff(0);
+    let den = r.den.coeff(0);
+    let q = crate::holonomic::qfield::rn_div(&num, &den)?;
+    if q.num.degree() > 0 || q.den.degree() > 0 {
+        return None;
+    }
+    let a = q.num.coeffs.first().cloned()?;
+    let b = q.den.coeffs.first().cloned()?;
+    if b == 0 {
+        return None;
+    }
+    Some(a / b)
+}
+
+/// Stage-1 entry point for the univariate case: `F'(x)/F(x)` as an expression
+/// in `x`, for a hyperexponential `F`.
+///
+/// The returned expression is the exact logarithmic-derivative certificate:
+/// `F = exp(∫ θ)` with `θ` rational, which is the definition of
+/// hyperexponential. No `n` is involved, so a fresh internal symbol stands in
+/// for the outer index and cannot appear in the result.
+pub fn hyperexp_log_derivative(
+    f: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+) -> Result<ExprId, DiffTelescopingError> {
+    let n = fresh_outer_index(pool);
+    let term = HyperExpTerm::parse(f, n, x, pool)?;
+    let theta = term.theta()?;
+    Ok(ratk_to_expr(pool, n, x, &theta))
+}
+
+/// A symbol for the outer index in calls that have no genuine outer index.
+///
+/// The name is deliberately not a plausible user symbol. Nothing in a
+/// univariate call can *produce* an occurrence of it, so its only effect is to
+/// give the shared bivariate machinery a second variable to be constant in.
+pub(super) fn fresh_outer_index(pool: &ExprPool) -> ExprId {
+    pool.symbol("__azeil_no_outer_index", Domain::Real)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::holonomic::hyperterm::ratk_to_expr;
+    use crate::kernel::Domain;
+
+    fn nx(pool: &ExprPool) -> (ExprId, ExprId) {
+        (
+            pool.symbol("n", Domain::Real),
+            pool.symbol("x", Domain::Real),
+        )
+    }
+
+    fn theta_str(expr: ExprId, pool: &ExprPool) -> String {
+        let (n, x) = nx(pool);
+        let t = HyperExpTerm::parse(expr, n, x, pool)
+            .expect("term parses")
+            .theta()
+            .expect("theta exists");
+        format!("{}", pool.display(ratk_to_expr(pool, n, x, &t)))
+    }
+
+    /// `θ` is a *function*, so comparing it against a hand-written expected
+    /// value is done by exact `Q(n)(x)` equality, not by string matching.
+    fn assert_theta_eq(expr: ExprId, expected: ExprId, pool: &ExprPool) {
+        let (n, x) = nx(pool);
+        let t = HyperExpTerm::parse(expr, n, x, pool)
+            .expect("term parses")
+            .theta()
+            .expect("theta exists");
+        let want = as_ratk(expected, n, x, pool, 0).expect("expected value is rational");
+        assert!(
+            t.eq_ratk(&want),
+            "theta mismatch: got {}, want {}",
+            pool.display(ratk_to_expr(pool, n, x, &t)),
+            pool.display(expected)
+        );
+    }
+
+    #[test]
+    fn power_of_x_with_rational_exponent() {
+        // F = x^(3/2)  ⇒  F'/F = (3/2)/x
+        let pool = ExprPool::new();
+        let (_, x) = nx(&pool);
+        let f = pool.pow(x, pool.rational(3, 2));
+        let expected = pool.mul(vec![pool.rational(3, 2), pool.pow(x, pool.integer(-1_i32))]);
+        assert_theta_eq(f, expected, &pool);
+    }
+
+    #[test]
+    fn exp_of_a_polynomial() {
+        // F = exp(x^2 - 3x)  ⇒  F'/F = 2x - 3
+        let pool = ExprPool::new();
+        let (_, x) = nx(&pool);
+        let arg = pool.add(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.mul(vec![pool.integer(-3_i32), x]),
+        ]);
+        let f = pool.func("exp", vec![arg]);
+        let expected = pool.add(vec![
+            pool.mul(vec![pool.integer(2_i32), x]),
+            pool.integer(-3_i32),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+    }
+
+    #[test]
+    fn one_minus_x_to_the_n() {
+        // F = (1-x)^n  ⇒  F'/F = -n/(1-x)
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let base = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let f = pool.pow(base, n);
+        let expected = pool.mul(vec![
+            pool.integer(-1_i32),
+            n,
+            pool.pow(base, pool.integer(-1_i32)),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+    }
+
+    #[test]
+    fn x_to_the_n_times_exp_minus_x() {
+        // F = x^n e^{-x}  ⇒  F'/F = n/x - 1, and F(n+1,x)/F(n,x) = x.
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+        ]);
+        let expected = pool.add(vec![
+            pool.mul(vec![n, pool.pow(x, pool.integer(-1_i32))]),
+            pool.integer(-1_i32),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+
+        let term = HyperExpTerm::parse(f, n, x, &pool).expect("parses");
+        let r1 = term.ratio_n(1).expect("hypergeometric in n");
+        assert!(r1.eq_ratk(&RatK::k()), "F(n+1,x)/F(n,x) must be x");
+    }
+
+    #[test]
+    fn gaussian_moment_term() {
+        // F = x^{2n} e^{-x^2}: θ = 2n/x - 2x, ratio = x^2.
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, pool.mul(vec![pool.integer(2_i32), n])),
+            pool.func(
+                "exp",
+                vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+            ),
+        ]);
+        let expected = pool.add(vec![
+            pool.mul(vec![
+                pool.integer(2_i32),
+                n,
+                pool.pow(x, pool.integer(-1_i32)),
+            ]),
+            pool.mul(vec![pool.integer(-2_i32), x]),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+
+        let term = HyperExpTerm::parse(f, n, x, &pool).expect("parses");
+        let r1 = term.ratio_n(1).expect("hypergeometric in n");
+        let want = RatK::k().mul(&RatK::k());
+        assert!(r1.eq_ratk(&want), "F(n+1,x)/F(n,x) must be x^2");
+    }
+
+    #[test]
+    fn rational_multiple_and_product() {
+        // F = (x/(x+1)) · x^n · (1-x)^n: θ must be the sum of the three parts.
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let one_minus = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let f = pool.mul(vec![
+            x,
+            pool.pow(pool.add(vec![x, pool.integer(1_i32)]), pool.integer(-1_i32)),
+            pool.pow(x, n),
+            pool.pow(one_minus, n),
+        ]);
+        let expected = pool.add(vec![
+            pool.pow(x, pool.integer(-1_i32)),
+            pool.mul(vec![
+                pool.integer(-1_i32),
+                pool.pow(pool.add(vec![x, pool.integer(1_i32)]), pool.integer(-1_i32)),
+            ]),
+            pool.mul(vec![n, pool.pow(x, pool.integer(-1_i32))]),
+            pool.mul(vec![
+                pool.integer(-1_i32),
+                n,
+                pool.pow(one_minus, pool.integer(-1_i32)),
+            ]),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+    }
+
+    #[test]
+    fn w_to_the_n_factor() {
+        // F = 2^n x^n: θ = n/x (the 2^n is x-free), ratio = 2x.
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![pool.pow(pool.integer(2_i32), n), pool.pow(x, n)]);
+        let expected = pool.mul(vec![n, pool.pow(x, pool.integer(-1_i32))]);
+        assert_theta_eq(f, expected, &pool);
+
+        let term = HyperExpTerm::parse(f, n, x, &pool).expect("parses");
+        let r1 = term.ratio_n(1).expect("hypergeometric in n");
+        let want = RatK::k().mul(&RatK::from_rn(rn_int(2)));
+        assert!(r1.eq_ratk(&want), "F(n+1,x)/F(n,x) must be 2x");
+    }
+
+    #[test]
+    fn sqrt_is_a_half_power() {
+        // F = sqrt(1 - x^2): θ = -x/(1-x^2).
+        let pool = ExprPool::new();
+        let (_, x) = nx(&pool);
+        let inner = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))]),
+        ]);
+        let f = pool.func("sqrt", vec![inner]);
+        let expected = pool.mul(vec![
+            pool.integer(-1_i32),
+            x,
+            pool.pow(inner, pool.integer(-1_i32)),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+    }
+
+    #[test]
+    fn univariate_entry_point() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.mul(vec![x, pool.func("exp", vec![x])]);
+        let theta = hyperexp_log_derivative(f, x, &pool).expect("hyperexponential");
+        // 1/x + 1
+        let s = format!("{}", pool.display(theta));
+        assert!(s.contains('x'), "log derivative should mention x, got {s}");
+    }
+
+    // --- negative tests: the class boundary --------------------------------
+
+    #[test]
+    fn log_is_refused() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.func("log", vec![x]);
+        let err = HyperExpTerm::parse(f, n, x, &pool).expect_err("log is not hyperexponential");
+        assert!(matches!(err, DiffTelescopingError::NotHyperexponential(_)));
+    }
+
+    #[test]
+    fn sum_of_hyperexponentials_is_refused() {
+        // e^x + e^{2x} is not hyperexponential: its logarithmic derivative is
+        // not rational. Refusing is the point — a wrong θ here would poison
+        // every downstream certificate.
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.add(vec![
+            pool.func("exp", vec![x]),
+            pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), x])]),
+        ]);
+        let err = HyperExpTerm::parse(f, n, x, &pool).expect_err("a sum is refused");
+        assert!(matches!(err, DiffTelescopingError::NotHyperexponential(_)));
+    }
+
+    #[test]
+    fn x_in_the_exponent_of_a_constant_is_refused() {
+        // 2^x = exp(x log 2) is hyperexponential over Q(log 2)(x), not over Q(x).
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.pow(pool.integer(2_i32), x);
+        let err = HyperExpTerm::parse(f, n, x, &pool).expect_err("2**x is refused");
+        assert!(matches!(err, DiffTelescopingError::NotHyperexponential(_)));
+    }
+
+    #[test]
+    fn exp_of_n_times_x_is_hyperexponential_but_not_hypergeometric_in_n() {
+        // The instructive case: θ exists, ratio_n does not.
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.func("exp", vec![pool.mul(vec![n, x])]);
+        let term = HyperExpTerm::parse(f, n, x, &pool).expect("hyperexponential in x");
+        let theta = term.theta().expect("theta exists");
+        assert!(
+            theta.eq_ratk(&RatK::from_rn(rn_var())),
+            "theta must be n, got {}",
+            pool.display(ratk_to_expr(&pool, n, x, &theta))
+        );
+        let err = term
+            .ratio_n(1)
+            .expect_err("ratio in n is exp(x), not rational");
+        assert!(matches!(err, DiffTelescopingError::NotHypergeometricInN(_)));
+    }
+
+    #[test]
+    fn sin_is_refused() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.func("sin", vec![x]);
+        let err = HyperExpTerm::parse(f, n, x, &pool).expect_err("sin is not hyperexponential");
+        assert!(matches!(err, DiffTelescopingError::NotHyperexponential(_)));
+    }
+
+    #[test]
+    fn identical_symbols_are_refused() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let err = HyperExpTerm::parse(x, x, x, &pool).expect_err("n and x must differ");
+        assert!(matches!(err, DiffTelescopingError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn theta_of_a_rational_function_is_its_log_derivative() {
+        // A rational F is hyperexponential with θ = F'/F — the degenerate but
+        // legitimate case.
+        let pool = ExprPool::new();
+        let (_, x) = nx(&pool);
+        let f = pool.pow(pool.add(vec![x, pool.integer(1_i32)]), pool.integer(3_i32));
+        let expected = pool.mul(vec![
+            pool.integer(3_i32),
+            pool.pow(pool.add(vec![x, pool.integer(1_i32)]), pool.integer(-1_i32)),
+        ]);
+        assert_theta_eq(f, expected, &pool);
+        let _ = theta_str(f, &pool);
+    }
+}

--- a/alkahest-core/src/holonomic/azeil/mod.rs
+++ b/alkahest-core/src/holonomic/azeil/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! with polynomial coefficients `a_i(n)` (not all zero, `a_J ≢ 0`) and an exact
 //! rational certificate `R ∈ Q(n)(x)`. That identity — and only that identity —
-//! is what `almkvist_zeilberger` verifies exactly before returning.
+//! is what [`almkvist_zeilberger`] verifies exactly before returning.
 //!
 //! | discrete ([`mod@super::zeilberger`]) | continuous (here) |
 //! |---|---|
@@ -36,7 +36,7 @@
 //!   right-hand side is fixed (`J = 0`, `a_0 = 1`) or carries unknowns.
 //! - `dgosper` — the indefinite case: decide whether `∫F dx = R·F` for a
 //!   rational `R`, and return it. This is `J = 0` with `a_0` normalised to `1`.
-//! - `search` — `almkvist_zeilberger` itself, ascending in `J` from `0`.
+//! - [`mod@search`] — [`almkvist_zeilberger`] itself, ascending in `J` from `0`.
 //! - `boundary` — the continuous analogue of [`super::boundary`]: deciding
 //!   whether `[R·F]_a^b` vanishes, so that the certificate becomes a recurrence
 //!   for `f(n) = ∫_a^b F(n,x) dx` rather than a statement about the integrand
@@ -89,7 +89,7 @@
 //!   whether that resonance occurs is not decidable at all, and this module
 //!   does not pretend otherwise: it searches `κ` and refuses with
 //!   [`DiffTelescopingError::SearchExhausted`] when the bound runs out.
-//! - **Minimal order, not minimal degree**: `search` ascends in `J` from `0`
+//! - **Minimal order, not minimal degree**: [`mod@search`] ascends in `J` from `0`
 //!   and tries every `(κ, d)` in bounds before moving on, so a returned order
 //!   *is* the least one reachable within `max_den_power`/`max_degree`. It is
 //!   not the cost-ordered iterative deepening [`mod@super::zeilberger`] uses, so
@@ -108,9 +108,11 @@
 pub mod dgosper;
 pub mod hyperexp;
 pub mod rde;
+pub mod search;
 
 pub use dgosper::{dgosper, dgosper_term};
 pub use hyperexp::{hyperexp_log_derivative, HyperExpTerm, PowerFactor};
+pub use search::{almkvist_zeilberger, integrand_antiderivative, AzResult};
 
 /// Search bounds for the continuous engine.
 ///

--- a/alkahest-core/src/holonomic/azeil/mod.rs
+++ b/alkahest-core/src/holonomic/azeil/mod.rs
@@ -22,7 +22,7 @@
 //! | shift `k → k+1`, `Δ_k` | derivation `D_x` |
 //! | proper hypergeometric term | hyperexponential term ([`mod@hyperexp`]) |
 //! | Gosper's algorithm | differential Gosper (`dgosper`) |
-//! | [`super::boundary`] | `boundary` |
+//! | [`mod@super::boundary`] | [`mod@boundary`] |
 //!
 //! # Module layout
 //!
@@ -37,7 +37,7 @@
 //! - `dgosper` — the indefinite case: decide whether `∫F dx = R·F` for a
 //!   rational `R`, and return it. This is `J = 0` with `a_0` normalised to `1`.
 //! - [`mod@search`] — [`almkvist_zeilberger`] itself, ascending in `J` from `0`.
-//! - `boundary` — the continuous analogue of [`super::boundary`]: deciding
+//! - [`mod@boundary`] — the continuous analogue of [`mod@super::boundary`]: deciding
 //!   whether `[R·F]_a^b` vanishes, so that the certificate becomes a recurrence
 //!   for `f(n) = ∫_a^b F(n,x) dx` rather than a statement about the integrand
 //!   alone.
@@ -54,9 +54,9 @@
 //! The certificate says nothing about it: `R·F` is a perfectly good
 //! antiderivative of the left-hand side whether or not it happens to vanish at
 //! the limits, and whether or not the integral converges there at all.
-//! `boundary::integral_boundary_status` decides it three-valued, in the same
+//! [`boundary::integral_boundary_status`] decides it three-valued, in the same
 //! discipline as the discrete module — see its docs, and do not read
-//! `boundary::IntegralBoundaryStatus::Unknown` as a vanishing boundary.
+//! [`boundary::IntegralBoundaryStatus::Unknown`] as a vanishing boundary.
 //!
 //! # Honest limitations (read before relying on this)
 //!
@@ -95,9 +95,9 @@
 //!   not the cost-ordered iterative deepening [`mod@super::zeilberger`] uses, so
 //!   raising `max_degree` is not free the way it is there.
 //! - **Boundary**: only constant (`n`-independent) limits are analysed, and
-//!   only the endpoint kinds `boundary` documents. Convergence conditions on
+//!   only the endpoint kinds [`mod@boundary`] documents. Convergence conditions on
 //!   `n` are *reported*, not silently assumed — see
-//!   `boundary::IntegralBoundaryStatus::side_conditions`.
+//!   [`boundary::IntegralBoundaryStatus::side_conditions`].
 //! - **Rust-internal**: there is no PyO3 binding for any of this yet.
 //!
 //! Every certificate returned by any entry point in this module has been
@@ -105,11 +105,13 @@
 //! [`super::zeilberger::zeilberger()`] does. A successful call is a proof; an
 //! unverifiable candidate is discarded and the search continues.
 
+pub mod boundary;
 pub mod dgosper;
 pub mod hyperexp;
 pub mod rde;
 pub mod search;
 
+pub use boundary::{integral_boundary_status, IntegralBoundaryStatus, IntegrationLimit};
 pub use dgosper::{dgosper, dgosper_term};
 pub use hyperexp::{hyperexp_log_derivative, HyperExpTerm, PowerFactor};
 pub use search::{almkvist_zeilberger, integrand_antiderivative, AzResult};

--- a/alkahest-core/src/holonomic/azeil/mod.rs
+++ b/alkahest-core/src/holonomic/azeil/mod.rs
@@ -21,7 +21,7 @@
 //! | `Σ_k F(n,k)` | `∫_a^b F(n,x) dx` |
 //! | shift `k → k+1`, `Δ_k` | derivation `D_x` |
 //! | proper hypergeometric term | hyperexponential term ([`mod@hyperexp`]) |
-//! | Gosper's algorithm | differential Gosper (`dgosper`) |
+//! | Gosper's algorithm | differential Gosper ([`mod@dgosper`]) |
 //! | [`mod@super::boundary`] | [`mod@boundary`] |
 //!
 //! # Module layout
@@ -30,17 +30,17 @@
 //!   `F(n,x) = R(n,x)·wⁿ·exp(η(x))·∏ B_j(x)^(α_j n + β_j)` and its two exact
 //!   certificates: the logarithmic derivative `θ = ∂_x F / F ∈ Q(n)(x)` and the
 //!   shift ratios `F(n+i,x)/F(n,x) ∈ Q(n)(x)`.
-//! - `rde` — the shared inner solver. Both stages below are the *same*
+//! - [`mod@rde`] — the shared inner solver. Both stages below are the *same*
 //!   parametric Risch differential equation `R' + θ·R = Σ_i a_i·r_i` solved by
 //!   undetermined coefficients over `Q(n)`; the only difference is whether the
 //!   right-hand side is fixed (`J = 0`, `a_0 = 1`) or carries unknowns.
-//! - `dgosper` — the indefinite case: decide whether `∫F dx = R·F` for a
+//! - [`mod@dgosper`] — the indefinite case: decide whether `∫F dx = R·F` for a
 //!   rational `R`, and return it. This is `J = 0` with `a_0` normalised to `1`.
 //! - [`mod@search`] — [`almkvist_zeilberger`] itself, ascending in `J` from `0`.
-//! - [`mod@boundary`] — the continuous analogue of [`mod@super::boundary`]: deciding
-//!   whether `[R·F]_a^b` vanishes, so that the certificate becomes a recurrence
-//!   for `f(n) = ∫_a^b F(n,x) dx` rather than a statement about the integrand
-//!   alone.
+//! - [`mod@boundary`] — the continuous analogue of [`mod@super::boundary`]:
+//!   deciding whether `[R·F]_a^b` vanishes, so that the certificate becomes a
+//!   recurrence for `f(n) = ∫_a^b F(n,x) dx` rather than a statement about the
+//!   integrand alone.
 //!
 //! # The integral recurrence carries a hypothesis
 //!

--- a/alkahest-core/src/holonomic/azeil/mod.rs
+++ b/alkahest-core/src/holonomic/azeil/mod.rs
@@ -105,9 +105,46 @@
 //! [`super::zeilberger::zeilberger()`] does. A successful call is a proof; an
 //! unverifiable candidate is discarded and the search continues.
 
+pub mod dgosper;
 pub mod hyperexp;
+pub mod rde;
 
+pub use dgosper::{dgosper, dgosper_term};
 pub use hyperexp::{hyperexp_log_derivative, HyperExpTerm, PowerFactor};
+
+/// Search bounds for the continuous engine.
+///
+/// All three are upper *bounds*, not starting points: the search walks the
+/// `(order, κ, degree)` grid from the cheapest corner, so raising any of them
+/// only widens what can be found. Unlike [`mod@super::zeilberger`]'s
+/// cost-ordered deepening, though, the walk here is plain ascending nested
+/// loops, so raising `max_degree` genuinely does cost more on an input that
+/// has no certificate at all.
+#[derive(Debug, Clone, Copy)]
+pub struct AzOpts {
+    /// Largest recurrence order `J` to try. Orders are searched from `0`
+    /// upward, so a returned order is the least one reachable within the other
+    /// two bounds. Ignored by [`dgosper()`], where the order is `0` by
+    /// definition.
+    pub max_order: usize,
+    /// Largest degree in `x` of the certificate numerator `P`.
+    pub max_degree: usize,
+    /// Largest power `κ` of `θ`'s denominator admitted in the certificate
+    /// denominator `D^κ·B`. See [`mod@rde`] for what this bound is and is not:
+    /// the denominator's *support* is forced, only its multiplicity is
+    /// searched.
+    pub max_den_power: usize,
+}
+
+impl Default for AzOpts {
+    fn default() -> Self {
+        AzOpts {
+            max_order: 4,
+            max_degree: 12,
+            max_den_power: 3,
+        }
+    }
+}
 
 use std::fmt;
 

--- a/alkahest-core/src/holonomic/azeil/mod.rs
+++ b/alkahest-core/src/holonomic/azeil/mod.rs
@@ -1,0 +1,209 @@
+//! Continuous creative telescoping: **Almkvist–Zeilberger**, the differential
+//! twin of [`mod@super::zeilberger`].
+//!
+//! # Scope
+//!
+//! Where the discrete engine takes a proper hypergeometric summand `F(n,k)`,
+//! the shift `k → k+1` and the difference operator `Δ_k`, this one takes a
+//! *hyperexponential* integrand `F(n,x)`, the derivation `D_x`, and produces
+//! the same shape of certificate:
+//!
+//! ```text
+//! Σ_{i=0}^{J} a_i(n)·F(n+i, x) = D_x( R(n,x)·F(n,x) )
+//! ```
+//!
+//! with polynomial coefficients `a_i(n)` (not all zero, `a_J ≢ 0`) and an exact
+//! rational certificate `R ∈ Q(n)(x)`. That identity — and only that identity —
+//! is what `almkvist_zeilberger` verifies exactly before returning.
+//!
+//! | discrete ([`mod@super::zeilberger`]) | continuous (here) |
+//! |---|---|
+//! | `Σ_k F(n,k)` | `∫_a^b F(n,x) dx` |
+//! | shift `k → k+1`, `Δ_k` | derivation `D_x` |
+//! | proper hypergeometric term | hyperexponential term ([`mod@hyperexp`]) |
+//! | Gosper's algorithm | differential Gosper (`dgosper`) |
+//! | [`super::boundary`] | `boundary` |
+//!
+//! # Module layout
+//!
+//! - [`mod@hyperexp`] — recognition of
+//!   `F(n,x) = R(n,x)·wⁿ·exp(η(x))·∏ B_j(x)^(α_j n + β_j)` and its two exact
+//!   certificates: the logarithmic derivative `θ = ∂_x F / F ∈ Q(n)(x)` and the
+//!   shift ratios `F(n+i,x)/F(n,x) ∈ Q(n)(x)`.
+//! - `rde` — the shared inner solver. Both stages below are the *same*
+//!   parametric Risch differential equation `R' + θ·R = Σ_i a_i·r_i` solved by
+//!   undetermined coefficients over `Q(n)`; the only difference is whether the
+//!   right-hand side is fixed (`J = 0`, `a_0 = 1`) or carries unknowns.
+//! - `dgosper` — the indefinite case: decide whether `∫F dx = R·F` for a
+//!   rational `R`, and return it. This is `J = 0` with `a_0` normalised to `1`.
+//! - `search` — `almkvist_zeilberger` itself, ascending in `J` from `0`.
+//! - `boundary` — the continuous analogue of [`super::boundary`]: deciding
+//!   whether `[R·F]_a^b` vanishes, so that the certificate becomes a recurrence
+//!   for `f(n) = ∫_a^b F(n,x) dx` rather than a statement about the integrand
+//!   alone.
+//!
+//! # The integral recurrence carries a hypothesis
+//!
+//! Integrating the certificate over `x ∈ [a,b]` gives
+//!
+//! ```text
+//! Σ_i a_i(n)·f(n+i) = [ R(n,x)·F(n,x) ]_a^b,     f(n) = ∫_a^b F(n,x) dx
+//! ```
+//!
+//! so `Σ_i a_i(n)·f(n+i) = 0` holds **only when that boundary term vanishes**.
+//! The certificate says nothing about it: `R·F` is a perfectly good
+//! antiderivative of the left-hand side whether or not it happens to vanish at
+//! the limits, and whether or not the integral converges there at all.
+//! `boundary::integral_boundary_status` decides it three-valued, in the same
+//! discipline as the discrete module — see its docs, and do not read
+//! `boundary::IntegralBoundaryStatus::Unknown` as a vanishing boundary.
+//!
+//! # Honest limitations (read before relying on this)
+//!
+//! - **Integrand class**: hyperexponential in `x` *and* hypergeometric in `n`,
+//!   in the specific shape [`hyperexp::HyperExpTerm`] parses — a rational
+//!   `Q(n)(x)` prefactor times `wⁿ` (`w ∈ Q`) times `exp(η)` with `η ∈ Q(n)(x)`
+//!   times finitely many `B(x)^(α·n + β)` with `α ∈ Z`, `β ∈ Q`. Anything
+//!   outside it — `log x`, `sin x`, a *sum* of two hyperexponential terms, an
+//!   algebraic function that is not a rational power — is refused as
+//!   [`DiffTelescopingError::NotHyperexponential`], never approximated.
+//!   `exp(n·x)` is the instructive refusal: it *is* hyperexponential in `x`,
+//!   but `F(n+1,x)/F(n,x) = eˣ` is not rational, so no algorithm in this family
+//!   applies and [`DiffTelescopingError::NotHypergeometricInN`] says so
+//!   specifically rather than reporting a shape failure.
+//! - **Formal, not analytic**: `B(x)^β` for non-integer `β` is treated as a
+//!   formal symbol whose logarithmic derivative is `β·B'/B`. The certificate is
+//!   an identity of formal hyperexponential expressions; reading it as an
+//!   identity of *functions* additionally requires a branch of `B^β` to be
+//!   fixed consistently on the interval in question. That is a real hypothesis
+//!   on e.g. `x^(1/2)` across `x = 0`, and it is stated rather than assumed.
+//! - **Certificate denominator**: the ansatz is `R = P(x)/(D(x)^κ·B(x))` with
+//!   `D` the denominator of `θ`, `B` the common denominator of the shift ratios,
+//!   `deg P ≤ d` and `κ ≤ max_den_power`. The *support* of that denominator is
+//!   not a guess — a pole of `R` must be a pole of `θ` or of the right-hand
+//!   side, which is exactly `D` and `B` — but the *multiplicity* `κ` is a
+//!   bounded search, and one specific case pushes it up without bound: at a
+//!   simple pole of `θ` with residue `ρ`, `R` may have a pole of order `ρ`
+//!   whenever `ρ` is a positive integer (`∫x²·eˣ dx = (x²−2x+2)·eˣ` needs
+//!   `κ = 2`). With a *symbolic* `ρ ∈ Q(n)` — the usual case for `xⁿ·…` —
+//!   whether that resonance occurs is not decidable at all, and this module
+//!   does not pretend otherwise: it searches `κ` and refuses with
+//!   [`DiffTelescopingError::SearchExhausted`] when the bound runs out.
+//! - **Minimal order, not minimal degree**: `search` ascends in `J` from `0`
+//!   and tries every `(κ, d)` in bounds before moving on, so a returned order
+//!   *is* the least one reachable within `max_den_power`/`max_degree`. It is
+//!   not the cost-ordered iterative deepening [`mod@super::zeilberger`] uses, so
+//!   raising `max_degree` is not free the way it is there.
+//! - **Boundary**: only constant (`n`-independent) limits are analysed, and
+//!   only the endpoint kinds `boundary` documents. Convergence conditions on
+//!   `n` are *reported*, not silently assumed — see
+//!   `boundary::IntegralBoundaryStatus::side_conditions`.
+//! - **Rust-internal**: there is no PyO3 binding for any of this yet.
+//!
+//! Every certificate returned by any entry point in this module has been
+//! re-derived and checked as an exact identity in `Q(n)(x)` first, exactly as
+//! [`super::zeilberger::zeilberger()`] does. A successful call is a proof; an
+//! unverifiable candidate is discarded and the search continues.
+
+pub mod hyperexp;
+
+pub use hyperexp::{hyperexp_log_derivative, HyperExpTerm, PowerFactor};
+
+use std::fmt;
+
+/// Errors from the continuous (differential) creative-telescoping engine.
+///
+/// A separate type from [`super::HolonomicError`] for the same reason
+/// [`super::telescoping2d::Telescoping2dError`] is: the public enums in this
+/// subsystem are exhaustive, so sharing one would make every new engine a
+/// major-version break, and a caller could not tell which engine refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffTelescopingError {
+    /// The integrand is not hyperexponential in `x` in the shape
+    /// [`hyperexp::HyperExpTerm`] recognises.
+    NotHyperexponential(String),
+    /// The integrand *is* hyperexponential in `x`, but `F(n+i,x)/F(n,x)` is not
+    /// a rational function of `x` — so creative telescoping in `n` does not
+    /// apply, however well-behaved the `x` side is. `exp(n·x)` is the canonical
+    /// case.
+    NotHypergeometricInN(String),
+    /// The bounded ansatz search (order, certificate degree, denominator power)
+    /// was exhausted without finding a certificate that passed exact
+    /// verification.
+    SearchExhausted(String),
+    /// A candidate was found by the search but failed the exact `Q(n)(x)`
+    /// identity check, and no other candidate succeeded. Refused rather than
+    /// returned unverified.
+    CertificateVerificationFailed(String),
+    /// Malformed call (`n` and `x` not distinct, degenerate bounds, …).
+    InvalidInput(String),
+}
+
+impl fmt::Display for DiffTelescopingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiffTelescopingError::NotHyperexponential(s) => {
+                write!(f, "almkvist-zeilberger: not a hyperexponential term: {s}")
+            }
+            DiffTelescopingError::NotHypergeometricInN(s) => {
+                write!(
+                    f,
+                    "almkvist-zeilberger: not hypergeometric in the outer index: {s}"
+                )
+            }
+            DiffTelescopingError::SearchExhausted(s) => {
+                write!(f, "almkvist-zeilberger: search exhausted: {s}")
+            }
+            DiffTelescopingError::CertificateVerificationFailed(s) => {
+                write!(
+                    f,
+                    "almkvist-zeilberger: certificate failed exact verification: {s}"
+                )
+            }
+            DiffTelescopingError::InvalidInput(s) => {
+                write!(f, "almkvist-zeilberger: invalid input: {s}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DiffTelescopingError {}
+
+impl crate::errors::AlkahestError for DiffTelescopingError {
+    fn code(&self) -> &'static str {
+        match self {
+            DiffTelescopingError::NotHyperexponential(_) => "E-HOLO-060",
+            DiffTelescopingError::NotHypergeometricInN(_) => "E-HOLO-061",
+            DiffTelescopingError::SearchExhausted(_) => "E-HOLO-062",
+            DiffTelescopingError::CertificateVerificationFailed(_) => "E-HOLO-063",
+            DiffTelescopingError::InvalidInput(_) => "E-HOLO-064",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        Some(match self {
+            DiffTelescopingError::NotHyperexponential(_) => {
+                "write the integrand as R(n,x)*w**n*exp(eta(x))*prod(B(x)**(a*n + b)) with \
+                 integer a and rational b; supported function heads are exp and sqrt, and a \
+                 sum of two hyperexponential terms is not itself hyperexponential"
+            }
+            DiffTelescopingError::NotHypergeometricInN(_) => {
+                "the x-side is fine but F(n+1,x)/F(n,x) is not rational in x — e.g. exp(n*x), \
+                 whose ratio is exp(x). No algorithm in this family applies; close the branch"
+            }
+            DiffTelescopingError::SearchExhausted(_) => {
+                "raise max_order, max_degree and/or max_den_power in AzOpts; if the integrand \
+                 genuinely has no such certificate within reach — or needs a certificate \
+                 denominator this module's D**kappa * B ansatz cannot represent — this method \
+                 does not apply"
+            }
+            DiffTelescopingError::CertificateVerificationFailed(_) => {
+                "internal: report the integrand as a minimal failing example"
+            }
+            DiffTelescopingError::InvalidInput(_) => {
+                "n and x must be distinct symbols; the max_order, max_degree and max_den_power \
+                 bounds must be within the documented ranges"
+            }
+        })
+    }
+}

--- a/alkahest-core/src/holonomic/azeil/rde.rs
+++ b/alkahest-core/src/holonomic/azeil/rde.rs
@@ -95,7 +95,8 @@
 //! ([`mod@super::super::zeilberger`]'s `field_gaussian_solve`).
 
 use crate::holonomic::qfield::{
-    polyk_deriv_k, ratk_deriv_k, rn_int, rn_is_zero, rn_neg, rn_one, rn_zero, PolyK, RatK, Rn,
+    polyk_deriv_k, ratk_deriv_k, rn_int, rn_is_zero, rn_mul, rn_neg, rn_one, rn_zero, PolyK, RatK,
+    Rn,
 };
 use crate::holonomic::zeilberger::field_gaussian_solve;
 
@@ -279,4 +280,21 @@ pub(super) fn verify(setup: &RdeSetup, a: &[Rn], r: &RatK) -> bool {
     }
     let rhs = ratk_deriv_k(r).add(&setup.theta.mul(r));
     lhs.sub(&rhs).is_zero()
+}
+
+/// Scale a solved `(a, R)` pair by a common `x`-free factor `s(n)`.
+///
+/// Both sides of `Σ_i a_i·r_i = R′ + θ·R` are `Q(n)`-linear and `s` does not
+/// depend on `x`, so this preserves the identity exactly. It is how the
+/// rational `a_i(n)` become the integer-content-primitive polynomials a caller
+/// wants to read as a recurrence — and the scaled pair, not the pre-scaled one,
+/// is what [`verify`] is then run on.
+pub(super) fn rescale(a: &[Rn], r: &RatK, s: &Rn) -> (Vec<Rn>, RatK) {
+    let a_s = a.iter().map(|ai| rn_mul(ai, s)).collect();
+    let r_s = RatK {
+        num: r.num.scale(s),
+        den: r.den.clone(),
+    }
+    .normalize();
+    (a_s, r_s)
 }

--- a/alkahest-core/src/holonomic/azeil/rde.rs
+++ b/alkahest-core/src/holonomic/azeil/rde.rs
@@ -1,0 +1,282 @@
+//! The shared inner solver: the **parametric Risch differential equation**
+//!
+//! ```text
+//! R'(x) + θ(x)·R(x) = Σ_{i=0}^{J} a_i·r_i(x)
+//! ```
+//!
+//! over `Q(n)(x)`, solved by undetermined coefficients.
+//!
+//! # Why one solver serves both stages
+//!
+//! Dividing the certificate identity `Σ_i a_i(n)·F(n+i,x) = D_x(R·F)` through
+//! by `F` turns it into exactly the equation above, with `θ = ∂_x F/F` and
+//! `r_i = F(n+i,x)/F(n,x)` — both supplied exactly by
+//! [`super::hyperexp::HyperExpTerm`]:
+//!
+//! ```text
+//! D_x(R·F) = (R' + θ·R)·F
+//! ```
+//!
+//! The indefinite case ([`mod@super::dgosper`]) is the same equation with `J = 0`
+//! and `a_0` normalised to `1`, i.e. `R' + θ·R = 1`; creative telescoping
+//! (`super::search`) is the same equation with `a_0 … a_{J−1}` unknown and
+//! `a_J = 1`. Writing two solvers would mean two ansatz shapes, two
+//! completeness stories and two places for a certificate to be wrong.
+//!
+//! # Relationship to `integrate::risch::rational_rde`
+//!
+//! `integrate::risch::rational_rde::solve_rational_rde_generalized` already
+//! solves `v' + f·v = c` over `ℚ(x)` for rational `f`, which is the `J = 0`,
+//! `n`-free case of this. It is **not** reused, for two independent reasons,
+//! and the first one is a correctness reason:
+//!
+//! 1. Its denominator bound for `v` is `E = gcd(D, D')` with `D` the
+//!    denominator of the right-hand side `c` — Bronstein §6.1, which is exact
+//!    when `f` is a *polynomial*. When `f` has poles, `v` may have poles that
+//!    `c` knows nothing about. Concretely, `∫ x²·eˣ dx = (x²−2x+2)·eˣ` is the
+//!    equation `R' + (2/x + 1)·R = 1`, whose solution `R = (x²−2x+2)/x²` has a
+//!    double pole at `0`, while `c = 1` gives `D = E = 1` and admits only
+//!    polynomial `v`. That solver returns `None` there — a false refusal for
+//!    this module's purposes. (Its `f` is `k·η'` in the exponential tower,
+//!    where the polynomial hypothesis does hold; the gap is in the
+//!    *generalized* entry point, not in the tower that uses it.)
+//! 2. It is over `ℚ`, not `Q(n)`, and the `a_i` unknowns of stage 3 are
+//!    coupled to the unknown numerator of `R` in one linear system. A
+//!    standalone RDE solve cannot express that coupling at all.
+//!
+//! Reusing it as a fast path for the `n`-free case and falling back here would
+//! give the same question two answers with two different completeness
+//! profiles. One solver, one ansatz, one honest limitation is better.
+//!
+//! # The ansatz, and exactly how much of it is a guess
+//!
+//! Write `θ = A/D` (reduced, `D` monic) and let `B` be a common denominator of
+//! the `r_i`, so `r_i = ρ_i/B` with `ρ_i ∈ Q(n)[x]`. The ansatz is
+//!
+//! ```text
+//! R = P(x) / (D(x)^κ · B(x)),    deg P ≤ d.
+//! ```
+//!
+//! The *support* of that denominator is forced, not guessed. Let `α` be a pole
+//! of `R` of order `m ≥ 1` and look at the orders on both sides of the
+//! equation at `α`:
+//!
+//! - `θ` regular at `α`: `R'` has a pole of order `m+1` and `θ·R` at most `m`,
+//!   so no cancellation is possible and the right-hand side must have a pole of
+//!   order `m+1` there. So `α` is a pole of some `r_i`, i.e. a root of `B`, and
+//!   `m ≤ ord_α(B) − 1`.
+//! - `θ` with a pole of order `e ≥ 2`: `θ·R` has order `m+e > m+1`, so again no
+//!   cancellation, `m + e = ord_α(RHS) ≤ ord_α(B)`.
+//! - `θ` with a *simple* pole of residue `ρ`: `R'` and `θ·R` both have order
+//!   `m+1`, with leading coefficients summing to `(ρ − m)·c`. Unless `ρ = m`
+//!   the same argument applies; when `ρ = m` they cancel and `R` may have a
+//!   pole of order `m` at a point the right-hand side is regular at.
+//!
+//! So a pole of `R` lies over a root of `D` or of `B` and nowhere else — which
+//! is what `D^κ·B` encodes. What is *not* forced is `κ`: it is exactly the
+//! resonance `ρ = m` of the third bullet, and `ρ ∈ Q(n)` is symbolic in the
+//! cases this module exists for (`θ = n/x + …` for `F = xⁿ·…`), so whether it
+//! occurs is not decidable. `κ` is therefore a bounded search, `d` likewise,
+//! and running out of either is [`super::DiffTelescopingError::SearchExhausted`] —
+//! never a certificate that was not verified.
+//!
+//! # The linear system
+//!
+//! Clearing `Q²·D` out of `Σ_i a_i·r_i = R' + θ·R` with `R = P/Q`,
+//! `Q = D^κ·B`, and using `Q²D/B = D^{2κ+1}·B`, gives a *polynomial* identity
+//! in `Q(n)[x]` that is linear in the unknowns:
+//!
+//! ```text
+//! Σ_i a_i · (ρ_i · D^{2κ+1} · B)  =  D·Q·P′  −  (D·Q′ − A·Q)·P
+//! ```
+//!
+//! Equating coefficients of each power of `x` is a linear system over the field
+//! `Q(n)`, solved by the same Gaussian elimination the discrete engine uses
+//! ([`mod@super::super::zeilberger`]'s `field_gaussian_solve`).
+
+use crate::holonomic::qfield::{
+    polyk_deriv_k, ratk_deriv_k, rn_int, rn_is_zero, rn_neg, rn_one, rn_zero, PolyK, RatK, Rn,
+};
+use crate::holonomic::zeilberger::field_gaussian_solve;
+
+/// Refuse a probe whose linear system would be larger than this.
+///
+/// The same protection [`super::super::telescoping2d`]'s `MAX_ANSATZ_UNKNOWNS`
+/// provides: the elimination is `O(rows · cols²)` over unbounded-precision
+/// rational functions, so a caller who raises the bounds far enough must still
+/// not be able to wedge the process. Every worked example in this module stays
+/// under 40.
+pub(super) const MAX_ANSATZ_UNKNOWNS: usize = 256;
+
+/// The degree-independent part of one order's setup: the shift ratios put over
+/// a common denominator, and `θ` split into numerator and denominator.
+#[derive(Clone, Debug)]
+pub(super) struct RdeSetup {
+    /// `A`, the numerator of `θ`.
+    pub a_num: PolyK,
+    /// `D`, the (monic) denominator of `θ`.
+    pub d_den: PolyK,
+    /// `B`, a common denominator of the shift ratios.
+    pub b_den: PolyK,
+    /// `ρ_i = r_i · B ∈ Q(n)[x]`, for `i = 0..=J`.
+    pub rho: Vec<PolyK>,
+    /// The shift ratios themselves, kept for exact verification.
+    pub ratios: Vec<RatK>,
+    /// `θ`, kept for exact verification.
+    pub theta: RatK,
+}
+
+impl RdeSetup {
+    /// Build the setup for the right-hand side `Σ_i a_i·r_i`.
+    ///
+    /// `None` (rather than `Err`) when the shift ratios have no common
+    /// denominator this construction can use — a structural dead end for this
+    /// order, not a statement about the integrand.
+    pub(super) fn new(theta: &RatK, ratios: Vec<RatK>) -> Option<RdeSetup> {
+        let mut b_den = PolyK::one();
+        for r in &ratios {
+            b_den = PolyK::lcm(&b_den, &r.den);
+        }
+        if b_den.is_zero() {
+            return None;
+        }
+        let rho: Option<Vec<PolyK>> = ratios
+            .iter()
+            .map(|r| PolyK::exact_div(&b_den.mul(&r.num), &r.den))
+            .collect();
+        Some(RdeSetup {
+            a_num: theta.num.clone(),
+            d_den: theta.den.clone(),
+            b_den,
+            rho: rho?,
+            ratios,
+            theta: theta.clone(),
+        })
+    }
+
+    /// Recurrence order `J` (`ratios.len() - 1`).
+    pub(super) fn order(&self) -> usize {
+        self.ratios.len() - 1
+    }
+}
+
+/// One solved candidate: the recurrence coefficients (with `a_J = 1`) and the
+/// certificate. **Not** yet verified — [`verify`] is a separate step on
+/// purpose, so that what makes a candidate a result is independent of how the
+/// search found it.
+#[derive(Clone, Debug)]
+pub(super) struct RdeCandidate {
+    pub a: Vec<Rn>,
+    pub r: RatK,
+}
+
+/// `x^j` as an element of `Q(n)[x]`.
+fn x_mono(j: usize) -> PolyK {
+    let mut coeffs = vec![rn_zero(); j + 1];
+    coeffs[j] = rn_one();
+    PolyK::from_coeffs(coeffs)
+}
+
+/// Try one `(κ, d)` probe: solve the linear system for `P` and `a_0..a_{J−1}`
+/// with `a_J = 1`.
+///
+/// `None` means this probe's system has no solution (or was refused as too
+/// large), which says nothing at all about neighbouring probes.
+pub(super) fn solve_probe(setup: &RdeSetup, kappa: usize, d: usize) -> Option<RdeCandidate> {
+    let order = setup.order();
+    let n_var = (d + 1) + order;
+    if n_var > MAX_ANSATZ_UNKNOWNS {
+        return None;
+    }
+
+    // Q = D^κ · B, and the multipliers of the polynomial identity
+    //     Σ_i a_i·(ρ_i·D^{2κ+1}·B) = D·Q·P′ − (D·Q′ − A·Q)·P.
+    let mut d_pow = PolyK::one();
+    for _ in 0..kappa {
+        d_pow = d_pow.mul(&setup.d_den);
+    }
+    let q = d_pow.mul(&setup.b_den);
+    if q.is_zero() {
+        return None;
+    }
+    let q_prime = polyk_deriv_k(&q);
+    let dq = setup.d_den.mul(&q);
+    let vv = setup.d_den.mul(&q_prime).sub(&setup.a_num.mul(&q));
+
+    // `D^{2κ+1}·B`, the factor the right-hand side picks up.
+    let mut d_pow2 = setup.d_den.clone();
+    for _ in 0..(2 * kappa) {
+        d_pow2 = d_pow2.mul(&setup.d_den);
+    }
+    let rhs_scale = d_pow2.mul(&setup.b_den);
+    let l: Vec<PolyK> = setup
+        .rho
+        .iter()
+        .map(|rho| rho.mul(&rhs_scale))
+        .collect::<Vec<_>>();
+
+    // M_j = D·Q·(j·x^{j−1}) − (D·Q′ − A·Q)·x^j.
+    let mut m: Vec<PolyK> = Vec::with_capacity(d + 1);
+    for j in 0..=d {
+        let dp = if j == 0 {
+            PolyK::zero()
+        } else {
+            dq.mul(&x_mono(j - 1)).scale(&rn_int(j as i64))
+        };
+        m.push(dp.sub(&vv.mul(&x_mono(j))));
+    }
+
+    let mut max_deg = 0i32;
+    for p in m.iter().chain(l.iter()) {
+        max_deg = max_deg.max(p.degree());
+    }
+    if max_deg < 0 {
+        max_deg = 0;
+    }
+    let n_eq = (max_deg as usize) + 1;
+
+    let mut mat = vec![vec![rn_zero(); n_var]; n_eq];
+    let mut rhs = vec![rn_zero(); n_eq];
+    for (row_idx, row) in mat.iter_mut().enumerate() {
+        for (j, mj) in m.iter().enumerate() {
+            row[j] = mj.coeff(row_idx);
+        }
+        for i in 0..order {
+            row[(d + 1) + i] = rn_neg(&l[i].coeff(row_idx));
+        }
+        rhs[row_idx] = l[order].coeff(row_idx);
+    }
+
+    let sol = field_gaussian_solve(mat, rhs)?;
+    let p_poly = PolyK::from_coeffs(sol[..=d].to_vec());
+    let mut a: Vec<Rn> = sol[(d + 1)..].to_vec();
+    a.push(rn_one());
+
+    let r = RatK {
+        num: p_poly,
+        den: q,
+    }
+    .normalize();
+    Some(RdeCandidate { a, r })
+}
+
+/// The **only** thing that makes a candidate a result: check
+/// `Σ_i a_i·r_i = R′ + θ·R` as an exact identity in `Q(n)(x)`.
+///
+/// This re-derives `R′` from `R` and never consults the linear system that
+/// produced it, so a bug in the ansatz bookkeeping cannot produce a passing
+/// certificate.
+pub(super) fn verify(setup: &RdeSetup, a: &[Rn], r: &RatK) -> bool {
+    if a.len() != setup.ratios.len() {
+        return false;
+    }
+    if a.iter().all(rn_is_zero) {
+        return false;
+    }
+    let mut lhs = RatK::zero();
+    for (ai, ri) in a.iter().zip(setup.ratios.iter()) {
+        lhs = lhs.add(&RatK::from_rn(ai.clone()).mul(ri));
+    }
+    let rhs = ratk_deriv_k(r).add(&setup.theta.mul(r));
+    lhs.sub(&rhs).is_zero()
+}

--- a/alkahest-core/src/holonomic/azeil/search.rs
+++ b/alkahest-core/src/holonomic/azeil/search.rs
@@ -41,7 +41,7 @@
 //! **integrand**. Integrating it over `[a,b]` gives
 //! `Σ_i a_i(n)·f(n+i) = [R·F]_a^b`, so the homogeneous recurrence for
 //! `f(n) = ∫_a^b F dx` needs that boundary term to vanish, which is
-//! `super::boundary`'s question and not this one's. `∫_0^1 x^n dx` is the
+//! [`mod@super::boundary`]'s question and not this one's. `∫_0^1 x^n dx` is the
 //! one-line reminder: the certificate is `R = x/(n+1)` at order `0`, and
 //! `[R·F]_0^1 = 1/(n+1) ≠ 0`, so "the certificate exists" and "the integral
 //! satisfies the homogeneous relation" are genuinely different statements.
@@ -60,7 +60,7 @@ use crate::matrix::normal_form::RatUniPoly;
 ///
 /// The verified content is the **telescoping identity in `x`**. Turning it into
 /// a recurrence for `f(n) = ∫_a^b F(n,x) dx` needs `[R·F]_a^b` to vanish; see
-/// the module docs and `super::boundary`.
+/// the module docs and [`mod@super::boundary`].
 #[derive(Debug, Clone)]
 pub struct AzResult {
     /// Recurrence order `J`; `coeffs.len() == order + 1`.
@@ -87,7 +87,7 @@ pub struct AzResult {
 /// [`almkvist_zeilberger`]. The recurrence for `f(n) = ∫_a^b F(n,x) dx` is
 /// `Σ_i a_i(n)·f(n+i) = G(n,b) − G(n,a)`, so this is exactly what a caller
 /// needs in order to discharge (or refute) the boundary hypothesis for their
-/// own limits by hand — `super::boundary` does it mechanically.
+/// own limits by hand — [`mod@super::boundary`] does it mechanically.
 pub fn integrand_antiderivative(result: &AzResult, term: ExprId, pool: &ExprPool) -> ExprId {
     crate::simplify::simplify(pool.mul(vec![result.certificate, term]), pool).value
 }

--- a/alkahest-core/src/holonomic/azeil/search.rs
+++ b/alkahest-core/src/holonomic/azeil/search.rs
@@ -1,0 +1,537 @@
+//! The Almkvist–Zeilberger search: continuous creative telescoping.
+//!
+//! Given `F(n,x)` hyperexponential in `x` and hypergeometric in `n`, find an
+//! order `J`, polynomial coefficients `a_0(n) … a_J(n)` (not all zero) and a
+//! rational certificate `R ∈ Q(n)(x)` with
+//!
+//! ```text
+//! Σ_{i=0}^{J} a_i(n)·F(n+i, x) = D_x( R(n,x)·F(n,x) ).
+//! ```
+//!
+//! # Method: undetermined coefficients, `J` ascending
+//!
+//! Exactly the shape `telescoping2d::search` uses for the
+//! discrete multi-sum case, and for the same reason: there is no differential
+//! analogue of Gosper's normal form that handles a *parametric* right-hand side,
+//! so the module does not pretend to one. Divide through by `F`, and the
+//! identity becomes the parametric Risch differential equation
+//!
+//! ```text
+//! R′ + θ·R = Σ_i a_i·r_i,     θ = ∂_x F/F,  r_i = F(n+i,x)/F(n,x),
+//! ```
+//! which [`mod@super::rde`] solves by clearing a fixed denominator and equating
+//! coefficients of `x` — one linear system over `Q(n)` in the unknowns
+//! `(a_0 … a_{J−1}, coefficients of P)`, with `a_J` normalised to `1`.
+//!
+//! The grid is walked `J`-major, ascending from `J = 0`, and every `(κ, d)` in
+//! bounds is tried before `J+1` is considered. So a returned order **is** the
+//! least one reachable within `max_den_power` and `max_degree` — which is the
+//! claim [`mod@super::super::zeilberger`]'s cost-ordered plan deliberately gives
+//! up in exchange for speed. Here the systems are small enough (a certificate
+//! numerator is `d+1` unknowns, not `(d+1)^(m+1)`) that the order-major sweep is
+//! affordable, and minimality is worth more than the last factor of two.
+//!
+//! Normalising `a_J = 1` excludes solutions with `a_J = 0`, which is exactly
+//! right under an ascending search: such a solution *is* a relation of lower
+//! order, and every lower order has already been exhausted.
+//!
+//! # What is proved, and what is not
+//!
+//! The verified content is the identity above — a statement about the
+//! **integrand**. Integrating it over `[a,b]` gives
+//! `Σ_i a_i(n)·f(n+i) = [R·F]_a^b`, so the homogeneous recurrence for
+//! `f(n) = ∫_a^b F dx` needs that boundary term to vanish, which is
+//! `super::boundary`'s question and not this one's. `∫_0^1 x^n dx` is the
+//! one-line reminder: the certificate is `R = x/(n+1)` at order `0`, and
+//! `[R·F]_0^1 = 1/(n+1) ≠ 0`, so "the certificate exists" and "the integral
+//! satisfies the homogeneous relation" are genuinely different statements.
+
+use super::hyperexp::HyperExpTerm;
+use super::rde::{rescale, solve_probe, verify, RdeSetup};
+use super::{AzOpts, DiffTelescopingError};
+use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
+use crate::holonomic::hyperterm::{ratk_to_expr, ratuni_to_expr};
+use crate::holonomic::qfield::{clear_denominators, rn_is_zero, rn_poly, RatK};
+use crate::kernel::{ExprId, ExprPool};
+use crate::matrix::normal_form::RatUniPoly;
+
+/// A verified Almkvist–Zeilberger certificate:
+/// `Σ_i coeffs[i](n)·F(n+i,x) = D_x(R·F)`.
+///
+/// The verified content is the **telescoping identity in `x`**. Turning it into
+/// a recurrence for `f(n) = ∫_a^b F(n,x) dx` needs `[R·F]_a^b` to vanish; see
+/// the module docs and `super::boundary`.
+#[derive(Debug, Clone)]
+pub struct AzResult {
+    /// Recurrence order `J`; `coeffs.len() == order + 1`.
+    ///
+    /// It is the least order for which a certificate exists within the
+    /// `max_degree` / `max_den_power` bounds of the call — the search is
+    /// order-major ascending, so every lower order was exhausted first.
+    pub order: usize,
+    /// `a_0(n), …, a_J(n)` as expressions in `n`; integer-content-primitive,
+    /// `a_J` not identically zero.
+    pub coeffs: Vec<ExprId>,
+    /// `R(n,x)` as an expression, with `G(n,x) = R(n,x)·F(n,x)` the quantity
+    /// whose values at the integration limits decide the boundary question.
+    pub certificate: ExprId,
+    /// How many `(order, κ, degree)` probes the search made, the successful one
+    /// included.
+    pub probes: usize,
+}
+
+/// `G(n,x) = R(n,x)·F(n,x)`, the antiderivative whose boundary values decide
+/// whether the certificate's recurrence holds for the *integral*.
+///
+/// `term` must be the same `F(n,x)` that was passed to
+/// [`almkvist_zeilberger`]. The recurrence for `f(n) = ∫_a^b F(n,x) dx` is
+/// `Σ_i a_i(n)·f(n+i) = G(n,b) − G(n,a)`, so this is exactly what a caller
+/// needs in order to discharge (or refute) the boundary hypothesis for their
+/// own limits by hand — `super::boundary` does it mechanically.
+pub fn integrand_antiderivative(result: &AzResult, term: ExprId, pool: &ExprPool) -> ExprId {
+    crate::simplify::simplify(pool.mul(vec![result.certificate, term]), pool).value
+}
+
+/// Almkvist–Zeilberger: find a verified differential creative-telescoping
+/// relation for a hyperexponential integrand `F(n, x)`.
+///
+/// Refuses with [`DiffTelescopingError`] rather than guessing when `term` is
+/// outside the class (see [`mod@super::hyperexp`]) or when the bounded search
+/// finds no certificate that passes exact verification.
+///
+/// ```
+/// use alkahest_cas::kernel::{Domain, ExprPool};
+/// use alkahest_cas::holonomic::azeil::{almkvist_zeilberger, AzOpts};
+///
+/// let pool = ExprPool::new();
+/// let n = pool.symbol("n", Domain::Real);
+/// let x = pool.symbol("x", Domain::Real);
+/// // F = x^n · e^(−x); ∫_0^∞ F dx = n!, so f(n+1) = (n+1)·f(n).
+/// let f = pool.mul(vec![
+///     pool.pow(x, n),
+///     pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+/// ]);
+/// let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+/// assert_eq!(out.value.order, 1);
+/// ```
+pub fn almkvist_zeilberger(
+    term: ExprId,
+    n: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+    opts: &AzOpts,
+) -> Result<DerivedExpr<AzResult>, DiffTelescopingError> {
+    if n == x {
+        return Err(DiffTelescopingError::InvalidInput(
+            "the outer index n and the integration variable x must be distinct symbols".into(),
+        ));
+    }
+
+    let f = HyperExpTerm::parse(term, n, x, pool)?;
+    let theta = f.theta()?;
+
+    // The shift ratios are built one order at a time, and a failure to build
+    // `r_J` ends the search rather than aborting it: `J = 0` needs no ratio at
+    // all, so an integrand that is hyperexponential in `x` but *not*
+    // hypergeometric in `n` (`exp(n·x)`) can still have an order-0 certificate,
+    // and does.
+    let mut ratios: Vec<RatK> = Vec::with_capacity(opts.max_order + 1);
+    let mut ratio_failure: Option<DiffTelescopingError> = None;
+    let mut probes = 0usize;
+
+    for order in 0..=opts.max_order {
+        while ratios.len() <= order {
+            match f.ratio_n(ratios.len() as i64) {
+                Ok(r) => ratios.push(r),
+                Err(e) => {
+                    ratio_failure = Some(e);
+                    break;
+                }
+            }
+        }
+        if ratios.len() <= order {
+            break;
+        }
+
+        let Some(setup) = RdeSetup::new(&theta, ratios.clone()) else {
+            continue;
+        };
+
+        for kappa in 0..=opts.max_den_power {
+            for d in 0..=opts.max_degree {
+                probes += 1;
+                let Some(cand) = solve_probe(&setup, kappa, d) else {
+                    continue;
+                };
+
+                // `a_J = 1`, so the common scale that clears denominators is
+                // just the integer-primitive image of `a_J`; applying it to `R`
+                // as well is an `x`-free rescale and preserves the identity.
+                let a_int: Vec<RatUniPoly> = clear_denominators(&cand.a);
+                if a_int.iter().all(|p| p.is_zero()) {
+                    continue;
+                }
+                let scale = rn_poly(a_int[order].clone());
+                if rn_is_zero(&scale) {
+                    continue;
+                }
+                let (a_scaled, r_final) = rescale(&cand.a, &cand.r, &scale);
+
+                // The only acceptance test, and it is run on the pair that is
+                // about to be returned — not on the pre-scaled candidate.
+                if !verify(&setup, &a_scaled, &r_final) {
+                    continue;
+                }
+
+                let coeffs: Vec<ExprId> =
+                    a_int.iter().map(|p| ratuni_to_expr(pool, n, p)).collect();
+                let certificate = ratk_to_expr(pool, n, x, &r_final);
+
+                let mut log = DerivationLog::new();
+                log.push(RewriteStep::simple(
+                    "almkvist_zeilberger_certificate",
+                    term,
+                    certificate,
+                ));
+                return Ok(DerivedExpr::with_log(
+                    AzResult {
+                        order,
+                        coeffs,
+                        certificate,
+                        probes,
+                    },
+                    log,
+                ));
+            }
+        }
+    }
+
+    // An `n`-ratio failure is reported as itself: it closes the branch for every
+    // algorithm in this family, where an exhausted grid merely invites larger
+    // bounds. Reporting the second when the first is what happened would send a
+    // caller off to raise bounds that cannot help.
+    if let Some(e) = ratio_failure {
+        return Err(e);
+    }
+    Err(DiffTelescopingError::SearchExhausted(format!(
+        "no verified relation of order <= {} with certificate numerator degree <= {} and \
+         denominator power <= {} was found for {} ({probes} probes)",
+        opts.max_order,
+        opts.max_degree,
+        opts.max_den_power,
+        pool.display(term)
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+    use std::collections::HashMap;
+
+    fn nx(pool: &ExprPool) -> (ExprId, ExprId) {
+        (
+            pool.symbol("n", Domain::Real),
+            pool.symbol("x", Domain::Real),
+        )
+    }
+
+    /// Check `a_i(n)/a_J(n)` against an expected closed form at several `n`.
+    ///
+    /// The certificate itself is already proved exactly by the search; what
+    /// these assertions pin is that the *recurrence* is the known one, checked
+    /// against an independent source (the classical identity), not against the
+    /// machinery that produced it.
+    fn assert_ratio(r: &AzResult, pool: &ExprPool, n: ExprId, i: usize, want: fn(f64) -> f64) {
+        for ni in [2.0_f64, 5.0, 9.5] {
+            let env = HashMap::from([(n, ni)]);
+            let aj = crate::eval_f64(r.coeffs[r.order], pool, &env).expect("a_J evaluates");
+            let ai = crate::eval_f64(r.coeffs[i], pool, &env).expect("a_i evaluates");
+            assert!(aj.abs() > 1e-12, "leading coefficient must not vanish");
+            let got = ai / aj;
+            let expect = want(ni);
+            assert!(
+                (got - expect).abs() < 1e-9,
+                "a_{i}/a_{J} at n={ni}: got {got}, want {expect}",
+                J = r.order
+            );
+        }
+    }
+
+    /// `∫_0^∞ xⁿ·e^(−x) dx = n!` — the Gamma recurrence `f(n+1) = (n+1)·f(n)`.
+    #[test]
+    fn gamma_moments() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 1, "expected the order-1 Gamma recurrence");
+        // (n+1)·F(n) − F(n+1) = D_x(x·F): a_0/a_1 = −(n+1).
+        assert_ratio(r, &pool, n, 0, |v| -(v + 1.0));
+    }
+
+    /// `∫_0^1 xⁿ(1−x)^(1/2) dx = B(n+1, 3/2)`, whose recurrence is
+    /// `f(n+1)/f(n) = (n+1)/(n+5/2)`.
+    ///
+    /// The second exponent is a concrete `1/2` because the coefficient field is
+    /// `Q(n)`: a second *symbolic* parameter would need `Q(n,m)`, which this
+    /// module does not have and does not pretend to.
+    #[test]
+    fn beta_integral() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let one_minus = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.pow(one_minus, pool.rational(1, 2)),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 1);
+        // (2n+2)F(n) − (2n+5)F(n+1) = D_x(2x(1−x)F): a_0/a_1 = −(n+1)/(n+5/2).
+        assert_ratio(r, &pool, n, 0, |v| -(v + 1.0) / (v + 2.5));
+    }
+
+    /// The same integrand with an *integer* second exponent is order **0**, and
+    /// that is the correct answer rather than a missed order-1 relation:
+    /// `xⁿ(1−x)³` expands to a `Q(n)`-combination of `x^(n+j)`, each of which
+    /// integrates to a rational multiple of `xⁿ`, so `F` is literally
+    /// `D_x(R·F)` for a rational `R`.
+    ///
+    /// It is also a clean reminder that an order-0 certificate proves nothing
+    /// about the integral by itself: here `[R·F]_0^1 = B(n+1,4) ≠ 0`, so the
+    /// "recurrence" `1·f(n) = 0` is exactly as false as the boundary term is
+    /// nonzero.
+    #[test]
+    fn beta_integral_with_an_integer_exponent_collapses_to_order_zero() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let one_minus = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.pow(one_minus, pool.integer(3_i32)),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_eq!(out.value.order, 0);
+    }
+
+    /// `∫_0^1 xⁿ(1−x)ⁿ dx` — both exponents moving, still order 1.
+    #[test]
+    fn central_beta_integral() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let one_minus = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let f = pool.mul(vec![pool.pow(x, n), pool.pow(one_minus, n)]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 1);
+        // f(n) = n!²/(2n+1)!, so f(n+1)/f(n) = (n+1)/(2(2n+3)):
+        // a_0/a_1 = −(n+1)/(2(2n+3)).
+        assert_ratio(r, &pool, n, 0, |v| -(v + 1.0) / (2.0 * (2.0 * v + 3.0)));
+    }
+
+    /// `∫_{−∞}^{∞} x^(2n)·e^(−x²) dx` — the Gaussian even-moment recurrence
+    /// `f(n+1) = (n + 1/2)·f(n)`.
+    #[test]
+    fn gaussian_even_moments() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, pool.mul(vec![pool.integer(2_i32), n])),
+            pool.func(
+                "exp",
+                vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+            ),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 1);
+        // (2n+1)F(n) − 2F(n+1) = D_x(x·F): a_0/a_1 = −(2n+1)/2.
+        assert_ratio(r, &pool, n, 0, |v| -(2.0 * v + 1.0) / 2.0);
+    }
+
+    /// `∫_0^∞ xⁿ·e^(−x²) dx = Γ((n+1)/2)/2` — genuinely order **2**, and the
+    /// middle coefficient is zero. The ascending search must not settle for a
+    /// spurious order-1 relation, and must not miss `a_1 = 0`.
+    #[test]
+    fn half_gaussian_moments_are_order_two() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.func(
+                "exp",
+                vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+            ),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 2, "f(n+2) = ((n+1)/2)·f(n) is an order-2 relation");
+        assert_ratio(r, &pool, n, 1, |_| 0.0);
+        assert_ratio(r, &pool, n, 0, |v| -(v + 1.0) / 2.0);
+    }
+
+    /// Bessel: `J_n(2) = (1/2πi)∮ e^(x − 1/x)·x^(−n−1) dx`, whose classical
+    /// three-term recurrence at `z = 2` is `J_n + J_(n+2) = (n+1)·J_(n+1)`.
+    ///
+    /// The certificate here is the whole point — the contour representation is
+    /// *outside* the interval boundary analysis, but the identity about the
+    /// integrand is the same one either way.
+    #[test]
+    fn bessel_contour_representation() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let arg = pool.add(vec![
+            x,
+            pool.mul(vec![
+                pool.integer(-1_i32),
+                pool.pow(x, pool.integer(-1_i32)),
+            ]),
+        ]);
+        let f = pool.mul(vec![
+            pool.func("exp", vec![arg]),
+            pool.pow(
+                x,
+                pool.add(vec![
+                    pool.mul(vec![pool.integer(-1_i32), n]),
+                    pool.integer(-1_i32),
+                ]),
+            ),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 2, "Bessel's is a three-term recurrence");
+        assert_ratio(r, &pool, n, 1, |v| -(v + 1.0));
+        assert_ratio(r, &pool, n, 0, |_| 1.0);
+    }
+
+    /// Legendre via the Schläfli integral at `z = 3`:
+    /// `P_n(3) = (1/2πi)∮ (x²−1)ⁿ / (2ⁿ·(x−3)^(n+1)) dx`, whose recurrence is
+    /// `(n+2)P_(n+2) − 3(2n+3)P_(n+1) + (n+1)P_n = 0`.
+    #[test]
+    fn legendre_schlafli_representation() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let x2m1 = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-1_i32)]);
+        let xm3 = pool.add(vec![x, pool.integer(-3_i32)]);
+        let f = pool.mul(vec![
+            pool.pow(x2m1, n),
+            pool.pow(pool.integer(2_i32), pool.mul(vec![pool.integer(-1_i32), n])),
+            pool.pow(
+                xm3,
+                pool.add(vec![
+                    pool.mul(vec![pool.integer(-1_i32), n]),
+                    pool.integer(-1_i32),
+                ]),
+            ),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let r = &out.value;
+        assert_eq!(r.order, 2);
+        assert_ratio(r, &pool, n, 1, |v| -3.0 * (2.0 * v + 3.0) / (v + 2.0));
+        assert_ratio(r, &pool, n, 0, |v| (v + 1.0) / (v + 2.0));
+    }
+
+    /// The order-0 case is legitimate and must not be skipped: `F = x·e^(−x²)`
+    /// carries no `n` at all and *is* `D_x(R·F)`.
+    #[test]
+    fn order_zero_is_reachable() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            x,
+            pool.func(
+                "exp",
+                vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+            ),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        assert_eq!(out.value.order, 0);
+    }
+
+    // --- negative tests ----------------------------------------------------
+
+    #[test]
+    fn out_of_class_integrand_is_refused() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![pool.pow(x, n), pool.func("log", vec![x])]);
+        let err = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default())
+            .expect_err("log is out of class");
+        assert!(matches!(err, DiffTelescopingError::NotHyperexponential(_)));
+    }
+
+    /// `exp(n·x)/x` is hyperexponential in `x`, has no order-0 certificate, and
+    /// is not hypergeometric in `n`. The refusal must say the *second* thing —
+    /// raising the search bounds cannot help.
+    #[test]
+    fn non_hypergeometric_in_n_is_refused_specifically() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.func("exp", vec![pool.mul(vec![n, x])]),
+            pool.pow(x, pool.integer(-1_i32)),
+        ]);
+        let err = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default())
+            .expect_err("exp(n*x)/x has no relation in this family");
+        assert!(
+            matches!(err, DiffTelescopingError::NotHypergeometricInN(_)),
+            "expected the n-side refusal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn identical_symbols_are_refused() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let err = almkvist_zeilberger(x, x, x, &pool, &AzOpts::default())
+            .expect_err("n and x must differ");
+        assert!(matches!(err, DiffTelescopingError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn bounds_too_small_refuse_rather_than_guess() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+        ]);
+        let opts = AzOpts {
+            max_order: 0,
+            max_degree: 4,
+            max_den_power: 1,
+        };
+        let err = almkvist_zeilberger(f, n, x, &pool, &opts).expect_err("bounds exhausted");
+        assert!(matches!(err, DiffTelescopingError::SearchExhausted(_)));
+    }
+
+    /// The antiderivative helper must return `R·F`, the object whose boundary
+    /// values the integral recurrence depends on.
+    #[test]
+    fn antiderivative_is_available() {
+        let pool = ExprPool::new();
+        let (n, x) = nx(&pool);
+        let f = pool.mul(vec![
+            pool.pow(x, n),
+            pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+        ]);
+        let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+        let g = integrand_antiderivative(&out.value, f, &pool);
+        let s = format!("{}", pool.display(g));
+        assert!(s.contains("exp"), "G must still carry the integrand: {s}");
+    }
+}

--- a/alkahest-core/src/holonomic/mod.rs
+++ b/alkahest-core/src/holonomic/mod.rs
@@ -73,7 +73,10 @@ pub mod qzeil;
 pub mod telescoping2d;
 pub mod zeilberger;
 
-pub use azeil::{hyperexp_log_derivative, DiffTelescopingError, HyperExpTerm, PowerFactor};
+pub use azeil::{
+    almkvist_zeilberger, dgosper, hyperexp_log_derivative, AzOpts, AzResult, DiffTelescopingError,
+    HyperExpTerm, PowerFactor,
+};
 
 pub use asymptotics::{
     asymptotics_from_recurrence, CharacteristicAnalysis, CharacteristicRoot, ConnectionConstant,

--- a/alkahest-core/src/holonomic/mod.rs
+++ b/alkahest-core/src/holonomic/mod.rs
@@ -64,6 +64,7 @@
 //! step is an exact nullspace the kernel already provides.
 
 pub mod asymptotics;
+pub mod azeil;
 pub mod boundary;
 pub mod hyperterm;
 pub mod modular;
@@ -71,6 +72,8 @@ pub mod qfield;
 pub mod qzeil;
 pub mod telescoping2d;
 pub mod zeilberger;
+
+pub use azeil::{hyperexp_log_derivative, DiffTelescopingError, HyperExpTerm, PowerFactor};
 
 pub use asymptotics::{
     asymptotics_from_recurrence, CharacteristicAnalysis, CharacteristicRoot, ConnectionConstant,

--- a/alkahest-core/src/holonomic/mod.rs
+++ b/alkahest-core/src/holonomic/mod.rs
@@ -74,8 +74,9 @@ pub mod telescoping2d;
 pub mod zeilberger;
 
 pub use azeil::{
-    almkvist_zeilberger, dgosper, hyperexp_log_derivative, AzOpts, AzResult, DiffTelescopingError,
-    HyperExpTerm, PowerFactor,
+    almkvist_zeilberger, dgosper, hyperexp_log_derivative, integral_boundary_status, AzOpts,
+    AzResult, DiffTelescopingError, HyperExpTerm, IntegralBoundaryStatus, IntegrationLimit,
+    PowerFactor,
 };
 
 pub use asymptotics::{

--- a/alkahest-core/src/holonomic/qfield.rs
+++ b/alkahest-core/src/holonomic/qfield.rs
@@ -266,6 +266,37 @@ pub fn rn_deriv(a: &Rn) -> Rn {
     RatFunc { num, den }.normalize()
 }
 
+/// `d/dk` of a `Q(n)[k]` polynomial.
+///
+/// The coefficient field `Q(n)` is *constant* with respect to `k`, so this is
+/// the plain power rule with no chain-rule term — which is exactly what makes
+/// `Q(n)(k)` a differential field over `Q(n)` and lets the continuous
+/// creative-telescoping engine ([`super::azeil`]) reuse this tower unchanged.
+pub fn polyk_deriv_k(p: &PolyK) -> PolyK {
+    if p.coeffs.len() <= 1 {
+        return PolyK::zero();
+    }
+    let coeffs: Vec<Rn> = p
+        .coeffs
+        .iter()
+        .enumerate()
+        .skip(1)
+        .map(|(i, c)| rn_mul(c, &rn_int(i as i64)))
+        .collect();
+    PolyK::from_coeffs(coeffs)
+}
+
+/// `d/dk` of a `Q(n)(k)` rational function, by the quotient rule.
+pub fn ratk_deriv_k(r: &RatK) -> RatK {
+    let nu = polyk_deriv_k(&r.num);
+    let dv = polyk_deriv_k(&r.den);
+    RatK {
+        num: nu.mul(&r.den).sub(&r.num.mul(&dv)),
+        den: r.den.mul(&r.den),
+    }
+    .normalize()
+}
+
 fn poly_eval(p: &RatUniPoly, x: &Rational) -> Rational {
     let mut acc = Rational::from(0);
     for c in p.coeffs.iter().rev() {

--- a/alkahest-core/src/holonomic/zeilberger.rs
+++ b/alkahest-core/src/holonomic/zeilberger.rs
@@ -239,7 +239,12 @@ fn gosper_normal_form_qn(mut p: PolyK, mut q: PolyK) -> Option<(PolyK, PolyK, Po
 /// structure as `sum::gosper::rational_gaussian_solve`, generalized to `Rn`
 /// pivots/division. A zero column is a free variable, set to zero. Returns
 /// `None` when the system is inconsistent.
-fn field_gaussian_solve(mut mat: Vec<Vec<Rn>>, mut rhs: Vec<Rn>) -> Option<Vec<Rn>> {
+///
+/// Shared with the continuous engine ([`super::azeil::rde`]): the linear
+/// algebra an undetermined-coefficients ansatz needs is the same whether the
+/// unknowns come from Gosper's key equation or from a parametric Risch
+/// differential equation, and there is no reason for two copies of it.
+pub(super) fn field_gaussian_solve(mut mat: Vec<Vec<Rn>>, mut rhs: Vec<Rn>) -> Option<Vec<Rn>> {
     let nrows = mat.len();
     if nrows == 0 {
         return Some(vec![]);

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -362,6 +362,14 @@ pub mod experimental {
         eval_complex_f64, eval_exact_rational, eval_f64, eval_interval, evaluate, ComplexF64,
         EvalError, EvalMode, EvalValue, UnsupportedReason,
     };
+    /// Continuous (differential) creative telescoping — Almkvist–Zeilberger,
+    /// the twin of `q_zeilberger`/`telescope2d` on the `D_x` side. Rust-only
+    /// for now: there is no PyO3 binding yet.
+    pub use crate::holonomic::azeil::{
+        almkvist_zeilberger, dgosper, dgosper_term, hyperexp_log_derivative,
+        integral_boundary_status, AzOpts, AzResult, DiffTelescopingError, HyperExpTerm,
+        IntegralBoundaryStatus, IntegrationLimit, PowerFactor,
+    };
     pub use crate::holonomic::{
         boundary_status_2d, telescope2d, telescope2d_search, BoundaryStatus2d, Telescoping2dError,
         Telescoping2dOpts, Telescoping2dResult,

--- a/alkahest-core/tests/azeil_continuous_telescoping.rs
+++ b/alkahest-core/tests/azeil_continuous_telescoping.rs
@@ -1,0 +1,219 @@
+//! End-to-end checks of the continuous creative-telescoping engine through the
+//! crate's `experimental` surface — the same route a downstream Rust caller
+//! takes, rather than the crate-internal module paths the unit tests use.
+//!
+//! Each case pairs a classical definite integral with the recurrence it is
+//! known to satisfy, and asserts both halves the engine is responsible for:
+//! the certificate's recurrence coefficients, and the boundary verdict that
+//! decides whether that recurrence transfers from the integrand to the
+//! integral.
+
+use alkahest_cas::experimental::{
+    almkvist_zeilberger, dgosper, integral_boundary_status, AzOpts, IntegralBoundaryStatus,
+    IntegrationLimit,
+};
+use alkahest_cas::kernel::{Domain, ExprId, ExprPool};
+use std::collections::HashMap;
+
+fn ratio_at(pool: &ExprPool, n: ExprId, num: ExprId, den: ExprId, ni: f64) -> f64 {
+    let env = HashMap::from([(n, ni)]);
+    let a = alkahest_cas::eval_f64(num, pool, &env).expect("coefficient evaluates");
+    let b = alkahest_cas::eval_f64(den, pool, &env).expect("coefficient evaluates");
+    a / b
+}
+
+/// `∫_0^∞ xⁿ·e^(−x) dx = n!`  ⇒  `f(n+1) = (n+1)·f(n)`, boundary vanishes.
+#[test]
+fn gamma_function_recurrence_end_to_end() {
+    let pool = ExprPool::new();
+    let n = pool.symbol("n", Domain::Real);
+    let x = pool.symbol("x", Domain::Real);
+    let f = pool.mul(vec![
+        pool.pow(x, n),
+        pool.func("exp", vec![pool.mul(vec![pool.integer(-1_i32), x])]),
+    ]);
+
+    let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+    let r = &out.value;
+    assert_eq!(r.order, 1);
+    for ni in [1.0_f64, 4.0, 12.5] {
+        let q = ratio_at(&pool, n, r.coeffs[0], r.coeffs[1], ni);
+        assert!(
+            (q + (ni + 1.0)).abs() < 1e-9,
+            "a_0/a_1 must be -(n+1); got {q} at n={ni}"
+        );
+    }
+
+    let status = integral_boundary_status(
+        r,
+        f,
+        n,
+        x,
+        &pool,
+        &IntegrationLimit::at(0),
+        &IntegrationLimit::PosInfinity,
+    )
+    .expect("boundary analysis");
+    assert_eq!(status.tag(), "vanishes");
+    assert!(status.implies_integral_recurrence());
+    // The one hypothesis left standing is exactly the convergence condition at
+    // the origin, and it is reported rather than assumed.
+    assert_eq!(status.conditions().len(), 1);
+}
+
+/// `∫_{−∞}^{∞} x^(2n)·e^(−x²) dx`  ⇒  `2·f(n+1) = (2n+1)·f(n)`, boundary
+/// vanishes with no condition on `n` at all.
+#[test]
+fn gaussian_moments_end_to_end() {
+    let pool = ExprPool::new();
+    let n = pool.symbol("n", Domain::Real);
+    let x = pool.symbol("x", Domain::Real);
+    let f = pool.mul(vec![
+        pool.pow(x, pool.mul(vec![pool.integer(2_i32), n])),
+        pool.func(
+            "exp",
+            vec![pool.mul(vec![pool.integer(-1_i32), pool.pow(x, pool.integer(2_i32))])],
+        ),
+    ]);
+
+    let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+    let r = &out.value;
+    assert_eq!(r.order, 1);
+    for ni in [0.0_f64, 3.0, 8.5] {
+        let q = ratio_at(&pool, n, r.coeffs[0], r.coeffs[1], ni);
+        assert!(
+            (q + (2.0 * ni + 1.0) / 2.0).abs() < 1e-9,
+            "a_0/a_1 must be -(2n+1)/2; got {q} at n={ni}"
+        );
+    }
+
+    let status = integral_boundary_status(
+        r,
+        f,
+        n,
+        x,
+        &pool,
+        &IntegrationLimit::NegInfinity,
+        &IntegrationLimit::PosInfinity,
+    )
+    .expect("boundary analysis");
+    assert_eq!(status.tag(), "vanishes");
+    assert!(status.conditions().is_empty());
+}
+
+/// `∫_0^1 xⁿ dx = 1/(n+1)`: the certificate exists at order 0 and the boundary
+/// term is `1/(n+1)`, *not* zero. The engine must return the inhomogeneous
+/// reading — this is the case a module that collapsed `Unknown` into `Vanishes`
+/// would turn into the false lemma `f(n) = 0`.
+#[test]
+fn nonvanishing_boundary_end_to_end() {
+    let pool = ExprPool::new();
+    let n = pool.symbol("n", Domain::Real);
+    let x = pool.symbol("x", Domain::Real);
+    let f = pool.pow(x, n);
+
+    let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+    assert_eq!(out.value.order, 0);
+
+    let status = integral_boundary_status(
+        &out.value,
+        f,
+        n,
+        x,
+        &pool,
+        &IntegrationLimit::at(0),
+        &IntegrationLimit::at(1),
+    )
+    .expect("boundary analysis");
+    match &status {
+        IntegralBoundaryStatus::Nonzero { rhs, .. } => {
+            for ni in [2.0_f64, 6.0] {
+                let env = HashMap::from([(n, ni)]);
+                let v = alkahest_cas::eval_f64(*rhs, &pool, &env).expect("rhs evaluates");
+                assert!((v - 1.0 / (ni + 1.0)).abs() < 1e-12, "rhs must be 1/(n+1)");
+            }
+        }
+        other => panic!("expected Nonzero, got {other:?}"),
+    }
+}
+
+/// Bessel's three-term recurrence, read off the Schläfli contour
+/// representation `J_n(2) = (1/2πi)∮ e^(x − 1/x)·x^(−n−1) dx`:
+/// `J_n + J_(n+2) = (n+1)·J_(n+1)`, certificate `R = 1`.
+#[test]
+fn bessel_recurrence_end_to_end() {
+    let pool = ExprPool::new();
+    let n = pool.symbol("n", Domain::Real);
+    let x = pool.symbol("x", Domain::Real);
+    let arg = pool.add(vec![
+        x,
+        pool.mul(vec![
+            pool.integer(-1_i32),
+            pool.pow(x, pool.integer(-1_i32)),
+        ]),
+    ]);
+    let f = pool.mul(vec![
+        pool.func("exp", vec![arg]),
+        pool.pow(
+            x,
+            pool.add(vec![
+                pool.mul(vec![pool.integer(-1_i32), n]),
+                pool.integer(-1_i32),
+            ]),
+        ),
+    ]);
+
+    let out = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect("certificate");
+    let r = &out.value;
+    assert_eq!(r.order, 2);
+    for ni in [1.0_f64, 5.0, 9.5] {
+        let q0 = ratio_at(&pool, n, r.coeffs[0], r.coeffs[2], ni);
+        let q1 = ratio_at(&pool, n, r.coeffs[1], r.coeffs[2], ni);
+        assert!((q0 - 1.0).abs() < 1e-9, "a_0/a_2 must be 1; got {q0}");
+        assert!(
+            (q1 + (ni + 1.0)).abs() < 1e-9,
+            "a_1/a_2 must be -(n+1); got {q1}"
+        );
+    }
+}
+
+/// The differential-Gosper half, through the same surface:
+/// `∫ x²·eˣ dx = (x²−2x+2)·eˣ`.
+#[test]
+fn dgosper_end_to_end() {
+    let pool = ExprPool::new();
+    let x = pool.symbol("x", Domain::Real);
+    let f = pool.mul(vec![
+        pool.pow(x, pool.integer(2_i32)),
+        pool.func("exp", vec![x]),
+    ]);
+    let r = dgosper(f, x, &pool, &AzOpts::default()).expect("certificate");
+    // R = (x²−2x+2)/x²: check numerically at a couple of points, independently
+    // of the exact arithmetic the engine already verified it with.
+    for xi in [0.5_f64, 2.0, 7.0] {
+        let env = HashMap::from([(x, xi)]);
+        let got = alkahest_cas::eval_f64(r.value, &pool, &env).expect("R evaluates");
+        let want = (xi * xi - 2.0 * xi + 2.0) / (xi * xi);
+        assert!((got - want).abs() < 1e-12, "R at x={xi}: {got} vs {want}");
+    }
+}
+
+/// Out of class in the `n` direction: `exp(n·x)/x` is hyperexponential in `x`
+/// but its `n`-ratio is `eˣ`. The refusal must be typed and specific, not a
+/// panic and not a wrong recurrence.
+#[test]
+fn out_of_class_refusal_end_to_end() {
+    let pool = ExprPool::new();
+    let n = pool.symbol("n", Domain::Real);
+    let x = pool.symbol("x", Domain::Real);
+    let f = pool.mul(vec![
+        pool.func("exp", vec![pool.mul(vec![n, x])]),
+        pool.pow(x, pool.integer(-1_i32)),
+    ]);
+    let err = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()).expect_err("out of class");
+    assert_eq!(
+        alkahest_cas::errors::AlkahestError::code(&err),
+        "E-HOLO-061",
+        "the n-side refusal has its own stable code"
+    );
+}

--- a/alkahest-core/tests/azeil_continuous_telescoping.rs
+++ b/alkahest-core/tests/azeil_continuous_telescoping.rs
@@ -217,3 +217,82 @@ fn out_of_class_refusal_end_to_end() {
         "the n-side refusal has its own stable code"
     );
 }
+
+/// A deterministic round-trip over a small grid of hyperexponential integrands:
+/// for every one the engine accepts, re-derive `θ` and the shift ratios *from
+/// the returned expressions* and re-check
+/// `Σ a_i·r_i = R′ + θ·R` in exact `Q(n)(x)` arithmetic.
+///
+/// The engine already verifies its certificate internally, so what this adds is
+/// the leg the internal check cannot cover: the trip out through `ExprId` and
+/// back. A bug in the `Q(n)(x)` → expression conversion would be invisible to
+/// the internal check and fatal to a caller, and this catches it.
+#[test]
+fn certificate_round_trips_through_the_expression_layer() {
+    use alkahest_cas::holonomic::hyperterm::as_ratk;
+    use alkahest_cas::holonomic::qfield::{ratk_deriv_k, RatK};
+
+    let pool = ExprPool::new();
+    let n = pool.symbol("n", Domain::Real);
+    let x = pool.symbol("x", Domain::Real);
+    let one_minus = pool.add(vec![
+        pool.integer(1_i32),
+        pool.mul(vec![pool.integer(-1_i32), x]),
+    ]);
+
+    let mut accepted = 0usize;
+    for alpha in [1_i32, 2] {
+        for beta in [0_i32, 1] {
+            // (1-x) exponent: 0, 1/2, 3, or n
+            for gamma in 0..4 {
+                for delta in [0_i32, -1] {
+                    let x_exp = pool.add(vec![
+                        pool.mul(vec![pool.integer(alpha), n]),
+                        pool.integer(beta),
+                    ]);
+                    let mut factors = vec![pool.pow(x, x_exp)];
+                    match gamma {
+                        0 => {}
+                        1 => factors.push(pool.pow(one_minus, pool.rational(1, 2))),
+                        2 => factors.push(pool.pow(one_minus, pool.integer(3_i32))),
+                        _ => factors.push(pool.pow(one_minus, n)),
+                    }
+                    if delta != 0 {
+                        factors
+                            .push(pool.func("exp", vec![pool.mul(vec![pool.integer(delta), x])]));
+                    }
+                    let f = pool.mul(factors);
+
+                    let Ok(out) = almkvist_zeilberger(f, n, x, &pool, &AzOpts::default()) else {
+                        continue;
+                    };
+                    accepted += 1;
+                    let r = &out.value;
+
+                    let term = alkahest_cas::experimental::HyperExpTerm::parse(f, n, x, &pool)
+                        .expect("an accepted integrand parses");
+                    let theta = term.theta().expect("theta exists");
+                    let cert = as_ratk(r.certificate, n, x, &pool, 0)
+                        .expect("the certificate is rational in (n, x)");
+
+                    let mut lhs = RatK::zero();
+                    for (i, c) in r.coeffs.iter().enumerate() {
+                        let ai = as_ratk(*c, n, x, &pool, 0).expect("a_i is rational in n");
+                        let ri = term.ratio_n(i as i64).expect("shift ratio");
+                        lhs = lhs.add(&ai.mul(&ri));
+                    }
+                    let rhs = ratk_deriv_k(&cert).add(&theta.mul(&cert));
+                    assert!(
+                        lhs.sub(&rhs).is_zero(),
+                        "round-trip failed for alpha={alpha} beta={beta} gamma={gamma} \
+                         delta={delta}: sum a_i r_i != R' + theta R"
+                    );
+                }
+            }
+        }
+    }
+    assert!(
+        accepted >= 24,
+        "the grid should be well inside the supported class; only {accepted} accepted"
+    );
+}


### PR DESCRIPTION
Adds the **differential** twin of the existing discrete holonomic stack. Alkahest had Zeilberger, q-Zeilberger and multi-sum Apagodu–Zeilberger (~16.7k lines) but nothing for `∫ F(n,x) dx`, even though the differential case is the easier one and both halves of the machinery already existed in modules that had never been connected.

New `alkahest-core/src/holonomic/azeil/`, one commit per stage:

1. **`hyperexp.rs`** — recognises `F(n,x) = R(n,x)·wⁿ·exp(η)·∏ B_j^(α_j·n+β_j)`, returns `θ = ∂_xF/F` exactly and the `n`-shift ratios. Built on the existing `qfield` tower.
2. **`dgosper.rs`** — differential Gosper: decides `∫F dx = R·F` for rational `R`.
3. **`search.rs`** — Almkvist–Zeilberger by undetermined coefficients, order-major ascending, so a returned order **is** minimal within the degree bounds.
4. **`boundary.rs`** — three-valued `Vanishes` / `Nonzero` / `Unknown`, nothing numeric. Where vanishing depends on `n`, the inequality is **returned as a condition** rather than assumed.

## Certificates produced

| integral | order | R | boundary |
|---|---|---|---|
| `∫_0^∞ xⁿe^{−x}` | 1 | `−x` | vanishes, `n+1 > 0` |
| `∫_{−∞}^{∞} x^{2n}e^{−x²}` | 1 | `−x` | vanishes, unconditional |
| `∫_0^1 xⁿ(1−x)^{1/2}` | 1 | `2x²−2x` | vanishes, `n+1 > 0` |
| `∫_0^1 xⁿ` | 0 | `x/(n+1)` | **nonzero**, `rhs = 1/(n+1)` |
| Bessel `J_n(2)`, Schläfli | 2 | `1` | unknown (essential singularity) |
| Legendre `P_n(3)`, Schläfli | 2 | — | — |

Recovers `J_n + J_{n+2} = (n+1)J_{n+1}` and `(n+1)P_n − 3(2n+3)P_{n+1} + (n+2)P_{n+2} = 0` exactly.

Every certificate is re-verified as an exact identity before return, matching the module's existing discipline; outside the class it refuses via a new `E-HOLO-06x` block rather than guessing.

Rust-only for now — no PyO3 binding, no Python export.

## Verification

`cargo test --workspace` green (47 azeil tests), clippy clean on default/`egraph`/`parallel`, `cargo doc` clean under `-D warnings`, error-code registry check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental continuous creative telescoping for deriving recurrences of parameterized integrals.
  - Added rational-certificate generation and indefinite integration for supported hyperexponential expressions.
  - Added boundary analysis for finite and infinite integration limits, reporting vanishing, nonzero, or unknown results.
  - Added support for configurable search limits and formal handling of supported power expressions.
- **Bug Fixes**
  - Added clear, typed error reporting for invalid, unsupported, or inconclusive calculations.
- **Documentation**
  - Added usage examples, limitations, and guidance for interpreting boundary conditions and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->