### PR TITLE
feat(simplify,depth): stop charging the depth ceiling to traversals that do not recurse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 ## Unreleased
 
+- **`ak.simplify` refused expressions it could handle, and crashed on one it
+  could not.** The `E-DEPTH-001` ceiling (`MAX_EXPR_DEPTH`, 2 048) is
+  calibrated against the shallowest walker that recurses without a net —
+  `symbolic_grad`, which segfaults at 4 687 — and was then applied uniformly at
+  the PyO3 boundary. That has been costing capability since the simplification
+  traversals stopped needing it: `simplify::engine` and `simplify::parallel`
+  run under the segmented-stack trampoline, and `simplify::redex` schedules the
+  DAG level by level and never recurses at all. Twelve entry points —
+  `simplify`, `simplify_par`, `simplify_redex`, `simplify_auto`,
+  `simplify_expanded`, `simplify_trig`, `simplify_trig_normal_form`,
+  `simplify_with`, `simplify_strategy`, `collect_like_terms`, `simplify_pauli`,
+  `simplify_clifford_orthogonal` — now accept input of any depth. Measured on
+  the release build with the usual 8 MiB main-thread stack, a 100 000-level
+  `sin` chain: `simplify` 0.09 s and 163 MiB, `simplify_par` 0.10 s,
+  `simplify_redex` 0.09 s, `simplify_auto` 0.07 s. Previously all four raised
+  at 2 049.
+
+  The ceiling was not pure ceremony there, though, and this is not a removed
+  check. Two plain recursions are still reachable from those entry points, both
+  confirmed to kill the process rather than raise:
+
+  - Every default simplification pass ends in the assumption-gated **colored
+    e-graph**, which runs whenever the expression carries a `Domain.Positive`
+    or `Domain.NonZero` symbol. `ColoredEgraph::from_expr` and `rebuild`
+    descend one native frame per level: `SIGSEGV` between 60 000 and 100 000
+    levels. It is also quadratic in node count (5 000 levels: 4.8 s; 20 000
+    levels: 100 s), so putting it on the trampoline would have traded a crash
+    for a hang.
+  - `alkahest-py` renders a returned derivation log with the same recursive
+    printer `str()` uses. A deep chain wrapped in a single redex — trampolined
+    traversal, one very deep step in the log — segfaulted at 30 000.
+
+  So the guard is now per *route* rather than per operation. A new
+  `alkahest_cas::simplify::check_simplify_depth` applies `MAX_EXPR_DEPTH` only
+  to inputs that would reach the colored pass, deciding by running the
+  simplifier's own `collect_static_domain_facts` so that the guard and the
+  thing it guards cannot drift apart. It is `O(1)` at or under the ceiling, so
+  the hot path costs exactly what it did before; only an expression already
+  past 2 048 levels pays the one extra iterative walk. `make_derived_result`
+  records an over-deep step's *depth* in place of its text, which is visible in
+  the `derivation` string rather than silent, and cannot affect any result
+  shallow enough to print. `E-DEPTH-001` keeps its meaning wherever it still
+  fires: same code, same `limit`, same reason.
+
+  Two entry points that could already reach the colored recursion had **no
+  depth guard at all** and would segfault on a deep input: `simplify_with`, and
+  `AssumptionContext.simplify` (which is what `ak.simplify(expr,
+  assumptions=…)` and `with ak.context(assumptions=…)` route through). Both are
+  guarded now — the latter unconditionally, because explicit facts send every
+  input through the e-graph whatever its symbols' domains are.
+
+  **Behaviour to plan for.** `ak.simplify(deep)` no longer raises
+  `DepthLimitError` for a deep expression over ordinary symbols, and
+  `simplify_many` no longer reports one on the item; code branching on that
+  refusal will now take the success path. Conversely, `ak.simplify(deep,
+  assumptions=ctx)` now raises where it previously took the process out.
+
 - **`simplify` could not cancel `¾·sin x − ¾·sin x`, and that cost the
   verification gate its strongest verdict.** `collect_add_terms` split each
   summand into a coefficient and a base using an *integer*-only extractor, so

--- a/alkahest-core/src/kernel/depth.rs
+++ b/alkahest-core/src/kernel/depth.rs
@@ -63,17 +63,18 @@
 //! matters: the guard sits on hot paths such as `__str__`, and anything that
 //! had to walk the tree to find its depth would cost more than it saves.
 //!
-//! The callers are the PyO3 bindings, and only those.  `alkahest-py` calls
-//! [`check_expr_depth`] — through its `guard_depth` / `guard_expr_depth`
-//! wrappers — or [`check_expr_depths`] at upwards of fifty entry points: every
-//! renderer, `diff`, `symbolic_grad`, `subs`, the evaluators and the JIT
-//! entry, the polynomial converters, the integrator, the SMT-LIB and Lean
-//! emitters, the plotters.  The simplification entry points are the exception
-//! and go through `guard_simplify_depth` instead; the two lists are pinned
-//! side by side in `tests/test_expression_depth_limit.py`.  Nothing inside
-//! this crate calls [`check_expr_depth`] or [`check_expr_depths`] directly —
-//! [`check_simplify_depth`](crate::simplify::check_simplify_depth) is the one
-//! in-crate caller, and it is itself only called from `alkahest-py`.
+//! Every call site is an entry point rather than a traversal: no walker checks
+//! its own input.  `alkahest-py` calls [`check_expr_depth`] — through its
+//! `guard_depth` / `guard_expr_depth` wrappers — or [`check_expr_depths`] at
+//! upwards of fifty of them: every renderer, `diff`, `symbolic_grad`, `subs`,
+//! the evaluators and the JIT entry, the polynomial converters, the
+//! integrator, the SMT-LIB and Lean emitters, the plotters.  The
+//! simplification entry points instead call `guard_simplify_depth`, which
+//! wraps this crate's own
+//! [`check_simplify_depth`](crate::simplify::check_simplify_depth) — the only
+//! caller of [`check_expr_depth`] inside `alkahest-cas`, and itself reached
+//! only from `alkahest-py`.  Both lists are pinned side by side in
+//! `tests/test_expression_depth_limit.py`.
 //!
 //! # What this does not cover
 //!

--- a/alkahest-core/src/kernel/depth.rs
+++ b/alkahest-core/src/kernel/depth.rs
@@ -42,6 +42,12 @@
 //! walker that still depends on this ceiling, and is what the number is
 //! calibrated against.
 //!
+//! Since the simplification traversals stopped needing it, the simplification
+//! entry points no longer apply this ceiling unconditionally — they call
+//! [`check_simplify_depth`](crate::simplify::check_simplify_depth), which
+//! applies it only to the inputs that still reach a recursion.  See *What this
+//! does not cover*.
+//!
 //! That calibration assumes the **shipped release build on an 8 MiB stack**,
 //! which is what a Python caller gets on the main thread.  A debug build has
 //! frames several times larger — one level of the simplifier was measured at
@@ -59,11 +65,15 @@
 //!
 //! The callers are the PyO3 bindings, and only those.  `alkahest-py` calls
 //! [`check_expr_depth`] — through its `guard_depth` / `guard_expr_depth`
-//! wrappers — or [`check_expr_depths`] at upwards of sixty entry points: every
+//! wrappers — or [`check_expr_depths`] at upwards of fifty entry points: every
 //! renderer, `diff`, `symbolic_grad`, `subs`, the evaluators and the JIT
 //! entry, the polynomial converters, the integrator, the SMT-LIB and Lean
-//! emitters, the plotters.  `tests/test_expression_depth_limit.py` pins that
-//! list.  Nothing inside this crate calls either function.
+//! emitters, the plotters.  The simplification entry points are the exception
+//! and go through `guard_simplify_depth` instead; the two lists are pinned
+//! side by side in `tests/test_expression_depth_limit.py`.  Nothing inside
+//! this crate calls [`check_expr_depth`] or [`check_expr_depths`] directly —
+//! [`check_simplify_depth`](crate::simplify::check_simplify_depth) is the one
+//! in-crate caller, and it is itself only called from `alkahest-py`.
 //!
 //! # What this does not cover
 //!
@@ -76,6 +86,14 @@
 //! * **New bindings.** A `#[pyfunction]` added without a `guard_depth` call
 //!   inherits nothing; the guard is a convention held up by that test file, not
 //!   by a type.
