### PR TITLE
fix(integrate,elliptic): narrow each reduction to the region it claims, and stop calling genus-1 curves genus ≥ 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,14 @@
   numeric grid and had the identical skip. `risch::exp_algebraic`'s local check
   now follows the rule too. `algebraic::genus_zero` was left alone: it already
   refuses on *any* non-finite sample, stricter than this rule rather than laxer.
-  The third, `integrate::gate::verify`, was changed and the change **reverted**,
-  because its callers rely on the skip on purpose: the elliptic route samples
-  every `P > 0` interval while its reduction is valid on only one of them, so
-  for `∫dx/√(x³−x)` the integrand is finite on `(−1, 0)` where the candidate's
-  derivative is not, and the stricter rule refused four correct,
-  branch-limited elliptic answers. Adopting it there needs each reduction's
-  sample set narrowed to the region it claims, which is a larger change than
-  this one; the reason is recorded in that module's honest-limitations list so
-  the experiment is not repeated.
+  The third, `integrate::gate::verify`, was changed and the change **reverted
+  at first**, because its callers were sampling beyond the region their
+  reduction claims: the elliptic route put points in every `P > 0` interval
+  while its reduction is valid on only one of them, so for `∫dx/√(x³−x)` the
+  integrand is finite on `(−1, 0)` where the candidate's derivative is not, and
+  the stricter rule refused four correct, branch-limited elliptic answers. The
+  sample set was the defect, not the rule; the next entry narrows it and adopts
+  the rule there too.
 
   **Cost: Charlwood's Fifty goes 33 → 32, and #35 is the only problem that
   moves.** It was also the only one of the fifty whose answer had a domain
@@ -234,6 +233,88 @@
   `simplify_many` no longer reports one on the item; code branching on that
   refusal will now take the success path. Conversely, `ak.simplify(deep,
   assumptions=ctx)` now raises where it previously took the process out.
+
+- **The elliptic route's verification gate sampled a wider set than its answer
+  claimed, which is what blocked the rule above from being applied there.**
+  `elliptic_output`'s `gate_samples` put points in **every** interval where the
+  radicand `P` is positive, and said so in as many words — "points where the
+  substitution is invalid simply evaluate non-finite and are skipped". But a
+  Byrd–Friedman normal form is real on only one of those intervals. For
+  `∫dx/√(x³−x)`, `P > 0` on `(−1, 0) ∪ (1, ∞)` while the three-real-root
+  reduction `sin²φ = (e1−e3)/(x−e3)` needs `x ≥ e1 = 1`; on `(−1, 0)` the
+  integrand is an ordinary finite real and the candidate's derivative is `NaN`.
+  Under a gate that reads that as a disagreement — which is the reading the
+  entry above establishes — a **correct** answer declines.
+
+  Each reduction now returns the region it claims alongside its own constants,
+  so the two cannot drift apart, and the gate's sample grid, in-domain
+  predicate and enclosure boxes are all built from it:
+
+  | root configuration | region claimed | `{P > 0}` |
+  |---|---|---|
+  | cubic, three real `e1>e2>e3` | `(e1, ∞)` | `(e3, e2) ∪ (e1, ∞)` |
+  | cubic, one real `y1` + pair | `(y1, ∞)` | `(y1, ∞)` |
+  | quartic, four real `a>b>c>d` | `(c, b)` | `(−∞, d) ∪ (c, b) ∪ (a, ∞)` |
+  | quartic, two real `b1>b2` + pair | `(b2, b1)` | `(b2, b1)`, negative lead |
+  | quartic, no real root | `ℝ` minus the `arctan` substitution's pole | `ℝ` |
+
+  Each region is derived from where the substitution is real (`sin²φ ∈ [0,1]`,
+  `|cos φ| ≤ 1`), not from where the answer happens to agree — the difference
+  matters, because "wherever it verifies" would make the claim unfalsifiable.
+  `P > 0` is still checked pointwise and deliberately **not** folded into the
+  region: for the two-real-root quartic the two coincide only when the leading
+  coefficient is negative, and where they are disjoint the gate declines for
+  want of in-domain points rather than reporting anything.
+
+  The second/third-kind path additionally cuts the isolated points its own
+  fitted block set is *written* singular at — `log|x−t|` at a twin preimage,
+  `√P/(x−p)` at a reduction pole, `EllipticPi`'s spurious twin pole. Those
+  cancel in the sum, so the residual's limit there is finite, but the
+  expression as written evaluates `∞ − ∞`. `∫dx/((x−2)√(x³+1))` has one at
+  exactly `x = 0`, inside its claimed `(−1, ∞)`, and the old grid already
+  contained that point.
+
+  With the sample sets honest, `gate::verify` adopts the non-finite rule
+  unweakened. **The 13 Rust and 4 Python tests that the reverted experiment
+  broke pass because the points that used to come back `NaN` are no longer
+  sampled**, not because anything was loosened — two new gate tests pin both
+  directions of the rule so a future weakening shows up as a test change.
+
+  **Cost: none measured.** Charlwood's Fifty is 32/50 before and after with no
+  problem moving and all 32 verified; the 40-case probe is unchanged
+  (35 solved / 4 `E-INT-004` / 1 `E-INT-001`, identical answers); the 110-case
+  Liouville corpus is unchanged at 84 solved; and a 29-case sweep covering
+  every handled root configuration across first, second and third kind returns
+  byte-identical answers. **No `E-INT-004` appears anywhere it did not appear
+  before.** One thing improved: all four first-kind reductions now reach a
+  rigorous `EnclosureVerified` (was three), and the `∫dx/√(x⁴+1)` coverage gap
+  is now a stated exclusion around the substitution's pole rather than a
+  branch-and-bound budget failure.
+
+- **Three declines on genus-1 curves reported themselves as "genus ≥ 2".**
+  `integrate_b_sqrt_high_degree` is guarded by `deg P ≥ 3`, which for
+  squarefree `P` is genus `⌊(deg P − 1)/2⌋` — genus **1** for `deg P ∈ {3, 4}`,
+  and genus ≥ 2 only from `deg P = 5`. Its three "not decided" messages said
+  "genus ≥ 2" regardless.
+
+  That is not cosmetic. Charlwood **#19** (`y² = x³+1`), **#38** and **#39**
+  (`y² = x⁴+1`) are all genus 1 and all reported "genus ≥ 2", which sends a
+  reader to the research-level genus-≥2 Coates gap when the real answer is a
+  genus-1 miss in an area the gap register calls complete — and it had already
+  talked at least one reader out of working on these problems. The 2026-08-24
+  benchmark flagged the wording; the 2026-08-30 re-measurement found it still
+  there, with the cluster's membership changed underneath it (now #5, #38, #39).
+
+  The messages now report the genus they **computed**, through the existing
+  `find_order::genus` — the same function `find_order_placed` grades the
+  decision with, so the number in the message is the number the decision used.
+  Where `genus` declines (a non-squarefree `P`) the message says the genus was
+  not determined rather than naming one; replacing one guess with another would
+  be the same bug in a new coat. A genus-0/1 decline additionally says that it
+  is *not* the Coates gap and that the curve only reached this fallback because
+  the genus-0/1 routes upstream declined first. #38 and #39 now read
+  `logarithmic part with algebraic residues on y² = P, deg P = 4 squarefree ⇒
+  genus 1: …`.
 
 - **`simplify` could not cancel `¾·sin x − ¾·sin x`, and that cost the
   verification gate its strongest verdict.** `collect_add_terms` split each

--- a/alkahest-core/src/integrate/algebraic/elliptic_output.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic_output.rs
@@ -66,6 +66,104 @@ use crate::simplify::engine::simplify;
 /// A complex root, stored as `(re, im)`.
 pub(super) type Croot = (f64, f64);
 
+/// The real set on which a Byrd–Friedman reduction **claims** `d/dx F = f`.
+///
+/// This is deliberately *not* `{P > 0}`.  Each reduction below is a
+/// substitution `φ(x)` that is real on only part of `{P > 0}`: the
+/// three-real-root cubic needs `x` beyond the largest root, the four-real-root
+/// quartic needs `x` between the two middle roots, and so on.  `∫dx/√(x³−x)`
+/// is the standard illustration — `P > 0` on `(−1, 0) ∪ (1, ∞)`, the reduction
+/// holds only on `(1, ∞)`, and on `(−1, 0)` the integrand is an ordinary finite
+/// real while the candidate's derivative is `NaN`.
+///
+/// Sampling the whole of `{P > 0}` therefore asks the candidate about points it
+/// never claimed, and a gate that reads "candidate undefined where the
+/// integrand is finite" as a disagreement (which is the right reading — see
+/// [`crate::integrate::gate`]) refuses a correct answer.  So every reduction
+/// states its region here, and the gate's sample grid, its in-domain predicate
+/// and its enclosure boxes are all built from it.
+///
+/// The region is an **open** interval: the finite endpoints are roots of `P`,
+/// where `1/√P` is unbounded and there is nothing to compare.  `cuts` removes
+/// finitely many interior points, of which there are two kinds and both are
+/// facts about the *written* candidate, not about the mathematics:
+///
+/// * the pole of the `arctan` substitution's Möbius argument (the no-real-root
+///   quartic), where `φ` jumps by `π`; and
+/// * the poles the fitted higher-kind block set is written with — `log|x−t|`
+///   at a twin preimage, `√P/(x−p)` at a reduction pole, `EllipticPi`'s
+///   spurious twin pole.  Those cancel in the sum, so the residual's *limit*
+///   there is finite, but the expression as written evaluates `∞ − ∞`.
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Region {
+    lo: f64,
+    hi: f64,
+    cuts: Vec<f64>,
+}
+
+impl Region {
+    /// The open interval `(lo, hi)`; either endpoint may be infinite.
+    fn open(lo: f64, hi: f64) -> Self {
+        Region {
+            lo,
+            hi,
+            cuts: Vec::new(),
+        }
+    }
+
+    /// The whole real line.
+    fn all() -> Self {
+        Region::open(f64::NEG_INFINITY, f64::INFINITY)
+    }
+
+    /// Remove the interior points `xs` (see the type docs for what qualifies).
+    fn cut_all(mut self, xs: impl IntoIterator<Item = f64>) -> Self {
+        for x in xs {
+            if x.is_finite() && x > self.lo && x < self.hi && !self.cuts.contains(&x) {
+                self.cuts.push(x);
+            }
+        }
+        self.cuts
+            .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        self
+    }
+
+    /// Is `x` a point this reduction claims?
+    ///
+    /// A cut is a single real number, but `f64` cannot see it that way: the
+    /// blocks whose poles cancel there are `O(1/(x−c))`, so evaluating within
+    /// `~ε/tol` of `c` loses the cancellation to rounding.  With `ε ≈ 2.2e−16`
+    /// and the gate's `1e−7` tolerance that boundary sits near `1e−9`; the
+    /// `1e−6` used here is three decades clear of it and still far narrower
+    /// than any domain hole the gate exists to catch.
+    fn contains(&self, x: f64) -> bool {
+        x.is_finite()
+            && x > self.lo
+            && x < self.hi
+            && !self
+                .cuts
+                .iter()
+                .any(|&c| (x - c).abs() <= 1e-6 * (1.0 + c.abs()))
+    }
+
+    /// The claimed set as disjoint open intervals, clipped to `[−window,
+    /// window]`.  Sub-intervals narrower than `min_width` are dropped.
+    fn components(&self, window: f64, min_width: f64) -> Vec<(f64, f64)> {
+        let lo = self.lo.max(-window);
+        let hi = self.hi.min(window);
+        if hi <= lo || hi.is_nan() || lo.is_nan() {
+            return Vec::new();
+        }
+        let mut cuts: Vec<f64> = vec![lo];
+        cuts.extend(self.cuts.iter().copied().filter(|&c| c > lo && c < hi));
+        cuts.push(hi);
+        cuts.windows(2)
+            .map(|w| (w[0], w[1]))
+            .filter(|&(a, b)| b - a >= min_width)
+            .collect()
+    }
+}
+
 /// Try to emit a first-kind `EllipticF` closed form for `∫ (a + b·√P) dx` when
 /// the integrand reduces to the pure first-kind shape `c/√P` (`a = 0`,
 /// `b = c/P` with `c` a constant) and `P` is a gate-verifiable cubic/quartic.
