### PR TITLE
fix(integrate): an antiderivative undefined on the interval is a refusal, not a skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,29 @@
   evaluate at all (`RootSum`, an unregistered head) is a property of the
   expression, not of the point, and is no information.
 
+  **What was actually being returned, stated precisely.** Evaluated on the
+  *principal complex branch*, all 22 of those answers are numerically right:
+  the `±iπ` the two endpoints pick up crossing the cut cancels in the
+  difference, and `∫_{0.1}^{1.4} dx/(1+tan x)` comes to `0.6769275912524469`,
+  matching `mpmath.quad` to 25 digits. They are not wrong values — they are
+  right values in a form the library's own `eval_expr` rejects with
+  `E-EVAL-009`, which the silent-error gate's vocabulary already classes as a
+  (weak) refusal. Two reasons to make the refusal explicit rather than keep
+  them:
+
+  * The agreement is **unverified luck of the branch**. It holds because both
+    endpoints land on the same side of every cut crossed between them; nothing
+    in the engine establishes that, and an odd number of crossings would leave
+    a wrong real part with no guard to notice. A `Solved` verdict has to mean
+    the FTC's hypotheses were checked, and here they fail.
+  * The value is unusable as returned: any caller that asks for a number gets
+    `E-EVAL-009` from a call that reported success. A coded refusal that names
+    the reason is strictly more information than an expression that blows up
+    on use.
+
+  Recovering these needs the real branch — `log|·|` rather than `log`,
+  `acoth` rather than `atanh` off `(−1, 1)` — not a laxer gate.
+
   **Measured on a 152-case definite corpus** (symmetric intervals, interior
   poles, convergent improper integrals, Weierstrass answers that jump, and
   answers whose branch cut lies in the interval): 62 → 62 correct values, 68 →
@@ -51,12 +74,17 @@
   `E-INT-001`; no new `E-INT-004`. The extra pass costs nothing measurable —
   a ten-integral sweep is 187–195 ms either side, inside the run-to-run spread.
 
