### PR TITLE
fix(integrate): a domain hole in a candidate antiderivative is a disagreement, not a skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Unreleased
 
+- **An antiderivative that is *undefined* on a whole component where the
+  integrand is finite passed the verification gate.** The gate's numeric grid
+  skipped every sample where either side came back non-finite, so a domain hole
+  cleared a grid built to catch sign errors. Charlwood **#35**
+  `∫x·asec(x)/√(x²−1) dx` was closed with `√(x²−1)·acos(1/x) − log(x + √(x²))`;
+  `√(x²)` is `|x|`, so that logarithm is `log(0)` for every `x < −1`, where the
+  integrand is an ordinary finite real (`−2.418…` at `x = −2`). Six positive
+  samples agreed, the six negative ones were skipped, and the answer was
+  reported `numerically_checked` with no domain caveat — behaviourally the
+  one-sided grid the previous release removed for **#22**, in a different
+  disguise.
+
+  The claim the gate actually makes is `F′ = f` **wherever `f` is defined**, and
+  each sample is now classified against it:
+
+  | `f` | `F′` | verdict |
+  |---|---|---|
+  | finite | finite | compare, as before |
+  | finite | non-finite | **disagreement** — refuse the candidate |
+  | non-finite | either | no information — skip |
+
+  The third row is deliberately not symmetric with the second, and that
+  asymmetry is why the obvious "any non-finite is a disagreement" fix
+  over-tightens. `F′` is `simplify(diff(F))` and is routinely defined on a
+  strictly larger set than `f` is — `∫x·√(x−1)/√(x−1) dx` is `x²/2`, whose
+  derivative is finite everywhere while the integrand is undefined below `1` —
+  so counting samples outside `f`'s domain against a candidate would turn
+  correct answers into declines. An *unevaluable* sample (unregistered head,
+  `RootSum`, unbound symbol) still skips: that is a property of the expression,
+  not evidence about the point.
+
+  The same rule now applies at the two other places that compare a candidate's
+  derivative to an integrand over a grid, `integrate::gate::verify` (the
+  propose–fit–verify block gate) and `risch::exp_algebraic`'s local check.
+  `algebraic::genus_zero` was checked and left alone: it already refuses on any
+  non-finite sample, which is stricter than this rule rather than laxer.
+
+  **Cost: Charlwood's Fifty goes 33 → 32, and #35 is the only problem that
+  moves.** It was also the only one of the fifty whose answer had a domain
+  hole. It declines with `E-INT-001`, never a certificate — the `NonElementary`
+  verdict is a structural Liouville pre-check that runs before any gate, so a
+  stricter gate cannot manufacture one. Off-suite the 40-case probe is
+  unchanged at 35 solved / 4 `E-INT-004` / 1 `E-INT-001` with no per-case
+  movement, and a 110-case Liouville corpus is unchanged at 84 solved. Decline
+  latency does not rise — a refusal now returns at the offending sample instead
+  of evaluating the rest of the grid: median 142 ms → 102–123 ms over three
+  runs on Charlwood, 398 ms → 180–231 ms on the 110-case corpus.
+
+  Recovering #35 needs a branch-correct answer, not a wider search. The
+  two-branch antiderivative is `√(x²−1)·asec(x) − sgn(x)·log|x|`: `d/dx asec(x)`
+  is `1/(|x|√(x²−1))`, so even the textbook `− log|x|` is right only on `x > 1`.
 - **The rational-function route returned answers nothing had checked, and
   nothing *could* check.** `integrate`'s Rothstein–Trager fallback was the one
   route in the integrator that returned its result directly, with no
@@ -532,10 +583,15 @@
     `I`. `∫sin(log x) dx = (x·sin(log x) − x·cos(log x))/2` is closed this way
     and by nothing else in the codebase.
   - Measured on Charlwood's Fifty: closes **#21** `x³·asin(x)/√(1−x⁴)`,
