### PR TITLE
fix(integrate): scope RootSum suppression to the frame that gates, not the whole subtree

### DIFF
--- a/alkahest-core/src/integrate/algebraic/generator_subst.rs
+++ b/alkahest-core/src/integrate/algebraic/generator_subst.rs
@@ -234,8 +234,18 @@ fn integrate_reduced(
     pool: &ExprPool,
 ) -> Result<(ExprId, usize), String> {
     // A `RootSum` is unevaluable by the gate's numeric tier and opaque to
-    // `simplify`, so it could never clear the gate; suppressing it makes the
-    // inner engine decline early rather than build one.
+    // `simplify`, so it could never clear *this* route's gate; suppressing it
+    // makes the inner engine decline early rather than build one.  The
+    // `contains_root_sum` check below is what enforces that, not this guard —
+    // the guard only saves the work.
+    //
+    // The suppression is per-frame, not per-subtree: if the reduced integral is
+    // itself algebraic and reaches `parametrize`, that frame re-declares itself
+    // with `RootSumExpandedByCaller`, because it turns a `RootSum` into explicit
+    // real `log`/`atan` before returning and so hands back something this gate
+    // can read.  Suppressing through it instead is what used to make
+    // `∫√(2+2·tan x+tan²x) dx` decline on a reduced integral that solves in
+    // 0.01 s at top level.
     let f_t = {
         let _guard = crate::integrate::risch::rational_integrate::RootSumSuppressed::enter();
         // Only `Ok` is consumed.  A `NonElementary` verdict on `∫h dt` is

--- a/alkahest-core/src/integrate/algebraic/generator_subst.rs
+++ b/alkahest-core/src/integrate/algebraic/generator_subst.rs
@@ -1306,6 +1306,40 @@ mod tests {
         assert_eq!(real, checked);
     }
 
+    /// Charlwood #8, `∫√(2+2·tan x+tan²x) dx` — the `RootSum`-expansion side of
+    /// the suppression guard.
+    ///
+    /// `t = tan x` reduces this to `∫√(t²+2t+2)/(1+t²) dt`, which the Euler
+    /// route solves — but only by way of a Rothstein–Trager `RootSum` whose
+    /// residues are the roots of a **biquadratic** (the `√5` and golden-ratio
+    /// radicals visible in the answer). `parametrize` expands that into explicit
+    /// real `log`/`atan` before returning, so nothing containing a `RootSum` ever
+    /// reaches the `contains_root_sum` check below or this route's gate.
+    ///
+    /// While `RootSumSuppressed` reached through the nested `parametrize` frame,
+    /// the sub-integral declined and so did this problem. The companion test is
+    /// `rational_integrate::expandable_caller_still_refuses_a_cubic_root_sum`,
+    /// which pins the shapes the narrowed guard still refuses.
+    #[test]
+    fn charlwood_8_sqrt_of_tan_quadratic() {
+        let (pool, x) = setup();
+        let t = tan(x, &pool);
+        let rad = pool.add(vec![
+            pool.integer(2_i32),
+            pool.mul(vec![pool.integer(2_i32), t]),
+            pool.pow(t, pool.integer(2_i32)),
+        ]);
+        let e = sqrt(rad, &pool);
+        let got = crate::integrate::integrate(e, x, &pool).expect("Charlwood #8 should close");
+        assert!(
+            !contains_root_sum(got.value, &pool),
+            "the answer must not contain a RootSum: {}",
+            pool.display(got.value)
+        );
+        let (checked, _real) = check_everywhere(got.value, e, x, &pool);
+        assert!(checked > 700, "only {checked} points checked");
+    }
+
     /// Charlwood #7, `∫tan x/√(1+sec³x) dx`.
     ///
     /// The generator here is `sec`, not `tan`: dividing by `(sec x)′` cancels

--- a/alkahest-core/src/integrate/algebraic/parametrize.rs
+++ b/alkahest-core/src/integrate/algebraic/parametrize.rs
@@ -86,9 +86,19 @@ pub(super) fn try_parametrize_genus0(
 
     // Integrate the rational-in-`s` integrand (always elementary), then
     // back-substitute s = r(x)^{1/n}.
-    let f_s = match crate::integrate::engine::integrate(integrand_s, s, pool) {
-        Ok(d) => d.value,
-        Err(_) => return None,
+    let f_s = {
+        // This frame consumes a `RootSum` rather than passing one up: see
+        // `expand_rootsums` on the next line.  Say so, or an enclosing
+        // `RootSumSuppressed` (from `generator_subst`, `subst` or the engine's
+        // Weierstrass / u-substitution routes) reaches down through this
+        // sub-integration and suppresses the very `RootSum` this route exists
+        // to expand.
+        let _expanded =
+            crate::integrate::risch::rational_integrate::RootSumExpandedByCaller::enter();
+        match crate::integrate::engine::integrate(integrand_s, s, pool) {
+            Ok(d) => d.value,
+            Err(_) => return None,
+        }
     };
     // Resolve an algebraic-residue `RootSum` into real `log`/`atan` before
     // back-substitution (`subs` cannot enter the binder), or decline.
@@ -202,9 +212,16 @@ pub(super) fn try_euler_quadratic(
     let core = to_t(expr, var, &quad, sqrt_t, x_of_t, pool)?;
     let dx_dt = simplify(crate::diff::diff(x_of_t, t, pool).ok()?.value, pool).value;
     let integrand_t = simplify(pool.mul(vec![core, dx_dt]), pool).value;
-    let f_t = match crate::integrate::engine::integrate(integrand_t, t, pool) {
-        Ok(d) => d.value,
-        Err(_) => return None,
+    let f_t = {
+        // As in `try_genus0_rational_radicand`: this frame expands `RootSum`s
+        // instead of passing them up, so an enclosing suppression must not
+        // reach into it.
+        let _expanded =
+            crate::integrate::risch::rational_integrate::RootSumExpandedByCaller::enter();
+        match crate::integrate::engine::integrate(integrand_t, t, pool) {
+            Ok(d) => d.value,
+            Err(_) => return None,
+        }
     };
     // An algebraic-residue logarithmic part comes back as a `RootSum` binder,
     // which `subs` cannot enter and no verification tier can evaluate.  Expand
@@ -345,7 +362,11 @@ pub(super) fn try_euler_quadratic_general(
     // out as a constant, collapse the remaining `t`-part into a single rational
     // function `N(t)/D(t)`, integrate that pure ℚ(t) integrand with the engine,
     // and multiply the constant back (linearity).
-    let f_t = integrate_scaled_rational(integrand_t, t, pool)?;
+    let f_t = {
+        let _expanded =
+            crate::integrate::risch::rational_integrate::RootSumExpandedByCaller::enter();
+        integrate_scaled_rational(integrand_t, t, pool)?
+    };
     // As in `try_euler_quadratic`: resolve an algebraic-residue `RootSum` into
     // real `log`/`atan` before back-substitution, or decline.
     let f_t = super::rootsum_expand::expand_rootsums(f_t, pool)?;
@@ -488,9 +509,13 @@ pub(super) fn try_euler_conic_point(
     let core = to_t(expr, var, &quad, sqrt_m, x_of_m, pool)?;
     let dx_dm = simplify(crate::diff::diff(x_of_m, m, pool).ok()?.value, pool).value;
     let integrand_m = simplify(pool.mul(vec![core, dx_dm]), pool).value;
-    let f_m = match crate::integrate::engine::integrate(integrand_m, m, pool) {
-        Ok(d) => d.value,
-        Err(_) => return None,
+    let f_m = {
+        let _expanded =
+            crate::integrate::risch::rational_integrate::RootSumExpandedByCaller::enter();
+        match crate::integrate::engine::integrate(integrand_m, m, pool) {
+            Ok(d) => d.value,
+            Err(_) => return None,
+        }
     };
     let f_m = super::rootsum_expand::expand_rootsums(f_m, pool)?;
     let mut back = HashMap::new();

--- a/alkahest-core/src/integrate/algebraic/rootsum_expand.rs
+++ b/alkahest-core/src/integrate/algebraic/rootsum_expand.rs
@@ -832,6 +832,7 @@ fn as_i64(e: ExprId, pool: &ExprPool) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::integrate::risch::poly_rde::qpoly_to_expr;
     use crate::kernel::Domain;
 
     /// `RootSum(r² + 1/2, r·log(t² − 4rt − 1))` is the log part Charlwood #30's
@@ -935,6 +936,58 @@ mod tests {
         let body = pool.mul(vec![r, pool.func("log", vec![pool.add(vec![t, r])])]);
         let rs = pool.root_sum(m, r, body);
         assert!(expand_rootsums(rs, &pool).is_none());
+    }
+
+    /// `minpoly_expandable` is what `rational_integrate` decides on, so it has
+    /// to track the real capability of [`split_factors`] rather than a guess at
+    /// it.  Each polynomial below is checked *both* through the predicate and
+    /// through a full `expand_rootsums` of a `RootSum` built on it.
+    #[test]
+    fn minpoly_expandable_matches_what_expansion_can_do() {
+        let pool = ExprPool::new();
+        let t = pool.symbol("t", Domain::Real);
+        let r = pool.symbol("$root$", Domain::Real);
+        let q = |cs: &[(i32, i32)]| -> QPoly {
+            cs.iter()
+                .map(|&(n, d)| Rational::from((n, d)))
+                .collect::<QPoly>()
+        };
+        // Coefficients are low-order-first.
+        let cases: [(&str, QPoly, bool); 6] = [
+            ("linear r − 2", q(&[(-2, 1), (1, 1)]), true),
+            ("quadratic r² + 1/2", q(&[(1, 2), (0, 1), (1, 1)]), true),
+            (
+                "biquadratic r⁴ − r²/4 + 1/16 (Charlwood #47)",
+                q(&[(1, 16), (0, 1), (-1, 4), (0, 1), (1, 1)]),
+                true,
+            ),
+            (
+                "cubic with a rational root, (r−1)(r²+1)",
+                q(&[(-1, 1), (1, 1), (-1, 1), (1, 1)]),
+                true,
+            ),
+            (
+                "irreducible cubic r³ − r − 1",
+                q(&[(-1, 1), (-1, 1), (0, 1), (1, 1)]),
+                false,
+            ),
+            (
+                "quartic r⁴ + r + 1: no rational root, not biquadratic",
+                q(&[(1, 1), (1, 1), (0, 1), (0, 1), (1, 1)]),
+                false,
+            ),
+        ];
+        for (name, m, want) in cases {
+            assert_eq!(minpoly_expandable(&m, &pool), want, "predicate on {name}");
+            let m_expr = qpoly_to_expr(&m, r, &pool);
+            let body = pool.mul(vec![r, pool.func("log", vec![pool.add(vec![t, r])])]);
+            let rs = pool.root_sum(m_expr, r, body);
+            assert_eq!(
+                expand_rootsums(rs, &pool).is_some(),
+                want,
+                "expansion of {name} disagrees with the predicate"
+            );
+        }
     }
 
     /// An expression with no `RootSum` passes through untouched.

--- a/alkahest-core/src/integrate/algebraic/rootsum_expand.rs
+++ b/alkahest-core/src/integrate/algebraic/rootsum_expand.rs
@@ -286,6 +286,28 @@ fn rewrite(expr: ExprId, pool: &ExprPool) -> Option<ExprId> {
     }
 }
 
+/// Could [`expand_rootsums`] rewrite `RootSum(m, r, …)` into explicit real
+/// form, judged from the minimal polynomial `m` alone?
+///
+/// This is the **decidable half** of the scope documented at the top of this
+/// module.  [`split_factors`] either finds a linear / monic-quadratic
+/// factorisation of `m` or it does not, and when it does not, [`expand_one`]
+/// returns `None` whatever the body looks like.  The body half is *not* decided
+/// here: [`eval_factor`] can still decline a body [`ceval`] cannot read.  So the
+/// predicate is **necessary but not sufficient** —
+///
+/// * `false` ⇒ expansion is impossible, and building the `RootSum` is waste;
+/// * `true`  ⇒ expansion is not ruled out by `m`, so it is worth building.
+///
+/// It exists for [`crate::integrate::risch::rational_integrate`], which has `m`
+/// in hand at the moment it would start the expensive Lazard–Rioboo–Trager log
+/// argument and can skip that work on a `false`.  It is a *cost* decision only:
+/// no verdict depends on it, and a `true` that expansion later refuses costs
+/// exactly the decline it costs today.
+pub(crate) fn minpoly_expandable(m: &[Rational], pool: &ExprPool) -> bool {
+    split_factors(&trim(m.to_vec()), pool).is_some()
+}
+
 /// Expand a single `RootSum(m(r), r . body)`.
 fn expand_one(poly: ExprId, rvar: ExprId, body: ExprId, pool: &ExprPool) -> Option<ExprId> {
     // A nested `RootSum` inside the body is out of scope.

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -58,9 +58,31 @@ use super::rational_rde::{
 // "A RootSum answer would be thrown away" — see `RootSumSuppressed`
 // ---------------------------------------------------------------------------
 
+/// What the *caller* of this integration will do with a `RootSum` in the result.
+///
+/// This is a statement about the caller's frame, not about the integral: it says
+/// only whether the Lazard–Rioboo–Trager work needed to build the `RootSum` can
+/// end up in an answer, or is certain to be thrown away.  No variant of it ever
+/// changes a verdict from `Solved` to `NonElementary` or back — the strict ones
+/// turn a `Some(F)` into a `None`, which is a decline.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RootSumUse {
+    /// Default: whatever comes back is kept as-is, so emit `RootSum`s freely.
+    Keep,
+    /// The caller pipes the result through
+    /// [`crate::integrate::algebraic::rootsum_expand::expand_rootsums`] before
+    /// anything else looks at it, so a `RootSum` *is* usable — but only if that
+    /// pass can rewrite it into explicit real form.  See
+    /// [`RootSumExpandedByCaller`].
+    Expandable,
+    /// The caller cannot use a `RootSum` at all.  See [`RootSumSuppressed`].
+    Discard,
+}
+
 std::thread_local! {
-    /// Whether a `RootSum` in the result is usable by the *caller*.
-    static ROOT_SUM_USABLE: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
+    /// What a `RootSum` in the result is worth to the caller, on this thread.
+    static ROOT_SUM_USE: std::cell::Cell<RootSumUse> =
+        const { std::cell::Cell::new(RootSumUse::Keep) };
 }
 
 /// Scope guard declaring that the caller will gate this integration through
@@ -78,24 +100,70 @@ std::thread_local! {
 /// whole integration (measured: 3.72 s of a 3.74 s `∫ cos·sin¹²/(sin⁹+sin+1)`,
 /// all of it discarded). Declining early returns exactly the same `None` the
 /// caller would have reached after paying for it.
-pub(crate) struct RootSumSuppressed(bool);
+///
+/// # Scope
+///
+/// The guard is a thread-local, so it also covers every *nested* integration
+/// underneath the caller — and that is where it used to overreach.  A frame
+/// that consumes `RootSum`s itself rather than passing them up (today:
+/// [`super::super::algebraic::parametrize`], which calls `expand_rootsums`
+/// before anything else touches its sub-integral) re-declares its own frame
+/// with [`RootSumExpandedByCaller`], and that inner declaration wins for the
+/// duration of the sub-integration.  Nothing about the outer caller's gate
+/// changes: what reaches it still contains no `RootSum`.
+pub(crate) struct RootSumSuppressed(RootSumUse);
 
 impl RootSumSuppressed {
     /// Suppress `RootSum` results until the returned guard is dropped.
     pub(crate) fn enter() -> Self {
-        Self(ROOT_SUM_USABLE.with(|c| c.replace(false)))
+        Self(ROOT_SUM_USE.with(|c| c.replace(RootSumUse::Discard)))
     }
 }
 
 impl Drop for RootSumSuppressed {
     fn drop(&mut self) {
-        ROOT_SUM_USABLE.with(|c| c.set(self.0));
+        ROOT_SUM_USE.with(|c| c.set(self.0));
     }
 }
 
-/// Whether emitting a `RootSum` is worth the work on this thread.
-fn root_sum_usable() -> bool {
-    ROOT_SUM_USABLE.with(|c| c.get())
+/// Scope guard declaring that the caller runs
+/// [`crate::integrate::algebraic::rootsum_expand::expand_rootsums`] on this
+/// integration's result — and declines when it will not expand.
+///
+/// A `RootSum` is therefore *not* waste here even though the caller's own gate
+/// could never accept one: it is consumed and replaced by explicit real
+/// `log`/`atan` before the gate ever sees it.  What remains worth suppressing is
+/// the narrower set that expansion cannot reach, and that is decided from the
+/// minimal polynomial by
+/// [`crate::integrate::algebraic::rootsum_expand::minpoly_expandable`] at the
+/// one point where the expensive work would otherwise start.
+pub(crate) struct RootSumExpandedByCaller(RootSumUse);
+
+impl RootSumExpandedByCaller {
+    /// Treat `RootSum` results as usable-if-expandable until the guard drops.
+    pub(crate) fn enter() -> Self {
+        Self(ROOT_SUM_USE.with(|c| c.replace(RootSumUse::Expandable)))
+    }
+}
+
+impl Drop for RootSumExpandedByCaller {
+    fn drop(&mut self) {
+        ROOT_SUM_USE.with(|c| c.set(self.0));
+    }
+}
+
+/// Whether emitting `RootSum(qf, r, …)` is worth the work on this thread.
+///
+/// `qf` is the minimal polynomial of the residues the binder would range over —
+/// exactly the polynomial `expand_rootsums` would later have to split.
+fn root_sum_wanted(qf: &QPoly, pool: &ExprPool) -> bool {
+    match ROOT_SUM_USE.with(|c| c.get()) {
+        RootSumUse::Keep => true,
+        RootSumUse::Expandable => {
+            crate::integrate::algebraic::rootsum_expand::minpoly_expandable(qf, pool)
+        }
+        RootSumUse::Discard => false,
+    }
 }
 
 /// Attempt to integrate `expr` as a rational function of `var`.
@@ -691,8 +759,11 @@ fn partial_fraction_log_arctan(
                             // RootSum(Q, t, t·log(S(t,x))).  The log argument is
                             // a number-field GCD and by far the most expensive
                             // step here, so skip it outright when the caller has
-                            // told us a `RootSum` cannot be used.
-                            if !root_sum_usable() {
+                            // told us this `RootSum` cannot be used — either
+                            // because no `RootSum` can be, or because this one's
+                            // minimal polynomial is outside `rootsum_expand`'s
+                            // reach and the caller would decline on it anyway.
+                            if !root_sum_wanted(qf, pool) {
                                 return None;
                             }
                             let s_expr = alg_log_argument(&n, &pp, p, qf, var, rvar, pool)?;

--- a/alkahest-core/src/integrate/risch/rational_integrate.rs
+++ b/alkahest-core/src/integrate/risch/rational_integrate.rs
@@ -1162,6 +1162,101 @@ mod tests {
         assert!(d.is_ok());
     }
 
+    /// `∫2x²/(x⁴+1) dx` — residues are the roots of `t⁴ + 1/16`, a
+    /// **biquadratic**, which `rootsum_expand::split_factors` splits into two
+    /// monic quadratics.  This is the permitted side of the narrowed guard: a
+    /// caller that expands must still get the `RootSum`.
+    #[test]
+    fn expandable_caller_admits_a_biquadratic_root_sum() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(4_i32)), pool.integer(1_i32)]);
+        let num = pool.mul(vec![pool.integer(2_i32), pool.pow(x, pool.integer(2_i32))]);
+        let f = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+
+        let plain = try_integrate_rational(f, x, &pool).expect("unguarded RootSum path");
+        assert!(pool.display(plain).to_string().contains("RootSum"));
+
+        // The guard the four `parametrize` sub-integrations declare.
+        let expandable = {
+            let _g = RootSumExpandedByCaller::enter();
+            try_integrate_rational(f, x, &pool)
+        };
+        assert_eq!(
+            expandable,
+            Some(plain),
+            "an expandable minimal polynomial must not be suppressed"
+        );
+
+        // The three callers that cannot use a `RootSum` at all are unchanged.
+        let suppressed = {
+            let _g = RootSumSuppressed::enter();
+            try_integrate_rational(f, x, &pool)
+        };
+        assert_eq!(suppressed, None, "full suppression must still suppress");
+    }
+
+    /// `∫1/(x³−3x+1) dx` — the residues' minimal polynomial is an irreducible
+    /// cubic with no rational root: not linear, not quadratic, not a
+    /// biquadratic, so `rootsum_expand` cannot split it and the caller would
+    /// decline on whatever came back.
+    ///
+    /// **This is the half of the guard that must not be removed.** Widening it
+    /// to admit this shape would buy nothing — the answer still cannot reach a
+    /// gate — while paying for the Lazard–Rioboo–Trager number-field GCD, which
+    /// is what the guard was introduced to avoid.
+    #[test]
+    fn expandable_caller_still_refuses_a_cubic_root_sum() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![
+            pool.pow(x, pool.integer(3_i32)),
+            pool.mul(vec![pool.integer(-3_i32), x]),
+            pool.integer(1_i32),
+        ]);
+        let f = pool.pow(den, pool.integer(-1_i32));
+
+        let plain = try_integrate_rational(f, x, &pool).expect("unguarded RootSum path");
+        assert!(pool.display(plain).to_string().contains("RootSum"));
+
+        let expandable = {
+            let _g = RootSumExpandedByCaller::enter();
+            try_integrate_rational(f, x, &pool)
+        };
+        assert_eq!(
+            expandable, None,
+            "a minimal polynomial `rootsum_expand` cannot split must stay suppressed"
+        );
+
+        let suppressed = {
+            let _g = RootSumSuppressed::enter();
+            try_integrate_rational(f, x, &pool)
+        };
+        assert_eq!(suppressed, None);
+    }
+
+    /// A guard restores the enclosing mode rather than resetting to the default,
+    /// so `RootSumSuppressed` nested inside `RootSumExpandedByCaller` (an
+    /// engine u-substitution under a `parametrize` frame) leaves the outer frame
+    /// intact when it drops.
+    #[test]
+    fn root_sum_guards_nest_and_restore() {
+        let pool = pool();
+        let x = pool.symbol("x", Domain::Real);
+        let den = pool.add(vec![pool.pow(x, pool.integer(4_i32)), pool.integer(1_i32)]);
+        let num = pool.mul(vec![pool.integer(2_i32), pool.pow(x, pool.integer(2_i32))]);
+        let f = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
+
+        let outer = RootSumExpandedByCaller::enter();
+        {
+            let _inner = RootSumSuppressed::enter();
+            assert_eq!(try_integrate_rational(f, x, &pool), None);
+        }
+        assert!(try_integrate_rational(f, x, &pool).is_some());
+        drop(outer);
+        assert!(try_integrate_rational(f, x, &pool).is_some());
+    }
+
     #[test]
     fn hermite_one_over_x_plus_1_squared() {
         // ∫ 1/(x+1)² dx = −1/(x+1)  (pure rational part, no log).


### PR DESCRIPTION
`generator_subst.rs` suppressed `RootSum` emission across an entire subtree on the grounds that "a `RootSum` can never clear the verification gate." Charlwood #8 was blocked by it. This narrows the guard; it does not remove it.

## The guard is still needed, and I verified that first

It arrived with `bd5f7c8`: *"the Risch rational route spent minutes inside `kpoly_gcd` computing a RootSum that `verify_antiderivative` is structurally guaranteed to reject — 869 s → 154 ms on one integrand, 106 s → 11.5 ms on another."*

I rebuilt the exact rational function in `t = tan(x/2)` that the Weierstrass route hands the rational integrator for the motivating case `∫cos x·sin¹²x/(sin⁹x + sin x + 1) dx` (deg num 14 / deg den 28) and integrated it with the guard off: **4.10 s, and the answer contains a `RootSum`** that the route's gate then discards. End to end the case is unchanged — `E-INT-001` in 0.535 s before, 0.523 s after.

**The stale part was narrower than the comment suggested.** "A `RootSum` can never clear the gate" is still true *of the gate*. What was wrong is that the guard is a **thread-local**, so it also suppressed at depths where the `RootSum` never reaches a gate at all — `algebraic/rootsum_expand.rs` consumes it first and returns `log`/`atan`.

## Two narrowings

**Scope.** `RootSumSuppressed` now restores to the enclosing mode rather than to a boolean, and `parametrize`'s four sub-integrations (`:89`, `:205`, `:349`, `:491` — exactly the four that pipe their result through `expand_rootsums`) re-declare their frame as `RootSumExpandedByCaller`. Those frames consume the `RootSum` and hand back something `RootSum`-free, so the outer caller's gate sees what it always saw. The three call sites with no expander — `engine.rs:1620` (Weierstrass), `engine.rs:3836` (u-substitution), `algebraic/subst.rs:545` — keep full suppression. `subst.rs:545` in particular must stay suppressed: it has no expander, and its substitute is the partial-fraction ansatz that exists for exactly the `∫2u²/(u⁴+1)` shape.

**Capability.** Inside an `Expandable` frame the emission site (`rational_integrate.rs:766`) asks `rootsum_expand::minpoly_expandable`, which calls the **same `split_factors`** the expansion itself would. The guard therefore fires precisely on the minimal polynomials expansion cannot split. It is deliberately *necessary but not sufficient* — `eval_factor` can still refuse a body `ceval` cannot read — and that is documented, because deciding the body half requires doing the work the guard exists to avoid. A false "yes" costs the decline it costs today and can never produce an answer, since everything still goes through the gate.

Note the motivating case is defended by the capability half alone: its minimal polynomial is a dense degree-9 rational whose cleared leading coefficient exceeds `rational_root`'s `MAX_ABS = 4096`, so no rational root is searched for and it is not biquadratic.

`generator_subst`'s own `contains_root_sum(f_t)` check is untouched — *that*, not the guard, is what enforces "no `RootSum` reaches this route's gate". The guard only saves the work. Its stale comment now says so.

## Measured, both builds at the same base

| corpus | before | after | moved |
|---|---|---|---|
| Charlwood 50 | 33 solved / 32 verified | **34 / 33** | **#8 only**, `DECLINED → SOLVED/VERIFIED` |
| 40-case probe | 35 ok, 4 `E-INT-004`, 1 `E-INT-001` | identical | **0** — every record byte-identical |
| Liouville unsolved-110 | 84 / 84 | 84 / 84 | **0** |
| Liouville corpus 800 | 475 solved / 473 verified | 475 / 473 | 2, both `BUDGET → DECLINED` (#455, #676 — already failing, now finishing inside the 15 s cap instead of tripping it) |
| textbook gate + silent errors | 576 passed | 576 passed | — |

**No `E-INT-004` anywhere**, before or after, on any corpus. The probe's four certified `NonElementary` verdicts are the same four, byte-identical.

Latency on the 800-case corpus by outcome class: **SOLVED (475) 11.9 s → 11.9 s (+0.0)**; DECLINED (307) 217.8 s → **215.8 s (−2.0)**; BUDGET (13) +3.7 s, which is meaningless under a wall cap. Charlwood 16.3 s → 15.3 s over all 50.

An earlier, noisier run had shown a +3–6% drift on declines. That was ruled out as load asymmetry by controlling on `sqrt` — the drift was *larger* on the 150 declining cases with no `sqrt`, which can never reach `parametrize` and whose code path is bit-identical, than on the 161 with one. The clean pair above shows no drift at all.

**A measurement error found and corrected mid-task, worth stating.** `maturin develop` installs *editable*: the `.so` lands in the worktree's `python/alkahest/`, so two venvs pointed at one worktree share a single build, and an early before/after pair was the same binary measured twice. The builds were re-snapshotted into separate trees selected by `PYTHONPATH`, separation confirmed via `alkahest.alkahest.__file__` and by #8 diverging, and **every** measurement above was retaken. `main` also moved twice during the work; all figures are from `82e4087`, the tree this branch sits on.

## The one new solve, verified three ways

Charlwood #8, `∫√(2 + 2·tan x + tan²x) dx`, 0.43 s. `t = tan x` → `∫√(t²+2t+2)/(1+t²) dt`; the Euler route's residues have a biquadratic minimal polynomial, expanded into the `√5`/golden-ratio `log` + `atan` form.

- Harness 42-point two-sided grid: **42 agreeing, 0 disagreeing**
- Dense grid `[−6, 6]` step 0.0073: **1640 in-domain samples, 1640 agreeing**, worst relative residual 1.23e-10
- Independent channel with no Alkahest code in it: answer re-parsed into SymPy, differentiated symbolically, evaluated with mpmath at 40 digits — **81 agreeing, 0 disagreeing**

Not a string comparison against Rubi; the form legitimately differs.

## Tests

- `expandable_caller_still_refuses_a_cubic_root_sum` — **the one that matters.** `∫1/(x³−3x+1)`, irreducible cubic. Asserts `None` under `RootSumExpandedByCaller` *and* under `RootSumSuppressed`, and `Some(RootSum)` unguarded. Widening past this buys nothing and costs the number-field GCD.
- `expandable_caller_admits_a_biquadratic_root_sum` — `∫2x²/(x⁴+1)`, permitted now, still suppressed under the old mode.
- `root_sum_guards_nest_and_restore`; `minpoly_expandable_matches_what_expansion_can_do`, which runs six minimal polynomials through *both* the predicate and a real `expand_rootsums` so they cannot drift; and `charlwood_8_sqrt_of_tan_quadratic` end-to-end, asserting no `RootSum` in the answer.

## A pre-existing finding, not caused by this change

**The top-level Rothstein–Trager route (`engine.rs:2614`) returns its result directly and is never run through `verify_antiderivative`.** `integrate(1/(x⁵−x−1))` and `integrate(x¹²/(x⁹+x+1))` both return `RootSum`-containing answers that no verification tier can evaluate. The strings are identical on both builds — the default mode is untouched here — but it is the one place a `RootSum` reaches output ungated, and it deserves its own issue.

## Gates

`cargo fmt --check` · `cargo test --workspace` 2659 + 72 passed, 0 failed · `cargo clippy --all-targets -D warnings` · `pytest tests/` 3670 passed, 76 skipped (all SMT-solver skips; sympy present, oracle tests ran) · `gen_certificate_ledger.py --check` clean (283 observations, 0 partial) · `ruff==0.15.14` format and check clean. No `unsafe`, no `is_none_or`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