-  The three that remain are elliptic: `PrimitiveRegistry::numeric_f64` answers
-  `None`, not `NaN`, for an out-of-domain `EllipticF`, so a branch-limited
-  elliptic answer evaluated off its branch (`∫_{-0.9}^{-0.1} dx/√(x³−x)`, whose
-  `F` is real only for `x ≥ 1`) is indistinguishable here from a `RootSum` and
-  is still returned. Closing that needs the registry to separate "outside my
-  domain" from "not implemented".
+  The three that remain are elliptic, and leaving them is the right call:
+  `PrimitiveRegistry::numeric_f64` answers `None`, not `NaN`, for an
+  out-of-domain `EllipticF`, so a branch-limited elliptic answer evaluated off
+  its branch (`∫_{-0.9}^{-0.1} dx/√(x³−x)`, whose `F` is real only for `x ≥ 1`)
+  is indistinguishable here from a `RootSum`, and *unevaluable* is no
+  information. All three are correct on the complex continuation —
+  `1.5300082013845898` against `mpmath`'s `1.5300082013845897` — so the rule
+  that would refuse them would be discarding right answers on the strength of
+  an evaluator limitation. Making them usable is a registry question ("outside
+  my domain" versus "not implemented") plus a real-valued reduction, not a
+  stricter gate.
 
 - **An antiderivative that is *undefined* on a whole component where the
   integrand is finite passed the verification gate.** The gate's numeric grid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
   87 refusals, 22 → 3 answers that do not reduce to a real number, and **no
   wrong number before or after**. All 19 that moved are the hole class above;
   no case that produced a correct value stopped producing it. Every refusal is
-  `E-INT-001`; no new `E-INT-004`.
+  `E-INT-001`; no new `E-INT-004`. The extra pass costs nothing measurable —
+  a ten-integral sweep is 187–195 ms either side, inside the run-to-run spread.
 
   The three that remain are elliptic: `PrimitiveRegistry::numeric_f64` answers
   `None`, not `NaN`, for an out-of-domain `EllipticF`, so a branch-limited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 ## Unreleased
 
+- **A definite integral whose antiderivative is not defined on the interval of
+  integration was answered rather than refused.** The FTC needs `F` continuous
+  on `[a, b]`; `engine::antiderivative_jump` is the guard that looks at `F`
+  rather than at the integrand, and it can only see a *jump*. Forming its
+  `|ΔF| / (h·sup|f|)` ratio needs `F` at both ends of a cell, so a **hole** —
+  `F` undefined across a whole sub-interval where the integrand is an ordinary
+  finite real — makes every cell undecidable and the scan silent, and silence
+  was read as "no evidence against the candidate".
+
+  Nothing downstream caught it either. The last endpoint gate,
+  `non_real_closed_form`, asks `eval::eval_f64`, which does not implement
+  `tan`, `atan`, `asin`, `atanh` or `EllipticF`; for any answer containing one
+  it reports "cannot decide" and correctly declines to reject. So
+  `∫_{0.1}^{1.4} dx/(1 + tan x)` came back `Solved`, as
+  `½·log(tan²(x/2) − 2·tan(x/2) − 1) − ½·log(tan²(x/2) + 1) + atan(tan(x/2))`,
+  whose first logarithm is `log` of a negative number for every `x` in
+  `(−π/4, 3π/4)` — the answer is undefined across the *entire* interval, while
+  the integrand runs smoothly from `0.909` to `0.147` and the value is `0.677`.
+  `∫_{-3}^{-2} dx/(x⁴−1)`, `∫_{-4}^{-2} dx/(1+x³)`, `∫_{-1/2}^{1/2} atanh x dx`
+  and `∫_{1/5}^{4/5} asin(x)/x² dx` are the same shape.
+
+  `antiderivative_domain_hole` now runs first, and classifies each sample of
+  the same grid:
+
+  | integrand | `F` | verdict |
+  |---|---|---|
+  | finite | finite | fine |
+  | finite | non-finite | **hole** — refuse |
+  | non-finite | either | no information |
+
+  The third row is what keeps genuine improper integrals working: `∫_0^1 log x`
+  and `∫_0^1 x^{-1/2}` have an integrand that is itself non-finite at an
+  endpoint, which is not this defect and stays with the machinery that handles
+  it today. A single non-finite sample is not enough — a candidate written with
+  a *removable* singularity is `NaN` at one isolated point and is still a good
+  antiderivative — so a hole must span a whole cell, `width/257`, confirmed at
+  its midpoint. As in the indefinite gate, a sample the interpreter cannot
+  evaluate at all (`RootSum`, an unregistered head) is a property of the
+  expression, not of the point, and is no information.
+
+  **Measured on a 152-case definite corpus** (symmetric intervals, interior
+  poles, convergent improper integrals, Weierstrass answers that jump, and
+  answers whose branch cut lies in the interval): 62 → 62 correct values, 68 →
+  87 refusals, 22 → 3 answers that do not reduce to a real number, and **no
+  wrong number before or after**. All 19 that moved are the hole class above;
+  no case that produced a correct value stopped producing it. Every refusal is
+  `E-INT-001`; no new `E-INT-004`.
+
+  The three that remain are elliptic: `PrimitiveRegistry::numeric_f64` answers
+  `None`, not `NaN`, for an out-of-domain `EllipticF`, so a branch-limited
+  elliptic answer evaluated off its branch (`∫_{-0.9}^{-0.1} dx/√(x³−x)`, whose
+  `F` is real only for `x ≥ 1`) is indistinguishable here from a `RootSum` and
+  is still returned. Closing that needs the registry to separate "outside my
+  domain" from "not implemented".
+
 - **An antiderivative that is *undefined* on a whole component where the
   integrand is finite passed the verification gate.** The gate's numeric grid
   skipped every sample where either side came back non-finite, so a domain hole

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -3433,6 +3433,28 @@ const HOLE_MIN_RUN: usize = 2;
 /// correctly declines to reject.  The registry-backed interpreter used here
 /// does implement them.
 ///
+/// # These answers are not *wrong*, and the refusal is still right
+///
+/// Stated precisely, because the distinction matters: on the principal complex
+/// branch every one of those differences is numerically correct — the `±iπ`
+/// each endpoint picks up crossing the cut cancels, and the `1/(1 + tan x)`
+/// case comes to `0.6769275912524469`, matching quadrature to 25 digits.  They
+/// are right values in a form [`crate::eval::eval_f64`] rejects, not wrong
+/// values.  Two reasons that is still a refusal:
+///
+/// * The agreement is **unverified luck of the branch**.  It holds because
+///   both endpoints land on the same side of every cut crossed between them.
+///   Nothing establishes that; an odd number of crossings would leave a wrong
+///   real part and no guard here or downstream would notice.  A `Solved`
+///   verdict has to mean the FTC's hypotheses were checked, and `F` not being
+///   real-valued on `[a, b]` is those hypotheses failing.
+/// * The value is unusable as returned — a caller asking for a number gets
+///   `E-EVAL-009` out of a call that reported success.  A coded refusal naming
+///   the reason is strictly more information.
+///
+/// Recovering them needs the real branch (`log|·|` rather than `log`, `acoth`
+/// rather than `atanh` outside `(−1, 1)`), not a laxer gate.
+///
 /// # The three classifications, and why they are not symmetric
 ///
 /// | integrand | `F` | verdict |
@@ -3456,12 +3478,17 @@ const HOLE_MIN_RUN: usize = 2;
 /// A sample where the interpreter returns *no value at all* (`RootSum`, an
 /// unregistered head) is a property of the expression, not of the point, so it
 /// is no information — the same call PR #344 made.  That leaves one known gap:
-/// `PrimitiveRegistry::numeric_f64` answers `None`, not `NaN`, for an
-/// out-of-domain `EllipticF`, so a branch-limited elliptic answer evaluated off
-/// its branch (`∫_{-0.9}^{-0.1} dx/√(x³−x)`, whose `F` is real only for
-/// `x ≥ 1`) is indistinguishable here from a `RootSum` and is still returned.
-/// Closing it needs the registry to separate "outside my domain" from "not
-/// implemented", not a change to this rule.
+/// [`crate::primitive::PrimitiveRegistry::numeric_f64`] answers `None`, not
+/// `NaN`, for an out-of-domain `EllipticF`, so a branch-limited elliptic answer
+/// evaluated off its branch (`∫_{-0.9}^{-0.1} dx/√(x³−x)`, whose `F` is real
+/// only for `x ≥ 1`) is indistinguishable here from a `RootSum` and is still
+/// returned.  Leaving it is the right call rather than a compromise: those
+/// answers are correct on the complex continuation (`1.5300082013845898`
+/// against quadrature's `1.5300082013845897`), so a rule that refused on
+/// *unevaluable* would be discarding right answers on the strength of an
+/// evaluator limitation.  Making them usable is a registry question — "outside
+/// my domain" versus "not implemented" — plus a real-valued reduction, not a
+/// change to this rule.
 fn antiderivative_domain_hole(
     f: ExprId,
     integrand: ExprId,

--- a/alkahest-core/src/integrate/engine.rs
+++ b/alkahest-core/src/integrate/engine.rs
@@ -3247,8 +3247,19 @@ const JUMP_REFINEMENTS: usize = 50;
 /// continuous, `|ΔF|` shrinks with the cell, and the ratio stays bounded.
 const JUMP_CONFIRM_RATIO: f64 = 1e6;
 
-/// Detect a jump discontinuity of the antiderivative `f` strictly inside
-/// `(lower, upper)`, which makes `F(b) − F(a)` not the value of the integral.
+/// Detect a *discontinuity* of the antiderivative `F` on `[lower, upper]`,
+/// which makes `F(b) − F(a)` not the value of the integral.
+///
+/// Two shapes are looked for, because `F` can fail to be continuous on the
+/// interval in two different ways and only one of them is a jump:
+///
+/// 1. **A hole** — `F` is not defined at all across a sub-interval on which
+///    the integrand is an ordinary finite real.  [`antiderivative_domain_hole`]
+///    goes first, because a hole makes every ratio below undecidable and so
+///    silences the scan that would otherwise have to answer.
+/// 2. **A jump** — `F` is finite either side of a point, and the increment
+///    across a shrinking bracket does not shrink with it.  This is the ratio
+///    scan below.
 ///
 /// This is the failure the other two guards structurally cannot see: they look
 /// at the *integrand*, and here the integrand is perfectly well behaved.
@@ -3284,6 +3295,13 @@ fn antiderivative_jump(
     let width = hi - lo;
     if !(width > 0.0) || !width.is_finite() {
         return None;
+    }
+
+    // Shape 1 first: an `F` that is not defined across part of the interval
+    // makes every ratio below undecidable, which is exactly how this class used
+    // to escape.
+    if let Some(reason) = antiderivative_domain_hole(f, integrand, var, lo, hi, pool) {
+        return Some(reason);
     }
 
     let at = |e: ExprId, t: f64| -> Option<f64> {
@@ -3370,6 +3388,130 @@ fn antiderivative_jump(
             best,
         )
     })
+}
+
+/// Consecutive hole samples needed before a hole is declared.
+///
+/// Two adjacent points of the [`JUMP_SCAN_CELLS`] grid, plus the midpoint
+/// between them, bracket a whole cell — `width / 257` of the interval, a set of
+/// positive measure — rather than one isolated point.  The distinction matters:
+/// an `F` written with a *removable* singularity (`x²·g(x)/x`) is non-finite at
+/// exactly one point and is still a perfectly good antiderivative, so a
+/// single-sample rule would refuse correct answers.
+const HOLE_MIN_RUN: usize = 2;
+
+/// Detect a **domain hole** of the antiderivative `F` inside `[lo, hi]`: a
+/// sub-interval on which `F` is undefined while the integrand is an ordinary
+/// finite real.
+///
+/// # Why this is a refusal and not a skip
+///
+/// The FTC needs `F` continuous on `[a, b]` and differentiable inside it.  If
+/// `F` is not even *defined* across a sub-interval where `f` is finite, then
+/// `F` is not that function, and `F(b) − F(a)` is not the integral — whatever
+/// the two endpoint values happen to come out as.  The scan in
+/// [`antiderivative_jump`] structurally cannot see this: every one of its cells
+/// needs `F` at both ends to form a ratio, so a hole makes each cell
+/// *undecidable* and the whole scan silent.  That silence used to be read as
+/// "no evidence against the candidate" and the difference was returned anyway.
+///
+/// It is the definite-integral sibling of the indefinite-path rule PR #344 put
+/// into [`classify_sample`], and it is what that rule cannot reach: the
+/// indefinite gate samples a fixed grid on the whole real line and asks about
+/// `F′`, while the question here is about `F` itself on the caller's interval.
+/// Measured, this class is large and every member of it returned `Solved`:
+/// `∫_{0.1}^{1.4} dx/(1 + tan x)` came back as
+/// `½·log(tan²(x/2) − 2·tan(x/2) − 1) − …`, whose logarithm is `log` of a
+/// negative number for every `x` in `(−π/4, 3π/4)` — the answer is undefined
+/// across the entire interval of integration, while the integrand runs
+/// smoothly from `0.909` down to `0.147` and the value is `0.677`.
+/// `∫_{-3}^{-2} dx/(x⁴−1)`, `∫_{-1/2}^{1/2} atanh(x) dx`,
+/// `∫_{1/5}^{4/5} asin(x)/x² dx` and `∫_{-4}^{-2} dx/(1+x³)` are the same
+/// shape.  The last endpoint gate, [`non_real_closed_form`], does not catch
+/// them: it asks [`crate::eval::eval_f64`], which does not implement `tan`,
+/// `atan`, `asin`, `atanh` or `EllipticF`, so it reports "cannot decide" and
+/// correctly declines to reject.  The registry-backed interpreter used here
+/// does implement them.
+///
+/// # The three classifications, and why they are not symmetric
+///
+/// | integrand | `F` | verdict |
+/// |---|---|---|
+/// | finite | finite | fine |
+/// | finite | non-finite | **hole** — evidence, refuse |
+/// | non-finite | either | no information |
+///
+/// The last row keeps genuine improper integrals working.  `∫_0^1 log x dx` has
+/// an integrand that is `−∞` at `0` and an `F = x·log x − x` that is `NaN`
+/// there; `∫_0^1 x^{-1/2} dx` has an integrand that blows up at `0`.  Neither
+/// is this defect, and both must stay with whatever machinery handles them
+/// today, so a point outside the *integrand's* domain is never held against
+/// `F`.  Symmetrically, this is why the rule is stated on `F` and the integrand
+/// rather than on `F′`: #344's asymmetry — `F′` is routinely defined on a
+/// strictly larger set than `f` — is about the derivative and does not arise
+/// here.
+///
+/// # What it deliberately does not decide
+///
+/// A sample where the interpreter returns *no value at all* (`RootSum`, an
+/// unregistered head) is a property of the expression, not of the point, so it
+/// is no information — the same call PR #344 made.  That leaves one known gap:
+/// `PrimitiveRegistry::numeric_f64` answers `None`, not `NaN`, for an
+/// out-of-domain `EllipticF`, so a branch-limited elliptic answer evaluated off
+/// its branch (`∫_{-0.9}^{-0.1} dx/√(x³−x)`, whose `F` is real only for
+/// `x ≥ 1`) is indistinguishable here from a `RootSum` and is still returned.
+/// Closing it needs the registry to separate "outside my domain" from "not
+/// implemented", not a change to this rule.
+fn antiderivative_domain_hole(
+    f: ExprId,
+    integrand: ExprId,
+    var: ExprId,
+    lo: f64,
+    hi: f64,
+    pool: &ExprPool,
+) -> Option<String> {
+    use crate::jit::InterpEvalError;
+
+    // `true` when the integrand is an ordinary finite real at `t` and `F` is
+    // *defined but not finite* there — the middle row of the table above.
+    let is_hole = |t: f64| -> bool {
+        let mut bindings = HashMap::new();
+        bindings.insert(var, t);
+        if crate::jit::eval_interp_checked(integrand, &bindings, pool).is_err() {
+            return false; // outside the integrand's domain: no claim to check
+        }
+        matches!(
+            crate::jit::eval_interp_checked(f, &bindings, pool),
+            Err(InterpEvalError::NonFinite)
+        )
+    };
+
+    let point = |i: usize| lo + (hi - lo) * (i as f64) / (JUMP_SCAN_CELLS as f64);
+    let mut run = 0_usize;
+    for i in 0..=JUMP_SCAN_CELLS {
+        if !is_hole(point(i)) {
+            run = 0;
+            continue;
+        }
+        run += 1;
+        // Confirm the cell just closed is a hole *throughout*, not two
+        // coincident isolated points.
+        if run >= HOLE_MIN_RUN && is_hole(0.5 * (point(i - 1) + point(i))) {
+            return Some(format!(
+                "improper application of the fundamental theorem: the antiderivative {} is \
+                 undefined across [{}, {}] ⊆ [{}, {}], where the integrand {} is an ordinary \
+                 finite real. F is therefore not continuous on the interval of integration, \
+                 and F(b) - F(a) is not the value of this integral",
+                pool.display(f),
+                point(i - 1),
+                point(i),
+                lo,
+                hi,
+                pool.display(integrand),
+            ));
+        }
+    }
+    None
 }
 
 /// Split `expr` into `(numerator, denominator)` by collecting factors carrying a
@@ -5712,6 +5854,112 @@ mod tests {
         // ∫_2^3 dx/(x²−1) = ½·ln((x−1)/(x+1)) |_2^3 = ½·(ln(1/2) − ln(1/3)).
         let expected = 0.5 * ((1.0_f64 / 2.0).ln() - (1.0_f64 / 3.0).ln());
         assert_num(r.value, expected, &pool);
+    }
+
+    // ── The antiderivative's *domain* over the interval ──────────────────────
+    //
+    // `antiderivative_domain_hole`. Three tests: the defect, the control that
+    // keeps genuine improper integrals working, and the control that keeps a
+    // removable singularity from being mistaken for a hole.
+
+    /// The defect. `∫_{-1/2}^{1/2} atanh(x) dx` was answered
+    /// `x·atanh x + ½·log(x²−1)`, whose logarithm is `log` of a negative number
+    /// for every `|x| < 1` — i.e. on the whole interval of integration, and
+    /// exactly where `atanh` is defined. The FTC difference is not a real
+    /// number, and the definite path returned it as a solved value: the jump
+    /// scan needs `F` at both ends of a cell to form its ratio, so a hole makes
+    /// every cell undecidable and the scan silent.
+    ///
+    /// The correct branch is `x·atanh x + ½·log(1−x²)`; recovering the answer
+    /// needs that, not a wider search.
+    #[test]
+    fn definite_domain_hole_across_the_whole_interval_is_refused() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.func("atanh", vec![x]);
+        let (lo, hi) = (pool.rational(-1_i32, 2_i32), pool.rational(1_i32, 2_i32));
+
+        // The premise: at x = 0 the integrand is finite and the emitted `F`
+        // is not.
+        let anti = integrate(f, x, &pool).expect("atanh integrates").value;
+        let mut env = HashMap::new();
+        env.insert(x, 0.0_f64);
+        assert!(
+            crate::jit::eval_interp(f, &env, &pool).is_some_and(|v| v.is_finite()),
+            "premise: the integrand must be finite at x = 0"
+        );
+        assert!(
+            crate::jit::eval_interp(anti, &env, &pool).map_or(true, |v| !v.is_finite()),
+            "premise: the antiderivative must be undefined at x = 0, got {}",
+            pool.display(anti)
+        );
+
+        match integrate_definite(f, x, lo, hi, &pool) {
+            Err(IntegrationError::NotImplemented(msg)) => assert!(
+                msg.contains("undefined across"),
+                "expected a domain-hole diagnostic, got: {msg}"
+            ),
+            Err(other) => panic!("expected NotImplemented, got {other:?}"),
+            Ok(v) => panic!("expected a refusal, got {}", pool.display(v.value)),
+        }
+    }
+
+    /// The control that matters most: a **genuine improper integral** has an
+    /// integrand that is itself non-finite at an endpoint, and must keep going
+    /// through whatever machinery handles it today. `∫_0^1 x^{-1/2} dx = 2`
+    /// converges; its integrand blows up at `0` and its `F = 2√x` does not, so
+    /// the hole rule must have no opinion about it.
+    #[test]
+    fn definite_endpoint_singularity_of_the_integrand_is_not_a_hole() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let f = pool.pow(x, pool.rational(-1_i32, 2_i32));
+        let r = integrate_definite(f, x, pool.integer(0_i32), pool.integer(1_i32), &pool)
+            .expect("a convergent improper integral must not be refused as a domain hole");
+        assert_num(r.value, 2.0, &pool);
+    }
+
+    /// A candidate written with a **removable** singularity is non-finite at
+    /// one isolated point and is still a perfectly good antiderivative, so a
+    /// single non-finite sample must not refuse it — hence `HOLE_MIN_RUN`.
+    ///
+    /// `F = x·(x−c)/(x−c)` with `c` placed exactly on grid point 1 of
+    /// `[0, 1]`: `0/0` is `NaN` there and `x` everywhere else. Asserted against
+    /// the helper directly, because `simplify` would cancel the factor before
+    /// `integrate_definite` ever saw it — the point is the rule, not this
+    /// spelling of it.
+    #[test]
+    fn definite_removable_singularity_of_the_antiderivative_is_not_a_hole() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Real);
+        let c = pool.rational(1_i32, JUMP_SCAN_CELLS as i32);
+        let shifted = pool.add(vec![x, pool.mul(vec![pool.integer(-1_i32), c])]);
+        let holed = pool.mul(vec![x, shifted, pool.pow(shifted, pool.integer(-1_i32))]);
+        let integrand = pool.integer(1_i32);
+
+        // The premise: exactly one grid point is non-finite.
+        let non_finite = (0..=JUMP_SCAN_CELLS)
+            .filter(|i| {
+                let mut env = HashMap::new();
+                env.insert(x, (*i as f64) / (JUMP_SCAN_CELLS as f64));
+                crate::jit::eval_interp(holed, &env, &pool).map_or(true, |v| !v.is_finite())
+            })
+            .count();
+        assert_eq!(non_finite, 1, "premise: exactly one grid sample is NaN");
+
+        assert!(
+            antiderivative_domain_hole(holed, integrand, x, 0.0, 1.0, &pool).is_none(),
+            "one isolated non-finite point is a removable singularity, not a hole"
+        );
+
+        // …and widening it to a whole cell *is* a hole: `√(c − x)` is undefined
+        // on all of `(c, 1]`, where the integrand is an ordinary finite real.
+        let flipped = pool.add(vec![c, pool.mul(vec![pool.integer(-1_i32), x])]);
+        let genuine = pool.func("sqrt", vec![flipped]);
+        assert!(
+            antiderivative_domain_hole(genuine, integrand, x, 0.0, 1.0, &pool).is_some(),
+            "a hole spanning a positive-measure sub-interval must be refused"
+        );
     }
 
     #[test]

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -3198,6 +3198,84 @@ CASES: list[Case] = [
             "refuse intervals that cross π, not the whole (a + b·cos x) family."
         ),
     ),