-    **#22** `x³·asec(x)/√(x⁴−1)` and **#35** `x·asec(x)/√(x²−1)`, all verified
-    by differentiation. The other 14 of the 17 C1/C3 problems produce *correct*
-    by-parts residuals that the downstream engine then declines; the binding
-    constraint on that cluster is the algebraic engine, not the by-parts layer.
+    verified by differentiation. It also produced answers for **#22**
+    `x³·asec(x)/√(x⁴−1)` and **#35** `x·asec(x)/√(x²−1)`, and both were
+    withdrawn later in this same release cycle when the gate learned to see
+    what was wrong with them: #22's is off by ≈1.1 for `x < −1` (caught by
+    making the grid two-sided) and #35's is *undefined* there (caught by the
+    non-finite-sample rule above). The other 14 of the 17 C1/C3 problems
+    produce *correct* by-parts residuals that the downstream engine then
+    declines; the binding constraint on that cluster is the algebraic engine,
+    not the by-parts layer.
   - Cost on integrands it fails on — the price paid on every decline —
     **5.1 ms mean, 13.9 ms worst** in a release build over the 40-case probe's
     six `E-INT-001` cases plus eight controls. The 40-case probe is unchanged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,19 @@
   `RootSum`, unbound symbol) still skips: that is a property of the expression,
   not evidence about the point.
 
-  The same rule now applies at the two other places that compare a candidate's
-  derivative to an integrand over a grid, `integrate::gate::verify` (the
-  propose–fit–verify block gate) and `risch::exp_algebraic`'s local check.
-  `algebraic::genus_zero` was checked and left alone: it already refuses on any
-  non-finite sample, which is stricter than this rule rather than laxer.
+  Three other places compare a candidate's derivative to an integrand over a
+  numeric grid and had the identical skip. `risch::exp_algebraic`'s local check
+  now follows the rule too. `algebraic::genus_zero` was left alone: it already
+  refuses on *any* non-finite sample, stricter than this rule rather than laxer.
+  The third, `integrate::gate::verify`, was changed and the change **reverted**,
+  because its callers rely on the skip on purpose: the elliptic route samples
+  every `P > 0` interval while its reduction is valid on only one of them, so
+  for `∫dx/√(x³−x)` the integrand is finite on `(−1, 0)` where the candidate's
+  derivative is not, and the stricter rule refused four correct,
+  branch-limited elliptic answers. Adopting it there needs each reduction's
+  sample set narrowed to the region it claims, which is a larger change than
+  this one; the reason is recorded in that module's honest-limitations list so
+  the experiment is not repeated.
 
   **Cost: Charlwood's Fifty goes 33 → 32, and #35 is the only problem that
   moves.** It was also the only one of the fifty whose answer had a domain

--- a/alkahest-core/src/integrate/by_parts.rs
+++ b/alkahest-core/src/integrate/by_parts.rs
@@ -3051,23 +3051,48 @@ mod tests {
     }
 
     /// The Charlwood problems this module closes, pinned so a regression is
-    /// visible.  Both are verified by differentiation, here and in the gate.
+    /// visible.  Verified by differentiation, here and in the gate.
     #[test]
