### PR TITLE
docs: correct a false example in the parser-duality warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,9 @@ Three consequences, all of which have bitten:
   `pytest` green while testing the unfixed path.
 - **`cargo test` cannot detect a divergence.** Nothing cross-checks the two implementations, so
   they drift silently.
-- **They already differ.** `cbrt(x)` parses in Rust and raises `unknown function 'cbrt'` in
-  Python.
+- **Nothing pins them together.** There is no conformance test feeding a shared corpus through
+  both and comparing the trees, so a divergence is found by whoever trips over it. Adding one
+  would be worth more than this warning.
 
 If you change tokenisation, precedence, associativity, or how a node is built, change both and
 say so in the commit message. If you add a function name to one, add it to the other.


### PR DESCRIPTION
#318 offered `cbrt(x)` as evidence the two parsers already differ — "parses in Rust and raises in Python."

**That is false.** `cbrt` is in neither parser and is not a registered primitive:

```
grep cbrt alkahest-core/src/parse.rs      -> nothing
grep cbrt python/alkahest/_parse.py       -> nothing
grep '"cbrt"' alkahest-core/src/primitive -> nothing
```

The claim came from `pool.func("cbrt", …)` in a Rust test, which constructs the node through the builder API and never touches a parser.

The section's substance stands — two hand-maintained parsers, a fix must be made twice, `cargo test` cannot detect drift. Only the example was wrong. Replaced with the accurate point: **nothing pins them together**, and a conformance test feeding a shared corpus through both would be worth more than the warning.

Found by an agent that hit the real consequence: it wanted `cbrt` in a probe and could not express it in either language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance on maintaining consistency between the Rust and Python parsers.
  * Documented the absence of shared conformance testing and recommended validating both implementations against a common corpus.
  * Clarified considerations for future parser changes and compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->