+    # ── the antiderivative's *domain* over the interval ─────────────────────
+    #
+    # The sibling of the two Weierstrass cases above.  There the antiderivative
+    # is defined on the interval and *jumps*; here it is not defined on the
+    # interval at all, because the branch alkahest emitted is real only
+    # elsewhere.  Both make `F(b) − F(a)` not the integral, but only the first
+    # is visible to a scan that needs `F` at both ends of a cell to form a
+    # ratio — a hole makes every cell undecidable and the scan silent.  Each of
+    # these was answered `Solved`, with a value containing a `log` of a
+    # negative number or an `asin` outside [−1, 1].
+    Case(
+        id="int_domain_hole_atanh_symmetric",
+        subsystem="integration_definite",
+        statement="∫_{-1/2}^{1/2} atanh(x) dx = 0, and its antiderivative is not real there",
+        op=definite(ak.atanh(X), _rat(-1, 2), _rat(1, 2)),
+        contract=RefusesOr(0.0),
+        verified_by=(
+            "atanh is odd and continuous on (-1, 1), so the integral over a symmetric interval "
+            "is 0 by antisymmetry. alkahest's antiderivative is x·atanh(x) + ½·log(x² - 1), "
+            "whose logarithm is log of a negative number for every |x| < 1 — i.e. on the whole "
+            "interval, and exactly where the integrand is defined. The real branch is "
+            "x·atanh(x) + ½·log(1 - x²); recovering the value needs that, not a wider search."
+        ),
+    ),
+    Case(
+        id="int_domain_hole_quartic_below_its_poles",
+        subsystem="integration_definite",
+        statement="∫_{-3}^{-2} dx/(x⁴-1) = 0.030418: bounded integrand, non-real antiderivative",
+        op=definite(1 / (X**4 - _int(1)), _int(-3), _int(-2)),
+        contract=RefusesOr(0.030417749724959134),
+        verified_by=(
+            "1/(x⁴-1) is continuous on [-3, -2] (its poles are at ±1), so the integral is an "
+            "ordinary number; value from ¼·log|(x-1)/(x+1)| - ½·atan(x) evaluated at the two "
+            "endpoints. alkahest emits -¼·log(x+1) + ¼·log(x-1) - ½·atan(x), and both "
+            "logarithms are of negative numbers below -1. The endpoint gate cannot catch it: "
+            "it asks eval_f64, which does not implement atan and so reports 'cannot decide'."
+        ),
+    ),
+    Case(
+        id="int_domain_hole_cubic_below_its_pole",
+        subsystem="integration_definite",
+        statement="∫_{-4}^{-2} dx/(1+x³) = -0.100340: bounded integrand, non-real antiderivative",
+        op=definite(1 / (_int(1) + X**3), _int(-4), _int(-2)),
+        contract=RefusesOr(-0.10034029061616050),
+        verified_by=(
+            "1/(1+x³) has its only real pole at x = -1, outside [-4, -2], so the integrand is "
+            "continuous and bounded there; value from mpmath.quad at dps=30, anchored by the "
+            "real closed form ⅓·log|x+1| - ⅙·log(x²-x+1) + atan((2x-1)/√3)/√3. alkahest emits "
+            "the same formula with log(x+1) rather than log|x+1|, which is not real for x < -1."
+        ),
+    ),
+    Case(
+        id="int_control_improper_but_convergent_endpoint",
+        subsystem="integration_definite",
+        statement="∫_0^1 x^{-1/2} dx = 2 — the integrand blows up at an endpoint and it converges",
+        op=definite(_int(1) / ak.sqrt(X), _int(0), _int(1)),
+        contract=Returns(2.0, tol=1e-12),
+        verified_by=(
+            "∫x^{-1/2} = 2√x, continuous on [0, 1]; the improper integral converges to 2. The "
+            "control for the three domain-hole cases: a *genuine* improper integral has a "
+            "non-finite integrand and a perfectly good antiderivative, and must not be swept "
+            "into the same refusal."
+        ),
+    ),
+    Case(
+        id="int_control_same_antiderivative_where_it_is_real",
+        subsystem="integration_definite",
+        statement="∫_2^3 dx/(x²-1) = ½·log(3/2) — the refused formula, on an interval it holds on",
+        op=definite(1 / (X**2 - _int(1)), _int(2), _int(3)),
+        contract=Returns(0.5 * math.log(1.5), tol=1e-12),
+        verified_by=(
+            "½·log((x-1)/(x+1)) is an antiderivative; at 3 it is ½·log(1/2), at 2 it is "
+            "½·log(1/3), so the value is ½·log(3/2), and the poles at ±1 are outside [2, 3]. "
+            "This is the same ½·log(x-1) - ½·log(x+1) that int_domain_hole_* refuses below -1, "
+            "evaluated where both logarithms are real: the rule has to be about the interval, "
+            "not about the shape of the formula."
+        ),
+    ),
     # ── root isolation ──────────────────────────────────────────────────────
     #
     # `real_roots` is load-bearing under `decide`, `solve` and the integrator's