-    fn charlwood_21_35_close_and_verify() {
+    fn charlwood_21_closes_and_verifies() {
         use crate::parse::parse;
         use std::collections::HashMap as Map;
 
         let pool = p();
         let x = pool.symbol("x", Domain::Real);
-        for src in [
-            "x^3*asin(x)/sqrt(1-x^4)",  // #21
-            "x*acos(1/x)/sqrt(-1+x^2)", // #35
-        ] {
-            let mut syms: Map<String, ExprId> = Map::from([("x".to_owned(), x)]);
-            let f = parse(src, &pool, &mut syms).expect("parses");
-            let res = solved(f, x, &pool);
-            let _ = res;
-        }
+        let mut syms: Map<String, ExprId> = Map::from([("x".to_owned(), x)]);
+        let f = parse("x^3*asin(x)/sqrt(1-x^4)", &pool, &mut syms).expect("parses");
+        let _ = solved(f, x, &pool);
+    }
+
+    /// Charlwood #35, `∫x·asec(x)/√(x²−1) dx`, is the *domain-hole* sibling of
+    /// #22 below, and must be refused for the same reason with a different
+    /// symptom.
+    ///
+    /// This module closed it with `√(x²−1)·acos(1/x) − log(x + √(x²))`.  On
+    /// `x > 1` that is right.  `√(x²)` is `|x|`, so on `x < −1` the logarithm
+    /// is `log(0)`: the answer is **undefined on a whole component where the
+    /// integrand is an ordinary finite real** (`−2.418…` at `x = −2`).  The
+    /// gate admitted it because it *skipped* every negative sample whose
+    /// derivative came back non-finite, which is the one-sided grid #22's fix
+    /// removed, wearing a different disguise.  A non-finite `F′` at a point
+    /// where `f` is finite is now a disagreement, so the candidate is refused.
+    ///
+    /// Recovering #35 needs `√(x²)` simplified to `|x|` — i.e. a correct
+    /// answer — not a wider search.
+    #[test]
+    fn charlwood_35_is_refused_because_its_candidate_has_a_domain_hole() {
+        use crate::parse::parse;
+        use std::collections::HashMap as Map;
+
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let mut syms: Map<String, ExprId> = Map::from([("x".to_owned(), x)]);
+        let f = parse("x*acos(1/x)/sqrt(-1+x^2)", &pool, &mut syms).expect("parses");
+        assert!(
+            integrate_by_parts(f, x, &pool).is_declined(),
+            "#35's candidate is undefined for x < −1, where the integrand is finite, \
+             and must be refused"
+        );
     }
 
     /// Charlwood #22 is **not** in the list above, and the reason is worth

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -4040,10 +4040,13 @@ pub enum AntiderivativeVerification {
 /// Soundness gate: verify `d/dx(candidate) == integrand`.
 ///
 /// Accepts when `d/dx(candidate) − integrand` simplifies structurally to zero,
-/// **or** when a numeric check agrees to ~1e-7 over several real sample points
-/// (skipping points where either side is non-finite, e.g. singularities).  A
-/// `candidate` whose derivative cannot be confirmed equal is rejected, so the
+/// **or** when a numeric check agrees to ~1e-7 over several real sample points.
+/// A `candidate` whose derivative cannot be confirmed equal is rejected, so the
 /// integrator never returns a wrong antiderivative.
+///
+/// The claim being checked is `F′ = f` **wherever `f` is defined**, and each
+/// sample is classified against that claim rather than simply dropped when a
+/// number fails to come out — see [`SampleVerdict`].
 pub fn verify_antiderivative_status(
     candidate: ExprId,
     integrand: ExprId,
@@ -4065,11 +4068,11 @@ pub fn verify_antiderivative_status(
     // `√` or a `log` is exactly the error a one-sided grid cannot see, so the
     // negative mirror of each point is now checked too.
     //
-    // This does not reject answers that are merely *undefined* on the negative
-    // side: `eval_interp` returns no value, or a non-finite one, at a point
-    // outside the domain, and both are skipped rather than counted as
-    // disagreement.  Nor does it reject a different branch constant — the
-    // comparison is between derivatives, where an additive constant has already
+    // Widening the grid was only half the fix, though: a *hole* in the
+    // candidate's domain still walked through it.  See [`classify_sample`].
+    //
+    // This still does not reject a different branch constant — the comparison
+    // is between derivatives, where an additive constant has already
     // differentiated away.
     let Ok(d_raw) = crate::diff::diff(candidate, var, pool) else {
         return None;
@@ -4083,26 +4086,90 @@ pub fn verify_antiderivative_status(
     for &xv in &samples {
         let mut env = HashMap::new();
         env.insert(var, xv);
-        let (Some(dv), Some(fv)) = (
-            crate::jit::eval_interp(d, &env, pool),
-            crate::jit::eval_interp(integrand, &env, pool),
-        ) else {
-            // Unevaluable expression — cannot certify numerically.
-            return None;
-        };
-        if !dv.is_finite() || !fv.is_finite() {
-            continue; // near a singularity; skip this sample
+        match classify_sample(d, integrand, &env, pool) {
+            SampleVerdict::Agrees => checked += 1,
+            SampleVerdict::NoInformation => continue,
+            SampleVerdict::Disagrees => return None,
         }
-        let tol = 1e-7 * (1.0 + dv.abs().max(fv.abs()));
-        if (dv - fv).abs() > tol {
-            return None;
-        }
-        checked += 1;
     }
 
     // Require at least a couple of usable samples so an all-singular set cannot
     // vacuously pass.
     (checked >= 2).then_some(AntiderivativeVerification::Numeric)
+}
+
+/// What one sample point of the antiderivative gate's grid establishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SampleVerdict {
+    /// Both sides produced the same finite real. Counts towards the quorum.
+    Agrees,
+    /// The sample says nothing about `F′ = f`, and is neither counted nor held
+    /// against the candidate.
+    NoInformation,
+    /// The sample is positive evidence that `F` is not an antiderivative of `f`
+    /// there. One is enough to refuse the candidate.
+    Disagrees,
+}
+
+/// Classify one grid point of [`verify_antiderivative_status`]'s numeric check.
+///
+/// The claim under test is `F′ = f` **on the domain of `f`**, so what a sample
+/// establishes depends on which of the two sides produced a finite real:
+///
+/// | `f` | `F′` | verdict | why |
+/// |---|---|---|---|
+/// | finite | finite | compare | the ordinary case |
+/// | finite | non-finite | **`Disagrees`** | `F` is not differentiable — not even defined — at a point where `f` is an ordinary real, so it is not an antiderivative of `f` there |
+/// | non-finite | either | `NoInformation` | outside `f`'s domain there is no claim to check |
+///
+/// The middle row is the one this function exists for, and it used to be
+/// treated as the third.  Charlwood #35, `∫x·asec(x)/√(x²−1) dx`, came back as
+/// `√(x²−1)·acos(1/x) − log(x + √(x²))`.  `√(x²)` is `|x|`, so that logarithm
+/// is `log(0)` for every `x < −1` — a whole component of the integrand's domain
+/// on which the answer is undefined, while the integrand itself is an ordinary
+/// finite real (`−2.418…` at `x = −2`).  Skipping those samples left the
+/// candidate admitted on the six positive points alone, which is behaviourally
+/// the one-sided grid PR #328 removed for #22: a domain hole clearing a grid
+/// built to catch a sign error.
+///
+/// The bottom row is deliberately *not* symmetric with the middle one, and the
+/// asymmetry is the whole reason the obvious "any non-finite is a
+/// disagreement" fix over-tightens.  `F′` is `simplify(diff(F))`, so it is
+/// routinely defined on a strictly larger set than `f` is: `∫ x·√(x−1)/√(x−1)`
+/// has `F = x²/2` with `F′ = x` finite everywhere, while the integrand is
+/// undefined for `x < 1`.  Nothing is wrong with that answer — it satisfies
+/// `F′ = f` at every point where `f` means anything — and counting the samples
+/// below `1` against it would turn a correct antiderivative into a decline.
+/// Symmetrically, `∫dx/x = log|x|` has a genuine pole at `0` in both, which is
+/// the top-left-empty case: both sides non-finite, still no information.
+fn classify_sample(
+    d: ExprId,
+    integrand: ExprId,
+    env: &HashMap<ExprId, f64>,
+    pool: &ExprPool,
+) -> SampleVerdict {
+    // `None` — an unbound symbol or a node the interpreter does not implement —
+    // is a property of the *expression*, not of this point, so it cannot be
+    // evidence against the candidate. It makes the whole numeric channel
+    // useless, and the caller's quorum requirement is what declines then.
+    let (Some(dv), Some(fv)) = (
+        crate::jit::eval_interp(d, env, pool),
+        crate::jit::eval_interp(integrand, env, pool),
+    ) else {
+        return SampleVerdict::NoInformation;
+    };
+    if !fv.is_finite() {
+        return SampleVerdict::NoInformation;
+    }
+    if !dv.is_finite() {
+        return SampleVerdict::Disagrees;
+    }
+    let tol = 1e-7 * (1.0 + dv.abs().max(fv.abs()));
+    if (dv - fv).abs() > tol {
+        SampleVerdict::Disagrees
+    } else {
+        SampleVerdict::Agrees
+    }
 }
 
 fn verify_antiderivative(
@@ -5418,6 +5485,150 @@ mod tests {
         let f = pool.pow(x, pool.integer(-1_i32));
         let r = integrate_definite(f, x, pool.integer(1_i32), pool.integer(2_i32), &pool).unwrap();
         assert_num(r.value, 2.0_f64.ln(), &pool);
+    }
+
+    // ── The antiderivative gate's non-finite-sample rule ─────────────────────
+    //
+    // Three rows, three verdicts — see `classify_sample`.  Each test states the
+    // row it pins, because getting any one of them wrong either admits a wrong
+    // answer or declines a right one.
+
+    /// **Row 2 — `f` finite, `F′` non-finite ⇒ refuse.**  Charlwood #35, pinned
+    /// at the gate rather than at the route that produced it.
+    ///
+    /// `∫x·asec(x)/√(x²−1) dx` was closed with
+    /// `√(x²−1)·acos(1/x) − log(x + √(x²))`.  `√(x²)` is `|x|`, so the
+    /// logarithm is `log(0)` for every `x < −1`; the answer is undefined on an
+    /// entire component of the integrand's domain, and the integrand there is
+    /// an ordinary finite real (`−2.418…` at `x = −2`).  The gate used to
+    /// `continue` past exactly those samples and admit the candidate on the
+    /// positive six alone.
+    #[test]
+    fn gate_refuses_an_antiderivative_with_a_domain_hole() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        let one = pool.integer(1_i32);
+        let neg1 = pool.integer(-1_i32);
+
+        // f = x·acos(1/x)/√(x²−1)
+        let radicand = pool.add(vec![x2, neg1]);
+        let root = pool.func("sqrt", vec![radicand]);
+        let acos_inv = pool.func("acos", vec![pool.pow(x, neg1)]);
+        let f = pool.mul(vec![x, acos_inv, pool.pow(root, neg1)]);
+
+        // F = √(x²−1)·acos(1/x) − log(x + √(x²))   — the answer with the hole.
+        let abs_like = pool.func("sqrt", vec![x2]);
+        let log_term = pool.func("log", vec![pool.add(vec![x, abs_like])]);
+        let holed = pool.add(vec![
+            pool.mul(vec![root, acos_inv]),
+            pool.mul(vec![neg1, log_term]),
+        ]);
+
+        // The premise: at x = −2 the integrand is finite and F′ is not.
+        let mut env = HashMap::new();
+        env.insert(x, -2.0_f64);
+        let d = simplify(crate::diff::diff(holed, x, &pool).unwrap().value, &pool).value;
+        assert!(
+            crate::jit::eval_interp(f, &env, &pool).is_some_and(|v| v.is_finite()),
+            "premise: the integrand must be finite at x = −2"
+        );
+        assert!(
+            crate::jit::eval_interp(d, &env, &pool).map_or(true, |v| !v.is_finite()),
+            "premise: the candidate's derivative must be undefined at x = −2"
+        );
+
+        assert!(
+            verify_antiderivative_status(holed, f, x, &pool).is_none(),
+            "an antiderivative undefined where the integrand is finite must not verify"
+        );
+
+        // And the gate is not merely refusing everything for this integrand.
+        // The two-branch answer is `√(x²−1)·acos(1/x) − sgn(x)·log|x|` —
+        // spelled here with `√(x²)` for `|x|` and `x/√(x²)` for `sgn(x)`,
+        // because the kernel has no differentiation rule for `abs`.  (Note the
+        // `sgn`: `d/dx acos(1/x)` is `1/(|x|√(x²−1))`, not `1/(x√(x²−1))`, so
+        // plain `−log|x|` is right only on `x > 1` and is off by `−2/x` below
+        // `−1`.)  It is defined on both components and it verifies.
+        let sgn = pool.mul(vec![x, pool.pow(abs_like, neg1)]);
+        let correct = pool.add(vec![
+            pool.mul(vec![root, acos_inv]),
+            pool.mul(vec![neg1, sgn, pool.func("log", vec![abs_like])]),
+        ]);
+        assert!(
+            verify_antiderivative_status(correct, f, x, &pool).is_some(),
+            "the branch-correct answer must still verify"
+        );
+        let _ = one;
+    }
+
+    /// **Row 3 — both sides non-finite ⇒ no information.**  `∫x/√(1−x²) dx` is
+    /// `−√(1−x²)`; outside `[−1, 1]` the radical is imaginary in the integrand
+    /// *and* in the derivative, and the eight grid points that land there must
+    /// be skipped rather than held against a correct answer.
+    #[test]
+    fn gate_skips_a_singularity_shared_by_both_sides() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let neg1 = pool.integer(-1_i32);
+        let radicand = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![neg1, pool.pow(x, pool.integer(2_i32))]),
+        ]);
+        let root = pool.func("sqrt", vec![radicand]);
+        let f = pool.mul(vec![x, pool.pow(root, neg1)]);
+        let cand = pool.mul(vec![neg1, root]);
+
+        // Premise: at x = 2.1719 neither side is a finite real.
+        let mut env = HashMap::new();
+        env.insert(x, 2.1719_f64);
+        let d = simplify(crate::diff::diff(cand, x, &pool).unwrap().value, &pool).value;
+        for (name, e) in [("integrand", f), ("derivative", d)] {
+            assert!(
+                crate::jit::eval_interp(e, &env, &pool).map_or(true, |v| !v.is_finite()),
+                "premise: the {name} must be undefined at x = 2.1719"
+            );
+        }
+
+        assert!(
+            verify_antiderivative_status(cand, f, x, &pool).is_some(),
+            "−√(1−x²) is the antiderivative of x/√(1−x²) and must verify"
+        );
+    }
+
+    /// **Row 3 again — `f` non-finite, `F′` finite ⇒ no information.**
+    ///
+    /// This is the asymmetry that keeps the rule from over-tightening.
+    /// `∫ x·√(x−1)/√(x−1) dx` is `x²/2`, whose derivative `x` is finite on all
+    /// of `ℝ` while the integrand is undefined below `1`.  The answer is
+    /// correct — `F′ = f` wherever `f` means anything — and the six negative
+    /// samples, where only the integrand fails, must not be evidence against
+    /// it.
+    #[test]
+    fn gate_ignores_samples_outside_the_integrands_domain() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let root = pool.func("sqrt", vec![pool.add(vec![x, pool.integer(-1_i32)])]);
+        let f = pool.mul(vec![x, root, pool.pow(root, pool.integer(-1_i32))]);
+        let big = pool.mul(vec![pool.rational(1, 2), pool.pow(x, pool.integer(2_i32))]);
+
+        // Premise: at x = −2.1719 the integrand is undefined and F′ is not.
+        let mut env = HashMap::new();
+        env.insert(x, -2.1719_f64);
+        let d = simplify(crate::diff::diff(big, x, &pool).unwrap().value, &pool).value;
+        assert!(
+            crate::jit::eval_interp(f, &env, &pool).map_or(true, |v| !v.is_finite()),
+            "premise: the integrand must be undefined at x = −2.1719"
+        );
+        assert!(
+            crate::jit::eval_interp(d, &env, &pool).is_some_and(|v| v.is_finite()),
+            "premise: the candidate's derivative must be finite at x = −2.1719"
+        );
+
+        assert!(
+            verify_antiderivative_status(big, f, x, &pool).is_some(),
+            "a correct antiderivative defined beyond the integrand's domain must verify"
+        );
     }
 
     // ── Interior-pole detection ──────────────────────────────────────────────

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -4046,7 +4046,7 @@ pub enum AntiderivativeVerification {
 ///
 /// The claim being checked is `F′ = f` **wherever `f` is defined**, and each
 /// sample is classified against that claim rather than simply dropped when a
-/// number fails to come out — see [`SampleVerdict`].
+/// number fails to come out — see the private `SampleVerdict` enum.
 pub fn verify_antiderivative_status(
     candidate: ExprId,
     integrand: ExprId,

--- a/alkahest-core/src/integrate/gate.rs
+++ b/alkahest-core/src/integrate/gate.rs
@@ -111,6 +111,25 @@
 //!   `crate::eval` `root_sum` module — numerically, by root-finding — which is
 //!   what makes a Rothstein–Trager answer with an algebraic residue something
 //!   this gate can have an opinion about at all.
+//! * **A candidate undefined where the integrand is finite is *skipped* here,
+//!   not refuted — unlike at the engine-level gate.**  That asymmetry is
+//!   deliberate and it is load-bearing, so it is worth stating plainly.
+//!   [`crate::integrate::verify_antiderivative_status`] treats a sample where
+//!   `f` is an ordinary finite real and `d/dx F` is not as a **disagreement**,
+//!   because there `F` is not an antiderivative of `f` (see
+//!   `engine::classify_sample`, and Charlwood #35, which is exactly that).
+//!   Applying the same rule *here* was tried and reverted: this gate's callers
+//!   deliberately sample beyond the region their reduction claims.
+//!   [`crate::integrate::algebraic::elliptic_output`]'s `gate_samples` puts
+//!   points in **every** `P > 0` interval and says so — "points where the
+//!   substitution is invalid simply evaluate non-finite and are skipped" —
+//!   while a cubic-three-real reduction is valid only beyond the largest root.
+//!   For `∫dx/√(x³−x)` the integrand is finite on `(−1, 0)` and the elliptic
+//!   candidate's derivative is not, so the stricter rule refuses four correct,
+//!   branch-limited elliptic answers (`tests/test_elliptic_integrate.py`).
+//!   Adopting it needs the sample set narrowed to the region each reduction
+//!   actually claims — or a [`Verdict`] that can name that region — not a
+//!   one-line change to the loop.
 //!
 //! # Relationship to `verify_antiderivative_status`
 //!

--- a/alkahest-core/src/integrate/risch/exp_algebraic.rs
+++ b/alkahest-core/src/integrate/risch/exp_algebraic.rs
@@ -253,10 +253,16 @@ fn verify_derivative(f: ExprId, integrand: ExprId, var: ExprId, pool: &ExprPool)
         else {
             continue;
         };
-        if !lhs.is_finite() || !rhs.is_finite() {
+        // Where the integrand is not a finite real there is no claim to check,
+        // so the sample is skipped — but where it *is* and `d/dx f` is not,
+        // `f` is not an antiderivative of it there and the candidate is
+        // refused.  Skipping that second case is how a candidate with a hole
+        // in its domain clears a grid built to catch sign errors; see
+        // [`crate::integrate::verify_antiderivative_status`].
+        if !rhs.is_finite() {
             continue;
         }
-        if (lhs - rhs).abs() > 1e-6 * (1.0 + rhs.abs()) {
+        if !lhs.is_finite() || (lhs - rhs).abs() > 1e-6 * (1.0 + rhs.abs()) {
             return false;
         }
         checked += 1;


### PR DESCRIPTION
The antiderivative gate accepted an answer that is **undefined across an entire component where the integrand is finite**. Charlwood #35 `∫x·asec(x)/√(x²−1)` returned a candidate containing `log(x+√(x²))`; since `√(x²)` is `|x|`, that is `log(0)` for every `x < −1`, where the integrand is an ordinary finite real. It was reported as `numerically_checked`.

This is the **#22 defect recurring in a different form**. #328 fixed #22 by widening the grid to be two-sided; #35 walked through because the loop *skipped* non-finite samples rather than counting them. The bug was the rule, not either problem.

## The rule

Verified against the code before implementing: `eval_interp` returns `Some(NaN/inf)` — not `None` — for `√(negative)` and `0⁻¹`, so the `continue` at `engine.rs:4046` was the live path. Measured on `main`, at `x = −1.42, −2.17, −2.81, −3.64` the integrand is finite and `d/dx F` is not.

Each sample is now classified against the claim actually being made — `F′ = f` **wherever `f` is defined** (`engine::classify_sample`):

| `f` | `F′` | verdict |
|---|---|---|
| finite | finite | compare |
| finite | non-finite | **disagreement — refuse** |
| non-finite | either | no information — skip |

**Row 3 is deliberately not the mirror of row 2**, and this is where the obvious fix over-tightens. `F′` is `simplify(diff(F))` and is routinely defined on a strictly *larger* set than `f`: `∫x·√(x−1)/√(x−1)` is `x²/2`, whose derivative `x` is finite everywhere while the integrand is undefined below 1. Counting those against the candidate would decline a correct answer. Unevaluable (`None`) still skips — that is a property of the expression, not of the point.

Three tests pin the three rows, plus `charlwood_35_is_refused_because_its_candidate_has_a_domain_hole` sitting next to the existing #22 test.

## Measured

- **Charlwood 33/50 → 32/50. Exactly one flip: #35 SOLVED → DECLINED.** Nothing else moves; all 32 survivors still verify. Instrumenting for it showed #35 was the *only* one of the fifty whose answer had a domain hole, which is why nothing else could move.
- **40-case probe unchanged** — 35 solved / 4 / 1, zero per-case flips.
- **110-case Liouville corpus: 84 → 84**, zero flips, zero domain holes in the baseline answers.
- **Textbook gate: 319 passed.**
- **Latency: not slower.** A refusal now returns at the offending sample instead of finishing the grid, so the reject path does strictly less work. Charlwood decline median 142 ms → 102–138 ms across three runs; Liouville decline median 398 ms → 159–231 ms. Run-to-run spread is wide enough that "not slower" is the honest claim rather than the apparent speedup.

## Soundness

**Zero `E-INT-004` on any Charlwood problem, before or after.** The 200-call form-robustness sweep (50 problems × 4 spellings) on the fixed build: 122 solved / 78 `E-INT-001` / **0 `E-INT-004`**. #35 declines with `E-INT-001` in all five spellings tried.

A stricter gate structurally cannot manufacture a `NonElementary`: that verdict comes from `known_nonelementary`, a Liouville pre-check that runs *before* any gate. It can only fail to soften an existing verdict into a special-function answer, and the probe's certificate count is unchanged at 4.

## A correction to the benchmark report

`charlwood50-2026-08-30.md` calls `√(x²−1)·asec(x) − log|x|` the correct closed form for #35. It is not. `d/dx asec(x) = 1/(|x|√(x²−1))`, so that expression is right only on `x > 1` and is off by `−2/x` below `−1`. The two-branch answer is `√(x²−1)·asec(x) − sgn(x)·log|x|`, verified numerically on both branches and used in the tests as the "a correct answer still verifies" control.

## The same pattern elsewhere — including one reverted attempt

Five further sites carry the skip. What was done at each:

- **`integrate::gate::verify` — tried, reverted.** Same shape and same contract, but applying the rule broke **13 Rust and 4 pytest tests, all elliptic**. `elliptic_output::gate_samples` deliberately samples every `P > 0` interval and documents that ("points where the substitution is invalid simply evaluate non-finite and are skipped"), while a cubic-three-real reduction is valid only beyond the largest root — for `∫dx/√(x³−x)` the integrand is finite on `(−1, 0)` and the candidate's derivative is not. Reverted, with the reason added to that module's honest-limitations list so it is not retried blind. Adopting it there needs each reduction's sample set narrowed to the region it claims, or a `Verdict` that can name the region.
- **`risch::exp_algebraic::verify_derivative`** — rule applied; covered by its own 9 tests plus the corpora.
- **`algebraic::genus_zero`** — already refuses on *any* non-finite sample. Stricter than this rule, not laxer. Left alone.
- **`ode/dsolve/verify.rs`** — pattern present, rule does not apply: it evaluates a single conflated residual, so there is no "the equation is fine here but the candidate is not" distinction to draw without restructuring. **Reported, not fixed.**
- **`engine::antiderivative_jump`** (definite path) — cells where `F` does not evaluate are treated as *undecidable* and skipped, so an `F` undefined across a sub-interval yields no jump verdict and `F(b) − F(a)` is returned anyway. Same defect shape, different decision procedure; the corpora here are all indefinite and **no live reproducer was constructed**. **Reported, not fixed.**
- `by_parts::sqrt_split_coverage` / `agrees_numerically` — same skip, but they compare two spellings of the *same* expression (symmetric, no privileged side) and document that losing domain is allowed because the real gate runs afterwards. Not gates; left alone, and now better backstopped since the gate they defer to compares against the original integrand.

## Gates

`cargo fmt` · `cargo test --workspace` 2648 passed / 0 failed · `cargo clippy --all-targets -D warnings` across five feature sets · `pytest tests/` 3667 passed, 76 skipped, 0 failed (sympy 1.14 present, no silently-skipped oracle block) · `gen_certificate_ledger.py --check` clean · `ruff==0.15.14` format and check clean.

The CHANGELOG also corrects the by-parts entry in this same unreleased cycle, which still listed #22 and #35 as closed — both have now been withdrawn by the two halves of this gate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved antiderivative verification to reject candidates undefined where the integrand is finite.
  * Continued ignoring samples where the integrand itself cannot be evaluated.
  * Corrected handling of domain holes and shared singularities.
  * Charlwood candidate `#35` is now declined when verification detects its invalid domain.
  * Improved verification of algebraic-residue results, including appropriate fallback when validation fails.

* **Documentation**
  * Clarified verification behavior and updated records for withdrawn integration candidates.
  * Added notes on expanded integration and certificate coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->