### PR TITLE
fix(matrix): satisfy clippy::needless_late_init in the Smith-form solvers — unblocks CI on main

### DIFF
--- a/adv_hh_huntB.log
+++ b/adv_hh_huntB.log
@@ -1,0 +1,1 @@
+/home/user/ak-venv/bin/python: can't open file '/home/user/alkahest/adv_hh_hunt.py': [Errno 2] No such file or directory

--- a/adv_hh_huntC.log
+++ b/adv_hh_huntC.log
@@ -1,0 +1,1 @@
+/home/user/ak-venv/bin/python: can't open file '/home/user/alkahest/adv_hh_hunt.py': [Errno 2] No such file or directory

--- a/alkahest-core/src/matrix/smith.rs
+++ b/alkahest-core/src/matrix/smith.rs
@@ -289,8 +289,7 @@ fn smith_decomp_rec(
         }
     }
 
-    let result: Vec<Integer>;
-    if m[0][0] != zero {
+    let result: Vec<Integer> = if m[0][0] != zero {
         let mut res = vec![m[0][0].clone()];
         res.extend(invs);
 
@@ -325,7 +324,7 @@ fn smith_decomp_rec(
             }
             i += 1;
         }
-        result = res;
+        res
     } else {
         if full {
             if let Some(ss) = s_opt.as_mut() {
@@ -345,8 +344,8 @@ fn smith_decomp_rec(
         }
         let mut res = invs;
         res.push(m[0][0].clone());
-        result = res;
-    }
+        res
+    };
 
     (result, s_opt, t_opt)
 }

--- a/alkahest-core/src/matrix/smith_poly.rs
+++ b/alkahest-core/src/matrix/smith_poly.rs
@@ -263,8 +263,7 @@ fn smith_decomp_rec(
         }
     }
 
-    let result: Vec<RatUniPoly>;
-    if !m[0][0].is_zero() {
+    let result: Vec<RatUniPoly> = if !m[0][0].is_zero() {
         let mut res = vec![m[0][0].clone()];
         res.extend(invs);
 
@@ -295,7 +294,7 @@ fn smith_decomp_rec(
             }
             i += 1;
         }
-        result = res;
+        res
     } else {
         if full {
             if let Some(ss) = s_opt.as_mut() {
@@ -315,8 +314,8 @@ fn smith_decomp_rec(
         }
         let mut res = invs;
         res.push(m[0][0].clone());
-        result = res;
-    }
+        res
+    };
 
     (result, s_opt, t_opt)
 }

--- a/kn_conj4_k5.log
+++ b/kn_conj4_k5.log
@@ -1,0 +1,1 @@
+/home/user/ak-venv/bin/python: can't open file '/home/user/alkahest/kn_search.py': [Errno 2] No such file or directory


### PR DESCRIPTION
`main` has been red on **Tier 1a — Rust + fast Python** since CI's clippy moved to 1.98.0, which blocks every open PR.

```
error: unneeded late initialization
   --> alkahest-core/src/matrix/smith.rs:292:5
error: unneeded late initialization
   --> alkahest-core/src/matrix/smith_poly.rs:266:5
error: could not compile `alkahest-cas` (lib) due to 2 previous errors
```

`clippy::needless_late_init` fires on the `let result: T;` + if/else-assign shape in both Smith normal form solvers. Rewritten as `let result: T = if … { … } else { … };`.

**Pure refactor** — the conditions, both branch bodies and the return are untouched; only the binding form changes.

Neither file is touched by any other in-flight work, so this is independent of the integration queue and safe to land first.

## Verification

- `cargo clippy -p alkahest-cas --lib` clean (was 2 errors)
- `cargo test -p alkahest-cas --lib matrix::` — 61 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal matrix decomposition result handling without changing behavior or outputs.
  * No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->