--- a/tests/test_definite_integral.py
+++ b/tests/test_definite_integral.py
@@ -140,3 +140,75 @@ def test_one_bound_raises():
     x = pool.symbol("x")
     with pytest.raises(ValueError):
         integrate(x**2, x, 0)
+
+
+# ---------------------------------------------------------------------------
+# The antiderivative's domain over the interval of integration
+#
+# The FTC needs F continuous on [a, b].  A candidate that is *undefined* across
+# a sub-interval where the integrand is an ordinary finite real is not that
+# function, and F(b) − F(a) is not the integral — whatever the two endpoint
+# values happen to come out as.  Each of these used to be answered `Solved`
+# with a value the evaluator itself rejects (a `log` of a negative number, or
+# an `asin` outside [−1, 1]); the jump scan could not see it, because forming
+# its ratio needs F at both ends of a cell and a hole makes every cell
+# undecidable.
+# ---------------------------------------------------------------------------
+
+
+def _refusal_code(exc):
+    return getattr(exc, "code", "") or str(exc)
+
+
+@pytest.mark.parametrize(
+    ("build", "lo", "hi", "what"),
+    [
+        # F = x·atanh x + ½·log(x²−1): the log is of a negative number for
+        # every |x| < 1, i.e. exactly where atanh is defined.  True value 0.
+        (lambda x: alkahest.atanh(x), -0.5, 0.5, "atanh over a symmetric interval"),
+        # F = −¼log(x+1) + ¼log(x−1) − ½atan(x): both logs are negative below
+        # −1, where 1/(x⁴−1) is finite.  True value 0.03042.
+        (lambda x: 1 / (x**4 - 1), -3, -2, "1/(x^4-1) below its poles"),
+        # F = ⅓log(x+1) − ⅙log(x²−x+1) + …: the first log is negative below
+        # −1, where 1/(1+x³) is finite.  True value −0.10034.
+        (lambda x: 1 / (1 + x**3), -4, -2, "1/(1+x^3) below its pole"),
+    ],
+)
+def test_definite_refuses_an_antiderivative_undefined_on_the_interval(build, lo, hi, what):
+    pool = ExprPool()
+    x = pool.symbol("x")
+    with pytest.raises(Exception) as exc:
+        integrate(build(x), x, lo, hi)
+    assert "E-INT-001" in _refusal_code(exc.value), f"{what}: {exc.value}"
+
+
+def test_definite_hole_refusal_names_the_reason():
+    # The diagnostic has to say which of the guards fired, or a caller cannot
+    # tell "your integrand has a pole" from "our answer has the wrong branch".
+    pool = ExprPool()
+    x = pool.symbol("x")
+    with pytest.raises(Exception) as exc:
+        integrate(alkahest.atanh(x), x, -0.5, 0.5)
+    assert "undefined across" in str(exc.value), str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("build", "lo", "hi", "expected"),
+    [
+        # A genuine improper integral: the *integrand* blows up at an endpoint
+        # and the antiderivative does not.  Must keep working.
+        (lambda x: x ** (-0.5), 0, 1, 2.0),
+        (lambda x: 1 / alkahest.sqrt(x), 0, 1, 2.0),
+        # F = ½log(x−1) − ½log(x+1) is perfectly defined on [2, 3]: the same
+        # antiderivative shape as the refused case above, on an interval where
+        # it holds.  The rule must be about the interval, not the formula.
+        (lambda x: 1 / (x**2 - 1), 2, 3, 0.5 * (math.log(0.5) - math.log(1 / 3))),
+        # A bounded integrand whose antiderivative is defined throughout.
+        (lambda x: 1 / (2 + alkahest.cos(x)), 0, 3, 1.6726765368776789),
+    ],
+)
+def test_definite_domain_rule_leaves_correct_answers_alone(build, lo, hi, expected):
+    pool = ExprPool()
+    x = pool.symbol("x")
+    r = integrate(build(x), x, lo, hi)
+    assert abs(_value(r) - expected) < 1e-9