+//! * **Rendering a derivation log.** A [`DerivationLog`](crate::DerivationLog)
+//!   holds `ExprId`s, and `alkahest-py` renders them into the `derivation` and
+//!   `steps` a `DerivedResult` carries using the same recursive printer
+//!   `str()` uses — which overflows around 24 500 levels.  A simplification
+//!   that is itself stack-safe at any depth can therefore still hand back a
+//!   log too deep to print, so `alkahest-py`'s `make_derived_result` checks
+//!   each step against this ceiling and records an over-deep expression's
+//!   depth in place of its text.
 //! * **The bottom-up simplification traversals**, which have something
 //!   stronger.  `simplify::engine`'s `simplify_node` and
 //!   `simplify_node_indexed`, and — under the `parallel` feature —
@@ -85,11 +103,22 @@
 //!   one is spent.  For those the depth bound is removed rather than lowered:
 //!   they are limited by how many threads the OS will hand out, not by any one
 //!   stack, and they truncate nothing.  The trampoline itself is not
-//!   feature-gated and is not confined to the parallel simplifier; the other
-//!   simplification strategies (`redex`, the e-graph passes) do not use it.
-//!   The ceiling here still applies to all of them at the PyO3 boundary, where
-//!   for the trampolined ones it is now a courtesy to the caller rather than
-//!   what keeps the process alive.
+//!   feature-gated and is not confined to the parallel simplifier;
+//!   `simplify::redex` reaches the same place differently, by scheduling the
+//!   DAG level by level and never recursing, while the e-graph passes do
+//!   neither.
+//!
+//!   Because that is real capability, the simplification entry points no
+//!   longer spend it: they call
+//!   [`check_simplify_depth`](crate::simplify::check_simplify_depth), which
+//!   applies this ceiling only to an input that would reach the one recursion
+//!   still on that path — the assumption-gated colored e-graph pass every
+//!   default simplification ends with when the expression contains a
+//!   `Domain::Positive` or `Domain::NonZero` symbol.  A 100 000-level `sin`
+//!   chain now simplifies (measured: 0.10 s, 162 MiB) where it used to be
+//!   refused at 2 049.  The e-graph entry points (`simplify_egraph`,
+//!   `simplify_log_exp`, `AssumptionContext.simplify`) are separate engines
+//!   that do recurse, and keep [`check_expr_depth`].
 //!
 //! The trampoline is also where this crate's one stack *measurement* lives, and
 //! it is deliberately not what bounds that recursion.  The probe takes the
@@ -135,7 +164,7 @@ use crate::errors::AlkahestError;
 use crate::kernel::{ExprId, ExprPool};
 use std::fmt;
 
-/// Deepest expression the PyO3 entry points will accept.
+/// Deepest expression a PyO3 entry point that recurses will accept.
 ///
 /// Compared against the cached node depth ([`ExprPool::depth`]); see the module
 /// documentation for the measurements behind the number and for the callers
@@ -145,10 +174,21 @@ use std::fmt;
 /// times larger than release ones), and for future walkers that use more stack
 /// per level than today's.
 ///
-/// It is deliberately *one* number rather than a per-operation table: a caller
+/// It is deliberately *one* number rather than a per-walker table: a caller
 /// that gets `str(expr)` to work should not then be surprised by a segfault
-/// from `symbolic_grad(expr)`.  It is not, however, automatic — a walker added
-/// later is covered only once its entry point calls [`check_expr_depth`].
+/// from `symbolic_grad(expr)`.  What it is not is one number for every
+/// *operation*.  An operation that does not recurse does not need a recursion
+/// limit, and charging it one is pure lost capability, so the simplification
+/// entry points ask
+/// [`check_simplify_depth`](crate::simplify::check_simplify_depth) instead —
+/// which applies this same constant, but only to the inputs that would reach
+/// the one recursive pass left on that path.  So the contract is per
+/// operation, while the number is still one number: an expression either
+/// reaches a recursion, and 2 048 is the ceiling, or it does not, and there is
+/// none.
+///
+/// It is not automatic either way — a walker added later is covered only once
+/// its entry point calls [`check_expr_depth`].
 ///
 /// Compile-time only.  Nothing reads it from the environment or lets a caller
 /// raise it, so a caller that needs deeper trees has to reshape them.
