### PR TITLE
fix(crosscheck): classify the four special-function primitives #323 left out

### DIFF
--- a/python/alkahest/crosscheck.py
+++ b/python/alkahest/crosscheck.py
@@ -205,6 +205,10 @@ FUNCTION_MAP: dict[str, str] = {
     "Ci": "Ci",
     "Shi": "Shi",
     "Chi": "Chi",
+    # Fresnel integrals. Both systems use the normalised (pi/2) convention
+    # (DLMF 7.2(iii)), so S(inf) = C(inf) = 1/2 in each and the names coincide.
+    "fresnels": "fresnels",
+    "fresnelc": "fresnelc",
 }
 
 #: Bessel functions of fixed integer order, which SymPy spells with the order as
@@ -226,6 +230,20 @@ REFUSED_FUNCTIONS: dict[str, str] = {
     "EllipticE": "elliptic integrals differ in modulus-vs-parameter convention between systems",
     "EllipticF": "elliptic integrals differ in modulus-vs-parameter convention between systems",
     "EllipticPi": "elliptic integrals differ in modulus-vs-parameter convention between systems",
+    # Not a convention mismatch — the values agree. SymPy simply spells these
+    # with the order as an argument (`polylog(2, z)`, `polygamma(1, z)`) rather
+    # than as their own names, so there is no name-for-name rename to put in
+    # FUNCTION_MAP. The `_FIXED_ORDER_BESSEL` mechanism above is the shape that
+    # would cover them; extending it is a better fix than either of these two
+    # tables and is left as a follow-up.
+    "dilog": (
+        "SymPy has no `dilog`; it is `polylog(2, z)`, an arity difference rather "
+        "than a value difference, so a name-for-name rename cannot express it"
+    ),
+    "trigamma": (
+        "SymPy has no `trigamma`; it is `polygamma(1, z)`, an arity difference "
+        "rather than a value difference, so a name-for-name rename cannot express it"
+    ),
 }
 
 #: Pool symbols with a reserved meaning. ``ExprPool.pos_infinity()`` and
@@ -966,6 +984,8 @@ _SYMPY_TO_ALKAHEST: dict[str, str] = {
     "Ci": "cos_integral",
     "Shi": "sinh_integral",
     "Chi": "cosh_integral",
+    "fresnels": "fresnels",
+    "fresnelc": "fresnelc",
 }
 
 


### PR DESCRIPTION
`test_registry_primitives_are_classified` fails on `main`.

#323 added ten special-function primitives but classified only the exponential-integral six in `crosscheck.FUNCTION_MAP`. `dilog`, `fresnelc`, `fresnels` and `trigamma` were left unclassified, and that test requires every registered primitive to appear in `FUNCTION_MAP` or `REFUSED_FUNCTIONS`.

Verified on `main`:

```
Ei         2 hits
Si         2 hits
dilog      0
fresnelc   0
fresnels   0
trigamma   0
```

## The fix

**`fresnels`/`fresnelc` → `FUNCTION_MAP`.** Both systems use the normalised (π/2) convention of DLMF 7.2(iii), so `S(∞) = C(∞) = ½` in each and the names coincide — a genuine name-for-name rename.

**`dilog`/`trigamma` → `REFUSED_FUNCTIONS`,** with the reason stated precisely. This is **not** a convention mismatch — the values agree. SymPy simply spells them `polylog(2, z)` and `polygamma(1, z)`, an *arity* difference that a name-for-name rename cannot express. `_FIXED_ORDER_BESSEL` (already in the file, for `bessel_j0`/`bessel_j1`) is the mechanism that would cover them properly; extending it is the better fix and is noted as a follow-up rather than rushed here.

Found by an agent working on the simplifier, which flagged it rather than touching a file outside its scope.

## Note

I could not run the test locally — the checked-in extension `.so` predates the special-function additions, so `import alkahest` fails on `cos_integral`. This is a data-table change with no logic; CI is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for round-tripping Fresnel integral functions between the application and SymPy.
  * Improved handling of dilogarithm and trigamma functions by clearly rejecting unsupported argument formats instead of applying incorrect name mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->