### PR TITLE
fix(ode,verify): classify a non-finite residual sample instead of skipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 ## Unreleased
 
+- **`dsolve`'s verification gate could certify a wrong `y(x)`.** Every solution
+  `dsolve` returns is checked by substituting the candidate back into the
+  original equation and requiring the residual to vanish — symbolically, or
+  numerically at 15 samples (5 values of `x` × 3 assignments of the integration
+  constants). A sample where the residual did not evaluate to a finite number
+  was **skipped** as "a pole here", and the candidate was then certified on the
+  remaining samples alone, subject only to a floor of six of them.
+
+  That floor is exactly six, and skipping is what makes it reachable. For
+  `y' = 0` — regular at every `x`, general solution `y = C1` — the candidate
+
+  ```
+  y = C1 + √(x − ½)·(x − 0.61)²·(x − 0.79)²
+  ```
+
+  is NaN at the samples `0.11, 0.27, 0.43` (negative radicand) and has a double
+  root at `0.61` and `0.79`, so the residual is exactly zero at the two samples
+  that do evaluate. Nine skips, six agreements, gate cleared, wrong answer
+  returned. The mistake is treating "did not evaluate" as "no information": a
+  candidate that blows up where the ODE itself is perfectly well-defined is
+  evidence that the candidate is wrong.
+
+  The residual alone cannot draw that distinction, because it conflates the
+  equation's coefficients and forcing term with the candidate's contribution
+  into a single expression. The gate now keeps the two halves separately and
+  **classifies** a non-finite sample instead of discarding it:
+
+  1. Probe the equation at that `x` with finite dummy values for `y, y', …`. If
+     nothing evaluates, the ODE is genuinely singular there — a `√(a − x)`
+     coefficient past its branch point, a pole in the forcing term — and the
+     sample really does carry no information. Skip.
+  2. Otherwise evaluate the candidate and its derivatives on their own. Not
+     finite, where the ODE is regular, is now a disagreement.
+  3. If both sides are finite and only the *simplified residual* was not, the
+     non-finiteness was an artefact of the residual's algebraic form; the
+     verdict comes from the original equation at the candidate's own values,
+     recovering a sample that used to be thrown away.
+
+  `E-ODE-011` now states the tally: agreeing, disagreeing, blow-ups at a regular
+  point, and each kind of skip.
+
+  The direction of the trade is deliberate: a decline is acceptable, a wrong
+  `y(x)` is not. For a *nonlinear* ODE a correct solution may have a movable
+  singularity at a regular point (`y' = 1 + y²` has `y = tan(x + C)`), and a
+  sample landing on one is now a decline rather than a skip.
+
+  **No capability change.** The ODE corpus is unchanged at 89/101, case for
+  case, and the classifier is never entered on it — all 15 samples of all 35
+  numerically-certified solutions are finite — so no evaluation work is added
+  and latency is unchanged. All 12 remaining declines are "no class produced a
+  candidate"; none is the gate refusing a correct answer (`cargo test
+  -p alkahest-cas ode::dsolve::corpus::decline_split_report -- --ignored
+  --nocapture`).
+
+  Two notes for anyone reasoning about this gate. The numeric fallback is not a
+  rarity — it is what certifies 35 of the 89 solved corpus cases, the symbolic
+  branch closing the other 54. And it is **not** blocked by a non-elementary
+  answer: `verify::eval` has no `f64` kernel for `Ei`/`Si`/`Ci`, but those
+  cancel out of the residual when the candidate is substituted, leaving
+  elementary leftovers such as `x⁻¹·eˣ·e⁻ˣ − x⁻¹` that the sampler evaluates
+  perfectly well. `y'' − y = 1/x`, `y'' − y = eˣ/x`, `y'' − 4y = 1/x` and
+  `y''' − y' = 1/x` are all certified numerically, not symbolically, so the
+  conflated residual is kept as the primary check — evaluating the split form
+  instead would lose them.
+
 - **`ak.simplify` refused expressions it could handle, and crashed on one it
   could not.** The `E-DEPTH-001` ceiling (`MAX_EXPR_DEPTH`, 2 048) is
   calibrated against the shallowest walker that recurses without a net —

--- a/alkahest-core/src/ode/dsolve/corpus.rs
+++ b/alkahest-core/src/ode/dsolve/corpus.rs
@@ -190,6 +190,44 @@ fn outcome(entry: &Entry) -> (String, String) {
     }
 }
 
+/// Split the corpus's declines into the two reasons they can have.
+///
+/// `DECLINED` conflates them: a class may never have matched (nothing to
+/// verify), or a class may have produced a candidate that the substitution gate
+/// then refused.  Only the second kind is a *gate* problem — an answer the
+/// solver had and threw away — so the ratio says whether work belongs in
+/// `verify.rs` or in the solving classes and the integration engine.
+#[test]
+#[ignore = "measurement harness; run explicitly with --nocapture"]
+fn decline_split_report() {
+    let (mut no_candidate, mut gate_refused) = (0usize, 0usize);
+    for e in CORPUS {
+        let pool = ExprPool::new();
+        let Some(input) = build(e, &pool) else {
+            continue;
+        };
+        let _ = super::verify::take_gate_tally();
+        let solved = dsolve(&input, &pool).is_ok();
+        let (offered, refused) = super::verify::take_gate_tally();
+        if solved {
+            continue;
+        }
+        // `offered == refused` and `offered > 0` means every candidate any class
+        // produced was rejected by the gate.
+        if refused > 0 {
+            gate_refused += 1;
+            println!(
+                "GATE_REFUSED\t{}\t{}\t{offered} offered, {refused} refused",
+                e.0, e.1
+            );
+        } else {
+            no_candidate += 1;
+            println!("NO_CANDIDATE\t{}\t{}", e.0, e.1);
+        }
+    }
+    println!("SPLIT\tno_candidate={no_candidate}\tgate_refused={gate_refused}");
+}
+
 #[test]
 #[ignore = "measurement harness; run explicitly with --nocapture"]
 fn corpus_report() {

--- a/alkahest-core/src/ode/dsolve/tests.rs
+++ b/alkahest-core/src/ode/dsolve/tests.rs
@@ -504,16 +504,30 @@ fn quadrature_over_the_special_function_basis_closes() {
     // gate threw them away, because the residual cancels only over *rational*
     // coefficients (`1/(2x) − 1/(2x)`), which `collect_add_terms` could not do
     // until it carried `rug::Rational`.  `solve_src` re-substitutes into the
-    // original equation independently of that gate, and `verify::eval_func`
-    // has no `f64` kernel for `Ei`/`Si`/`Ci` — so its numeric fallback cannot
-    // fire and these pass on an exact symbolic `residual ≡ 0`.
+    // original equation independently of that gate.
+    //
+    // Which half of the gate certifies them is asserted, not assumed.  It is
+    // tempting to reason that `verify::eval_func` has no `f64` kernel for
+    // `Ei`/`Si`/`Ci`, so the numeric fallback cannot fire and these must pass
+    // on an exact symbolic `residual ≡ 0`.  That is wrong, and measurably so:
+    // the special functions cancel *out of the residual* when the candidate is
+    // substituted, leaving an elementary expression the sampler evaluates
+    // perfectly well — `x⁻¹·eˣ·e⁻ˣ − x⁻¹` for the first — which is not the
+    // symbolic zero, because nothing in the default rule set collapses
+    // `eˣ·e⁻ˣ`.  **Both** of these are certified by the numeric fallback, which
+    // is load-bearing rather than unreachable; the same is true of
+    // `y'' − 4y = 1/x` and `y''' − y' = 1/x` in the corpus.
     for (src, basis) in [
         ("ypp - y - 1/x", &["Ei"] as &[&str]),
         // `basis_functions_used` returns the names sorted.
         ("ypp + y - 1/x", &["Ci", "Si"]),
     ] {
-        let (pool, _, sol) = solve_src(2, src);
+        let (pool, input, sol) = solve_src(2, src);
         assert_eq!(sol.constants.len(), 2, "`{src}`: wrong constant count");
+        assert!(
+            !super::verify::certifies_symbolically(&input, sol.y_of_x, &pool),
+            "`{src}`: now certified symbolically — the comment above is stale",
+        );
         assert_eq!(
             basis_functions_used(sol.y_of_x, &pool),
             basis,

--- a/alkahest-core/src/ode/dsolve/verify.rs
+++ b/alkahest-core/src/ode/dsolve/verify.rs
@@ -84,6 +84,22 @@ pub(crate) fn take_gate_tally() -> (usize, usize) {
     GATE_TALLY.with(|t| t.replace((0, 0)))
 }
 
+/// Would this candidate be certified by the *symbolic* branch alone?
+///
+/// Exposed so tests can pin which half of the gate a case depends on; the two
+/// halves have very different reach and a comment claiming one of them is stale
+/// as soon as `simplify` changes.
+#[cfg(test)]
+pub(crate) fn certifies_symbolically(input: &OdeInput, y_of_x: ExprId, pool: &ExprPool) -> bool {
+    match build_residual(input, y_of_x, pool) {
+        Ok((residual, _)) => {
+            is_symbolic_zero(residual, pool)
+                || is_symbolic_zero(super::simp_plain(residual, pool), pool)
+        }
+        Err(_) => false,
+    }
+}
+
 /// Verify a candidate `y(x)` against `input.equation = 0`.
 ///
 /// Returns `Ok(())` if the residual is symbolically or numerically zero.
@@ -312,6 +328,8 @@ fn classify_nonfinite(
     //    values — a real verdict where the old code had none.
     let mut eq_env: HashMap<ExprId, f64> = HashMap::with_capacity(vals.len() + 1);
     eq_env.insert(input.x, xv);
+    // `build_residual` always pushes `y(x)` first and the loop above either
+    // filled `vals` completely or returned, so index 0 exists.
     eq_env.insert(input.y, vals[0]);
     for (k, &dsym) in input.derivs.iter().enumerate() {
         eq_env.insert(dsym, vals[k + 1]);

--- a/alkahest-core/src/ode/dsolve/verify.rs
+++ b/alkahest-core/src/ode/dsolve/verify.rs
@@ -5,10 +5,84 @@
 //! derivatives, then require the residual to be the symbolic zero, or — when
 //! `simplify` cannot close it — numerically `≈ 0` at several `x` samples over
 //! several random assignments of the integration constants.
+//!
+//! # Why the residual is not evaluated alone
+//!
+//! The substituted residual is a *conflation*: the equation's own coefficients
+//! and forcing term and the candidate's contribution are mixed into one
+//! expression, so when it fails to evaluate at a sample there is, on the face
+//! of it, nothing to compare against.  Skipping every such sample is what makes
+//! the gate unsound — a candidate that blows up at a point where the ODE is
+//! perfectly regular is *evidence that the candidate is wrong*, and blanket
+//! skipping throws that evidence away.  A wrong candidate accepted exactly that
+//! way is pinned in
+//! `tests::wrong_candidate_blowing_up_at_a_regular_point_is_rejected`.
+//!
+//! So a non-finite sample is **classified** rather than skipped, by asking the
+//! two questions the conflated residual cannot answer separately:
+//!
+//! 1. *Is the ODE itself evaluable at this `x`?*  Probe `input.equation` with
+//!    finite dummy values bound to `y, y', …` ([`ode_is_regular_at`]).  If no
+//!    probe is finite the equation is singular there (a `√(a − x)` coefficient
+//!    past its branch point, a pole in the forcing term) and the sample really
+//!    does carry no information — skip it.
+//! 2. *Does the candidate stay finite at this `x`?*  Evaluate `y(x)` and its
+//!    derivatives on their own.  If the ODE is regular here and the candidate
+//!    is not, that is a disagreement, not a skip.
+//!
+//! If both sides are finite and only the *simplified residual* was not, the
+//! non-finiteness was an artefact of the residual's algebraic form (an
+//! `∞ − ∞` produced by a rewriting).  Every quantity involved is then a real
+//! number, so the verdict is taken from the original equation evaluated at the
+//! candidate's own values — which recovers a sample the old code discarded and
+//! catches a disagreement it used to hide.
+//!
+//! The conflated residual remains the *primary* numeric check and is not
+//! replaced.  It has to be: `simplify` frequently cancels the non-elementary
+//! part of a candidate (`Ei`, `Si`, `Ci`) out of the residual, leaving an
+//! elementary expression this module can evaluate, while the candidate itself
+//! cannot be evaluated at all.  Four corpus ODEs (`y''−y=1/x`, `y''−y=eˣ/x`,
+//! `y''−4y=1/x`, `y'''−y'=1/x`) certify only because of that cancellation, so
+//! evaluating the split form *instead* would lose them.  The split evaluation
+//! is a discriminator layered on top, reached only for samples the conflated
+//! residual could not resolve.
+//!
+//! **Known conservatism.** For a *nonlinear* ODE a correct solution may have a
+//! movable singularity at a regular point (`y' = 1 + y²` has `y = tan(x + C)`).
+//! Landing a sample on one is now a decline rather than a skip.  That is the
+//! intended direction of the trade: a decline is acceptable, a wrong `y(x)` is
+//! not.  In practice `powf` and division produce a finite (merely huge) value
+//! near a pole, so the case is not reached on the corpus — where the classifier
+//! is never entered at all, every sample of every numerically-certified
+//! solution being finite.
 
 use super::{ddx, simp, subs1, DsolveError, OdeInput};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use std::collections::HashMap;
+use std::fmt;
+
+/// Absolute tolerance for "this sample of the residual is zero".
+const ZERO_TOL: f64 = 1e-6;
+
+/// Minimum number of resolved, agreeing samples before a numeric certificate is
+/// issued.  Samples the classifier could not resolve do not count towards it.
+const MIN_AGREEING_SAMPLES: usize = 6;
+
+// Per-thread `(candidates offered, candidates refused)` tally, so the corpus
+// harness can split a decline into "no method produced a candidate" and "the
+// gate refused the candidate a method produced".  Test-only; nothing outside
+// the measurement harness reads it.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static GATE_TALLY: std::cell::Cell<(usize, usize)> =
+        const { std::cell::Cell::new((0, 0)) };
+}
+
+/// Reset [`GATE_TALLY`] and return the tally accumulated since the last reset.
+#[cfg(test)]
+pub(crate) fn take_gate_tally() -> (usize, usize) {
+    GATE_TALLY.with(|t| t.replace((0, 0)))
+}
 
 /// Verify a candidate `y(x)` against `input.equation = 0`.
 ///
@@ -19,20 +93,22 @@ pub(crate) fn residual_is_zero(
     constants: &[ExprId],
     pool: &ExprPool,
 ) -> Result<(), DsolveError> {
-    // Build the residual: substitute y → y(x), y^(k) → d^k/dx^k y(x).
-    let mut residual = input.equation;
-    // highest derivative first so we don't clobber lower-order symbols that
-    // also appear inside higher-derivative expressions (they are distinct
-    // symbols, so order does not actually matter, but do y then derivs).
-    residual = subs1(residual, input.y, y_of_x, pool);
+    let outcome = verify_inner(input, y_of_x, constants, pool);
+    #[cfg(test)]
+    GATE_TALLY.with(|t| {
+        let (offered, refused) = t.get();
+        t.set((offered + 1, refused + usize::from(outcome.is_err())));
+    });
+    outcome
+}
 
-    let mut cur = y_of_x;
-    for &dsym in &input.derivs {
-        cur = ddx(cur, input.x, pool)?;
-        residual = subs1(residual, dsym, cur, pool);
-    }
-
-    let residual = simp(residual, pool);
+fn verify_inner(
+    input: &OdeInput,
+    y_of_x: ExprId,
+    constants: &[ExprId],
+    pool: &ExprPool,
+) -> Result<(), DsolveError> {
+    let (residual, candidate_derivs) = build_residual(input, y_of_x, pool)?;
 
     // Symbolic zero?  Try both the expanded and the plain (non-expanding)
     // normal forms — expansion flattens polynomial cancellations, while plain
@@ -43,27 +119,115 @@ pub(crate) fn residual_is_zero(
     }
 
     // Numeric fallback: sample x over several constant assignments.
-    if numeric_zero(residual, input.x, constants, pool) {
+    let report = numeric_report(input, residual, &candidate_derivs, constants, pool);
+    if report.certifies() {
         return Ok(());
     }
 
     Err(DsolveError::VerificationFailed(format!(
-        "residual did not reduce to zero: {}",
+        "residual did not reduce to zero ({report}): {}",
         pool.display(residual)
     )))
+}
+
+/// Substitute the candidate into the equation.
+///
+/// Returns the simplified residual **and** the candidate's contribution kept on
+/// its own — `candidate_derivs[k]` is `dᵏ/dxᵏ y(x)`, with `[0] = y(x)`.  Keeping
+/// the second half is the whole point: it is what lets [`classify_nonfinite`]
+/// ask about the candidate without the equation's coefficients mixed in.
+fn build_residual(
+    input: &OdeInput,
+    y_of_x: ExprId,
+    pool: &ExprPool,
+) -> Result<(ExprId, Vec<ExprId>), DsolveError> {
+    let mut candidate_derivs = Vec::with_capacity(input.derivs.len() + 1);
+    candidate_derivs.push(y_of_x);
+    let mut cur = y_of_x;
+    for _ in &input.derivs {
+        cur = ddx(cur, input.x, pool)?;
+        candidate_derivs.push(cur);
+    }
+
+    // Substitute y → y(x), y^(k) → d^k/dx^k y(x).  They are distinct symbols,
+    // so substitution order does not matter.
+    let mut residual = subs1(input.equation, input.y, y_of_x, pool);
+    for (k, &dsym) in input.derivs.iter().enumerate() {
+        residual = subs1(residual, dsym, candidate_derivs[k + 1], pool);
+    }
+    Ok((simp(residual, pool), candidate_derivs))
 }
 
 fn is_symbolic_zero(expr: ExprId, pool: &ExprPool) -> bool {
     matches!(pool.get(expr), ExprData::Integer(n) if n.0 == 0)
 }
 
+/// Per-sample tally produced by [`numeric_report`].
+///
+/// Every sample of the `x × constants` grid lands in exactly one bucket, unless
+/// `unevaluable` is set, in which case sampling stopped early.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+struct NumericReport {
+    /// Resolved to a finite value `≈ 0`.
+    agree: usize,
+    /// Resolved to a finite value that is **not** `≈ 0` — the candidate is wrong.
+    disagree: usize,
+    /// The ODE is regular at this `x` but the candidate is not finite there —
+    /// also evidence the candidate is wrong (see the module docs for the
+    /// nonlinear movable-singularity caveat).
+    blowup_at_regular_point: usize,
+    /// The equation itself is not evaluable at this sample — no information.
+    skipped_singular_ode: usize,
+    /// The candidate contains a construct [`eval`] does not know, so the sample
+    /// could not be classified either way — no information.
+    skipped_unknown_construct: usize,
+    /// The residual itself contains a construct [`eval`] does not know; the gate
+    /// refuses to certify numerically at all.
+    unevaluable: bool,
+}
+
+impl NumericReport {
+    fn certifies(&self) -> bool {
+        !self.unevaluable
+            && self.disagree == 0
+            && self.blowup_at_regular_point == 0
+            && self.agree >= MIN_AGREEING_SAMPLES
+    }
+}
+
+impl fmt::Display for NumericReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.unevaluable {
+            return write!(
+                f,
+                "residual contains a construct the sampler cannot evaluate"
+            );
+        }
+        write!(
+            f,
+            "samples: {} agreeing, {} disagreeing, {} candidate blow-ups at a regular point, \
+             {} skipped (ODE singular), {} skipped (unknown construct)",
+            self.agree,
+            self.disagree,
+            self.blowup_at_regular_point,
+            self.skipped_singular_ode,
+            self.skipped_unknown_construct
+        )
+    }
+}
+
 /// Numerically check residual ≈ 0 at several `x` over random constants.
-fn numeric_zero(residual: ExprId, x: ExprId, constants: &[ExprId], pool: &ExprPool) -> bool {
+fn numeric_report(
+    input: &OdeInput,
+    residual: ExprId,
+    candidate_derivs: &[ExprId],
+    constants: &[ExprId],
+    pool: &ExprPool,
+) -> NumericReport {
     // Deterministic pseudo-random constant assignments (no rng dependency).
     // Constants are kept positive and reasonably large so that radicands such as
     // `sqrt(4·C − 3x²)` arising from quadratic-implicit solutions stay real over
-    // the (small) x-sample range; samples that still hit a pole/branch-cut are
-    // skipped rather than failing.
+    // the (small) x-sample range.
     let const_sets: [&[f64]; 3] = [
         &[5.7, 4.3, 6.4, 5.1, 4.9],
         &[8.5, 7.8, 6.6, 9.2, 7.1],
@@ -71,29 +235,113 @@ fn numeric_zero(residual: ExprId, x: ExprId, constants: &[ExprId], pool: &ExprPo
     ];
     let x_samples = [0.11, 0.27, 0.43, 0.61, 0.79];
 
-    let mut checked = 0usize;
-    let mut ok = 0usize;
+    let mut report = NumericReport::default();
     for cs in const_sets {
         let mut env: HashMap<ExprId, f64> = HashMap::new();
         for (i, &c) in constants.iter().enumerate() {
             env.insert(c, cs[i % cs.len()]);
         }
         for &xv in &x_samples {
-            env.insert(x, xv);
+            env.insert(input.x, xv);
             match eval(residual, &env, pool) {
-                Some(v) if v.is_finite() => {
-                    checked += 1;
-                    if v.abs() < 1e-6 {
-                        ok += 1;
-                    }
+                Some(v) if v.is_finite() => record(&mut report, v),
+                // Non-finite: the conflated residual cannot say whose fault it
+                // is.  Ask the equation and the candidate separately.
+                Some(_) => classify_nonfinite(input, candidate_derivs, &env, xv, pool, &mut report),
+                // Unknown construct → refuse to certify numerically.
+                None => {
+                    report.unevaluable = true;
+                    return report;
                 }
-                Some(_) => { /* non-finite (pole at this sample) — skip */ }
-                None => return false, // unknown construct → cannot certify numerically
             }
         }
     }
-    // Require a healthy number of finite samples and all of them ≈ 0.
-    checked >= 6 && ok == checked
+    report
+}
+
+/// Bucket a finite residual value as agreement or disagreement.
+fn record(report: &mut NumericReport, v: f64) {
+    if v.abs() < ZERO_TOL {
+        report.agree += 1;
+    } else {
+        report.disagree += 1;
+    }
+}
+
+/// Decide what a non-finite sample of the conflated residual means.
+///
+/// See the module docs for the three outcomes.  The ordering matters: "the ODE
+/// is singular here" dominates, because nothing can be concluded about a
+/// candidate at a point the equation itself does not reach.
+fn classify_nonfinite(
+    input: &OdeInput,
+    candidate_derivs: &[ExprId],
+    env: &HashMap<ExprId, f64>,
+    xv: f64,
+    pool: &ExprPool,
+    report: &mut NumericReport,
+) {
+    // 1. Is the equation itself well-defined at this `x`, candidate aside?
+    if !ode_is_regular_at(input, xv, pool) {
+        report.skipped_singular_ode += 1;
+        return;
+    }
+
+    // 2. It is.  Does the candidate stay finite here?
+    let mut vals = Vec::with_capacity(candidate_derivs.len());
+    for &d in candidate_derivs {
+        match eval(d, env, pool) {
+            Some(v) if v.is_finite() => vals.push(v),
+            // The ODE is regular here and the candidate is not: evidence of a
+            // wrong answer, which is exactly what the old blanket skip lost.
+            Some(_) => {
+                report.blowup_at_regular_point += 1;
+                return;
+            }
+            // Cannot evaluate the candidate (e.g. it contains `Ei`), so no
+            // conclusion is available either way.
+            None => {
+                report.skipped_unknown_construct += 1;
+                return;
+            }
+        }
+    }
+
+    // 3. Both sides are finite, so the non-finiteness came from the residual's
+    //    algebraic form.  Re-ask the original equation at the candidate's own
+    //    values — a real verdict where the old code had none.
+    let mut eq_env: HashMap<ExprId, f64> = HashMap::with_capacity(vals.len() + 1);
+    eq_env.insert(input.x, xv);
+    eq_env.insert(input.y, vals[0]);
+    for (k, &dsym) in input.derivs.iter().enumerate() {
+        eq_env.insert(dsym, vals[k + 1]);
+    }
+    match eval(input.equation, &eq_env, pool) {
+        Some(v) if v.is_finite() => record(report, v),
+        // The equation is singular at *this state*, not merely at this `x` (a
+        // `1/(y − 3)` reached exactly at `y = 3`) — no information.
+        _ => report.skipped_singular_ode += 1,
+    }
+}
+
+/// Is `input.equation` evaluable to a finite value at `x = xv`, independently of
+/// the candidate?
+///
+/// Probes several finite states `(y, y', y'', …)`; one finite result is enough,
+/// since the question is whether the *equation* has a singularity at this `x`,
+/// not whether some particular state is admissible.  Distinct values per
+/// derivative order stop a probe from cancelling the equation by accident.
+fn ode_is_regular_at(input: &OdeInput, xv: f64, pool: &ExprPool) -> bool {
+    const PROBES: [f64; 4] = [1.0, 2.5, 0.5, -1.5];
+    PROBES.iter().any(|&p| {
+        let mut env: HashMap<ExprId, f64> = HashMap::with_capacity(input.derivs.len() + 2);
+        env.insert(input.x, xv);
+        env.insert(input.y, p);
+        for (k, &dsym) in input.derivs.iter().enumerate() {
+            env.insert(dsym, p + 0.25 * (k as f64 + 1.0));
+        }
+        matches!(eval(input.equation, &env, pool), Some(v) if v.is_finite())
+    })
 }
 
 /// Evaluate `expr` to an `f64` given a symbol→value environment.
@@ -157,3 +405,6 @@ fn eval_func(name: &str, a: &[f64]) -> Option<f64> {
         _ => return None,
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/alkahest-core/src/ode/dsolve/verify/tests.rs
+++ b/alkahest-core/src/ode/dsolve/verify/tests.rs
@@ -1,0 +1,254 @@
+//! Tests for the verification gate itself.
+//!
+//! These call [`residual_is_zero`] directly with hand-built candidates rather
+//! than going through `dsolve`, because the point is to pin what the *gate*
+//! does with a candidate — including candidates no implemented solving class
+//! would ever produce.  Both directions are pinned: a correct solution of a
+//! singular ODE must still verify, and a wrong candidate whose blow-up used to
+//! be skipped must now be caught.
+
+use super::*;
+use crate::kernel::Domain;
+
+/// `y`, `y'`, … named as `OdeInput` names them, plus an integration constant.
+struct Fixture {
+    pool: ExprPool,
+    x: ExprId,
+    y: ExprId,
+    c1: ExprId,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let c1 = pool.symbol("C1", Domain::Real);
+        Fixture { pool, x, y, c1 }
+    }
+
+    fn neg(&self, e: ExprId) -> ExprId {
+        self.pool.mul(vec![self.pool.integer(-1_i32), e])
+    }
+
+    /// `x − n/d`.
+    fn x_minus(&self, n: i32, d: i32) -> ExprId {
+        let r = self.pool.rational(n, d);
+        self.pool.add(vec![self.x, self.neg(r)])
+    }
+
+    /// `√(1/2 − x)` — real for `x < 1/2`, NaN for the `0.61` and `0.79`
+    /// samples, which is what makes an expression containing it "singular
+    /// there" for the sampler.
+    fn sqrt_half_minus_x(&self) -> ExprId {
+        let half = self.pool.rational(1_i32, 2_i32);
+        let arg = self.pool.add(vec![half, self.neg(self.x)]);
+        self.pool.func("sqrt", vec![arg])
+    }
+
+    /// `eˣ·e⁻ˣ`, which is `1` but which `simplify` does not collapse.
+    ///
+    /// Multiplying a term by this is how these tests force the gate past its
+    /// symbolic-zero branch and onto the numeric sampler — the same artefact
+    /// the real corpus residuals carry (`x⁻¹·eˣ·e⁻ˣ − x⁻¹` for `y'' − y = 1/x`).
+    fn one_that_does_not_simplify(&self) -> ExprId {
+        let ex = self.pool.func("exp", vec![self.x]);
+        let emx = self.pool.func("exp", vec![self.neg(self.x)]);
+        self.pool.mul(vec![ex, emx])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The soundness direction: a wrong candidate must not be certified
+// ---------------------------------------------------------------------------
+
+/// The reproducer for the bug this module was restructured to fix.
+///
+/// The ODE is `y' = 0`, which is regular at every `x`; its general solution is
+/// `y = C1`.  The candidate adds `√(x − ½)·(x − 0.61)²·(x − 0.79)²`, which is
+///
+/// * NaN at the samples `0.11, 0.27, 0.43` (negative radicand), and
+/// * a double root at `0.61` and `0.79`, so the residual `y'` is exactly zero
+///   at the two samples that *do* evaluate.
+///
+/// The old gate skipped the three NaN samples, saw `2 × 3 = 6` finite samples
+/// all `≈ 0`, cleared its `≥ 6` bar and returned `Ok(())` — a wrong `y(x)`
+/// certified.  The candidate blows up where the ODE is perfectly regular, so
+/// the classifier now books those samples as blow-ups and refuses.
+#[test]
+fn wrong_candidate_blowing_up_at_a_regular_point_is_rejected() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let input = input.with_equation(yp);
+
+    let root = f.pool.func("sqrt", vec![f.x_minus(-1, -2)]);
+    let sq = |n: i32, d: i32| f.pool.pow(f.x_minus(n, d), f.pool.integer(2_i32));
+    let wrong = simp(
+        f.pool
+            .add(vec![f.c1, f.pool.mul(vec![root, sq(61, 100), sq(79, 100)])]),
+        &f.pool,
+    );
+
+    let (residual, derivs) = build_residual(&input, wrong, &f.pool).expect("residual builds");
+    let report = numeric_report(&input, residual, &derivs, &[f.c1], &f.pool);
+
+    // The shape of the trap: exactly six agreeing samples, no disagreement, and
+    // nine samples that the old code discarded.
+    assert_eq!(report.agree, 6, "report: {report}");
+    assert_eq!(report.disagree, 0, "report: {report}");
+    assert_eq!(report.blowup_at_regular_point, 9, "report: {report}");
+    assert_eq!(report.skipped_singular_ode, 0, "report: {report}");
+    assert!(!report.certifies(), "report: {report}");
+
+    residual_is_zero(&input, wrong, &[f.c1], &f.pool)
+        .expect_err("a candidate that blows up where the ODE is regular must not certify");
+}
+
+/// A candidate that simply disagrees at finite samples is still rejected — the
+/// restructure must not have loosened the ordinary path.  `y = C1·eˣ` is not a
+/// solution of `y' = 2y`.
+#[test]
+fn plain_finite_disagreement_is_still_rejected() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    // y' − 2·y·(eˣ·e⁻ˣ) = 0, i.e. y' = 2y, spelled so the symbolic branch misses.
+    let two_y = f.pool.mul(vec![
+        f.pool.integer(-2_i32),
+        f.y,
+        f.one_that_does_not_simplify(),
+    ]);
+    let input = input.with_equation(f.pool.add(vec![yp, two_y]));
+
+    let cand = simp(
+        f.pool.mul(vec![f.c1, f.pool.func("exp", vec![f.x])]),
+        &f.pool,
+    );
+    let (residual, derivs) = build_residual(&input, cand, &f.pool).expect("residual builds");
+    let report = numeric_report(&input, residual, &derivs, &[f.c1], &f.pool);
+    assert_eq!(report.agree, 0, "report: {report}");
+    assert_eq!(report.disagree, 15, "report: {report}");
+    assert!(!report.certifies(), "report: {report}");
+}
+
+// ---------------------------------------------------------------------------
+// The capability direction: a correct solution must still be certified
+// ---------------------------------------------------------------------------
+
+/// A correct solution of an ODE that is *singular over part of the sample
+/// range* must still verify.
+///
+/// The equation is `y' − y − √(½ − x)·eˣ·e⁻ˣ + √(½ − x) = 0`.  The last two
+/// terms cancel as functions (`eˣ·e⁻ˣ = 1`), so the equation is `y' = y` and
+/// `y = C1·eˣ` is exactly right — but as *written* the equation does not
+/// evaluate at all for `x > ½`, so the samples `0.61` and `0.79` carry no
+/// information about the candidate and must be skipped, not counted against it.
+#[test]
+fn correct_solution_of_a_singular_ode_still_verifies() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let root = f.sqrt_half_minus_x();
+    let eq = f.pool.add(vec![
+        yp,
+        f.neg(f.y),
+        f.neg(f.pool.mul(vec![root, f.one_that_does_not_simplify()])),
+        root,
+    ]);
+    let input = input.with_equation(eq);
+
+    let cand = simp(
+        f.pool.mul(vec![f.c1, f.pool.func("exp", vec![f.x])]),
+        &f.pool,
+    );
+
+    // The premise: the ODE really is unevaluable past the branch point, and
+    // fine before it.
+    assert!(ode_is_regular_at(&input, 0.43, &f.pool));
+    assert!(!ode_is_regular_at(&input, 0.61, &f.pool));
+
+    let (residual, derivs) = build_residual(&input, cand, &f.pool).expect("residual builds");
+    let report = numeric_report(&input, residual, &derivs, &[f.c1], &f.pool);
+    assert_eq!(report.agree, 9, "report: {report}");
+    assert_eq!(report.disagree, 0, "report: {report}");
+    assert_eq!(report.blowup_at_regular_point, 0, "report: {report}");
+    assert_eq!(report.skipped_singular_ode, 6, "report: {report}");
+    assert!(report.certifies(), "report: {report}");
+
+    residual_is_zero(&input, cand, &[f.c1], &f.pool)
+        .expect("a correct solution of a singular ODE must still verify");
+}
+
+/// When the candidate blows up *and* the ODE is singular at the same sample,
+/// the sample is still information-free and must stay a skip.
+///
+/// `y' = y·eˣ·e⁻ˣ/√(½ − x)` has the correct solution `y = C1·e^{−2√(½ − x)}`.
+/// Both the equation and the solution are NaN for `x > ½`, so the ordering in
+/// [`classify_nonfinite`] — singular ODE first — is what keeps this verifying.
+#[test]
+fn candidate_blowup_where_the_ode_is_also_singular_stays_a_skip() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let root = f.sqrt_half_minus_x();
+    let inv_root = f.pool.pow(root, f.pool.integer(-1_i32));
+    let rhs = f
+        .pool
+        .mul(vec![f.y, f.one_that_does_not_simplify(), inv_root]);
+    let input = input.with_equation(f.pool.add(vec![yp, f.neg(rhs)]));
+
+    // y = C1·exp(−2·√(½ − x))
+    let expo = f.pool.mul(vec![f.pool.integer(-2_i32), root]);
+    let cand = simp(
+        f.pool.mul(vec![f.c1, f.pool.func("exp", vec![expo])]),
+        &f.pool,
+    );
+
+    assert!(!ode_is_regular_at(&input, 0.61, &f.pool));
+
+    let (residual, derivs) = build_residual(&input, cand, &f.pool).expect("residual builds");
+    let report = numeric_report(&input, residual, &derivs, &[f.c1], &f.pool);
+    assert_eq!(report.disagree, 0, "report: {report}");
+    assert_eq!(report.blowup_at_regular_point, 0, "report: {report}");
+    assert_eq!(report.skipped_singular_ode, 6, "report: {report}");
+    assert_eq!(report.agree, 9, "report: {report}");
+
+    residual_is_zero(&input, cand, &[f.c1], &f.pool)
+        .expect("correct solution, ODE singular past the branch point");
+}
+
+// ---------------------------------------------------------------------------
+// The regularity probe
+// ---------------------------------------------------------------------------
+
+/// `ode_is_regular_at` must answer about the *equation*, not about one state:
+/// a single unlucky probe value may make a perfectly regular equation
+/// unevaluable, so one finite probe is enough to call it regular.
+#[test]
+fn regularity_probe_ignores_an_unlucky_state() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    // y' − log(y) = 0: NaN for the negative probe, finite for the positive ones.
+    let eq = f.pool.add(vec![yp, f.neg(f.pool.func("log", vec![f.y]))]);
+    let input = input.with_equation(eq);
+    assert!(ode_is_regular_at(&input, 0.43, &f.pool));
+
+    // y' − log(½ − x) = 0 is genuinely unevaluable past the branch point, for
+    // every state.
+    let (input2, yp2) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let half = f.pool.rational(1_i32, 2_i32);
+    let arg = f.pool.add(vec![half, f.neg(f.x)]);
+    let eq2 = f.pool.add(vec![yp2, f.neg(f.pool.func("log", vec![arg]))]);
+    let input2 = input2.with_equation(eq2);
+    assert!(ode_is_regular_at(&input2, 0.43, &f.pool));
+    assert!(!ode_is_regular_at(&input2, 0.61, &f.pool));
+}
+
+/// An equation the sampler cannot evaluate at all (an unknown special function)
+/// is never called regular, so a candidate is never condemned on the strength
+/// of a probe that did not run.
+#[test]
+fn regularity_probe_declines_on_an_unknown_construct() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let ei = f.pool.func("Ei", vec![f.x]);
+    let input = input.with_equation(f.pool.add(vec![yp, f.neg(ei)]));
+    assert!(!ode_is_regular_at(&input, 0.43, &f.pool));
+}


