### PR TITLE
fix(lean): print a negation as a negation, so the goal matches the cited theorem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **A Lean certificate cited a theorem it had not stated.** The kernel folds
+  `-e` into `Mul[e, -1]`, and the Lean printer rendered that literally, so the
+  `Filter.Tendsto` certificate for `exp(-x) → 0` emitted the goal
+  `Tendsto (fun x => rexp (x * -1)) atTop (𝓝 0)` while citing
+  `tendsto_exp_neg_atTop_nhds_zero`, which proves the `rexp (-x)` form. Lean
+  rejected it, so nothing unsound was ever handed out — but the emitter's
+  contract is that what it emits typechecks, and `Verify Lean 4 proofs` has
+  been red on `main` since the Tendsto certificates landed. The printer now
+  renders a lone `-1` factor as a negation of the remaining product. The
+  existing test asserted only that the output *named* the theorem, never that
+  the printed goal was the theorem's statement; it now checks both.
+
 - **`limit()` now returns `DerivedResult`**, matching `diff` / `integrate`, so
   `.certificate` can carry a Lean `Filter.Tendsto` proof. Recognised `x → +∞`
   patterns (`exp(-x) → 0`, `xⁿ exp(-x) → 0`, `exp(x) → +∞`, a crude exp-ratio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@
   `tendsto_exp_neg_atTop_nhds_zero`, which proves the `rexp (-x)` form. Lean
   rejected it, so nothing unsound was ever handed out — but the emitter's
   contract is that what it emits typechecks, and `Verify Lean 4 proofs` has
-  been red on `main` since the Tendsto certificates landed. The printer now
-  renders a lone `-1` factor as a negation of the remaining product. The
-  existing test asserted only that the output *named* the theorem, never that
-  the printed goal was the theorem's statement; it now checks both.
+  been red on `main` since the Tendsto certificates landed. The Tendsto
+  emitter now renders a lone `-1` factor as a negation of the remaining
+  product. That rendering is deliberately *not* the default: the `diff` and
+  definite-integral emitters pair their printed goal with witness terms built
+  as strings in the matching `c * f` shape (`.const_mul ((-1 : ℝ))`), and
+  printing `-e` there leaves Lean unifying `-rexp x` against `-1 * rexp x` by
+  defeq until it exhausts the `whnf` heartbeat budget. Their output is
+  byte-identical to before. The existing test asserted only that the emitter
+  *named* the theorem, never that the printed goal was the theorem's
+  statement; it now checks both.
 
 - **`limit()` now returns `DerivedResult`**, matching `diff` / `integrate`, so
   `.certificate` can carry a Lean `Filter.Tendsto` proof. Recognised `x → +∞`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   *named* the theorem, never that the printed goal was the theorem's
   statement; it now checks both.
 
+  `Tier 1a` was red on `main` for the same stretch and from the same commit,
+  for an unrelated reason: `ruff format --check` failed on three of the test
+  files added with the Tendsto work. Reformatted; the changes are whitespace
+  only.
+
 - **`limit()` now returns `DerivedResult`**, matching `diff` / `integrate`, so
   `.certificate` can carry a Lean `Filter.Tendsto` proof. Recognised `x → +∞`
   patterns (`exp(-x) → 0`, `xⁿ exp(-x) → 0`, `exp(x) → +∞`, a crude exp-ratio)

--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -1780,6 +1780,24 @@ fn expr_to_lean(expr: ExprId, pool: &ExprPool) -> String {
             format!("({})", parts.join(" + "))
         }
         ExprData::Mul(args) => {
+            // The kernel folds `-e` into `Mul[e, -1]`, but Mathlib states its
+            // lemmas about `-e`. Printing the literal `e * -1` produces a goal
+            // that no longer matches the theorem the emitter just selected:
+            // `tendsto_exp_neg_atTop_nhds_zero` proves
+            // `Tendsto (fun x => rexp (-x)) atTop (nhds 0)` and Lean rejects it
+            // against `fun x => rexp (x * -1)`. Print the negation instead.
+            let neg_one =
+                |a: ExprId| pool.with(a, |d| matches!(d, ExprData::Integer(n) if n.0 == -1));
+            let rest: Vec<ExprId> = args.iter().copied().filter(|&a| !neg_one(a)).collect();
+            if args.iter().filter(|&&a| neg_one(a)).count() == 1 && !rest.is_empty() {
+                let inner = if rest.len() == 1 {
+                    expr_to_lean(rest[0], pool)
+                } else {
+                    let parts: Vec<String> = rest.iter().map(|&a| expr_to_lean(a, pool)).collect();
+                    format!("({})", parts.join(" * "))
+                };
+                return format!("(-{inner})");
+            }
             let parts: Vec<String> = args.iter().map(|&a| expr_to_lean(a, pool)).collect();
             format!("({})", parts.join(" * "))
         }
@@ -3332,6 +3350,42 @@ mod tests {
         assert!(
             lean.contains("tendsto_exp_neg_atTop_nhds_zero"),
             "expected known tactic: {lean}"
+        );
+        // Naming the theorem is not enough: the goal we print has to *be* the
+        // theorem's statement. `tendsto_exp_neg_atTop_nhds_zero` is about
+        // `fun x => rexp (-x)`, and Lean rejects it against `rexp (x * -1)`,
+        // which is what the kernel's `Mul[x, -1]` spelling used to render as.
+        assert!(
+            !lean.contains("* (-1 : \u{211d})"),
+            "goal must print the negation, not the folded `* -1`: {lean}"
+        );
+        assert!(
+            lean.contains("Real.exp ((-(x : \u{211d})))"),
+            "goal must state `exp (-x)` to match the cited lemma: {lean}"
+        );
+    }
+
+    #[test]
+    fn negation_prints_as_negation_not_times_minus_one() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
+        assert_eq!(expr_to_lean(neg_x, &pool), "(-(x : \u{211d}))");
+
+        // A `-1` among several factors negates the remaining product.
+        let y = pool.symbol("y", Domain::Real);
+        let neg_xy = pool.mul(vec![pool.integer(-1_i32), x, y]);
+        assert_eq!(
+            expr_to_lean(neg_xy, &pool),
+            "(-((x : \u{211d}) * (y : \u{211d})))"
+        );
+
+        // A coefficient that merely happens to be negative is not a negation
+        // of the rest and must keep printing as a product.
+        let neg_two_x = pool.mul(vec![pool.integer(-2_i32), x]);
+        assert_eq!(
+            expr_to_lean(neg_two_x, &pool),
+            "((x : \u{211d}) * (-2 : \u{211d}))"
         );
     }
 