--- a/tests/test_definite_integral.py
+++ b/tests/test_definite_integral.py
@@ -197,8 +197,8 @@ def test_definite_hole_refusal_names_the_reason():
     [
         # A genuine improper integral: the *integrand* blows up at an endpoint
         # and the antiderivative does not.  Must keep working.
-        (lambda x: x ** (-0.5), 0, 1, 2.0),
         (lambda x: 1 / alkahest.sqrt(x), 0, 1, 2.0),
+        (lambda x: alkahest.sqrt(x), 0, 4, 16.0 / 3.0),
         # F = ½log(x−1) − ½log(x+1) is perfectly defined on [2, 3]: the same
         # antiderivative shape as the refused case above, on an interval where
         # it holds.  The rule must be about the interval, not the formula.


### PR DESCRIPTION
> **Stacked on #344 (`fix/gate-nonfinite`)** — that branch fixes this defect for the indefinite path; this does the definite one. Merge #344 first.

## No wrong number exists here, and that is the finding

I went looking for a definite integral returning a wrong *value* through a domain hole. **There is none, before or after** — and the reason is structural, not luck.

For `f` finite on `[a,b]`, a hole in `F` is always bounded by a zero of a log argument or a root of a radicand — which is exactly a pole or branch point of the *integrand*, and those are already refused by the two pole guards. So any interval meeting a hole has its **endpoints inside the hole too**, and `F(b) − F(a)` comes out non-real rather than wrongly finite.

This was hunted deliberately: a 66-integrand Rust scan over `[−8, 8]` for "interior hole with finite endpoints", targeted Weierstrass intervals crossing π, exact-rational bounds so constant folding could collapse the cancelling logs, and `sqrt(x²)`/cube-root artefacts. Every candidate hit that wall.

## What is actually wrong

A class of 22 in a 152-case corpus where `integrate(f, x, a, b)` returns **`Solved` with a value that is not a real number** — the library's own `eval_expr` rejects it with `E-EVAL-009`.

Checked on the principal complex branch, **all 22 are numerically correct**: `∫_{0.1}^{1.4} dx/(1+tan x)` → `0.6769275912524469`, matching mpmath to 25 digits. The `±iπ` each endpoint picks up crossing the cut cancels in the difference. **These are right values in an unusable form, not wrong ones.**

Reproducer: `∫_{0.1}^{1.4} dx/(1 + tan x)` answers `½·log(tan²(x/2) − 2·tan(x/2) − 1) − ½·log(tan²(x/2)+1) + atan(tan(x/2))`, whose first logarithm takes a negative argument for every `x ∈ (−π/4, 3π/4)` — undefined across the *entire* interval, while the integrand runs smoothly from 0.909 to 0.147. Also `∫_{-3}^{-2} dx/(x⁴−1)`, `∫_{-4}^{-2} dx/(1+x³)`, `∫_{-1/2}^{1/2} atanh x`, `∫_{1/5}^{4/5} asin(x)/x²`.

Two gates had to fail together. `antiderivative_jump` needs `F` at *both ends of a cell* to form its ratio, so a hole makes every cell undecidable and the scan goes silent. And `non_real_closed_form`, the last endpoint gate, asks `eval::eval_f64`, which implements neither `tan`, `atan`, `asin`, `atanh` nor `EllipticF` — so it honestly reports "cannot decide" and declines to reject.

## The fix

A repair, not a new concern: the jump analysis already exists to detect a discontinuity of `F` on `[a,b]`, but its ratio test cannot express *"F is not defined here"*. `antiderivative_domain_hole` is a sibling rule in the same function, running first, on the same grid.

Integrand finite + `F` non-finite → refuse. Integrand non-finite → no information, which is what keeps `∫_0^1 log x` and `∫_0^1 x^{-1/2}` working. Interpreter returns *nothing* → no information, matching #344. One sample is not enough — a removable singularity is `NaN` at a point and still a good antiderivative — so a hole must span a full cell and be confirmed at its midpoint.

## Measured

| 152-case definite corpus | before | after |
|---|---|---|
| correct values | 62 | 62 |
| refusals | 68 | 87 |
| non-real "solved" values | 22 | 3 |
| **wrong numbers** | **0** | **0** |

19 cases move, every one `NONREAL → E-INT-001`. **No correct real-valued answer is lost.** No new `E-INT-004` — the rule can only emit `NotImplemented`. Latency 187–195 ms either side, inside the noise.

**This is a contract change, and worth naming as one:** those 19 were correct on the complex continuation. A caller willing to work on that branch loses access to them. The judgement is that `Solved` carrying a value the library's own evaluator rejects is a worse contract than an honest refusal — but the right destination is a real-valued form, not a decline. See the residual gap below.

Suites: integration subset (763 tests incl. `textbook_gate` and `silent_errors`) 759 pass / 4 fail before — my new tests, by design — and **763 pass** after. `pytest tests/` 3680 passed, 76 skipped. `cargo test --workspace` 2651 lib + 12 binaries, 0 failed. clippy `-D warnings` across default/groebner/egraph, `cargo fmt --check`, `ruff==0.15.14` format and check, `gen_certificate_ledger.py --check` — all clean. Two builds snapshotted into separate trees selected by `PYTHONPATH`, distinct md5s confirmed, sympy in both.

## The corpus that should have caught this

A definite corpus **did** exist — 36 `integration_definite` cases in `tests/silent_errors/corpus.py` — and it scored 0 silent errors / 30 ok / 11 refusal, *identically* before and after.

That is the finding: the gate's `refusal_or_value` counts "a returned expression that cannot be reduced to a number" as an **honest refusal**, so this entire class was invisible to it by construction. Five cases added — three holes as `RefusesOr(true_value)`, two controls.

## Residual gap, deliberately left

Three elliptic cases stay non-real (`∫_{-0.9}^{-0.1} dx/√(x³−x)` and relatives). `numeric_f64` answers `None`, not `NaN`, for out-of-domain `EllipticF`, so they are indistinguishable from a `RootSum`. All three are **correct on the complex continuation**, so a rule treating *unevaluable* as evidence would discard right answers on the strength of an evaluator limitation. Closing it is a registry question — "outside my domain" versus "not implemented" — plus a real-valued reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Definite integrals are now refused when their antiderivative is undefined across an interval within the bounds.
  * Valid improper integrals, removable singularities, and intervals with defined antiderivatives continue to return correct results.
  * Refusal messages now clearly identify the undefined-domain condition.

* **Tests**
  * Added regression coverage for domain holes and controls confirming valid integrations remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->