### PR DESCRIPTION
`dsolve`'s verifier accepted a wrong `y(x)`. `residual_is_zero` skipped non-finite samples, so a candidate that blows up where the ODE is perfectly regular could clear the gate on the handful of points that happened to evaluate.

## Reproducer

For `y' = 0` — regular everywhere, solution `y = C1` — the candidate

```
y = C1 + √(x − ½)·(x − 0.61)²·(x − 0.79)²
```

is NaN at samples 0.11, 0.27, 0.43, and the double roots at 0.61 and 0.79 make the residual exactly zero at the two samples that do evaluate. Nine skips, six agreements, bar of `checked >= 6 && ok == checked` → **`Ok(())` for a wrong solution.** Confirmed against unmodified code before writing the fix; now pinned as `verify::tests::wrong_candidate_blowing_up_at_a_regular_point_is_rejected`.

## The restructure

PR #344's rule — non-finite where the other side is finite means disagreement — could not be applied directly here, because `residual_is_zero` evaluates a **single conflated residual**: substitute `y`, `y′`, `y″` into the equation and ask whether the whole thing is zero. When that fails to evaluate there is nothing to compare against.

`build_residual` now returns the residual **and** the candidate's own `y, y′, y″, …`, so a non-finite sample is classified rather than skipped:

1. Probe `input.equation` at that `x` with finite dummy states. Not evaluable ⇒ the ODE is genuinely singular there ⇒ skip, no information.
2. ODE regular ⇒ evaluate the candidate alone. Non-finite ⇒ **disagreement**.
3. Both finite ⇒ the non-finiteness was an artefact of the residual's *form*; take the verdict from the original equation at the candidate's values. This recovers a sample that used to be discarded, and can catch a disagreement that was previously hidden.

The conflated residual stays the **primary** check. Replacing it with the split form would lose the `Ei`-cancellation cases below.

`E-ODE-011` now reports the tally — agreeing, disagreeing, blow-ups, and each kind of skip. One documented conservatism: a nonlinear movable singularity landing on a regular point is now a decline rather than a skip.

## A correction: the numeric path is load-bearing, and a test comment said otherwise

PR #330 recorded that `residual_is_zero`'s numeric fallback "cannot fire for `Ei`" because `eval_func` has no `Ei` kernel — and wrote that into a test comment. **It is false.**

`Ei`, `Si` and `Ci` **cancel out of the residual** when the candidate is substituted; what remains is elementary and the sampler handles it. For `y''−y=1/x` the residual is `x⁻¹·eˣ·e⁻ˣ − x⁻¹` — not symbolic zero, since nothing collapses `eˣ·e⁻ˣ`, but perfectly evaluable. `y''−y=1/x`, `y''−y=eˣ/x`, `y''−4y=1/x` and `y'''−y'=1/x` all certify **numerically**, not symbolically.

