### PR TITLE
fix(risch): decline a negative log power instead of allocating until abort

### DIFF
--- a/alkahest-core/src/integrate/risch/tower.rs
+++ b/alkahest-core/src/integrate/risch/tower.rs
@@ -381,7 +381,16 @@ fn decompose_log_inner(
                 pool.mul(f)
             };
 
-            let deg = log_power as usize;
+            // `log_power` is an `i64` accumulated from exponents, so it is
+            // negative whenever the generator sits in a *denominator*
+            // (`log(x)^-1`).  `as usize` wraps that to ~2^64 and the loop below
+            // then pushes zeros until the allocator aborts the process — a 4 GiB
+            // request, reached from `∫ dx/(x·log x·(1 + log²(log x)))`, which no
+            // wall-clock budget can interrupt because the loop never returns to a
+            // cooperative checkpoint.  A negative power is not representable as a
+            // polynomial in `log(h)` — which is exactly what this decomposition
+            // builds — so decline and let the caller try another route.
+            let deg = usize::try_from(log_power).ok()?;
             while coeffs.len() <= deg {
                 coeffs.push(pool.integer(0_i32));
             }
@@ -469,5 +478,53 @@ pub fn poly_degree(expr: ExprId, var: ExprId, pool: &ExprPool) -> Option<u32> {
         },
         ExprData::Pow { base, .. } if is_free_of_var(base, var, pool) => Some(0),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod log_power_underflow_tests {
+    use super::*;
+    use crate::kernel::{Domain, ExprPool};
+
+    /// A log generator in a *denominator* gives `log_power < 0`.
+    ///
+    /// `log_power as usize` used to wrap that to ~2^64, and the zero-fill loop
+    /// then pushed until the allocator aborted the process. A 4 GiB request was
+    /// reachable from `∫ dx/(x·log x·(1 + log²(log x)))` — an elementary
+    /// integral — and no `Budget(wall_ms=…)` could interrupt it, because the
+    /// loop never returns to a cooperative checkpoint.
+    ///
+    /// This decomposition builds a *polynomial* in `log(h)`, so a negative
+    /// power is simply not representable: it must decline, promptly.
+    #[test]
+    fn negative_log_power_declines_instead_of_allocating() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let logx = pool.func("log", vec![x]);
+
+        for power in [-1_i32, -2, -7] {
+            let f = pool.mul(vec![
+                pool.pow(x, pool.integer(-1_i32)),
+                pool.pow(logx, pool.integer(power)),
+            ]);
+            let got = decompose_as_log_poly(f, logx, &pool);
+            assert!(
+                got.is_none(),
+                "log(x)^{power} is not a polynomial in log(x); expected a decline, got {got:?}"
+            );
+        }
+    }
+
+    /// The non-negative path is untouched: `x·log(x)^2` still decomposes.
+    #[test]
+    fn non_negative_log_power_still_decomposes() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let logx = pool.func("log", vec![x]);
+        let f = pool.mul(vec![x, pool.pow(logx, pool.integer(2_i32))]);
+        assert!(
+            decompose_as_log_poly(f, logx, &pool).is_some(),
+            "x·log(x)^2 is a polynomial in log(x) and must still decompose"
+        );
     }
 }


### PR DESCRIPTION
An integer-underflow-driven unbounded allocation that **aborts the process** and cannot be stopped by a budget.

`decompose_as_log_poly` accumulates a generator's exponents into an `i64`, so `log_power` is negative whenever the generator sits in a **denominator** (`log(x)^-1`). `alkahest-core/src/integrate/risch/tower.rs:384` then did:

```rust
let deg = log_power as usize;          // -1i64 as usize == 18446744073709551615
while coeffs.len() <= deg { coeffs.push(...) }
```

Reachable from one line of public API:

```python
f = ak.simplify(ak.diff(ak.parse("atan(log(log(x)))", p), x).value).value
with ak.context(pool=p, budget=ak.Budget(wall_ms=3000)):
    ak.integrate(f, x)      # 4 GiB allocation, SIGABRT
```

The integrand is `1/(x·log x·(1 + log²(log x)))` — **elementary**, equal to `atan(log(log x))`. Measured at ~52 MB/s growth, reaching 26 GB RSS in 10 minutes under a 3-second budget. `Budget(wall_ms=…)` cannot interrupt it: the loop never returns to a cooperative checkpoint, so the deadline gets exactly one look before it starts.

A negative power is not representable as a polynomial in `log(h)` — which is precisely what this decomposition builds — so it declines via `usize::try_from(..).ok()?` and the caller tries another route. The sibling `Pow` arm was already safe (`to_u32()` rejects negatives).

## Verification

- Two regression tests: negative powers (`-1`, `-2`, `-7`) decline promptly; `x·log(x)^2` still decomposes.
- `cargo test -p alkahest-cas --lib integrate::risch::tower` — 24 passed, 0 failed.

## Note

This is the *root cause*. A complementary defence-in-depth change (a growth ceiling in `crate::budget`, so any runaway allocation yields `E-BUDGET-002` rather than an abort) is on a separate branch and is worth landing too — the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)