@@ -196,9 +236,11 @@ impl AlkahestError for DepthLimitError {
 /// the stack.
 ///
 /// Call this at the entry point of anything that walks an expression
-/// recursively: nothing calls it for you, and today every caller is in
-/// `alkahest-py`.  See the [module documentation](self) for why, and for what
-/// the check does not reach.
+/// recursively: nothing calls it for you.  Every caller is in `alkahest-py`
+/// except [`check_simplify_depth`](crate::simplify::check_simplify_depth),
+/// which wraps it for the entry points that recurse only on some inputs.  See
+/// the [module documentation](self) for why, and for what the check does not
+/// reach.
 ///
 /// ```
 /// use alkahest_cas::kernel::depth::{check_expr_depth, MAX_EXPR_DEPTH};

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -142,8 +142,8 @@ pub use simplify::rulesets::{
     log_exp_rules, log_exp_rules_safe, trig_normal_form_rules, trig_rules,
 };
 pub use simplify::{
-    assumptions_satisfy, rules_for_config, simplify, simplify_batch, simplify_colored,
-    simplify_egraph, simplify_egraph_with, simplify_expanded, simplify_log_exp,
+    assumptions_satisfy, check_simplify_depth, rules_for_config, simplify, simplify_batch,
+    simplify_colored, simplify_egraph, simplify_egraph_with, simplify_expanded, simplify_log_exp,
     simplify_trig_normal_form, simplify_with, ColorId, ColoredEgraph, DepthCost, EgraphConfig,
     EgraphCost, NoncommutativeCost, OpCost, PatternRule, RewriteRule, SimplifyConfig, SizeCost,
     StabilityCost, CONTEXT_COLOR, ROOT_COLOR,
@@ -325,9 +325,10 @@ pub mod stable {
         cad_lift, cad_project, decide, decide_expr, routh_hurwitz, CadError, QeResult, RouthHurwitz,
     };
     pub use crate::simplify::{
-        simplify, simplify_egraph, simplify_egraph_with, simplify_trig_normal_form, simplify_with,
-        simplify_with_assumptions, AssumptionContext, DepthCost, EgraphConfig, EgraphCost,
-        NoncommutativeCost, OpCost, SimplifyConfig, SizeCost, StabilityCost,
+        check_simplify_depth, simplify, simplify_egraph, simplify_egraph_with,
+        simplify_trig_normal_form, simplify_with, simplify_with_assumptions, AssumptionContext,
+        DepthCost, EgraphConfig, EgraphCost, NoncommutativeCost, OpCost, SimplifyConfig, SizeCost,
+        StabilityCost,
     };
     #[cfg(feature = "groebner")]
     pub use crate::solver::{

--- a/alkahest-core/src/simplify/depth.rs
+++ b/alkahest-core/src/simplify/depth.rs
@@ -1,0 +1,235 @@
+//! The depth ceiling as the simplification entry points actually need it.
+//!
+//! [`crate::kernel::MAX_EXPR_DEPTH`] is one number for every walker in the
+//! crate, calibrated against the shallowest one that recurses without a net.
+//! The simplification traversals are not that: `simplify::engine`'s
+//! `simplify_node` and `simplify_node_indexed`, and — under the `parallel`
+//! feature — `simplify::parallel`'s `simplify_node_par`, all run under the
+//! segmented-stack trampoline in `simplify::stack`, and
+//! `simplify::redex` does not recurse at all.  For those the depth bound is
+//! removed rather than lowered, so applying a 2 048-level ceiling to them
+//! costs capability and buys nothing.
+//!
+//! One thing on that path is still a plain recursion, though, and this module
+//! is what keeps it from being reached.
+//!
+//! # The one route that is still bounded by the stack
+//!
+//! Every default simplification pass ends the same way.  `simplify_with`,
+//! `simplify_par_with_config` and `simplify_redex_with_config` each collect
+//! the facts implied by static symbol domains — a [`Domain::Positive`] or
+//! [`Domain::NonZero`] symbol anywhere in the result — and, if there are any,
+//! hand the expression to [`crate::simplify::colored_egraph`] for an
+//! assumption-gated pass.  That pass is *not* trampolined:
+//! `ColoredEgraph::from_expr`'s node collection and `ColoredEgraph::rebuild`
+//! both descend one native frame per level, and on an 8 MiB stack a release
+//! build segfaults somewhere between 60 000 and 100 000 levels.  It is also
+//! quadratic in node count — a 5 000-level chain took 4.8 s, a 20 000-level
+//! one 100 s — so "make it trampolined" would trade a crash for a hang.
+//!
+//! So the ceiling still has to apply, but only to the expressions that reach
+//! that pass.  [`check_simplify_depth`] is that test: past
+//! [`MAX_EXPR_DEPTH`](crate::kernel::MAX_EXPR_DEPTH) it asks whether this
+//! expression would take the colored
+//! route, and refuses only if it would.
+//!
+//! # Why the predicate is the real collector rather than a cheaper copy
+//!
+//! [`check_simplify_depth`] decides by running
+//! `simplify::assumptions`'s own `collect_static_domain_facts` and looking at
+//! whether it produced anything.  A hand-written "does this contain a
+//! positive symbol" scan would be faster and would drift: the moment a new
+//! `Domain` or node kind starts contributing a fact, the guard and the thing
+//! it guards would disagree, and the disagreement that matters — guard says
+//! no, simplifier says yes — is a segfault.  Sharing the collector makes that
+//! impossible by construction.
+//!
+//! The cost is one extra iterative walk of an expression already past 2 048
+//! levels deep.  Expressions at or under the ceiling never reach it: the depth
+//! comparison is checked first and is a single array read, so the hot path
+//! pays exactly what it paid before.
+//!
+//! # What this does not cover
+//!
+//! * **The e-graph simplifiers.** `simplify_egraph` and `simplify_colored`
+//!   are separate engines with their own unbounded recursion, reached through
+//!   their own entry points.  They keep [`check_expr_depth`] and are not this
+//!   function's business.
+//! * **Rendering the derivation log.** The log a simplification returns holds
+//!   `ExprId`s, and `alkahest-py` renders them with the same recursive printer
+//!   `str()` uses, which overflows around 24 500 levels.  That is handled
+//!   where it happens, in `alkahest-py`'s `make_derived_result`, by recording
+//!   an over-deep step's depth instead of its text.
+//! * **Explicit assumption contexts.** A caller who passes an
+//!   [`AssumptionContext`](crate::simplify::AssumptionContext) has asked for
+//!   the colored pass outright, so its entry point keeps the unconditional
+//!   [`check_expr_depth`].
+//!
+//! [`Domain::Positive`]: crate::kernel::Domain::Positive
+//! [`Domain::NonZero`]: crate::kernel::Domain::NonZero
+
+use crate::deriv::SideCondition;
+use crate::kernel::depth::{check_expr_depth, DepthLimitError};
+use crate::kernel::{ExprId, ExprPool};
+
+/// Refuse `id` only if simplifying it would recurse without a net.
+///
+/// The bottom-up simplification traversals are stack-safe at any depth (see
+/// the [module documentation](self)), so this accepts expressions far past
+/// [`MAX_EXPR_DEPTH`](crate::kernel::MAX_EXPR_DEPTH) — a 100 000-level `sin`
+/// chain simplifies in about
+/// 0.1 s.  What it still refuses is a too-deep expression that would be
+/// handed to the assumption-gated colored e-graph pass, which is a plain
+/// recursion: that is an expression past the ceiling containing a
+/// `Domain::Positive` or `Domain::NonZero` symbol.
+///
+/// The error, when there is one, is the same [`DepthLimitError`] with the same
+/// `E-DEPTH-001` code and the same `limit` as [`check_expr_depth`]; a caller
+/// cannot tell the two guards apart, and does not need to.
+///
+/// O(1) at or below the ceiling.  Past it, one iterative walk of the
+/// expression — no recursion, so this cannot overflow the stack in the course
+/// of deciding whether something else would.
+///
+/// ```
+/// use alkahest_cas::kernel::{Domain, ExprPool, MAX_EXPR_DEPTH};
+/// use alkahest_cas::simplify::check_simplify_depth;
+///
+/// let pool = ExprPool::new();
+///
+/// // Deep, but nothing in it routes to the colored pass: accepted.
+/// let x = pool.symbol("x", Domain::Real);
+/// let mut deep = x;
+/// for _ in 0..MAX_EXPR_DEPTH + 100 {
+///     deep = pool.func("sin", vec![deep]);
+/// }
+/// assert!(check_simplify_depth(&pool, deep).is_ok());
+///
+/// // The same shape over a positive symbol takes the recursive route.
+/// let p = pool.symbol("p", Domain::Positive);
+/// let mut deep_positive = p;
+/// for _ in 0..MAX_EXPR_DEPTH + 100 {
+///     deep_positive = pool.func("sin", vec![deep_positive]);
+/// }
+/// let err = check_simplify_depth(&pool, deep_positive).unwrap_err();
+/// assert_eq!(err.limit, MAX_EXPR_DEPTH);
+/// ```
+pub fn check_simplify_depth(pool: &ExprPool, id: ExprId) -> Result<(), DepthLimitError> {
+    // Cheap first: at or under the ceiling nothing can go wrong on any route,
+    // and this is the hot path every ordinary `simplify` call takes.
+    let shallow_enough = check_expr_depth(pool, id);
+    if shallow_enough.is_ok() {
+        return Ok(());
+    }
+    if takes_colored_route(id, pool) {
+        return shallow_enough;
+    }
+    Ok(())
+}
+
+/// Whether a default simplification of `expr` would end in the colored
+/// e-graph pass.
+///
+/// Deliberately the same collector the simplifier itself uses, so the two
+/// cannot disagree about which expressions take that route.
+fn takes_colored_route(expr: ExprId, pool: &ExprPool) -> bool {
+    let mut facts: Vec<SideCondition> = Vec::new();
+    super::assumptions::collect_static_domain_facts(expr, pool, &mut facts);
+    !facts.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::AlkahestError;
+    use crate::kernel::{Domain, MAX_EXPR_DEPTH};
+
+    /// `depth` levels of `sin` over `leaf`.
+    fn chain(pool: &ExprPool, leaf: ExprId, depth: u32) -> ExprId {
+        let mut acc = leaf;
+        for _ in 0..depth {
+            acc = pool.func("sin", vec![acc]);
+        }
+        acc
+    }
+
+    /// The capability this whole module exists to hand back: past the ceiling
+    /// and still accepted, because nothing on the route recurses.
+    #[test]
+    fn deep_is_accepted_when_no_assumption_pass_will_run() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let deep = chain(&pool, x, MAX_EXPR_DEPTH * 8);
+        assert!(pool.depth(deep) > MAX_EXPR_DEPTH);
+        assert!(check_simplify_depth(&pool, deep).is_ok());
+        // …and the unconditional guard would have refused exactly this.
+        assert!(check_expr_depth(&pool, deep).is_err());
+    }
+
+    /// A positive symbol anywhere in the tree routes the whole expression into
+    /// the colored pass, which is a plain recursion — so the ceiling has to
+    /// come back, whatever else the expression is made of.
+    #[test]
+    fn deep_is_refused_when_a_static_domain_fact_routes_it_to_the_egraph() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let p = pool.symbol("p", Domain::Positive);
+        // The positive symbol is a leaf of one branch only; the guard must
+        // still see it.
+        let deep = chain(&pool, x, MAX_EXPR_DEPTH * 2);
+        let mixed = pool.add(vec![deep, p]);
+        let err = check_simplify_depth(&pool, mixed).expect_err("must be refused");
+        assert_eq!(err.limit, MAX_EXPR_DEPTH);
+        assert_eq!(err.code(), "E-DEPTH-001");
+    }
+
+    /// `Domain::NonZero` authorizes rewrites too, so it routes the same way.
+    #[test]
+    fn a_nonzero_symbol_routes_the_same_way_as_a_positive_one() {
+        let pool = ExprPool::new();
+        let nz = pool.symbol("nz", Domain::NonZero);
+        let deep = chain(&pool, nz, MAX_EXPR_DEPTH * 2);
+        assert!(check_simplify_depth(&pool, deep).is_err());
+    }
+
+    /// Below the ceiling the colored pass is reached at a depth its recursion
+    /// survives, so a positive symbol must not make an ordinary expression
+    /// unsimplifiable.
+    #[test]
+    fn a_shallow_expression_is_accepted_however_it_would_route() {
+        let pool = ExprPool::new();
+        let p = pool.symbol("p", Domain::Positive);
+        let shallow = chain(&pool, p, MAX_EXPR_DEPTH - 1);
+        assert_eq!(pool.depth(shallow), MAX_EXPR_DEPTH);
+        assert!(check_simplify_depth(&pool, shallow).is_ok());
+        assert!(check_expr_depth(&pool, shallow).is_ok());
+    }
+
+    /// The guard and the simplifier must agree about which expressions take
+    /// the colored route: the guard refusing one the simplifier would not send
+    /// there costs capability, and accepting one it would send there is a
+    /// segfault.  Asserted against the collector's own output rather than a
+    /// restatement of it.
+    #[test]
+    fn the_predicate_agrees_with_the_collector_the_simplifier_uses() {
+        let pool = ExprPool::new();
+        for domain in [
+            Domain::Real,
+            Domain::Complex,
+            Domain::Integer,
+            Domain::NonNegative,
+            Domain::Positive,
+            Domain::NonZero,
+        ] {
+            let leaf = pool.symbol(format!("s_{domain:?}"), domain);
+            let deep = chain(&pool, leaf, MAX_EXPR_DEPTH + 1);
+            let mut facts = Vec::new();
+            crate::simplify::assumptions::collect_static_domain_facts(deep, &pool, &mut facts);
+            assert_eq!(
+                check_simplify_depth(&pool, deep).is_err(),
+                !facts.is_empty(),
+                "guard and collector disagree for {domain:?}"
+            );
+        }
+    }
+}

--- a/alkahest-core/src/simplify/depth.rs
+++ b/alkahest-core/src/simplify/depth.rs
@@ -2,13 +2,21 @@
 //!
 //! [`crate::kernel::MAX_EXPR_DEPTH`] is one number for every walker in the
 //! crate, calibrated against the shallowest one that recurses without a net.
-//! The simplification traversals are not that: `simplify::engine`'s
-//! `simplify_node` and `simplify_node_indexed`, and — under the `parallel`
-//! feature — `simplify::parallel`'s `simplify_node_par`, all run under the
-//! segmented-stack trampoline in `simplify::stack`, and
-//! `simplify::redex` does not recurse at all.  For those the depth bound is
-//! removed rather than lowered, so applying a 2 048-level ceiling to them
-//! costs capability and buys nothing.
+//! The simplification traversals are not that.  `simplify::engine`'s
+//! `simplify_node` and `simplify_node_indexed` run under the segmented-stack
+//! trampoline in `simplify::stack`, which continues the recursion on a freshly
+//! spawned, larger-stacked thread before the current one is spent.  For those
+//! the depth bound is removed rather than lowered, so applying a 2 048-level
+//! ceiling to them costs capability and buys nothing.
+//!
+//! Neither of the two `parallel`-gated strategies changes that, and both had
+//! to be checked rather than assumed: `simplify::parallel`'s
+//! `simplify_node_par` goes through the same trampoline, and
+//! `simplify::redex` buckets the DAG by height and rewrites a level at a time,
+//! so it does not recurse at all.  With the feature off, both entry points
+//! fall back to `simplify::engine`.  Every branch of every `cfg` on this path
+//! is therefore stack-safe, which is what makes it safe to lift the ceiling
+//! from an entry point whose implementation depends on a feature flag.
 //!
 //! One thing on that path is still a plain recursion, though, and this module
 //! is what keeps it from being reached.
@@ -30,8 +38,7 @@
 //! So the ceiling still has to apply, but only to the expressions that reach
 //! that pass.  [`check_simplify_depth`] is that test: past
 //! [`MAX_EXPR_DEPTH`](crate::kernel::MAX_EXPR_DEPTH) it asks whether this
-//! expression would take the colored
-//! route, and refuses only if it would.
+//! expression would take the colored route, and refuses only if it would.
 //!
 //! # Why the predicate is the real collector rather than a cheaper copy
 //!
@@ -77,11 +84,10 @@ use crate::kernel::{ExprId, ExprPool};
 /// The bottom-up simplification traversals are stack-safe at any depth (see
 /// the [module documentation](self)), so this accepts expressions far past
 /// [`MAX_EXPR_DEPTH`](crate::kernel::MAX_EXPR_DEPTH) — a 100 000-level `sin`
-/// chain simplifies in about
-/// 0.1 s.  What it still refuses is a too-deep expression that would be
-/// handed to the assumption-gated colored e-graph pass, which is a plain
-/// recursion: that is an expression past the ceiling containing a
-/// `Domain::Positive` or `Domain::NonZero` symbol.
+/// chain simplifies in about 0.1 s.  What it still refuses is a too-deep
+/// expression that would be handed to the assumption-gated colored e-graph
+/// pass, which is a plain recursion: that is an expression past the ceiling
+/// containing a `Domain::Positive` or `Domain::NonZero` symbol.
 ///
 /// The error, when there is one, is the same [`DepthLimitError`] with the same
 /// `E-DEPTH-001` code and the same `limit` as [`check_expr_depth`]; a caller

--- a/alkahest-core/src/simplify/mod.rs
+++ b/alkahest-core/src/simplify/mod.rs
@@ -1,5 +1,6 @@
 pub mod assumptions;
 pub mod colored_egraph;
+pub mod depth;
 pub mod discrimination_net;
 #[cfg(feature = "parallel")]
 pub mod dispatch;
@@ -20,6 +21,7 @@ pub use assumptions::{simplify_with_assumptions, AssumptionContext, AssumptionEr
 pub use colored_egraph::{
     assumptions_satisfy, simplify_colored, ColorId, ColoredEgraph, CONTEXT_COLOR, ROOT_COLOR,
 };
+pub use depth::check_simplify_depth;
 pub use discrimination_net::{expr_head, pattern_head, DiscriminationIndex, PatternHead};
 pub use egraph::{
     simplify_egraph, simplify_egraph_with, DepthCost, EgraphConfig, EgraphCost, NoncommutativeCost,

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -10308,10 +10308,15 @@ fn py_simplify_auto(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedRe
 #[pyfunction]
 #[pyo3(name = "simplify_strategy")]
 fn py_simplify_strategy(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<String> {
+    // Outside the `cfg`s on purpose. `choose_strategy` is iterative and could
+    // answer for any depth, but this reports what `simplify_auto` *would* do,
+    // and an answer for an expression `simplify_auto` will refuse is not one
+    // worth having. Guarding both branches identically also keeps the two
+    // builds from disagreeing about which inputs are answerable.
+    guard_simplify_depth(&expr.pool.borrow(py).inner, expr.id)?;
     #[cfg(feature = "parallel")]
     {
         let pool_ref = expr.pool.borrow(py);
-        guard_simplify_depth(&pool_ref.inner, expr.id)?;
         let strategy = alkahest_core::choose_strategy(expr.id, &pool_ref.inner);
         Ok(match strategy {
             alkahest_core::Strategy::ForkJoin => "fork_join".to_string(),
@@ -10320,7 +10325,6 @@ fn py_simplify_strategy(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<String>
     }
     #[cfg(not(feature = "parallel"))]
     {
-        let _ = (py, expr);
         Ok("sequential".to_string())
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -268,6 +268,21 @@ fn guard_expr_depth(py: Python<'_>, expr: &PyExpr) -> PyResult<()> {
     guard_depth(&expr.pool.borrow(py).inner, expr.id)
 }
 
+/// [`guard_depth`] for the simplification entry points, which mostly do not
+/// recurse.
+///
+/// The bottom-up traversals underneath `simplify` are stack-safe at any depth
+/// — trampolined in `simplify::engine` and `simplify::parallel`, iterative in
+/// `simplify::redex` — so charging them a 2 048-level ceiling refuses work
+/// they can do. This refuses only the inputs that still reach a recursion:
+/// see [`alkahest_core::check_simplify_depth`]. The error a caller sees is
+/// identical to [`guard_depth`]'s, `E-DEPTH-001` and all.
+///
+/// O(1) at or under the ceiling; past it, one iterative walk.
+fn guard_simplify_depth(pool: &ExprPool, id: ExprId) -> PyResult<()> {
+    alkahest_core::check_simplify_depth(pool, id).map_err(depth_error_to_py)
+}
+
 /// Largest `n_pts` a plotting call will accept.
 ///
 /// The renderers hand `n_pts` straight to `Vec::with_capacity`, so without a
@@ -2072,6 +2087,11 @@ impl PyAssumptions {
         }
         let derived = {
             let pool = self.pool.borrow(py);
+            // Not `guard_simplify_depth`: explicit facts send *every* input
+            // through the colored e-graph, so the recursion this bounds is
+            // taken unconditionally here rather than only for expressions
+            // carrying a static domain.
+            guard_depth(&pool.inner, expr.id)?;
             self.inner.simplify(expr.id, &pool.inner)
         };
         Ok(make_derived_result(
@@ -2619,6 +2639,82 @@ impl PyDerivedResult {
     }
 }
 
+/// Render `id`, unless printing it would overflow the stack.
+///
+/// `ExprPool::display` is a structural recursion — it is the same printer
+/// behind `str(expr)`, and it segfaults somewhere past 24 000 levels. Every
+/// entry point that hands an expression straight to it guards the *input*, but
+/// a derivation log is not an input: it comes back from an operation, holding
+/// whatever subexpressions the rules happened to fire on. Since `simplify`
+/// stopped refusing deep inputs, a log can legitimately contain a step far
+/// deeper than any printer can walk.
+///
+/// So this reports the depth instead of the text. A caller reading a
+/// derivation gets a step it can see happened and a reason it cannot read it,
+/// rather than a dead interpreter — and the `value` the result is actually for
+/// is unaffected either way.
+fn render_expr_or_depth(pool: &ExprPool, id: ExprId) -> String {
+    match alkahest_core::check_expr_depth(pool, id) {
+        Ok(()) => pool.display(id).to_string(),
+        Err(e) => format!("<expression too deep to render: depth {}>", e.depth),
+    }
+}
+
+/// [`render_expr_or_depth`] for the expression inside a side condition.
+fn render_side_condition_or_depth(pool: &ExprPool, cond: &SideCondition) -> String {
+    match cond {
+        SideCondition::NonZero(id) => format!("{} ≠ 0", render_expr_or_depth(pool, *id)),
+        SideCondition::Positive(id) => format!("{} > 0", render_expr_or_depth(pool, *id)),
+        SideCondition::InDomain(id, d) => {
+            format!("{} ∈ {:?}", render_expr_or_depth(pool, *id), d)
+        }
+    }
+}
+
+/// The `derivation` string, falling back to [`render_expr_or_depth`] only when
+/// some step is too deep for the printer.
+///
+/// The common case still goes through `DerivationLog::display_with`, so the
+/// text a caller has always seen is produced by the same code that always
+/// produced it and cannot drift from it.
+fn render_derivation(pool: &ExprPool, log: &alkahest_core::DerivationLog) -> String {
+    let printable = |id: ExprId| alkahest_core::check_expr_depth(pool, id).is_ok();
+    let all_printable = log.steps().iter().all(|step| {
+        printable(step.before)
+            && printable(step.after)
+            && step.side_conditions.iter().all(|c| match c {
+                SideCondition::NonZero(id)
+                | SideCondition::Positive(id)
+                | SideCondition::InDomain(id, _) => printable(*id),
+            })
+    });
+    if all_printable {
+        return log.display_with(pool).to_string();
+    }
+    // Mirrors `DerivationLog`'s own `LogDisplay`, with the two expression
+    // renderings and the side conditions routed through the depth check.
+    let mut out = String::new();
+    for (i, step) in log.steps().iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "step {}: {} applied to {} → {}",
+            i + 1,
+            step.rule_name,
+            render_expr_or_depth(pool, step.before),
+            render_expr_or_depth(pool, step.after)
+        ));
+        for cond in &step.side_conditions {
+            out.push_str(&format!(
+                "  [{}]",
+                render_side_condition_or_depth(pool, cond)
+            ));
+        }
+    }
+    out
+}
+
 fn make_derived_result(
     py: Python<'_>,
     derived: alkahest_core::DerivedExpr<alkahest_core::ExprId>,
@@ -2627,7 +2723,7 @@ fn make_derived_result(
 ) -> PyDerivedResult {
     let derivation = {
         let pool = pool_py.borrow(py);
-        derived.log.display_with(&pool.inner).to_string()
+        render_derivation(&pool.inner, &derived.log)
     };
     let steps_raw: Vec<_> = {
         let pool = pool_py.borrow(py);
@@ -2636,12 +2732,12 @@ fn make_derived_result(
             .steps()
             .iter()
             .map(|step| {
-                let before_str = pool.inner.display(step.before).to_string();
-                let after_str = pool.inner.display(step.after).to_string();
+                let before_str = render_expr_or_depth(&pool.inner, step.before);
+                let after_str = render_expr_or_depth(&pool.inner, step.after);
                 let conds: Vec<String> = step
                     .side_conditions
                     .iter()
-                    .map(|c| c.display_with(&pool.inner).to_string())
+                    .map(|c| render_side_condition_or_depth(&pool.inner, c))
                     .collect();
                 (step.rule_name.to_string(), before_str, after_str, conds)
             })
@@ -3093,7 +3189,7 @@ fn elliptic_pi(py: Python<'_>, n: PyRef<PyExpr>, phi: PyRef<PyExpr>, m: PyRef<Py
 fn py_simplify(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let derived = {
         let pool = expr.pool.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         core_simplify(expr.id, &pool.inner)
     };
     let pool_py = expr.pool.clone_ref(py);
@@ -7201,7 +7297,7 @@ fn py_simplify_with(
     py: Python<'_>,
     expr: PyRef<PyExpr>,
     rules: Vec<PyRef<PyRewriteRule>>,
-) -> PyDerivedResult {
+) -> PyResult<PyDerivedResult> {
     // We can't easily collect into `Vec<Box<dyn RewriteRule>>` due to trait
     // object lifetime constraints from PyO3, so we re-implement the engine loop.
     // Build a list of lhs/rhs pairs and apply PatternRule inline.
@@ -7213,6 +7309,11 @@ fn py_simplify_with(
 
     let derived = {
         let pool = pool_py.borrow(py);
+        // This ran unguarded, which was safe only as long as the traversal was
+        // the whole story. It is not: the pass ends in the colored e-graph
+        // when the expression carries static domain facts, and that recursion
+        // segfaults on a deep enough input.
+        guard_simplify_depth(&pool.inner, expr.id)?;
         // Build boxed rules list
         let boxed: Vec<Box<dyn RewriteRule>> = lhs_rhs
             .into_iter()
@@ -7222,7 +7323,7 @@ fn py_simplify_with(
             .collect();
         core_simplify_with(expr.id, &pool.inner, &boxed, SimplifyConfig::default())
     };
-    make_derived_result(py, derived, pool_py, None)
+    Ok(make_derived_result(py, derived, pool_py, None))
 }
 
 /// `alkahest.simplify_expanded(expr)` — simplify with distributive expansion.
@@ -7233,7 +7334,7 @@ fn py_simplify_with(
 fn py_simplify_expanded(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let derived = {
         let pool = expr.pool.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         alkahest_core::simplify_expanded(expr.id, &pool.inner)
     };
     let pool_py = expr.pool.clone_ref(py);
@@ -7246,7 +7347,7 @@ fn py_simplify_expanded(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDeriv
 fn py_simplify_trig(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let derived = {
         let pool = expr.pool.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         let rules = trig_rules();
         core_simplify_with(expr.id, &pool.inner, &rules, SimplifyConfig::default())
     };
@@ -7273,7 +7374,7 @@ fn py_simplify_trig(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedRe
 fn py_simplify_trig_normal_form(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let derived = {
         let pool = expr.pool.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         core_simplify_trig_normal_form(expr.id, &pool.inner)
     };
     let pool_py = expr.pool.clone_ref(py);
@@ -10106,7 +10207,7 @@ fn py_evaluate(
 #[pyo3(name = "simplify_par")]
 fn py_simplify_par(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let pool_ref = expr.pool.borrow(py);
-    guard_depth(&pool_ref.inner, expr.id)?;
+    guard_simplify_depth(&pool_ref.inner, expr.id)?;
     // Bind out of the `PyRef` first: it carries a `Python` marker and so is
     // not `Sync`, but the pool and id themselves are safe to send.
     #[cfg(feature = "parallel")]
@@ -10142,7 +10243,7 @@ fn py_simplify_par(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedRes
 #[pyo3(name = "simplify_redex")]
 fn py_simplify_redex(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let pool_ref = expr.pool.borrow(py);
-    guard_depth(&pool_ref.inner, expr.id)?;
+    guard_simplify_depth(&pool_ref.inner, expr.id)?;
     // Bind out of the `PyRef` first: it carries a `Python` marker and so is
     // not `Sync`, but the pool and id themselves are safe to send.
     #[cfg(feature = "parallel")]
@@ -10176,7 +10277,7 @@ fn py_simplify_redex(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedR
 #[pyo3(name = "simplify_auto")]
 fn py_simplify_auto(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedResult> {
     let pool_ref = expr.pool.borrow(py);
-    guard_depth(&pool_ref.inner, expr.id)?;
+    guard_simplify_depth(&pool_ref.inner, expr.id)?;
     // Bind out of the `PyRef` first: it carries a `Python` marker and so is
     // not `Sync`, but the pool and id themselves are safe to send.
     #[cfg(feature = "parallel")]
@@ -10210,7 +10311,7 @@ fn py_simplify_strategy(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<String>
     #[cfg(feature = "parallel")]
     {
         let pool_ref = expr.pool.borrow(py);
-        guard_depth(&pool_ref.inner, expr.id)?;
+        guard_simplify_depth(&pool_ref.inner, expr.id)?;
         let strategy = alkahest_core::choose_strategy(expr.id, &pool_ref.inner);
         Ok(match strategy {
             alkahest_core::Strategy::ForkJoin => "fork_join".to_string(),
@@ -10534,7 +10635,7 @@ fn py_collect_like_terms(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDeri
     let pool_py = expr.pool.clone_ref(py);
     let derived = {
         let pool = pool_py.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         let rules = rules_for_config(&SimplifyConfig::default());
         simplify_with(expr.id, &pool.inner, &rules, SimplifyConfig::default())
     };
@@ -10554,7 +10655,7 @@ fn py_simplify_pauli(py: Python<'_>, expr: PyRef<PyExpr>) -> PyResult<PyDerivedR
     let pool_py = expr.pool.clone_ref(py);
     let derived = {
         let pool = pool_py.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         let mut rules = rules_for_config(&SimplifyConfig::default());
         rules.extend(pauli_product_rules());
         simplify_with(expr.id, &pool.inner, &rules, SimplifyConfig::default())
@@ -10574,7 +10675,7 @@ fn py_simplify_clifford_orthogonal(
     let pool_py = expr.pool.clone_ref(py);
     let derived = {
         let pool = pool_py.borrow(py);
-        guard_depth(&pool.inner, expr.id)?;
+        guard_simplify_depth(&pool.inner, expr.id)?;
         let mut rules = rules_for_config(&SimplifyConfig::default());
         rules.extend(clifford_orthogonal_rules());
         simplify_with(expr.id, &pool.inner, &rules, SimplifyConfig::default())

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -156,16 +156,32 @@ class AssumptionError(AlkahestError):
 class DepthLimitError(AlkahestError):
     """An expression was too deeply nested to walk by recursion.
 
-    Alkahest processes expressions by structural recursion, and a native stack
-    overflow is a ``SIGSEGV`` rather than an exception — it would kill the
+    Alkahest processes most expressions by structural recursion, and a native
+    stack overflow is a ``SIGSEGV`` rather than an exception — it would kill the
     interpreter outright, with no traceback for a caller to log.  Past a
     measured ceiling the operation therefore declines instead, which is
     something ``except Exception`` can actually catch.
 
-    Depth is *nesting*, not size.  ``pool.add([t1, ..., t100000])`` has depth 2
-    and is fine; ``t1 + t2 + ... + t100000`` written with repeated ``+`` builds
-    100 000 nested binary ``Add`` nodes and is not.  Building the wide form, or
-    splitting the work into subexpressions, is the fix.
+    Depth is *nesting*, not size: ``pool.add([t1, ..., t100000])`` has depth 2
+    and is fine.  So does the same sum written with repeated ``+`` — ``Add`` and
+    ``Mul`` splice nested same-operator children when they are built, so a
+    left-associated chain of ``+`` is the very same flat, depth-2 node.  What
+    still nests is everything else: ``Pow`` towers, function chains such as
+    ``sin(sin(sin(...)))``, and ``Piecewise`` nesting.
+
+    **Which operations raise this is per operation.**  The simplification entry
+    points (:func:`~alkahest.simplify` and its variants) do not walk by
+    recursion — their traversals are trampolined or iterative — and accept
+    input of any depth.  They still raise here for an input that would reach
+    the one recursive pass on that path: the assumption-gated e-graph, which
+    runs when the expression contains a ``Domain.Positive`` or
+    ``Domain.NonZero`` symbol, or when an explicit :class:`~alkahest.Assumptions`
+    context is supplied.  Everything else — printing, ``diff``,
+    ``symbolic_grad``, ``subs``, the evaluators, the emitters — recurses, and
+    raises past the ceiling.
+
+    Rebuilding the expression with less nesting, or splitting the work into
+    subexpressions, is the fix.
     """
 
     def __init__(

--- a/tests/test_expression_depth_limit.py
+++ b/tests/test_expression_depth_limit.py
@@ -1,12 +1,12 @@
-"""Deeply nested expressions must be refused, not fatal.
+"""Deep expressions: refused where recursing over them would be fatal, run where it would not.
 
-Every operation on an expression is a structural recursion over the DAG, and a
+Most operations on an expression are a structural recursion over the DAG, and a
 native stack overflow is a ``SIGSEGV`` — the process dies with no traceback and
 no exception, so an unattended loop's ``except Exception`` never runs and the
 whole run is lost.  Past a measured ceiling those operations raise
 :class:`~alkahest.DepthLimitError` (``E-DEPTH-001``) instead.
 
-Before this guard the following killed the interpreter outright, at these
+Before that guard the following killed the interpreter outright, at these
 depths, on a release build with the usual 8 MiB main-thread stack:
 
 ===============================  ============  ==========
@@ -19,12 +19,36 @@ operation                        deepest OK    segfaulted
 ``str`` / ``repr``                   23 552       24 576
 ===============================  ============  ==========
 
-Every test here stays **just past** the limit rather than out at the old crash
+**The contract is per operation, not one contract for all of them.**  The
+``simplify`` row above is history: those traversals no longer recurse without a
+net — ``simplify::engine`` and ``simplify::parallel`` run under a
+segmented-stack trampoline, ``simplify::redex`` schedules the DAG level by
+level and does not recurse at all — so the simplification entry points accept
+input of any depth.  A 100 000-level ``sin`` chain simplifies in about 0.1 s.
+
+What they still refuse is an input that would reach the one recursion left on
+that path: every default simplification ends in the assumption-gated colored
+e-graph pass when the expression carries a ``Domain.Positive`` or
+``Domain.NonZero`` symbol, and that pass recurses (SIGSEGV between 60 000 and
+100 000 levels) *and* is quadratic (5 000 levels: 4.8 s; 20 000: 100 s).  So
+the same shape over a positive symbol is still refused, with the same code.
+
+Three groups of tests below, in that order:
+
+1. entry points that still recurse — the ceiling, unchanged;
+2. entry points that no longer do — deep input succeeds;
+3. the route that puts a lifted entry point back on a recursion — refused again.
+
+Tests in group 1 stay **just past** the limit rather than out at the old crash
 depths: a regression must fail the assertion, not take the test process down
-with it.
+with it.  Tests in group 2 have to go well past it, because succeeding at 2 049
+would prove nothing.
 """
 
 from __future__ import annotations
+
+import re
+from pathlib import Path
 
 import alkahest as ak
 import pytest
@@ -33,6 +57,15 @@ import pytest
 #: than imported so that lowering the Rust constant without updating the
 #: documented contract shows up here.
 MAX_EXPR_DEPTH = 2048
+
+#: Far enough past the ceiling that no fixed limit could be hiding behind a
+#: pass: ten times ``MAX_EXPR_DEPTH``, and past every crash depth in the table
+#: above.
+DEEP = 20_000
+
+#: The headline number.  One test uses it; the rest use :data:`DEEP`, which is
+#: already past everything and costs less to build.
+VERY_DEEP = 100_000
 
 
 @pytest.fixture
@@ -59,8 +92,20 @@ def too_deep(x: ak.Expr) -> ak.Expr:
     return nest(x, MAX_EXPR_DEPTH)  # depth = MAX_EXPR_DEPTH + 1 counting `x`
 
 
+@pytest.fixture
+def deep(x: ak.Expr) -> ak.Expr:
+    """Deep enough that only an unbounded traversal can get through it."""
+    return nest(x, DEEP)
+
+
+@pytest.fixture
+def deep_positive(pool: ak.ExprPool) -> ak.Expr:
+    """:data:`DEEP`, but over a symbol whose domain routes it to the e-graph."""
+    return nest(pool.symbol("p", "positive"), DEEP)
+
+
 # ---------------------------------------------------------------------------
-# The boundary itself
+# 1. The entry points that still recurse
 # ---------------------------------------------------------------------------
 
 
@@ -78,13 +123,13 @@ def test_one_past_the_limit_is_refused(too_deep: ak.Expr):
     assert "2048" in str(excinfo.value)
 
 
-def test_refusal_is_catchable_as_a_plain_exception(too_deep: ak.Expr):
+def test_refusal_is_catchable_as_a_plain_exception(too_deep: ak.Expr, x: ak.Expr):
     """The whole point: a loop wrapping work in ``except Exception`` must
     survive.  A ``PanicException`` (a ``BaseException``) or a segfault would
     both slip past the ``except Exception`` a real loop is written with."""
     caught: Exception | None = None
     try:
-        ak.simplify(too_deep)
+        ak.symbolic_grad(too_deep, [x])
     except Exception as e:  # deliberately broad: catching it here is the test
         caught = e
     assert isinstance(caught, ak.AlkahestError), (
@@ -100,11 +145,6 @@ def test_width_is_not_depth(pool: ak.ExprPool, x: ak.Expr):
     assert len(str(wide)) > 100_000
 
 
-# ---------------------------------------------------------------------------
-# Every entry point that used to die
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "call",
     [
@@ -112,14 +152,8 @@ def test_width_is_not_depth(pool: ak.ExprPool, x: ak.Expr):
         pytest.param(lambda e, x, p: repr(e), id="repr"),
         pytest.param(lambda e, x, p: ak.latex(e), id="latex"),
         pytest.param(lambda e, x, p: ak.unicode_str(e), id="unicode_str"),
-        pytest.param(lambda e, x, p: ak.simplify(e), id="simplify"),
-        pytest.param(lambda e, x, p: ak.simplify_par(e), id="simplify_par"),
-        pytest.param(lambda e, x, p: ak.simplify_redex(e), id="simplify_redex"),
-        pytest.param(lambda e, x, p: ak.simplify_auto(e), id="simplify_auto"),
         pytest.param(lambda e, x, p: ak.simplify_egraph(e), id="simplify_egraph"),
-        pytest.param(lambda e, x, p: ak.simplify_expanded(e), id="simplify_expanded"),
-        pytest.param(lambda e, x, p: ak.simplify_trig(e), id="simplify_trig"),
-        pytest.param(lambda e, x, p: ak.collect_like_terms(e), id="collect_like_terms"),
+        pytest.param(lambda e, x, p: ak.simplify_log_exp(e), id="simplify_log_exp"),
         pytest.param(lambda e, x, p: ak.diff(e, x), id="diff"),
         pytest.param(lambda e, x, p: ak.symbolic_grad(e, [x]), id="symbolic_grad"),
         pytest.param(lambda e, x, p: ak.jacobian([e], [x]), id="jacobian"),
@@ -162,16 +196,203 @@ def test_entry_point_refuses_instead_of_recursing(
     assert excinfo.value.code == "E-DEPTH-001"
 
 
+def test_explicit_assumptions_are_refused_at_the_plain_ceiling(
+    too_deep: ak.Expr, x: ak.Expr, pool: ak.ExprPool
+):
+    """An explicit context sends *every* input through the colored e-graph, so
+    unlike bare :func:`simplify` there is no depth at which it is safe."""
+    ctx = ak.Assumptions(pool)
+    ctx.refine(pool.gt(x, pool.integer(0)))
+
+    with pytest.raises(ak.DepthLimitError):
+        ctx.simplify(too_deep)
+    with pytest.raises(ak.DepthLimitError):
+        ak.simplify(too_deep, assumptions=ctx)
+    with pytest.raises(ak.DepthLimitError), ak.context(assumptions=ctx):
+        ak.simplify(too_deep)
+
+
 def test_batch_entry_points_report_the_refusal_per_item(too_deep: ak.Expr, x: ak.Expr):
     """``*_many`` collect per-item outcomes rather than raising, so the refusal
     has to show up in the item, not as a crash."""
-    (item,) = ak.simplify_many([too_deep])
-    assert item.error is not None
-    assert item.error["code"] == "E-DEPTH-001"
-
     (item,) = ak.diff_many([too_deep], x)
     assert item.error is not None
     assert item.error["code"] == "E-DEPTH-001"
+
+
+# ---------------------------------------------------------------------------
+# 2. The entry points that do not
+# ---------------------------------------------------------------------------
+
+#: Every simplification entry point whose traversal is stack-safe at any depth.
+#: Kept as a list so :func:`test_the_lift_is_exactly_this_list` can check it
+#: against the guard the Rust bindings actually call.
+LIFTED = [
+    pytest.param(lambda e: ak.simplify(e), id="simplify"),
+    pytest.param(lambda e: ak.simplify_par(e), id="simplify_par"),
+    pytest.param(lambda e: ak.simplify_redex(e), id="simplify_redex"),
+    pytest.param(lambda e: ak.simplify_auto(e), id="simplify_auto"),
+    pytest.param(lambda e: ak.simplify_expanded(e), id="simplify_expanded"),
+    pytest.param(lambda e: ak.simplify_trig(e), id="simplify_trig"),
+    pytest.param(lambda e: ak.simplify_trig_normal_form(e), id="simplify_trig_normal_form"),
+    pytest.param(lambda e: ak.collect_like_terms(e), id="collect_like_terms"),
+    pytest.param(lambda e: ak.simplify_pauli(e), id="simplify_pauli"),
+    pytest.param(lambda e: ak.simplify_clifford_orthogonal(e), id="simplify_clifford_orthogonal"),
+    pytest.param(lambda e: ak.simplify_with(e, []), id="simplify_with"),
+    pytest.param(lambda e: ak.simplify_strategy(e), id="simplify_strategy"),
+]
+
+
+@pytest.mark.parametrize("call", LIFTED)
+def test_lifted_entry_point_accepts_a_deep_expression(call, deep: ak.Expr):
+    """The capability this file exists to pin: 20 000 levels, ten times the
+    ceiling and past every crash depth in the table, and it returns."""
+    assert call(deep) is not None
+
+
+def test_simplify_returns_the_right_answer_at_a_hundred_thousand_levels(pool: ak.ExprPool):
+    """Not merely "does not crash": the rewrite still has to happen, and the
+    result has to be the expression the rules say it is.
+
+    ``sin`` chains are inert, so the outermost node is a redex the simplifier
+    must actually remove — which also puts a 100 000-level expression into the
+    derivation log, where the recursive printer lives.
+    """
+    x = pool.symbol("x", "real")
+    chain = nest(x, VERY_DEEP)
+    result = ak.simplify(pool.mul([chain, pool.integer(1)]))
+    assert result.value == chain
+
+
+def test_a_deep_derivation_is_reported_rather_than_printed(pool: ak.ExprPool):
+    """A log holds whatever subexpressions the rules fired on, and the renderer
+    behind it is the same recursion as ``str()``.  Past the printer's reach the
+    step is still reported — with its depth in place of its text — instead of
+    taking the process out."""
+    x = pool.symbol("x", "real")
+    result = ak.simplify(pool.mul([nest(x, DEEP), pool.integer(1)]))
+
+    (step,) = result.steps
+    assert step["rule"] == "mul_one"
+    assert "too deep to render" in step["before"]
+    # `x`, `DEEP` levels of `sin`, and the `* 1` the rule removed.
+    assert str(DEEP + 2) in step["before"]
+    assert "too deep to render" in result.derivation
+
+
+def test_simplify_many_no_longer_reports_a_refusal_for_a_deep_item(deep: ak.Expr):
+    """The batch wrapper reports whatever the single call does, so lifting the
+    single call has to show up here too."""
+    (item,) = ak.simplify_many([deep])
+    assert item.error is None
+
+
+def test_shallow_results_render_exactly_as_before(pool: ak.ExprPool):
+    """The depth-aware renderer must be invisible to every ordinary call: below
+    the ceiling the derivation text is produced by the same code that always
+    produced it."""
+    x = pool.symbol("x", "real")
+    result = ak.simplify(pool.mul([x, pool.integer(1)]))
+    assert result.value == x
+    (step,) = result.steps
+    assert step["before"] == "(x * 1)"
+    assert step["after"] == "x"
+    assert "too deep" not in result.derivation
+
+
+# ---------------------------------------------------------------------------
+# 3. The route that puts a lifted entry point back on a recursion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("call", LIFTED)
+def test_lifted_entry_point_still_refuses_what_would_reach_the_e_graph(
+    call, deep_positive: ak.Expr
+):
+    """A ``Domain.Positive`` symbol anywhere in the expression sends the whole
+    thing to the colored e-graph pass, which recurses and is quadratic.  Same
+    shape, same depth, same entry points as the group above — and refused."""
+    with pytest.raises(ak.DepthLimitError) as excinfo:
+        call(deep_positive)
+    assert excinfo.value.code == "E-DEPTH-001"
+
+
+def test_a_nonzero_domain_routes_the_same_way(pool: ak.ExprPool):
+    """``Domain.NonZero`` authorizes conditional rewrites too, so it takes the
+    same route as ``Domain.Positive`` and must be refused with it."""
+    with pytest.raises(ak.DepthLimitError):
+        ak.simplify(nest(pool.symbol("nz", "nonzero"), DEEP))
+
+
+def test_the_domain_only_matters_past_the_ceiling(pool: ak.ExprPool):
+    """Below the ceiling the e-graph pass recurses at a depth it survives, so a
+    positive symbol must not make an ordinary expression unsimplifiable."""
+    p = pool.symbol("p", "positive")
+    shallow = nest(p, MAX_EXPR_DEPTH - 1)
+    assert ak.simplify(shallow) is not None
+
+
+# ---------------------------------------------------------------------------
+# Which guard each binding calls
+# ---------------------------------------------------------------------------
+
+_LIB_RS = Path(__file__).resolve().parents[1] / "alkahest-py" / "src" / "lib.rs"
+
+#: The Rust ``#[pyfunction]`` / ``#[pymethods]`` entries that call
+#: ``guard_simplify_depth`` rather than ``guard_depth``.  A binding added to
+#: this list without a matching entry in :data:`LIFTED` is a lift nobody
+#: tested; one removed from it is capability silently taken back.
+EXPECTED_SIMPLIFY_GUARDED = {
+    "py_collect_like_terms",
+    "py_simplify",
+    "py_simplify_auto",
+    "py_simplify_clifford_orthogonal",
+    "py_simplify_expanded",
+    "py_simplify_par",
+    "py_simplify_pauli",
+    "py_simplify_redex",
+    "py_simplify_strategy",
+    "py_simplify_trig",
+    "py_simplify_trig_normal_form",
+    "py_simplify_with",
+}
+
+
+def _functions_calling(guard: str) -> set[str]:
+    """Names of the Rust functions whose body calls ``guard``."""
+    source = _LIB_RS.read_text()
+    current = None
+    found = set()
+    fn_start = re.compile(r"^\s*(?:pub(?:\(crate\))?\s+)?fn\s+([A-Za-z0-9_]+)")
+    for line in source.splitlines():
+        match = fn_start.match(line)
+        if match:
+            current = match.group(1)
+        if guard + "(" in line and current is not None and not line.lstrip().startswith("fn "):
+            found.add(current)
+    return found
+
+
+def test_the_lift_is_exactly_this_list():
+    """The lifted set is a decision about which traversals do not recurse, and
+    it is not something a reader can infer from a function's name.  Pinning it
+    against the source means a new binding has to choose a guard on purpose."""
+    assert _functions_calling("guard_simplify_depth") == EXPECTED_SIMPLIFY_GUARDED
+
+
+def test_every_lifted_binding_has_a_test_here():
+    """Both directions of the same fact, so neither list can drift alone."""
+    tested = {p.id for p in LIFTED}
+    guarded = {name.removeprefix("py_") for name in EXPECTED_SIMPLIFY_GUARDED}
+    assert tested == guarded
+
+
+def test_the_unconditional_guard_is_still_the_common_case():
+    """Lifting a dozen entry points must not have quietly lifted the rest: the
+    plain ceiling is still what most of the boundary uses."""
+    plain = _functions_calling("guard_depth") | _functions_calling("guard_expr_depth")
+    assert len(plain) > 40
+    assert not plain & EXPECTED_SIMPLIFY_GUARDED
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`ak.simplify` refused expressions it could handle: the PyO3 boundary raised `E-DEPTH-001` past depth 2048 while the traversal beneath it is trampolined through `simplify::stack::with_stack_segment` and never touches the caller's stack. Twelve entry points now use a route-aware guard instead of the flat ceiling.

At depth 100 000, `simplify` returns in **0.09 s / 163 MB**; at 1 000 000, 2.64 s / 1 258 MB. It previously refused all of it.

## This is not a blanket lift, because the family was only partially protected

Two plain recursions are reachable from `simplify`, and both kill the process rather than raise:

1. **The colored e-graph tail.** `simplify_with`, `simplify_par_with_config` and `simplify_redex_with_config` all finish by calling `collect_static_domain_facts` and, when it yields facts, `simplify_colored`. `ColoredEgraph::from_expr`'s `collect_nodes`/`rebuild_rec` descend one frame per level. With the guard removed: depth 20 000 returned in 100 s, depth 100 000 **SIGSEGV**. It is also quadratic — 2 500 → 1.06 s, 5 000 → 4.79 s, 10 000 → 19.1 s, 20 000 → 99.8 s — so trampolining it would have swapped a crash for a hang. Left recursive deliberately.
2. **The derivation-log renderer** in `make_derived_result`, which shares the recursive printer used by `str()`. A deep chain wrapped in a single redex — trampolined traversal, one deep step in the log — **SIGSEGV at 30 000**, consistent with the 24 576 figure already documented for `str`.

So `check_simplify_depth` applies `MAX_EXPR_DEPTH` only when `pool.depth > 2048` **and** the expression would take the colored route. It decides by running the simplifier's own `collect_static_domain_facts`, so the guard and the thing it guards cannot drift apart. `O(1)` at or below the ceiling — the hot path is untouched. The renderer now records an over-deep step's depth rather than its text.

## Two entry points had no guard at all

`simplify_with` and `AssumptionContext.simplify` would segfault today on deep input. The second is what `ak.simplify(expr, assumptions=…)` and `with ak.context(assumptions=…)` route through — a reachable crash on the public API, found while tracing which paths were safe to lift. Both are guarded now.

## Evidence the ceiling is still load-bearing where it was kept

In a subprocess with the main stack shrunk to 128 KiB, `symbolic_grad` and `str` **SIGSEGV at depth 2 048 — the deepest the guard permits** — while `simplify` at 100 001 completes in 0.29 s. The lifted paths do not run on the caller's stack at all; the others plainly still need the ceiling. At the normal 8 MiB, all 35 parametrised non-lifted entry points refuse at 2 049 with `E-DEPTH-001`.

Still on the flat ceiling: `simplify_egraph`/`simplify_egraph_with` (separate recursive engine), `simplify_log_exp` and `AssumptionContext.simplify` (explicit facts route *every* input to the e-graph, so partially protected was treated as unprotected), and the ~50 non-simplify bindings.

## Which routes were lifted, and why each is stack-safe

| entry point | evidence |
|---|---|
| `simplify`, `simplify_expanded`, `simplify_trig`, `simplify_trig_normal_form`, `collect_like_terms`, `simplify_pauli`, `simplify_clifford_orthogonal`, `simplify_with` | route to `simplify::engine::simplify_with` → `simplify_node`, whose body is wrapped in `with_stack_segment` (`engine.rs:179`, indexed twin at `:228`) |
| `simplify_par` | `parallel::simplify_node_par` → `with_stack_segment` (`parallel.rs:137`); feature-off falls back to `alkahest_core::simplify`, i.e. the trampoline again |
| `simplify_redex` | not trampolined and does not need to be — `redex::build_levels`/`one_pass` are an explicit `Vec` worklist with no recursion; feature-off falls back to `simplify` |
| `simplify_auto`, `simplify_strategy` | `dispatch::shape` is iterative and dispatches only to the above |

`with_stack_segment` has exactly three call sites in the crate, all listed. Both branches of every `cfg` on the path were checked, which is what makes lifting from a feature-gated entry point safe.

## Tests

Restructured into per-operation contracts rather than one uniform limit: the ceiling for entry points that still recurse; all twelve lifted entry points at 20 000 levels plus one at 100 000 that asserts the *answer* (`simplify(chain * 1) == chain`); the same twelve refused on the same shape over a `Positive`/`NonZero` symbol, since that routes to the e-graph.

`test_the_lift_is_exactly_this_list` scans `alkahest-py/src/lib.rs` for which guard each binding calls and cross-checks it against the tested list **in both directions**, so adding a binding to either side without the other fails.

## Gates

`cargo fmt --check` · `cargo test --workspace` (2 649 + 73, 0 failed) · `cargo clippy --all-targets -D warnings` across default/egraph/parallel/cranelift/groebner · `RUSTDOCFLAGS="-D warnings" cargo doc` · `pytest tests/` (3 695 passed) · `ruff==0.15.14` check and format · `cargo semver-checks` 223 pass, additions only, `alkahest.__all__` unchanged.

`E-DEPTH-001` keeps the same code, `limit` field and meaning wherever it still fires. No `unsafe`, no `is_none_or`.

**One caveat:** `cargo semver-checks` with its default all-features build fails locally on `llvm-sys` (no LLVM on the machine); the clean result above is from `--default-features`. CI runs the real thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
