### PR TITLE
fix(ci): stop llvm@15 shadowing rustc's own LLVM on the macOS cross job

### DIFF
--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -76,7 +76,16 @@ jobs:
         run: |
           brew install llvm@15
           echo "LLVM_SYS_150_PREFIX=$(brew --prefix llvm@15)" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=$(brew --prefix llvm@15)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+          # DYLD_FALLBACK_LIBRARY_PATH, not DYLD_LIBRARY_PATH: the latter is
+          # searched *before* a binary's own install paths and applies to every
+          # later process in the job, so pointing it at llvm@15 made dyld resolve
+          # `rustc`'s own (much newer) LLVM symbols against LLVM 15. Once stable
+          # rustc's bundled LLVM moved past 15, plain `rustc -vV` began aborting
+          # with `Symbol not found: ..SmallVectorBase..mallocForGrow`, failing the
+          # job before it compiled anything. The fallback variant is consulted
+          # only when the normal search fails, so inkwell still finds llvm@15
+          # while rustc keeps its own.
+          echo "DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix llvm@15)/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}" >> $GITHUB_ENV
 
       - name: Set up MSYS2 + FLINT (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
`ci-cross` has been red on **every branch since 2026-08-18**, dying before it compiles anything:

```
dyld: Symbol not found: __ZN4llvm15SmallVectorBaseIjE13mallocForGrowEPvmmRm
error: process didn't exit successfully: `rustc -vV` (signal: 6, SIGABRT)
```

This is our config, not a broken runner image. The job exported

```
DYLD_LIBRARY_PATH=$(brew --prefix llvm@15)/lib
```

into `$GITHUB_ENV`, so it applied to **every subsequent process in the job**, not just the `jit` build that needs it. `DYLD_LIBRARY_PATH` is searched *ahead* of a binary's own install paths, so dyld resolved `rustc`'s LLVM symbols against LLVM 15. `mallocForGrow` is a modern `SmallVectorBase` API that does not exist in LLVM 15 — harmless while stable rustc's bundled LLVM was close enough, fatal once it moved past 15.

Switches to `DYLD_FALLBACK_LIBRARY_PATH`, consulted only when the normal search fails: inkwell still resolves llvm@15 via `LLVM_SYS_150_PREFIX`, and rustc keeps its own LLVM.

## Follow-up, not in this PR

`macos-14` is the GitHub runner label for macOS Sonoma (2023). Labels track Apple's major versions, and Apple has since moved to year-based numbering, so this image is a couple of generations behind. Worth bumping — but separately, because `inkwell` pins LLVM 15 (see this file's header comment) and `brew install llvm@15` availability on a newer image needs checking on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build and testing reliability for features requiring LLVM 15.
  * Updated library path handling to help resolve LLVM 15 components correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->