Instrumenting the whole corpus: of the 89 solved cases, **54 certify symbolically and 35 certify only numerically**. The fallback is not a rarity. The corrected comment is now pinned by a test-only `certifies_symbolically` so it cannot go stale again.

## Corpus, and the decline split

**89/101 → 89/101, identical case for case.** The non-finite skip fires **zero times** across the corpus — all 15 samples of all 35 numerically-certified solutions are finite — so this is a soundness fix with no capability movement.

A new test-only `decline_split_report` harness answers the question worth asking about the remaining 12:

- **12 declined because no solving class produced a candidate**
- **0 declined because the gate refused a correct answer**

So there is no capability sitting behind this gate to recover. The remaining 12 are integration-engine and solving-class work.

## Tests

Six. Four pin the classification's corners — wrong-candidate blow-up rejected; a correct solution of a *singular* ODE still verifies; a candidate blow-up where the ODE is also singular stays a skip; plain finite disagreement still rejected — plus two on the regularity probe.

## Gates

`cargo fmt --check` · `cargo test --workspace` 2669 lib, 0 failures across 13 result lines · `cargo clippy --all-targets -D warnings` across `""`, `egraph`, `parallel`, `cranelift`, `groebner` · `pytest tests/` **3718 passed, 61 skipped, 0 failed** · `gen_certificate_ledger.py --check` clean (288 observations) · `ruff==0.15.14` format and check clean. No `unsafe`, no `is_none_or`, no panics on user input; `ode/` contains no `NonElementary` path.

Build isolation was verified rather than assumed — `alkahest.alkahest.__file__` confirmed to resolve into this worktree, with sympy 1.14 installed so the oracle tests actually ran.

**One gap, stated rather than papered over:** no paired before/after latency run. Producing one required `git checkout origin/main -- <ode files>`, which the permission classifier blocked, and that was not worked around. The absolute figure is 0.40 s for the full 101-case harness (release, three identical runs). The argument that the delta is negligible is measured, not assumed: the classifier is entered only on a non-finite sample and there are zero of those on the corpus, so the only unconditional addition is one `Vec<ExprId>` of length `order+1` per call, replacing a single reused variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