--- a/alkahest-core/src/lean/mod.rs
+++ b/alkahest-core/src/lean/mod.rs
@@ -891,7 +891,9 @@ pub fn emit_tendsto_cert(expr: ExprId, var: ExprId, lim: ExprId, pool: &ExprPool
         ExprData::Symbol { name, .. } => name.clone(),
         _ => "x".to_string(),
     });
-    let body = expr_to_lean(expr, pool);
+    // The tactics below cite bare Mathlib lemmas stated about `-x`, so the
+    // goal has to print the negation rather than the kernel's `x * -1`.
+    let body = expr_to_lean_neg(expr, pool);
     let (codom_filter, limit_display) = lean_codom_filter(lim, pool);
     let tactic = tendsto_tactic(expr, var, lim, pool);
 
@@ -1762,6 +1764,26 @@ pub fn emit_definite_integration_cert(
 
 /// Convert a symbolic expression to a Lean 4 term.
 fn expr_to_lean(expr: ExprId, pool: &ExprPool) -> String {
+    expr_to_lean_opts(expr, pool, false)
+}
+
+/// As [`expr_to_lean`], but printing `Mul[e, -1]` as `-e`.
+///
+/// Use this only where the emitted goal is discharged by a bare Mathlib lemma
+/// stated about `-e`: `tendsto_exp_neg_atTop_nhds_zero` proves
+/// `Tendsto (fun x => rexp (-x)) atTop (nhds 0)`, and Lean rejects it against a
+/// goal printed as `fun x => rexp (x * -1)`.
+///
+/// Do *not* use it for the `diff` or definite-integral emitters. Those pair the
+/// goal with witness terms built as strings in the matching `c * f` shape — e.g.
+/// `(Real.hasDerivAt_exp x).const_mul ((-1 : \u{211d}))`. Printing the goal as `-e`
+/// there leaves Lean unifying `-rexp x` against `-1 * rexp x` by defeq, which
+/// exhausts the `whnf` heartbeat budget on `int_def_neg_exp_0_1`.
+fn expr_to_lean_neg(expr: ExprId, pool: &ExprPool) -> String {
+    expr_to_lean_opts(expr, pool, true)
+}
+
+fn expr_to_lean_opts(expr: ExprId, pool: &ExprPool, neg_form: bool) -> String {
     pool.with(expr, |data| match data {
         ExprData::Integer(n) => {
             let v = n.0.to_i64().unwrap_or(0);
@@ -1776,33 +1798,43 @@ fn expr_to_lean(expr: ExprId, pool: &ExprPool) -> String {
         // Bare names leave metavariables in goals like `(x ^ (1 : ℕ) = x)` (`HPow ?m ℕ ?m`).
         ExprData::Symbol { name, .. } => format!("({name} : ℝ)"),
         ExprData::Add(args) => {
-            let parts: Vec<String> = args.iter().map(|&a| expr_to_lean(a, pool)).collect();
+            let parts: Vec<String> = args
+                .iter()
+                .map(|&a| expr_to_lean_opts(a, pool, neg_form))
+                .collect();
             format!("({})", parts.join(" + "))
         }
         ExprData::Mul(args) => {
-            // The kernel folds `-e` into `Mul[e, -1]`, but Mathlib states its
-            // lemmas about `-e`. Printing the literal `e * -1` produces a goal
-            // that no longer matches the theorem the emitter just selected:
-            // `tendsto_exp_neg_atTop_nhds_zero` proves
-            // `Tendsto (fun x => rexp (-x)) atTop (nhds 0)` and Lean rejects it
-            // against `fun x => rexp (x * -1)`. Print the negation instead.
-            let neg_one =
-                |a: ExprId| pool.with(a, |d| matches!(d, ExprData::Integer(n) if n.0 == -1));
-            let rest: Vec<ExprId> = args.iter().copied().filter(|&a| !neg_one(a)).collect();
-            if args.iter().filter(|&&a| neg_one(a)).count() == 1 && !rest.is_empty() {
-                let inner = if rest.len() == 1 {
-                    expr_to_lean(rest[0], pool)
-                } else {
-                    let parts: Vec<String> = rest.iter().map(|&a| expr_to_lean(a, pool)).collect();
-                    format!("({})", parts.join(" * "))
-                };
-                return format!("(-{inner})");
+            // The kernel folds `-e` into `Mul[e, -1]`. Most emitters here pair
+            // the printed goal with hand-built witness terms stated in the same
+            // `c * f` shape (`.const_mul ((-1 : \u{211d}))`), so the two agree and
+            // printing the product is what keeps them matching. Only `neg_form`
+            // callers want the negation; see `expr_to_lean_neg`.
+            if neg_form {
+                let neg_one =
+                    |a: ExprId| pool.with(a, |d| matches!(d, ExprData::Integer(n) if n.0 == -1));
+                let rest: Vec<ExprId> = args.iter().copied().filter(|&a| !neg_one(a)).collect();
+                if args.iter().filter(|&&a| neg_one(a)).count() == 1 && !rest.is_empty() {
+                    let inner = if rest.len() == 1 {
+                        expr_to_lean_opts(rest[0], pool, neg_form)
+                    } else {
+                        let parts: Vec<String> = rest
+                            .iter()
+                            .map(|&a| expr_to_lean_opts(a, pool, neg_form))
+                            .collect();
+                        format!("({})", parts.join(" * "))
+                    };
+                    return format!("(-{inner})");
+                }
             }
-            let parts: Vec<String> = args.iter().map(|&a| expr_to_lean(a, pool)).collect();
+            let parts: Vec<String> = args
+                .iter()
+                .map(|&a| expr_to_lean_opts(a, pool, neg_form))
+                .collect();
             format!("({})", parts.join(" * "))
         }
         ExprData::Pow { base, exp } => {
-            let b = expr_to_lean(*base, pool);
+            let b = expr_to_lean_opts(*base, pool, neg_form);
             let neg_int = pool.with(*exp, |d| match d {
                 ExprData::Integer(n) if n.0 < 0 => n.0.to_i64(),
                 _ => None,
@@ -1819,13 +1851,16 @@ fn expr_to_lean(expr: ExprId, pool: &ExprPool) -> String {
                 // Using `(n : ℝ)` leads to `Real.rpow` and stuck metavariables on goals like `x^1 = x`.
                 let e = pool.with(*exp, |d| match d {
                     ExprData::Integer(n) if n.0 >= 0 => format!("({} : ℕ)", n.0),
-                    _ => expr_to_lean(*exp, pool),
+                    _ => expr_to_lean_opts(*exp, pool, neg_form),
                 });
                 format!("({b}) ^ {e}")
             }
         }
         ExprData::Func { name, args } => {
-            let arg_strs: Vec<String> = args.iter().map(|&a| expr_to_lean(a, pool)).collect();
+            let arg_strs: Vec<String> = args
+                .iter()
+                .map(|&a| expr_to_lean_opts(a, pool, neg_form))
+                .collect();
             // Always parenthesize the argument: `Real.log Real.exp x` parses as
             // `(Real.log Real.exp) x`, and `Real.log x ^ 3` parses as
             // `(Real.log x) ^ 3` — both are type/math errors.
@@ -3370,13 +3405,20 @@ mod tests {
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
         let neg_x = pool.mul(vec![pool.integer(-1_i32), x]);
-        assert_eq!(expr_to_lean(neg_x, &pool), "(-(x : \u{211d}))");
+        assert_eq!(expr_to_lean_neg(neg_x, &pool), "(-(x : \u{211d}))");
+        // The default printer keeps the product form, because the diff and
+        // definite-integral emitters pair it with `.const_mul ((-1 : \u{211d}))`
+        // witness terms stated the same way.
+        assert_eq!(
+            expr_to_lean(neg_x, &pool),
+            "((x : \u{211d}) * (-1 : \u{211d}))"
+        );
 
         // A `-1` among several factors negates the remaining product.
         let y = pool.symbol("y", Domain::Real);
         let neg_xy = pool.mul(vec![pool.integer(-1_i32), x, y]);
         assert_eq!(
-            expr_to_lean(neg_xy, &pool),
+            expr_to_lean_neg(neg_xy, &pool),
             "(-((x : \u{211d}) * (y : \u{211d})))"
         );
 
@@ -3384,7 +3426,7 @@ mod tests {
         // of the rest and must keep printing as a product.
         let neg_two_x = pool.mul(vec![pool.integer(-2_i32), x]);
         assert_eq!(
-            expr_to_lean(neg_two_x, &pool),
+            expr_to_lean_neg(neg_two_x, &pool),
             "((x : \u{211d}) * (-2 : \u{211d}))"
         );
     }

--- a/tests/lean_tendsto_corpus.py
+++ b/tests/lean_tendsto_corpus.py
@@ -24,6 +24,7 @@ import alkahest
 
 FORBIDDEN_TOKENS = ("sorry", "admit", "axiom")
 
+
 def _exp_neg_at_top(pool):
     x = pool.symbol("x")
     return alkahest.limit(alkahest.exp(-x), x, pool.pos_infinity())

--- a/tests/test_limit_termination.py
+++ b/tests/test_limit_termination.py
@@ -134,9 +134,7 @@ def test_request_cancel_interrupts_a_limit(pool, x):
 def test_a_solvable_limit_under_a_generous_budget_still_answers(pool, x):
     """The checkpoints must not turn working limits into budget errors."""
     with ak.context(budget=ak.Budget(wall_ms=10_000, max_steps=1_000_000)):
-        assert ak.limit(ak.sqrt(x**2 + x) - x, x, pool.pos_infinity()).value == pool.rational(
-            1, 2
-        )
+        assert ak.limit(ak.sqrt(x**2 + x) - x, x, pool.pos_infinity()).value == pool.rational(1, 2)
         assert str(ak.limit(ak.sin(x) / x, x, pool.integer(0)).value) == "1"
 
 

--- a/tests/textbook_gate/test_tg_limits.py
+++ b/tests/textbook_gate/test_tg_limits.py
@@ -56,9 +56,7 @@ def assert_limit_equals(
 
 
 def assert_limit_is_pos_infinity(result: ak.Expr | ak.DerivedResult) -> None:
-    assert str(_limit_value(result)) == "∞", (
-        f"expected positive-infinity marker, got {result!r}"
-    )
+    assert str(_limit_value(result)) == "∞", f"expected positive-infinity marker, got {result!r}"
 
 
 def assert_limit_is_neg_infinity(result: ak.Expr | ak.DerivedResult) -> None:


### PR DESCRIPTION
`Verify Lean 4 proofs` has been red on `main` since the Tendsto certificates landed in #331 — `0f02f38` was green, `e2ec2b4` is not, and it stayed red through #326 and #327. This fixes it.

## The bug

The kernel folds `-e` into `Mul[e, -1]` (#320). `expr_to_lean` rendered that literally, so the certificate for `exp(-x) → 0` emitted

```lean
example : Filter.Tendsto (fun (x : ℝ) => Real.exp (((x : ℝ) * (-1 : ℝ)))) Filter.atTop (nhds (0 : ℝ)) :=
  tendsto_exp_neg_atTop_nhds_zero
```

while `tendsto_exp_neg_atTop_nhds_zero` proves `Tendsto (fun x => rexp (-x)) atTop (𝓝 0)`. Lean reports the type mismatch and the job fails.

**Nothing unsound was handed out** — Lean rejected it, which is the gate working. But the emitter's contract is that what it emits typechecks, and it was not honouring that.

## The fix

Render a lone `-1` factor as a negation of the remaining product. A merely negative coefficient is not a negation of the rest, so `-2·x` still prints as a product — pinned by test.

Regenerating the corpus now gives `Real.exp ((-(x : ℝ)))`, which matches the cited lemma.

## Why it shipped

`emit_tendsto_exp_neg_x` asserted only that the output *contained* `"tendsto_exp_neg_atTop_nhds_zero"` — that the emitter had *named* a theorem, never that the goal it printed was that theorem's statement. That is the same shape as the false-certificate families fixed earlier in this series: checking that machinery ran rather than that it was right. The test now asserts both, and a new `negation_prints_as_negation_not_times_minus_one` pins the printer directly.

## Verification

`cargo test -p alkahest-cas --lib lean::` 70 passed · Lean-related Python tests 96 passed · full workspace suite running.

I have no Lean toolchain on this machine, so the actual typecheck is CI's — that is the check this PR exists to turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Lean goal output for expressions containing a lone `-1` factor.
  * Negative exponential goals now render as `exp (-x)`, matching the applicable theorem format.
  * Preserved standard product formatting for other negative coefficients.

* **Tests**
  * Added coverage for negated single-factor and multi-factor products.
  * Enhanced exponential limit tests to verify theorem naming and printed goal output.

* **Documentation**
  * Added a changelog entry describing the certificate printer fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->