@@ -124,7 +222,7 @@ pub fn try_elliptic_output_with(
         return None;
     }
 
-    let (g, m, phi) = first_kind_reduction(&coeffs, deg, lead, var, pool)?;
+    let (g, m, phi, region) = first_kind_reduction(&coeffs, deg, lead, var, pool)?;
 
     // F_cand = (c · g) · EllipticF(phi, m).
     let m_expr = float_to_expr(m, pool);
@@ -132,19 +230,29 @@ pub fn try_elliptic_output_with(
     let coeff = float_to_expr(c * g, pool);
     let f_cand = simplify(pool.mul(vec![coeff, f]), pool).value;
 
-    // Soundness gate: d/dx F_cand = c/√P on the region where P > 0.
-    if verify(f_cand, &coeffs, c, c_expr, p_expr, var, pool, gate_opts).is_verified() {
+    // Soundness gate: d/dx F_cand = c/√P on the region this reduction claims,
+    // intersected with `P > 0`.
+    if verify(
+        f_cand, &coeffs, c, c_expr, p_expr, var, region, pool, gate_opts,
+    )
+    .is_verified()
+    {
         Some(f_cand)
     } else {
         None
     }
 }
 
-/// Compute the shared first-kind Legendre reduction `(g, m, φ(x))` for `√P`,
-/// chosen so that `d/dx[g·EllipticF(φ,m)] = 1/√P` on the real region where
-/// `P > 0`.  This is the *same* substitution used by every higher-kind
-/// reduction (B&F: all of `∫R(x,√P)dx` reduce under one substitution), so the
-/// second/third-kind paths reuse it verbatim.
+/// Compute the shared first-kind Legendre reduction `(g, m, φ(x), R)` for
+/// `√P`, chosen so that `d/dx[g·EllipticF(φ,m)] = 1/√P` on the region `R`.
+/// This is the *same* substitution used by every higher-kind reduction (B&F:
+/// all of `∫R(x,√P)dx` reduce under one substitution), so the second/third-kind
+/// paths reuse it verbatim — region included.
+///
+/// `R` is **not** `{P > 0}`.  Each B&F normal form is real on one component of
+/// `{P > 0}` (or, for the four-real-root quartic, on the bounded middle one),
+/// and every caller must verify only there; see [`Region`].  Each case returns
+/// its own region next to its own constants, so the two cannot drift apart.
 ///
 /// Returns `None` for radicand shapes outside the handled cubic/quartic
 /// root-configurations (e.g. all-complex quartic).
@@ -154,7 +262,7 @@ fn first_kind_reduction(
     lead: f64,
     var: ExprId,
     pool: &ExprPool,
-) -> Option<(f64, f64, ExprId)> {
+) -> Option<(f64, f64, ExprId, Region)> {
     let roots = poly_roots(coeffs)?;
     let (mut reals, pairs) = classify_roots(&roots);
     reals.sort_by(|a, b| b.partial_cmp(a).unwrap()); // descending
@@ -320,8 +428,8 @@ pub fn try_elliptic_output_higher_kind_with(
         return None;
     }
 
-    // The shared first-kind substitution.
-    let (g, m, phi) = first_kind_reduction(&p_coeffs, deg, lead, var, pool)?;
+    // The shared first-kind substitution, and the region it claims.
+    let (g, m, phi, region) = first_kind_reduction(&p_coeffs, deg, lead, var, pool)?;
     if !(g.is_finite() && m.is_finite()) || m >= 1.0 {
         return None;
     }
@@ -374,6 +482,26 @@ pub fn try_elliptic_output_higher_kind_with(
     // Second-kind reduction poles (where the `EllipticE` block's `sin²φ(x)`
     // introduces non-`P` poles that the algebraic ansatz must cancel).
     let red_poles = reduction_poles(&p_coeffs, deg);
+
+    // Points at which some block below is *written* with a pole that the fitted
+    // combination cancels: `√P/(x−p)` and `√P/(x−p)²` at the reduction poles and
+    // at the roots of `P`, `log|x−t|` and `EllipticPi`'s spurious twin pole at a
+    // twin preimage.  The residual's limit at such a point is finite — that is
+    // the whole reason the block is in the ansatz — but the expression as
+    // written evaluates `∞ − ∞`, so `d/dx F` comes back non-finite where the
+    // integrand is an ordinary real.  Under the gate's rule that is a
+    // disagreement, and it would be a false one: the candidate does not claim
+    // these isolated points.  They are cut from the region, so the claim and
+    // the sample set stay the same set.
+    //
+    // The union over *all* recipes is cut, not just the winning one's, because
+    // one domain serves the whole `propose_fit_verify` search.  That is a few
+    // isolated points wider than strictly necessary; each is named and finite,
+    // and none of them is an interval, which is the thing the rule exists to
+    // catch.
+    let mut written_poles: Vec<f64> = Vec::new();
+    written_poles.extend(red_poles.iter().copied());
+    written_poles.extend(p_roots.iter().copied());
 
     // Helper to build `xʲ·√P` and `√P/(x−r)^k` blocks.
     let poly_block = |j: usize, pool: &ExprPool| -> ExprId {
@@ -503,6 +631,7 @@ pub fn try_elliptic_output_higher_kind_with(
             }
         })
         .collect();
+    written_poles.extend(pi_poles.iter().map(|&(p, _)| p));
     if !pi_poles.is_empty() {
         let build_pi = |s: &mut Vec<ExprId>, pool: &ExprPool| {
             for &(_p, np) in &pi_poles {
@@ -542,10 +671,14 @@ pub fn try_elliptic_output_higher_kind_with(
         //     of the Π derivative can be cancelled and the fit can close.  Two
         //     variants: minimal (ladder + F + Π + logs) for clean coefficients,
         //     and rich (also E) as a fallback.
-        let twin_logs: Vec<ExprId> = pi_poles
+        let twins: Vec<f64> = pi_poles
             .iter()
             .filter_map(|&(p, _)| twin_pole(p, phi, var, pool))
-            .flat_map(|t| elem_log_blocks(t, p_expr, sqrt_p, var, pool))
+            .collect();
+        written_poles.extend(twins.iter().copied());
+        let twin_logs: Vec<ExprId> = twins
+            .iter()
+            .flat_map(|&t| elem_log_blocks(t, p_expr, sqrt_p, var, pool))
             .collect();
         if !twin_logs.is_empty() {
             // 4c) minimal + twin logs.
@@ -571,8 +704,11 @@ pub fn try_elliptic_output_higher_kind_with(
         }
     }
 
-    // Sample grid (shared across recipes) where `P > 0` and away from b-poles.
-    let samples = sample_grid(&p_coeffs, &b_den_f);
+    let region = region.cut_all(written_poles);
+
+    // Sample grid (shared across recipes) inside the claimed region and away
+    // from b-poles.
+    let samples = sample_grid(&p_coeffs, &b_den_f, &region);
 
     // `b·√P` in `f64`, restricted to the in-domain points.  The *same* closure
     // drives the least-squares fit and the gate's `f64` screen, so the two can
@@ -586,7 +722,7 @@ pub fn try_elliptic_output_higher_kind_with(
         Some(bv * pv.sqrt())
     };
     let integrand = simplify(pool.mul(vec![b_part, sqrt_p]), pool).value;
-    let domain = elliptic_domain(&p_coeffs);
+    let domain = elliptic_domain(&p_coeffs, region);
     let target = gate::Target::symbolic(integrand).with_numeric(&rhs);
     let to_expr = |v: f64, p: &ExprPool| float_to_expr(v, p);
 
@@ -745,16 +881,23 @@ fn elem_log_blocks(
     blocks
 }
 
-/// Sample grid for the fit, biased to the `P > 0` region and away from poles.
-fn sample_grid(p_coeffs: &[f64], b_den: &[f64]) -> Vec<f64> {
+/// Sample grid for the least-squares *fit*, restricted to the region the
+/// reduction claims and kept away from the weight's poles.
+///
+/// The region filter does not change which rows the fit sees — every recipe
+/// contains an `EllipticF` block, whose derivative is `NaN` outside the region,
+/// so [`gate::fit_blocks`] already dropped those rows.  It is applied because
+/// the design matrix should be built from the set the answer is about, rather
+/// than from a wider set that happens to self-filter.
+fn sample_grid(p_coeffs: &[f64], b_den: &[f64], region: &Region) -> Vec<f64> {
     let mut xs = Vec::new();
     let mut x = -4.0_f64;
     while x <= 6.0 {
-        // Skip points too close to a denominator zero.
-        if eval_poly(b_den, x).abs() > 1e-3 {
+        // Skip points outside the claim, and points too close to a denominator
+        // zero.
+        if region.contains(x) && eval_poly(p_coeffs, x) > 1e-6 && eval_poly(b_den, x).abs() > 1e-3 {
             xs.push(x);
         }
-        let _ = p_coeffs;
         x += 0.137;
     }
     xs
@@ -764,15 +907,24 @@ fn sample_grid(p_coeffs: &[f64], b_den: &[f64]) -> Vec<f64> {
 // Reduction cases (Byrd & Friedman normal forms)
 // ---------------------------------------------------------------------------
 
-/// Cubic, three real roots `e1 > e2 > e3` (region `x ≥ e1`, where `P > 0` for a
-/// positive leading coefficient): `sin²φ = (e1−e3)/(x−e3)`,
+/// Cubic, three real roots `e1 > e2 > e3`: `sin²φ = (e1−e3)/(x−e3)`,
 /// `m = (e2−e3)/(e1−e3)`, `g = −2/√(e1−e3)`.
+///
+/// **Region `(e1, ∞)`.**  `sin²φ = (e1−e3)/(x−e3)` lies in `[0, 1]` exactly for
+/// `x ≥ e1`: below `e1` (but above `e3`) the ratio exceeds `1`, and below `e3`
+/// it is negative, so `asin(√·)` is not real either way.  For a positive
+/// leading coefficient `{P > 0}` is `(e3, e2) ∪ (e1, ∞)` — strictly wider — and
+/// `∫dx/√(x³−x)` on `(−1, 0)` is the case that makes the difference visible.
+/// The `P > 0` half of the claim is *not* assumed here: it is re-checked
+/// pointwise by [`elliptic_domain`]'s predicate, which is what makes a negative
+/// leading coefficient (where this region and `{P > 0}` are disjoint) decline
+/// rather than misreport.
 fn cubic_three_real(
     reals: &[f64],
     inv_sqrt_lead: f64,
     var: ExprId,
     pool: &ExprPool,
-) -> Option<(f64, f64, ExprId)> {
+) -> Option<(f64, f64, ExprId, Region)> {
     let (e1, e2, e3) = (reals[0], reals[1], reals[2]);
     let denom = e1 - e3;
     if denom <= 0.0 {
@@ -788,19 +940,26 @@ fn cubic_three_real(
     ]);
     let s = pool.func("sqrt", vec![ratio]);
     let phi = pool.func("asin", vec![s]);
-    Some((g, m, phi))
+    Some((g, m, phi, Region::open(e1, f64::INFINITY)))
 }
 
-/// Cubic, one real root `y1` and a complex pair `b1 ± i·a1` (region `x ≥ y1`):
+/// Cubic, one real root `y1` and a complex pair `b1 ± i·a1`:
 /// `A = √((y1−b1)² + a1²)`, `g = 1/√A`, `m = (A + (b1−y1))/(2A)`,
 /// `cos φ = (A − (x−y1))/(A + (x−y1))`.
+///
+/// **Region `(y1, ∞)`.**  With `u = x − y1 > 0` the quotient `(A−u)/(A+u)` runs
+/// over `(−1, 1)`; for `u < 0` it leaves `[−1, 1]` (and passes through a pole at
+/// `u = −A`), so `acos` is not real.  Here the region coincides with `{P > 0}`
+/// for a positive leading coefficient — the narrowing is a no-op for this
+/// case — and it is stated anyway so that every reduction makes the same kind
+/// of claim.
 fn cubic_one_real(
     y1: f64,
     pair: Croot,
     inv_sqrt_lead: f64,
     var: ExprId,
     pool: &ExprPool,
-) -> Option<(f64, f64, ExprId)> {
+) -> Option<(f64, f64, ExprId, Region)> {
     let (b1, a1) = pair;
     let aa = ((y1 - b1).powi(2) + a1 * a1).sqrt();
     if aa <= 0.0 {
@@ -817,18 +976,25 @@ fn cubic_one_real(
     let den = pool.add(vec![float_to_expr(aa, pool), x_minus_y1]);
     let cosphi = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
     let phi = pool.func("acos", vec![cosphi]);
-    Some((g, m, phi))
+    Some((g, m, phi, Region::open(y1, f64::INFINITY)))
 }
 
-/// Quartic, four real roots `a > b > c > d` (region `c ≤ x ≤ b`, where `P > 0`):
+/// Quartic, four real roots `a > b > c > d`:
 /// `sn²φ = (b−d)(x−c)/((b−c)(x−d))`, `m = (b−c)(a−d)/((a−c)(b−d))`,
 /// `g = 2/√((a−c)(b−d))`.
+///
+/// **Region `(c, b)`.**  Write `h(x) = K(x−c)/(x−d)` with `K = (b−d)/(b−c) > 1`.
+/// `h` is increasing on each side of its pole at `d`, `h(c) = 0` and `h(b) = 1`,
+/// so `h ∈ [0, 1]` exactly on `[c, b]`: above `b` it exceeds `1`, on `(d, c)` it
+/// is negative, and below `d` it exceeds `1` again.  For a positive leading
+/// coefficient `{P > 0}` is `(−∞, d) ∪ (c, b) ∪ (a, ∞)`, so this reduction
+/// claims one bounded component out of three.
 fn quartic_four_real(
     reals: &[f64],
     inv_sqrt_lead: f64,
     var: ExprId,
     pool: &ExprPool,
-) -> Option<(f64, f64, ExprId)> {
+) -> Option<(f64, f64, ExprId, Region)> {
     let (a, b, c, d) = (reals[0], reals[1], reals[2], reals[3]);
     let ac = a - c;
     let bd = b - d;
@@ -846,21 +1012,29 @@ fn quartic_four_real(
     let ratio = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
     let s = pool.func("sqrt", vec![ratio]);
     let phi = pool.func("asin", vec![s]);
-    Some((g, m, phi))
+    Some((g, m, phi, Region::open(c, b)))
 }
 
-/// Quartic, two real roots `b1 > b2` and a complex pair `b3 ± i·a3`
-/// (region `b2 ≤ x ≤ b1`, where `P > 0`):
+/// Quartic, two real roots `b1 > b2` and a complex pair `b3 ± i·a3`:
 /// `A1 = √((b1−b3)² + a3²)`, `A2 = √((b2−b3)² + a3²)`, `g = 1/√(A1·A2)`,
 /// `m = ((A1+A2)² − (b1−b2)²)/(4·A1·A2)`,
 /// `cos φ = ((b1−x)A2 − (x−b2)A1)/((b1−x)A2 + (x−b2)A1)`.
+///
+/// **Region `(b2, b1)`.**  Writing `u = (b1−x)A2` and `v = (x−b2)A1`,
+/// `cos φ = (u−v)/(u+v)` has modulus `< 1` exactly when `u` and `v` are both
+/// positive, i.e. strictly between the two real roots; it is `+1` at `b2`, `−1`
+/// at `b1`, and of modulus `> 1` immediately outside.  `P > 0` on this interval
+/// requires a *negative* leading coefficient (`1 − x⁴` is the usual instance);
+/// with a positive one the region and `{P > 0}` are disjoint and the gate
+/// declines for want of in-domain points, which is the honest outcome rather
+/// than a mis-stated one.
 fn quartic_two_real(
     reals: &[f64],
     pair: Croot,
     inv_sqrt_lead: f64,
     var: ExprId,
     pool: &ExprPool,
-) -> Option<(f64, f64, ExprId)> {
+) -> Option<(f64, f64, ExprId, Region)> {
     let (b1, b2) = (reals[0], reals[1]);
     let (b3, a3) = pair;
     let aa1 = ((b1 - b3).powi(2) + a3 * a3).sqrt();
@@ -882,7 +1056,7 @@ fn quartic_two_real(
     let den = pool.add(vec![t1, t2]);
     let cosphi = pool.mul(vec![num, pool.pow(den, pool.integer(-1_i32))]);
     let phi = pool.func("acos", vec![cosphi]);
-    Some((g, m, phi))
+    Some((g, m, phi, Region::open(b2, b1)))
 }
 
 /// Quartic with **no real roots** — two complex-conjugate pairs `b1 ± i·a1`,
@@ -1005,7 +1179,7 @@ fn quartic_no_real(
     lead: f64,
     var: ExprId,
     pool: &ExprPool,
-) -> Option<(f64, f64, ExprId)> {
+) -> Option<(f64, f64, ExprId, Region)> {
     let (p, q, r, s, m, g) = quartic_no_real_consts(pair1, pair2, lead)?;
     // φ(x) = arctan( L(x) ),  L = (p·x+q)/(r·x+s).  The raw `(p,q,r,s)` are
     // `cos/sin θ`-scaled (θ a fixed angle of the substitution), so individually
@@ -1032,79 +1206,115 @@ fn quartic_no_real(
     ]);
     let l = pool.mul(vec![lp, pool.pow(ld, pool.integer(-1_i32))]);
     let phi = pool.func("atan", vec![l]);
-    Some((g, m, phi))
+    // Region: the whole real line — `P > 0` everywhere and `atan` is real for
+    // every argument — **minus the pole of `L` at `x = −s/r`**.  There `φ` jumps
+    // from `+π/2` to `−π/2`, so the candidate is discontinuous across it (the
+    // one-sided derivatives are still right; the jump is the additive constant a
+    // branch change contributes).  The written derivative is `0/0` exactly at
+    // the pole, so the point is cut rather than sampled.  Rescaling
+    // `(p, q, r, s)` above does not move `−s/r`.
+    let region = if r.abs() > 1e-12 {
+        Region::all().cut_all([-s / r])
+    } else {
+        Region::all()
+    };
+    Some((g, m, phi, region))
 }
 
 // ---------------------------------------------------------------------------
 // Verification gate
 // ---------------------------------------------------------------------------
 
-/// Region-aware sample points for the soundness gate.
+/// Sample points for the soundness gate, drawn from the region the reduction
+/// **claims** — and from nowhere else.
 ///
-/// The reduction's substitution is only valid on *part* of the `P > 0` set — a
-/// cubic-three-real reduction is valid only beyond the largest root, a
-/// quartic-two-real one only outside the real roots, etc.  A fixed grid can land
-/// fewer than the three required points in that valid region and make a *correct*
-/// reduction spuriously decline (e.g. `∫dx/√(x³−7x−6)`, region `x ≥ 3`;
-/// `∫dx/√(x⁴−1)`, region `|x| > 1`).
+/// This used to put points in *every* `P > 0` interval and say so, on the
+/// reasoning that "points where the substitution is invalid simply evaluate
+/// non-finite and are skipped".  That is true only of a gate that skips them.
+/// A gate that reads "the candidate is undefined where the integrand is an
+/// ordinary finite real" as a **disagreement** — which is the right reading,
+/// and is what [`crate::integrate::verify_antiderivative_status`] has done
+/// since PR #344 — refuses a correct answer instead: for `∫dx/√(x³−x)` the
+/// integrand is finite all over `(−1, 0)` while the cubic-three-real
+/// candidate's derivative is `NaN` there, because that component is not part
+/// of the claim.  The sample set was wider than the claim, so the fix belongs
+/// here and not in the rule.
 ///
-/// This derives points from `P`'s real roots so every `P > 0` interval is
-/// covered — in particular the unbounded region beyond the largest (and below the
-/// smallest) real root — on top of a wide fixed grid.  Adding points never
-/// weakens the gate: it still rejects on *any* disagreement, and points where the
-/// substitution is invalid simply evaluate non-finite and are skipped.
-fn gate_samples(p_coeffs: &[f64]) -> Vec<f64> {
-    let mut xs: Vec<f64> = vec![
-        -3.5, -2.7, -1.6, -0.9, -0.4, 0.15, 0.3, 0.55, 0.7, 0.9, 1.1, 1.4, 1.9, 2.6, 3.4, 4.7, 5.3,
+/// So: points come from `region` only.  A wide fixed grid supplies the ordinary
+/// case, and region-derived points guarantee the gate's three-point minimum is
+/// reachable however narrow or far away the region is (`∫dx/√(x³−7x−6)`, region
+/// `(3, ∞)`, was the case that motivated deriving them at all).  Every point is
+/// still re-checked against `P > 0`: a region and `{P > 0}` can be disjoint
+/// when the leading coefficient has the wrong sign for the normal form, and
+/// then the gate declines for want of points rather than reporting anything.
+///
+/// The offsets and fractions are deliberately not round numbers.  That is not
+/// superstition: a fitted higher-kind block set carries `log|x−t|` and
+/// `√P/(x−p)` written singularities, and those *are* cut from the region by the
+/// caller — but only the ones the caller knows about, so a grid that avoids
+/// landing on tidy values is one less way to trip over one it does not.
+fn gate_samples(p_coeffs: &[f64], region: &Region) -> Vec<f64> {
+    /// Offsets inward from a finite endpoint of an unbounded component.
+    const OFFSETS: [f64; 9] = [
+        0.0613, 0.1373, 0.2917, 0.6131, 1.2437, 2.5391, 5.1173, 10.241, 20.487,
     ];
-    let mut reals = poly_roots(p_coeffs)
-        .map(|roots| classify_roots(&roots).0)
-        .unwrap_or_default();
-    reals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    /// Fractions along a bounded component.
+    const FRACTIONS: [f64; 11] = [
+        0.0137, 0.0731, 0.1523, 0.2417, 0.3313, 0.4909, 0.6121, 0.7213, 0.8317, 0.9109, 0.9767,
+    ];
     let pos = |x: f64| eval_poly(p_coeffs, x) > 1e-6;
-    if let (Some(&lo), Some(&hi)) = (reals.first(), reals.last()) {
-        // Unbounded regions beyond the extreme roots (where most odd-degree /
-        // two-real-root reductions are valid).
-        for o in [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0] {
-            let (rgt, lft) = (hi + o, lo - o);
-            if pos(rgt) {
-                xs.push(rgt);
-            }
-            if pos(lft) {
-                xs.push(lft);
-            }
+    let mut xs: Vec<f64> = Vec::new();
+    let push = |x: f64, xs: &mut Vec<f64>| {
+        if region.contains(x) && pos(x) {
+            xs.push(x);
         }
-        // Interior of each bounded `P > 0` interval between consecutive roots.
-        for w in reals.windows(2) {
-            let (a, b) = (w[0], w[1]);
-            if b - a < 1e-6 {
-                continue;
-            }
-            for f in [0.15, 0.3, 0.45, 0.6, 0.75, 0.85] {
-                let x = a + (b - a) * f;
-                if pos(x) {
-                    xs.push(x);
+    };
+    for &x in &[
+        -3.5_f64, -2.7, -1.6, -0.9, -0.4, 0.15, 0.3, 0.55, 0.7, 0.9, 1.1, 1.4, 1.9, 2.6, 3.4, 4.7,
+        5.3,
+    ] {
+        push(x, &mut xs);
+    }
+    for (lo, hi) in region.components(f64::INFINITY, 0.0) {
+        match (lo.is_finite(), hi.is_finite()) {
+            (true, true) => {
+                for f in FRACTIONS {
+                    push(lo + (hi - lo) * f, &mut xs);
                 }
             }
+            (true, false) => {
+                for o in OFFSETS {
+                    push(lo + o, &mut xs);
+                }
+            }
+            (false, true) => {
+                for o in OFFSETS {
+                    push(hi - o, &mut xs);
+                }
+            }
+            // Doubly unbounded: the fixed grid above already covers it.
+            (false, false) => {}
         }
     }
     xs
 }
 
-/// Closed boxes **strictly inside** the `P > 0` region, for the gate's rigorous
-/// enclosure tier.
+/// Closed boxes **strictly inside the region the reduction claims**, for the
+/// gate's rigorous enclosure tier.
 ///
 /// The residual `d/dx F − f` carries a `1/√P` factor and is therefore unbounded
 /// at every root of `P`: no rigorous bound over a box that touches a root can
-/// exist, and asking for one only wastes the subdivision budget.  So each
-/// component of `{P > 0}` is inset away from its finite endpoints and clipped
-/// to a finite window, and the widest surviving box comes first (the gate takes
-/// them in order, up to its `max_boxes`).
+/// exist, and asking for one only wastes the subdivision budget.  The same
+/// goes for the interior points `region` cuts out.  So each component of the
+/// region is clipped to a finite window, inset away from its finite endpoints,
+/// and the widest survivor comes first (the gate takes them in order, up to its
+/// `max_boxes`).
 ///
 /// This is the domain-awareness of [`gate_samples`], expressed as a box instead
-/// of a point set — the two must agree, or the enclosure would certify a region
-/// the reduction was never claimed to be valid on.
-fn gate_boxes(p_coeffs: &[f64]) -> Vec<(f64, f64)> {
+/// of a point set — both are built from the same [`Region`], because an
+/// enclosure over a wider set would certify something the reduction never
+/// claimed.
+fn gate_boxes(p_coeffs: &[f64], region: &Region) -> Vec<(f64, f64)> {
     let mut reals = poly_roots(p_coeffs)
         .map(|roots| classify_roots(&roots).0)
         .unwrap_or_default();
@@ -1113,24 +1323,16 @@ fn gate_boxes(p_coeffs: &[f64]) -> Vec<(f64, f64)> {
     let span = reals.iter().fold(1.0_f64, |m, r| m.max(r.abs()));
     let window = span + 3.0;
 
-    // Endpoints of the candidate components: −window, the roots, +window.
-    let mut cuts = vec![-window];
-    cuts.extend(reals.iter().copied().filter(|r| r.abs() < window));
-    cuts.push(window);
-
     let mut boxes: Vec<(f64, f64)> = Vec::new();
-    for w in cuts.windows(2) {
-        let (mut lo, mut hi) = (w[0], w[1]);
-        if hi - lo < 0.3 {
-            continue;
-        }
-        // Inset away from a finite root; the outer window edges are already
-        // interior points, so they need no inset.
+    for (mut lo, mut hi) in region.components(window, 0.3) {
+        // Inset away from an endpoint the region itself put there (a root of
+        // `P`, or a cut point); the artificial `±window` clips are ordinary
+        // interior points and need no inset.
         let inset = (0.12 * (hi - lo)).clamp(0.05, 1.0);
-        if reals.iter().any(|r| (r - lo).abs() < 1e-9) {
+        if lo > -window {
             lo += inset;
         }
-        if reals.iter().any(|r| (r - hi).abs() < 1e-9) {
+        if hi < window {
             hi -= inset;
         }
         if hi - lo < 0.2 {
@@ -1168,12 +1370,22 @@ fn gate_boxes(p_coeffs: &[f64]) -> Vec<(f64, f64)> {
     boxes
 }
 
-/// The gate's view of "where this reduction is claimed to hold": the
-/// region-aware sample grid, the `P > 0` predicate, and the enclosure boxes.
-fn elliptic_domain(p_coeffs: &[f64]) -> gate::Domain<'_> {
-    gate::Domain::from_samples(gate_samples(p_coeffs))
-        .with_predicate(move |x: f64| eval_poly(p_coeffs, x) > 1e-6)
-        .with_boxes(gate_boxes(p_coeffs))
+/// The gate's view of "where this reduction is claimed to hold": the sample
+/// grid drawn from `region`, the conjunction of `region` and `P > 0` as the
+/// in-domain predicate, and enclosure boxes inside the same set.
+///
+/// Both halves of the predicate are load-bearing and neither implies the other.
+/// `region` is where the substitution is real; `P > 0` is where the integrand
+/// is.  They coincide for some root configurations and are disjoint for others
+/// (a normal form applied with the wrong sign of leading coefficient), and the
+/// gate must sample the intersection — which is exactly the set on which
+/// `d/dx F = f` is being asserted.
+fn elliptic_domain(p_coeffs: &[f64], region: Region) -> gate::Domain<'_> {
+    let samples = gate_samples(p_coeffs, &region);
+    let boxes = gate_boxes(p_coeffs, &region);
+    gate::Domain::from_samples(samples)
+        .with_predicate(move |x: f64| region.contains(x) && eval_poly(p_coeffs, x) > 1e-6)
+        .with_boxes(boxes)
 }
 
 /// Default gate configuration for this route.
@@ -1211,7 +1423,8 @@ fn gate_options() -> gate::GateOptions {
     }
 }
 
-/// Verify `d/dx F_cand = c/√P` on the region where `P > 0`.
+/// Verify `d/dx F_cand = c/√P` on `region ∩ {P > 0}` — the set this reduction
+/// claims, not the whole of `{P > 0}`.
 ///
 /// `c_expr` is the exact symbolic constant (`c` is its `f64` value), so the
 /// symbolic and enclosure tiers see the true integrand rather than a float
@@ -1224,6 +1437,7 @@ fn verify(
     c_expr: ExprId,
     p_expr: ExprId,
     var: ExprId,
+    region: Region,
     pool: &ExprPool,
     gate_opts: &gate::GateOptions,
 ) -> gate::Verdict {
@@ -1240,7 +1454,7 @@ fn verify(
         }
         Some(c / pv.sqrt())
     };
-    let domain = elliptic_domain(coeffs);
+    let domain = elliptic_domain(coeffs, region);
     let target = gate::Target::symbolic(integrand).with_numeric(&rhs);
     gate::verify(f_cand, &target, var, &domain, gate_opts, pool)
 }
@@ -1763,13 +1977,94 @@ mod tests {
             }
             Some(eval_ratio(b_num, b_den, xv)? * pv.sqrt())
         };
-        let domain = elliptic_domain(p_coeffs);
+        let domain = elliptic_domain(p_coeffs, region_of(p_coeffs, var, pool));
         let target = gate::Target::symbolic(integrand).with_numeric(&rhs);
         gate::verify(f_cand, &target, var, &domain, &gate_options(), pool).is_verified()
     }
 
     fn x_dummy(pool: &ExprPool) -> ExprId {
         pool.symbol("__unused__", Domain::Real)
+    }
+
+    /// The region the first-kind reduction for `p_coeffs` claims, taken from
+    /// [`first_kind_reduction`] itself rather than restated here — a test that
+    /// hard-coded the interval would keep passing after the reduction changed.
+    fn region_of(p_coeffs: &[f64], var: ExprId, pool: &ExprPool) -> Region {
+        let deg = p_coeffs.len() - 1;
+        let lead = *p_coeffs.last().expect("non-empty coefficients");
+        first_kind_reduction(p_coeffs, deg, lead, var, pool)
+            .expect("a handled cubic/quartic root configuration")
+            .3
+    }
+
+    /// The gate's domain for a three-real-root cubic is the component the
+    /// reduction claims, and nothing else.
+    ///
+    /// `P = x³ − x` is positive on `(−1, 0)` and on `(1, ∞)`; the B&F
+    /// `sin²φ = (e1−e3)/(x−e3)` normal form is real only on the second.  The
+    /// grid used to cover both and rely on the gate skipping the `NaN`s, which
+    /// is exactly what stopped the gate from being allowed to treat a `NaN`
+    /// derivative as a disagreement.  Nothing may be sampled in `(−1, 0)`, and
+    /// the surviving points must still clear the gate's three-point minimum.
+    #[test]
+    fn gate_domain_is_the_claimed_component_only() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let coeffs = [0.0, -1.0, 0.0, 1.0]; // x³ − x
+        let region = region_of(&coeffs, x, &pool);
+        assert_eq!(region, Region::open(1.0, f64::INFINITY));
+
+        let domain = elliptic_domain(&coeffs, region);
+        let live: Vec<f64> = domain
+            .samples()
+            .iter()
+            .copied()
+            .filter(|&v| domain.contains(v))
+            .collect();
+        assert!(
+            live.len() >= 3,
+            "narrowing must not starve the gate: {live:?}"
+        );
+        for &v in &live {
+            assert!(
+                v > 1.0,
+                "sampled {v}, which is outside the claimed region (1, ∞)"
+            );
+        }
+        // The other `P > 0` component is positive and *not* claimed.
+        for &v in &[-0.9_f64, -0.5, -0.1] {
+            assert!(eval_poly(&coeffs, v) > 0.0, "{v} should have P > 0");
+            assert!(!domain.contains(v), "{v} is in the domain but not claimed");
+        }
+        for b in domain.boxes() {
+            assert!(b.0 > 1.0, "enclosure box {b:?} leaves the claimed region");
+        }
+    }
+
+    /// The no-real-root quartic cuts the pole of its `arctan` substitution.
+    ///
+    /// `φ = atan(L)` with `L` a Möbius function has one real pole; `φ` jumps by
+    /// `π` across it and the written derivative is `0/0` there.  The region
+    /// removes it, so the two components either side are claimed and the point
+    /// itself is not — a `Region` fact, not a budget accident of the enclosure
+    /// tier.
+    #[test]
+    fn quartic_no_real_region_cuts_the_substitution_pole() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let coeffs = [1.0, 0.0, 0.0, 0.0, 1.0]; // x⁴ + 1
+        let region = region_of(&coeffs, x, &pool);
+        assert_eq!(region.cuts.len(), 1, "expected exactly one cut: {region:?}");
+        let pole = region.cuts[0];
+        assert!(!region.contains(pole));
+        assert!(region.contains(pole - 0.5) && region.contains(pole + 0.5));
+        let domain = elliptic_domain(&coeffs, region);
+        for b in domain.boxes() {
+            assert!(
+                pole <= b.0 || pole >= b.1,
+                "enclosure box {b:?} straddles the substitution pole {pole}"
+            );
+        }
     }
 
     #[test]
@@ -1888,7 +2183,7 @@ mod tests {
                 }
                 Some(1.0 / pv.sqrt())
             };
-            let domain = elliptic_domain(coeffs);
+            let domain = elliptic_domain(coeffs, region_of(coeffs, x, &pool));
             assert!(
                 !domain.boxes().is_empty(),
                 "{name}: no in-domain box was produced"

--- a/alkahest-core/src/integrate/algebraic/elliptic_output.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic_output.rs
@@ -35,7 +35,7 @@
 //! `∂φ F = 1/√(1 − m·sin²φ)`, `∂φ E = √(1 − m·sin²φ)`,
 //! `∂φ Π = 1/((1 − n sin²φ)√(1 − m sin²φ))`, all elementary since `m`, `n` are
 //! constant here) is checked against the integrand on `R ∩ {P > 0}`, where `R`
-//! is the [`Region`] the reduction claims — **not** on all of `{P > 0}`, which
+//! is the `Region` the reduction claims — **not** on all of `{P > 0}`, which
 //! is a strictly larger set for most root configurations:
 //!
 //! * first, symbolically — `simplify(d/dx F − f) == 0` gives
@@ -56,7 +56,7 @@
 //! The region is load-bearing rather than an optimisation, because the gate
 //! treats "the candidate is undefined where the integrand is an ordinary finite
 //! real" as a **disagreement**.  Under that rule a sample set wider than the
-//! claim is not extra caution; it refutes correct answers.  See [`Region`].
+//! claim is not extra caution; it refutes correct answers.  See `Region`.
 //!
 //! What the enclosure tier does *not* cover is stated where it belongs, in the
 //! gate's own [honest-limitations list](crate::integrate::gate): neighbourhoods
@@ -256,7 +256,7 @@ pub fn try_elliptic_output_with(
 ///
 /// `R` is **not** `{P > 0}`.  Each B&F normal form is real on one component of
 /// `{P > 0}` (or, for the four-real-root quartic, on the bounded middle one),
-/// and every caller must verify only there; see [`Region`].  Each case returns
+/// and every caller must verify only there; see `Region`.  Each case returns
 /// its own region next to its own constants, so the two cannot drift apart.
 ///
 /// Returns `None` for radicand shapes outside the handled cubic/quartic
@@ -1322,7 +1322,7 @@ fn gate_samples(p_coeffs: &[f64], region: &Region) -> Vec<f64> {
 /// `max_boxes`).
 ///
 /// This is the domain-awareness of [`gate_samples`], expressed as a box instead
-/// of a point set — both are built from the same [`Region`], because an
+/// of a point set — both are built from the same `Region`, because an
 /// enclosure over a wider set would certify something the reduction never
 /// claimed.
 fn gate_boxes(p_coeffs: &[f64], region: &Region) -> Vec<(f64, f64)> {

--- a/alkahest-core/src/integrate/algebraic/elliptic_output.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic_output.rs
@@ -273,7 +273,13 @@ fn first_kind_reduction(
         (4, 4, 0) => quartic_four_real(&reals, inv_sqrt_lead, var, pool),
         (4, 2, 1) => quartic_two_real(&reals, pairs[0], inv_sqrt_lead, var, pool),
         (4, 0, 2) => quartic_no_real(pairs[0], pairs[1], lead, var, pool),
-        _ => None, // genus-2 / unhandled config: declined (falls through)
+        // Not the genus-≥2 case, whatever the arms above look like: every
+        // caller has already required `deg ∈ {3, 4}`, so a quintic never
+        // reaches here.  Since `reals + 2·pairs` is the degree, the arms above
+        // exhaust both degrees, and this one is left for a root split the
+        // numeric solver produced that does not add up — a lost or spurious
+        // root.  Declining falls through to the caller's own analysis.
+        _ => None,
     }
 }
 

--- a/alkahest-core/src/integrate/algebraic/elliptic_output.rs
+++ b/alkahest-core/src/integrate/algebraic/elliptic_output.rs
@@ -34,29 +34,34 @@
 //! differentiates the elliptic functions through the primitive registry —
 //! `∂φ F = 1/√(1 − m·sin²φ)`, `∂φ E = √(1 − m·sin²φ)`,
 //! `∂φ Π = 1/((1 − n sin²φ)√(1 − m sin²φ))`, all elementary since `m`, `n` are
-//! constant here) is checked against the integrand on the region where
-//! `P > 0`:
+//! constant here) is checked against the integrand on `R ∩ {P > 0}`, where `R`
+//! is the [`Region`] the reduction claims — **not** on all of `{P > 0}`, which
+//! is a strictly larger set for most root configurations:
 //!
 //! * first, symbolically — `simplify(d/dx F − f) == 0` gives
 //!   [`gate::Verdict::Proven`];
-//! * then by `f64` sampling at the region-aware `gate_samples` grid, at a
-//!   `1e-7` relative tolerance over at least three points
+//! * then by `f64` sampling at the `gate_samples` grid, which is drawn from
+//!   `R`, at a `1e-7` relative tolerance over at least three points
 //!   ([`gate::Verdict::SampledOnly`]) — this tier is the **acceptance
-//!   decision**, exactly as before;
+//!   decision**;
 //! * then, on the candidate that already survived that screen, by a rigorous
 //!   Taylor-model enclosure of `d/dx F − f` over a closed box strictly inside
-//!   the `P > 0` region ([`gate::Verdict::EnclosureVerified`]).  This tier is
-//!   *additive*: it can only strengthen the recorded evidence, never widen
-//!   what is accepted.
+//!   `R` ([`gate::Verdict::EnclosureVerified`]).  This tier is *additive*: it
+//!   can only strengthen the recorded evidence, never widen what is accepted.
 //!
 //! A form is emitted **only** if the gate passes; otherwise the caller falls
 //! through to `NonElementary`.  An imperfect fit can therefore never produce a
 //! wrong answer — it merely declines.
 //!
+//! The region is load-bearing rather than an optimisation, because the gate
+//! treats "the candidate is undefined where the integrand is an ordinary finite
+//! real" as a **disagreement**.  Under that rule a sample set wider than the
+//! claim is not extra caution; it refutes correct answers.  See [`Region`].
+//!
 //! What the enclosure tier does *not* cover is stated where it belongs, in the
 //! gate's own [honest-limitations list](crate::integrate::gate): neighbourhoods
-//! of the roots of `P` (where `1/√P` is unbounded and no finite bound exists)
-//! and the unbounded tails are never inside a box.
+//! of the roots of `P` (where `1/√P` is unbounded and no finite bound exists),
+//! the points `R` cuts out, and the unbounded tails are never inside a box.
 
 use crate::integrate::gate::{self, eval_at as eval};
 use crate::integrate::risch::poly_rde::{expr_to_qpoly, is_free_of_var};
@@ -1321,13 +1326,15 @@ fn gate_samples(p_coeffs: &[f64], region: &Region) -> Vec<f64> {
 /// enclosure over a wider set would certify something the reduction never
 /// claimed.
 fn gate_boxes(p_coeffs: &[f64], region: &Region) -> Vec<(f64, f64)> {
-    let mut reals = poly_roots(p_coeffs)
+    // A finite window to clip an unbounded component to.  It only has to be
+    // wide enough to hold the interesting part of the curve; the region's own
+    // endpoints, not this, are what the boxes are inset from.
+    let window = poly_roots(p_coeffs)
         .map(|roots| classify_roots(&roots).0)
-        .unwrap_or_default();
-    reals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    reals.dedup_by(|a, b| (*a - *b).abs() < 1e-9);
-    let span = reals.iter().fold(1.0_f64, |m, r| m.max(r.abs()));
-    let window = span + 3.0;
+        .unwrap_or_default()
+        .iter()
+        .fold(1.0_f64, |m, r| m.max(r.abs()))
+        + 3.0;
 
     let mut boxes: Vec<(f64, f64)> = Vec::new();
     for (mut lo, mut hi) in region.components(window, 0.3) {

--- a/alkahest-core/src/integrate/algebraic/generator_subst.rs
+++ b/alkahest-core/src/integrate/algebraic/generator_subst.rs
@@ -301,12 +301,19 @@ fn integrate_reduced(
     // Among the candidates the gate accepts, the one that is real over the most
     // of the original integrand's domain wins.
     //
-    // The gate *skips* a sample where a side does not evaluate to a real, which
-    // is how a form real on only one component still clears it (`log` written
-    // without absolute values — the convention the rest of the integrator
-    // uses).  Correctness is the gate's business either way; this only decides
-    // which correct form to hand back, and the sign-repaired candidates are
-    // exactly the ones that tend to widen it.
+    // The gate skips a sample where the *integrand* is not a finite real, so a
+    // form real on only one component of the integrand's domain can still clear
+    // it — but only through its **derivative**.  `F` itself may be complex
+    // where `d/dx F` is an ordinary real, which is exactly the `log` case
+    // (`log(u)` for `u < 0` is complex; `u'/u` is not), and it is the
+    // convention the rest of the integrator writes its logs in.  What the gate
+    // does *not* skip any more is `d/dx F` failing to be real where the
+    // integrand is: that is a refutation (`gate`'s honest-limitations list), so
+    // a candidate whose derivative has a domain hole is rejected outright and
+    // never reaches this ranking.  Correctness is the gate's business either
+    // way; this only decides which of the accepted forms to hand back, and the
+    // sign-repaired candidates are the ones that tend to widen the region on
+    // which `F` itself is real.
     let mut best: Option<(usize, ExprId)> = None;
     for candidate in candidates {
         if !gate::verify(candidate, &target, var, &domain, &opts, pool).is_verified() {

--- a/alkahest-core/src/integrate/algebraic/genus_zero.rs
+++ b/alkahest-core/src/integrate/algebraic/genus_zero.rs
@@ -27,7 +27,7 @@ use crate::simplify::engine::simplify;
 use rug::{Integer, Rational};
 
 use super::coates::{coates_hyperelliptic, CoatesPlace};
-use super::find_order::{find_order_placed, FindOrder};
+use super::find_order::{find_order_placed, genus, FindOrder};
 use super::jacobian_torsion::AlgPlace;
 use super::residues::{certified_residue_divisor, AlgResidue, PlacedResidue};
 use super::sqrt_rde::{self, SqrtRde};
@@ -707,11 +707,25 @@ fn binomial_coeff(n: u64, k: u64) -> rug::Integer {
 //    polynomial weights `∫5x⁴√(x⁵+1) = ⅔(x⁵+1)^{3/2}`.
 //
 //  * **Logarithmic part**: with residues, FIND-ORDER decides: a **non-torsion**
-//    divisor ⇒ `NonElementary`; otherwise (torsion log part) emitting it on a
-//    genus ≥ 2 curve needs Coates' construction (genus 0/1 are handled upstream
-//    by the parametrization / genus-1 capstone), so we decline.  With *no*
-//    residues anywhere, Liouville leaves only an exact algebraic derivative, so
-//    an empty divisor plus "no algebraic primitive" certifies `NonElementary`.
+//    divisor ⇒ `NonElementary`; otherwise (torsion log part) emitting it needs
+//    Coates' construction, so we decline.  With *no* residues anywhere,
+//    Liouville leaves only an exact algebraic derivative, so an empty divisor
+//    plus "no algebraic primitive" certifies `NonElementary`.
+//
+// # This route is not genus-graded, and its declines must not pretend to be
+//
+// The guard above is `deg P ≥ 3`.  For squarefree `P` that is genus `⌊(deg P −
+// 1)/2⌋`, i.e. genus **1** for `deg P ∈ {3, 4}` and genus ≥ 2 only from `deg P
+// = 5`.  Genus 0 and 1 are *meant* to be taken upstream (rational
+// parametrisation; the genus-1 elliptic capstone in [`super::elliptic_output`]
+// and [`super::genus1_log`]) — but when those decline, a genus-1 integrand
+// arrives here and is decided, or not decided, by exactly this code.  The
+// decline messages below therefore state the genus they **computed** from
+// `deg P` via [`genus`], and never the genus the route was written for.  They
+// used to say "genus ≥ 2" unconditionally; Charlwood #19 (`y² = x³+1`), #38 and
+// #39 (`y² = x⁴+1`) are all genus 1, all reported "genus ≥ 2", and that wording
+// sent at least one reader to attribute three genus-1 misses to the
+// research-level genus-≥2 Coates gap.
 //
 // # Both premises of the empty-divisor certificate are load-bearing
 //
@@ -737,6 +751,43 @@ fn binomial_coeff(n: u64, k: u64) -> rug::Integer {
 // premise 1 only: a non-torsion residue divisor rules out an elementary integral
 // on its own, whatever the integral part does.
 // ---------------------------------------------------------------------------
+
+/// How to name the curve `y² = P` in a decline message, with the genus
+/// **computed** rather than assumed.
+///
+/// [`genus`] returns `⌊(deg P − 1)/2⌋` for squarefree `P` and `None` otherwise
+/// (a repeated root makes the affine model singular, and the normalisation's
+/// genus is then lower than that formula). When it returns `None` this says so
+/// instead of naming a number: an unearned genus in a message is the bug this
+/// function exists to stop, and replacing one guess with another would repeat
+/// it.
+fn curve_note(p_poly: &QPoly) -> String {
+    let d = degree(p_poly);
+    match genus(2, p_poly) {
+        Some(g) => format!("on y² = P, deg P = {d} squarefree ⇒ genus {g}"),
+        // Unreachable from the call sites below (they are past the squarefree
+        // check), and still not a licence to name a genus here.
+        None => format!(
+            "on y² = P, deg P = {d}, genus not determined (P is not squarefree, so \
+             ⌊(deg P − 1)/2⌋ does not describe the normalised curve)"
+        ),
+    }
+}
+
+/// The clause that stops a genus-0/1 decline from reading as a genus-≥2 one.
+///
+/// Empty above genus 1, and empty when the genus was not computed — this says
+/// something only where something was established.
+fn route_note(p_poly: &QPoly) -> &'static str {
+    match genus(2, p_poly) {
+        Some(g) if g <= 1 => {
+            ".  This is not the genus-≥2 Coates gap: a genus-1 curve reaches this \
+             deg P ≥ 3 fallback only when the genus-0/1 routes upstream (rational \
+             parametrisation, the genus-1 elliptic capstone) have already declined"
+        }
+        _ => "",
+    }
+}
 
 fn integrate_b_sqrt_high_degree(
     b: ExprId,
@@ -839,17 +890,23 @@ fn integrate_b_sqrt_high_degree(
                 // `d/dx F = B·√P` gate — else decline honestly.
                 match try_emit_genus2_coates_log(&p_poly, &divisor, order, &h, var, pool, log) {
                     Some(f) => Ok(f),
-                    None => Err(notdecided(
-                        "genus ≥ 2 torsion log part: Coates construction did not yield \
-                         a gate-verified antiderivative in the handled scope (even-\
-                         degree/real model, or an unverified argument)",
-                    )),
+                    None => Err(notdecided(&format!(
+                        "torsion logarithmic part {}: the residue divisor is torsion \
+                         (FIND-ORDER order {order}), but the Coates construction did not \
+                         yield a gate-verified antiderivative in the handled scope \
+                         (odd-degree/imaginary model only, or the constructed argument \
+                         failed the d/dx F = B·√P check){}",
+                        curve_note(&p_poly),
+                        route_note(&p_poly)
+                    ))),
                 }
             }
-            FindOrder::NotDecided => Err(notdecided(
-                "genus ≥ 2 residue divisor: torsion order could not be decided \
-                 (FIND-ORDER undecided) — elementarity unknown",
-            )),
+            FindOrder::NotDecided => Err(notdecided(&format!(
+                "residue divisor {}: FIND-ORDER could not decide whether the divisor \
+                 is torsion, so elementarity is unknown{}",
+                curve_note(&p_poly),
+                route_note(&p_poly)
+            ))),
         };
     }
 
@@ -867,15 +924,21 @@ fn integrate_b_sqrt_high_degree(
             "Trager ℚ-basis criterion: a residue component is non-torsion ⇒ \
              no elementary logarithmic part",
         )),
-        _ => Err(notimpl(
-            "genus ≥ 2 logarithmic part with algebraic residues: not decided \
-             (torsion log not yet emittable, or out of the handled scope — \
-             non-Galois tower / base degree ≥ 3)",
-        )),
+        _ => Err(notimpl(&format!(
+            "logarithmic part with algebraic residues {}: not decided (a torsion log \
+             part is not yet emittable on this route, or the residue tower is out of \
+             the handled scope — non-Galois tower / base degree ≥ 3){}",
+            curve_note(&p_poly),
+            route_note(&p_poly)
+        ))),
     }
 }
 
-/// Construct and **gate-verify** the genus ≥ 2 torsion logarithmic part.
+/// Construct and **gate-verify** the torsion logarithmic part via Coates.
+///
+/// Named `genus2` for the case it was written for; it is reached for any
+/// squarefree `deg P ≥ 3`, genus 1 included, so nothing it returns or reports
+/// may assert a genus.
 ///
 /// Given the rational residue divisor `δ` and its torsion order `N`
 /// (`FindOrder::Principal{N}`), primitivize `δ = (gg/L)·δ_prim` (integer
@@ -1385,6 +1448,87 @@ fn neg_c_power(c: &rug::Integer, n: i64) -> rug::Integer {
 #[cfg(test)]
 mod genus2_log_tests {
     use super::*;
+    /// The `deg P ≥ 3` route's declines must report the genus they computed.
+    ///
+    /// Every integrand here is on a curve of genus **1** (`deg P ∈ {3, 4}`,
+    /// squarefree). They reach this route because the genus-1 handlers upstream
+    /// declined, and the messages used to call them "genus ≥ 2" — which is not a
+    /// cosmetic slip: it points a reader at the research-level Coates gap
+    /// instead of at a genus-1 miss in an area the gap register calls complete.
+    /// The `√(1+x³)/x`, `(1±x²)/((1∓x²)√(1+x⁴))` cases are Charlwood #19, #38
+    /// and #39.
+    #[test]
+    fn deg_ge_3_declines_report_the_genus_they_computed() {
+        use crate::kernel::{Domain, ExprPool};
+        let cases: [(&str, i32, i32); 4] = [
+            // (name, degree of P, ·) — √(1+x³)/x  (Charlwood #19)
+            ("sqrt(1+x^3)/x", 3, 0),
+            // x/√(1+x⁴) — elementary (½·asinh(x²)), and this route misses it
+            ("x/sqrt(1+x^4)", 4, 1),
+            // 1/(x·√(1+x⁴))
+            ("1/(x*sqrt(1+x^4))", 4, 2),
+            // (1+x²)/((1−x²)√(1+x⁴))  (Charlwood #38)
+            ("(1+x^2)/((1-x^2)*sqrt(1+x^4))", 4, 3),
+        ];
+        let mut seen = 0;
+        for (name, deg, _tag) in cases {
+            let pool = ExprPool::new();
+            let x = pool.symbol("x", Domain::Real);
+            let one = pool.integer(1_i32);
+            let x2 = pool.pow(x, pool.integer(2_i32));
+            let x3 = pool.pow(x, pool.integer(3_i32));
+            let x4 = pool.pow(x, pool.integer(4_i32));
+            let inv = |e: ExprId| pool.pow(e, pool.integer(-1_i32));
+            let integrand = match deg {
+                3 => {
+                    // √(1+x³)/x
+                    let p = pool.add(vec![one, x3]);
+                    pool.mul(vec![pool.func("sqrt", vec![p]), inv(x)])
+                }
+                _ => {
+                    let p = pool.add(vec![one, x4]);
+                    let sq = pool.func("sqrt", vec![p]);
+                    match _tag {
+                        1 => pool.mul(vec![x, inv(sq)]),
+                        2 => pool.mul(vec![inv(x), inv(sq)]),
+                        _ => {
+                            let num = pool.add(vec![one, x2]);
+                            let den = pool.add(vec![one, pool.mul(vec![pool.integer(-1_i32), x2])]);
+                            pool.mul(vec![num, inv(den), inv(sq)])
+                        }
+                    }
+                }
+            };
+            let Err(e) = crate::integrate::engine::integrate(integrand, x, &pool) else {
+                continue; // solved outright: nothing to say about a decline
+            };
+            let msg = e.to_string();
+            // Whatever declines, it must never certify non-elementarity here:
+            // every one of these integrands is on a genus-1 curve and three of
+            // them have elementary antiderivatives.
+            assert!(
+                !matches!(e, IntegrationError::NonElementary(_)),
+                "{name}: certified non-elementary — {msg}"
+            );
+            if !msg.contains("genus") {
+                continue; // declined earlier, before this route's messages
+            }
+            seen += 1;
+            assert!(
+                !msg.contains("genus ≥ 2"),
+                "{name}: genus-1 curve reported as genus ≥ 2 — {msg}"
+            );
+            assert!(
+                msg.contains("genus 1"),
+                "{name}: expected the computed genus in the message — {msg}"
+            );
+        }
+        assert!(
+            seen > 0,
+            "no case reached the deg P ≥ 3 route's genus-reporting declines"
+        );
+    }
+
     use crate::integrate::algebraic::residues::{PlacedResidue, Residue};
     use crate::integrate::risch::rational_rde::poly_sub;
     use crate::kernel::Domain;

--- a/alkahest-core/src/integrate/gate.rs
+++ b/alkahest-core/src/integrate/gate.rs
@@ -38,7 +38,9 @@
 //!    sample points in IEEE-754 double precision and compare with a relative
 //!    tolerance.  A single in-domain disagreement is a **refutation**
 //!    ([`Verdict::Failed`]); too few evaluable points is a **decline**
-//!    ([`Verdict::Declined`]), never a pass.
+//!    ([`Verdict::Declined`]), never a pass.  A point where `f` is an ordinary
+//!    finite real and `d/dx F` is not counts as a disagreement, not as a
+//!    skip — see the honest-limitations list.
 //! 3. **Rigorous enclosure.**  Bound `d/dx F − f` over the caller's closed
 //!    boxes with [`crate::validated::bounds::bound_on_box`] — Taylor models in
 //!    outward-rounded [`crate::ball`] arithmetic.  When the bound clears the
@@ -53,7 +55,7 @@
 //! | [`Verdict::Proven`] | `d/dx F − f` is the zero expression after simplification: an identity wherever both sides are defined | nothing about domains — `F` may still be the wrong branch on part of the real line |
 //! | [`Verdict::EnclosureVerified`] | `sup{ \|d/dx F(x) − f(x)\| : x ∈ ⋃ boxes } ≤ residual_bound`, rigorously (outward rounding, remainder terms folded in, never dropped) | that the residual is *exactly* zero; that anything holds **outside** the listed boxes — in particular near branch points, poles and at infinity |
 //! | [`Verdict::SampledOnly`] | `\|d/dx F − f\| ≤ tol·(1+\|f\|)` at the reported number of in-domain `f64` sample points | any statement between the sample points — agreement at finitely many points is evidence, not an identity |
-//! | [`Verdict::Failed`] | the candidate disagrees with the integrand at a specific in-domain point, beyond tolerance and beyond plausible `f64` error | — |
+//! | [`Verdict::Failed`] | the candidate disagrees with the integrand at a specific in-domain point: either the two finite values differ beyond tolerance and beyond plausible `f64` error, or `d/dx F` is not a finite real where `f` is one | — |
 //! | [`Verdict::Declined`] | nothing at all — the gate could not run | — |
 //!
 //! [`Verdict::Failed`] and [`Verdict::Declined`] both mean *do not emit*.  They
@@ -94,9 +96,14 @@
 //!   perfectly finite — `bound_on_box` refuses on that box.  The gate halves
 //!   and retries, so the certified coverage is the box *minus a
 //!   neighbourhood of the written singularity*, and the gap is visible in the
-//!   `boxes` list.  It is not filled in silently.  (The `∫dx/√(x⁴+1)`
-//!   reduction is a live example: it certifies `[0, 2.2]`, `[−2.2, −1.1]` and
-//!   `[−0.55, 0]`, and leaves `(−1.1, −0.55)` uncovered.)
+//!   `boxes` list.  It is not filled in silently.  A caller that *knows* where
+//!   its candidate is written singular should hand in boxes that already
+//!   exclude those points, and say so in its region: the halve-and-retry path
+//!   is the backstop for the ones it did not know about.  (The `∫dx/√(x⁴+1)`
+//!   reduction does exactly this — the `arctan` substitution's Möbius argument
+//!   has a pole at `x = −1`, which its region cuts out, so the gate is offered
+//!   and certifies `[−4, −1.36]` and `[−0.4, 4]` and the uncovered
+//!   `(−1.36, −0.4)` is a stated exclusion rather than a budget failure.)
 //! * **The `f64` tier can be defeated by catastrophic cancellation.**  A
 //!   residual whose true value is `1e-9` and whose evaluation error is `1e-8`
 //!   is indistinguishable from zero at these tolerances.  This is exactly the
@@ -111,25 +118,35 @@
 //!   `crate::eval` `root_sum` module — numerically, by root-finding — which is
 //!   what makes a Rothstein–Trager answer with an algebraic residue something
 //!   this gate can have an opinion about at all.
-//! * **A candidate undefined where the integrand is finite is *skipped* here,
-//!   not refuted — unlike at the engine-level gate.**  That asymmetry is
-//!   deliberate and it is load-bearing, so it is worth stating plainly.
-//!   [`crate::integrate::verify_antiderivative_status`] treats a sample where
-//!   `f` is an ordinary finite real and `d/dx F` is not as a **disagreement**,
-//!   because there `F` is not an antiderivative of `f` (see
-//!   `engine::classify_sample`, and Charlwood #35, which is exactly that).
-//!   Applying the same rule *here* was tried and reverted: this gate's callers
-//!   deliberately sample beyond the region their reduction claims.
-//!   [`crate::integrate::algebraic::elliptic_output`]'s `gate_samples` puts
-//!   points in **every** `P > 0` interval and says so — "points where the
-//!   substitution is invalid simply evaluate non-finite and are skipped" —
-//!   while a cubic-three-real reduction is valid only beyond the largest root.
-//!   For `∫dx/√(x³−x)` the integrand is finite on `(−1, 0)` and the elliptic
-//!   candidate's derivative is not, so the stricter rule refuses four correct,
-//!   branch-limited elliptic answers (`tests/test_elliptic_integrate.py`).
-//!   Adopting it needs the sample set narrowed to the region each reduction
-//!   actually claims — or a [`Verdict`] that can name that region — not a
-//!   one-line change to the loop.
+//! * **A candidate undefined where the integrand is finite is refuted, and
+//!   that puts the burden on the caller's domain.**  A sample where `f` is an
+//!   ordinary finite real and `d/dx F` is not is a [`Verdict::Failed`], the
+//!   same reading [`crate::integrate::verify_antiderivative_status`] takes
+//!   (see `engine::classify_sample`, and Charlwood #35, which is exactly that:
+//!   an answer containing `log(x + √(x²))`, i.e. `log 0` for every `x < −1`,
+//!   on a component of the integrand's domain).
+//!
+//!   Adopting it here was tried once and reverted, because it refused thirteen
+//!   Rust and four Python tests' worth of *correct* elliptic answers.  The rule
+//!   was not the defect; the sample sets were.
+//!   [`crate::integrate::algebraic::elliptic_output`] used to put points in
+//!   **every** `P > 0` interval and say so — "points where the substitution is
+//!   invalid simply evaluate non-finite and are skipped" — while a
+//!   cubic-three-real Byrd–Friedman reduction is valid only beyond the largest
+//!   root.  For `∫dx/√(x³−x)` the integrand is finite all over `(−1, 0)` and
+//!   the candidate's derivative is not, so a set wider than the claim read as
+//!   a disagreement and a correct answer declined.  Each reduction now states
+//!   its own region (`elliptic_output::Region`), the grid, the predicate and
+//!   the boxes are all built from it, and the rule applies unweakened on it.
+//!
+//!   The lesson generalises to every caller of this module: **the domain you
+//!   hand in is the claim you are making.**  Sampling wider than the claim is
+//!   not free caution — under this rule it is a way to refute yourself.  Two
+//!   kinds of point must be excluded, and both are the caller's to know: those
+//!   where the *reduction* is not valid, and those where the *written*
+//!   candidate has a removable singularity its own blocks cancel (a
+//!   `log|x−t|` paired with an `EllipticPi`, say, which evaluates `∞ − ∞` at
+//!   `t` while the residual's limit there is finite).
 //!
 //! # Relationship to `verify_antiderivative_status`
 //!
@@ -255,7 +272,11 @@ pub enum Verdict {
     Failed {
         /// Where.
         at: f64,
-        /// `|d/dx F − f|` there.
+        /// `|d/dx F − f|` there — or `f64::INFINITY` when `d/dx F` was not a
+        /// finite real at an `at` where `f` was.  The residual is *undefined*
+        /// in that case rather than merely large, and `INFINITY` is how that
+        /// is reported; the two are distinguishable because a finite residual
+        /// always satisfies `residual > tolerance·(1+|f|)` for a finite `f`.
         residual: f64,
         /// The relative tolerance that was exceeded.
         tolerance: f64,
@@ -296,10 +317,13 @@ impl Verdict {
 
 /// Where the candidate is claimed to be an antiderivative.
 ///
-/// Domain-awareness is not decoration.  A Byrd–Friedman reduction is only
-/// valid on the real region where the radicand is positive; sampling outside
-/// it compares two things that are both `NaN` and proves nothing.  The caller
-/// owns that knowledge, so the caller supplies it here.
+/// Domain-awareness is not decoration, and since the `f64` screen refutes a
+/// candidate that is undefined where the integrand is finite, it is not merely
+/// an optimisation either: **this is the claim being verified**.  A
+/// Byrd–Friedman reduction is valid on one component of `{P > 0}`, not on all
+/// of it, and a domain wider than that turns points the candidate never
+/// claimed into evidence against it.  The caller owns that knowledge, so the
+/// caller supplies it here.
 ///
 /// * `samples` — candidate abscissae for the `f64` screen.  Points failing
 ///   `predicate` are skipped, not counted, and never cause a failure.
@@ -587,8 +611,30 @@ pub fn verify(
         let Some(lhs) = eval_at(dfs, var, x, pool) else {
             continue;
         };
-        if !lhs.is_finite() || !rhs.is_finite() {
+        // Outside `f`'s domain there is no claim to check, whatever the
+        // candidate does — `F` is routinely defined on a strictly larger set
+        // than `f` is, and holding that against it would refuse correct
+        // answers.  So a non-finite `f` is no information, in either
+        // direction.
+        if !rhs.is_finite() {
             continue;
+        }
+        // The other direction is *not* symmetric.  `f` is an ordinary finite
+        // real here and `d/dx F` is not, so `F` is not differentiable — not
+        // even defined — at a point the caller's own domain says the candidate
+        // covers.  That is a disagreement, not a skip; skipping it is how a
+        // domain hole clears a grid built to catch one (Charlwood #35).  The
+        // matching rule at the engine-level gate is `engine::classify_sample`.
+        //
+        // This is only sound because `domain` is the region the caller
+        // actually claims: see the honest-limitations list, and
+        // `elliptic_output::Region` for a caller that has to work for it.
+        if !lhs.is_finite() {
+            return Verdict::Failed {
+                at: x,
+                residual: f64::INFINITY,
+                tolerance: opts.tolerance,
+            };
         }
         let err = (lhs - rhs).abs();
         if err > opts.tolerance * (1.0 + rhs.abs()) {
@@ -1166,6 +1212,66 @@ mod tests {
         (0..=n)
             .map(|i| lo + (hi - lo) * (i as f64) / (n as f64))
             .collect()
+    }
+
+    /// A candidate undefined on part of the domain the caller handed in is
+    /// **refuted**, not skipped.
+    ///
+    /// `F = log(x + √(x²)) = log(x + |x|)` is `log 0` for every `x < 0`, while
+    /// the integrand `1/x` is an ordinary finite real there.  This is Charlwood
+    /// #35 in miniature, and it is the rule the elliptic route's sample regions
+    /// had to be narrowed to allow: if this test ever goes back to
+    /// `SampledOnly`, the rule has been weakened rather than the samples fixed.
+    #[test]
+    fn a_domain_hole_in_the_candidate_is_a_refutation() {
+        let (pool, x) = pool_and_x();
+        let abs_x = pool.func("sqrt", vec![pool.pow(x, pool.integer(2_i32))]);
+        let f_cand = pool.func("log", vec![pool.add(vec![x, abs_x])]);
+        let integrand = pool.pow(x, pool.integer(-1_i32));
+        // Both signs, and no `x = 0`: the integrand is finite at every sample.
+        let dom = Domain::from_samples(vec![-3.1, -2.3, -1.7, -0.9, 0.9, 1.7, 2.3, 3.1]);
+        let opts = GateOptions {
+            symbolic: false,
+            enclosure: EnclosurePolicy::Skip,
+            ..GateOptions::default()
+        };
+        let v = verify(f_cand, &Target::symbolic(integrand), x, &dom, &opts, &pool);
+        match v {
+            Verdict::Failed { at, residual, .. } => {
+                assert!(at < 0.0, "refuted at {at}, expected a negative sample");
+                assert!(
+                    residual.is_infinite(),
+                    "a non-finite derivative reports an infinite residual, got {residual}"
+                );
+            }
+            other => panic!("expected a refutation, got {other:?}"),
+        }
+    }
+
+    /// The other direction stays a skip: `F` defined where `f` is not is fine.
+    ///
+    /// `∫ x·√(x−1)/√(x−1) dx = x²/2` has a derivative finite everywhere while
+    /// the integrand is undefined below `1`.  Counting those samples against
+    /// the candidate would turn a correct antiderivative into a decline, which
+    /// is why the rule above is deliberately one-sided.
+    #[test]
+    fn a_candidate_defined_beyond_the_integrand_is_not_refuted() {
+        let (pool, x) = pool_and_x();
+        let half = pool.rational(rug::Integer::from(1), rug::Integer::from(2));
+        let f_cand = pool.mul(vec![half, pool.pow(x, pool.integer(2_i32))]);
+        let root = pool.func("sqrt", vec![pool.add(vec![x, pool.integer(-1_i32)])]);
+        let integrand = pool.mul(vec![x, root, pool.pow(root, pool.integer(-1_i32))]);
+        let dom = Domain::from_samples(vec![-2.0, -1.0, 0.0, 1.5, 2.5, 3.5, 4.5]);
+        let opts = GateOptions {
+            symbolic: false,
+            enclosure: EnclosurePolicy::Skip,
+            ..GateOptions::default()
+        };
+        let v = verify(f_cand, &Target::symbolic(integrand), x, &dom, &opts, &pool);
+        assert!(
+            matches!(v, Verdict::SampledOnly { .. }),
+            "samples below 1 are outside the integrand's domain and say nothing, got {v:?}"
+        );
     }
 
     #[test]

--- a/examples/risch_integration.py
+++ b/examples/risch_integration.py
@@ -146,7 +146,12 @@ def main():
     # Genus 1 (deg P = 3) is no longer a decline: it comes back in terms of
     # the elliptic-integral primitives, e.g.
     #   ∫ sqrt(x³+1) dx → (2/5)·x·sqrt(x³+1) + (3/5)·3^(-1/4)·EllipticF(…)
-    # The guard now fires for genus ≥ 2, where no such reduction exists.
+    # The guard below fires here because deg P = 5 is genus 2, where no such
+    # reduction exists.  It is not a *genus* guard, though: the route it lands
+    # in is guarded by deg P >= 3, so a genus-1 curve whose elliptic reduction
+    # declines upstream reaches it too (Charlwood #38/#39 on y^2 = x^4+1).  Its
+    # messages report the genus they computed, so a decline can be read for
+    # which it is.
     pool = ExprPool(); x = pool.symbol("x")
     p_ell = x ** 5 + x + pool.integer(1)
     s_ell = sqrt(p_ell)


### PR DESCRIPTION
> **Stacked on #344 (`fix/gate-nonfinite`).** That branch tightened the indefinite gate but had to *revert* the same tightening in `integrate::gate::verify`, because 13 Rust and 4 pytest elliptic tests broke. This makes the tightening possible there. Merge #344 first.

## Why the extension broke, and why the rule was not at fault

`elliptic_output::gate_samples` sampled *every* interval where `P > 0` and documented doing so, while a given Byrd–Friedman reduction is valid only on part of that set. For a cubic with three real roots the reduction holds only beyond the largest root, so `∫dx/√(x³−x)` was sampled on `(−1, 0)` — integrand finite, candidate's derivative not — and the strict rule correctly read that as disagreement. The sample set was wider than the claim being verified.

I narrowed the regions rather than building a region-naming `Verdict`. The argument: naming is a *reporting* change. It would not stop `gate::verify` from sampling `(−1, 0)` and refuting a correct answer. Narrowing is necessary; naming is not sufficient. The region stays visible anyway, through `EnclosureVerified.boxes`.

Each reduction now returns its region alongside its own constants, so the two cannot drift. Every region is derived from **where the substitution is real** — never from where the answer happens to agree:

| configuration | region claimed | `{P > 0}` | derivation |
|---|---|---|---|
| cubic, 3 real `e1>e2>e3` | `(e1, ∞)` | `(e3,e2) ∪ (e1,∞)` | `sin²φ = (e1−e3)/(x−e3) ∈ [0,1]` iff `x ≥ e1` |
| cubic, 1 real `y1` + pair | `(y1, ∞)` | `(y1, ∞)` | `(A−u)/(A+u) ∈ (−1,1)` iff `u = x−y1 > 0` (a no-op here, stated for uniformity) |
| quartic, 4 real `a>b>c>d` | `(c, b)` | `(−∞,d) ∪ (c,b) ∪ (a,∞)` | `h(x)=K(x−c)/(x−d)`, `K>1`, monotone either side of `d`, `h(c)=0`, `h(b)=1` |
| quartic, 2 real `b1>b2` + pair | `(b2, b1)` | same, **negative lead only** | `cos φ=(u−v)/(u+v)` has modulus `<1` iff `u,v>0` |
| quartic, no real root | `ℝ` minus the pole of `L` | `ℝ` | `φ = atan(L)` jumps by `π` at `−s/r`; the written derivative is `0/0` there |

`P > 0` is still checked pointwise and deliberately **not** folded into the region: for the two-real quartic the two coincide only when the leading coefficient is negative, and where they are disjoint the gate declines for want of points rather than reporting anything.

**One case I did not anticipate.** The higher-kind path's *fitted* block sets carry written singularities that the fit cancels — `log|x−t|` at a twin preimage, `√P/(x−p)` at a reduction pole, `EllipticPi`'s spurious twin pole. The residual's limit there is finite while the expression as written evaluates `∞ − ∞`. `∫dx/((x−2)√(x³+1))` has one at exactly `x = 0`, inside its claimed `(−1, ∞)`, **and the old grid already contained that point**. Those are excluded as isolated named points — union over all recipes, since one domain serves the whole `propose_fit_verify` search — and never as an interval, which is what the rule exists to catch.

## Do the 13 + 4 pass for the right reason?

Measured, not assumed. I built a **third** binary — base plus the strict rule, without the narrowing — and confirmed the exact failure set: the 13 named Rust tests and precisely 4 pytest tests (`test_integral_one_over_sqrt_cubic_three_real`, `test_integral_sqrt_cubic_three_real_needs_e`, `test_integral_third_kind_cubic_three_real_emits_pi`, `test_integral_third_kind_cubic_one_real_emits_pi_and_log`), each failing with `E-INT-001` and never a certificate.

They pass now because the points that returned `NaN` are no longer sampled. In-domain point counts went **up** in every configuration — for `x⁴+1`, 35 usable points from a grid that previously produced none from the roots at all.

Two new gate tests pin both directions, so a future weakening shows up as a test change: `log(x+√(x²))` against `1/x` **must** be refuted; `x²/2` against `x·√(x−1)/√(x−1)` **must not**.

## Did narrowing cost a verified answer?

No. A purpose-built 29-case elliptic sweep — every handled root configuration × first/second/third kind, plus negative-lead and genus-2 controls — gives 24 solved / 18 with an elliptic function / 3 `E-INT-004` / 0 failing verification, **identical before and after, answer strings byte-identical**, 900 agreeing points and 0 disagreements. Charlwood: 32 solved, 813 agreeing points, **0** disagreeing, identical both sides.

One gain: all four first-kind reductions now reach `EnclosureVerified` (was 3/4). The `x⁴+1` gap is now a stated exclusion around the substitution pole rather than a branch-and-bound budget failure.

**Zero new `E-INT-004`** across Charlwood, the 40-case probe, the 110-case Liouville corpus and the elliptic sweep — identical certificate sets, and byte-identical answers on the probe and the sweep.

## The genus message

`genus_zero.rs` now computes the genus with the existing `find_order::genus` — the same function `find_order_placed` grades the decision with, so the number in the message is the number the decision used. #38/#39 now read:

> `logarithmic part with algebraic residues on y² = P, deg P = 4 squarefree ⇒ genus 1: not decided (a torsion log part is not yet emittable on this route, or the residue tower is out of the handled scope — non-Galois tower / base degree ≥ 3).  This is not the genus-≥2 Coates gap: a genus-1 curve reaches this deg P ≥ 3 fallback only when the genus-0/1 routes upstream (rational parametrisation, the genus-1 elliptic capstone) have already declined`

It claims the model, the degree, that `P` is squarefree, the genus that follows, which guard refused, and what is out of scope. It does **not** claim the integral is non-elementary, nor that the genus-1 machinery is complete. When `genus` declines — non-squarefree `P` — the message says the genus was not determined rather than naming one.

Cluster membership has moved: at this HEAD **#19 solves** (verified at 30 points), so C5 is now #5, #38, #39. `∫x/√(1+x⁴)` and `∫dx/(x√(1+x⁴))` — the 08-24 report's "highest-value reproducer" — also solve now.

## Five more unearned claims, fixed

1. `gate_samples`' own doc — "points where the substitution is invalid simply evaluate non-finite and are **skipped**" — true only of a gate that skips them.
2. Reduction docs said "(region `b2 ≤ x ≤ b1`, **where `P > 0`**)", true only for one sign of the leading coefficient.
3. `generator_subst.rs`: "The gate *skips* a sample where a side does not evaluate to a real" — now false in one direction; a candidate whose derivative has a hole is refuted and never reaches candidate ranking.
4. `first_kind_reduction`'s fallthrough commented "genus-2 / unhandled config" — a quintic can never reach it, since callers require `deg ∈ {3,4}` and `reals + 2·pairs = deg` makes the arms above exhaustive.
5. `examples/risch_integration.py`: "The guard now fires for genus ≥ 2" — it fires on `deg P ≥ 3`.

**Reported, not fixed:** five user-facing messages still say "v1.1 supports only degree-2 / sqrt extensions" (`algebraic/mod.rs:341,346`, `engine.rs:41,66,136`) on a 3.9.0 crate. Stale rather than unearned, and three sit in `engine.rs`, which another branch is editing.

## Gates

`cargo fmt` · `cargo test --workspace` 2653+ pass, 0 fail · `cargo clippy --all-targets -D warnings` clean, plus `--features egraph` and `--features parallel` · `pytest tests/` 3682 passed / 61 skipped, identical on both builds · silent-error gate 0 · `gen_certificate_ledger.py --check` clean · `ruff==0.15.14` format and check clean. No `unsafe`, no `is_none_or`, no new panics.

Three wheels installed with `pip --target` into separate trees selected by `PYTHONPATH`, distinct md5s confirmed, `alkahest.alkahest.__file__` checked, sympy present (`test_oracle.py` 339 passed, not silently skipped). The final tree was re-measured after the last refactor and matches `after` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
