### PR TITLE
fix(ci): stop instrumenting single-threaded solvers in the tsan shard

### DIFF
--- a/.github/tsan-scope.txt
+++ b/.github/tsan-scope.txt
@@ -1,0 +1,53 @@
+# ThreadSanitizer shard scope — libtest filters for the `alkahest-cas` **unit**
+# test binary (`cargo test -p alkahest-cas --lib`).
+#
+# Read by two places, which is the point of the file existing:
+#
+#   * `.github/workflows/ci.yml`, step "ThreadSanitizer" — passes every line
+#     below to libtest as a filter, and fails if any line matches zero tests.
+#   * `alkahest-core/tests/tsan_scope.rs` — an ordinary test, so it runs in
+#     Tier-1 `cargo test --workspace`. It fails if a module that can put two
+#     threads on the same data is *not* covered by a line below, and it fails
+#     if a line below names a module that no longer exists.
+#
+# Nothing else is narrowed. Every integration test target (including
+# `tests/parallel_stress.rs`, which exists for this shard) and every other
+# package's unit tests run in full — see the step's comment in ci.yml.
+#
+# Entries are matched as libtest substring filters, and by the guard as module
+# path prefixes. Over-inclusion is safe; under-inclusion is a defect.
+
+# ── Rayon: two workers on one `ExprPool` at the same time ──────────────────
+# The parallel simplifiers. `simplify_par` forks `Add`/`Mul` children onto a
+# Rayon pool and memoises through a shared `DashMap`; `simplify_redex` level-
+# schedules a redex bag through `par_iter`; `dispatch` picks between them and
+# reads `rayon::current_num_threads`. This is the only code in the crate where
+# two threads touch the same pool concurrently by design.
+simplify::parallel::
+simplify::redex::
+simplify::dispatch::
+
+# ── The segmented-stack thread handoff ─────────────────────────────────────
+# `with_stack_segment` continues a deep recursion on a freshly spawned thread
+# and joins it immediately, so only one thread is ever runnable — it cannot
+# race with itself. It is in scope anyway because the handoff moves a
+# thread-local `SEGMENT` and a `DerivationLog` across a thread boundary, which
+# is precisely the happens-before edge TSan exists to check. `simplify::engine`
+# is the sequential caller of that helper and spawns small-stack threads of its
+# own in `deep_chain_*`; `parse` does the same in `parse_code_on_big_stack`.
+simplify::stack::
+simplify::engine::
+parse::
+
+# ── The shared data structure itself ───────────────────────────────────────
+# `ExprPool`'s index is a sharded `DashMap` under `--features parallel` and the
+# node array is an append-only `boxcar::Vec`. Its own unit tests are single-
+# threaded, but this is the object every racing thread above converges on, and
+# the tests are cheap, so they stay instrumented.
+kernel::pool::
+
+# ── Rayon fan-out in the compiled-function batch path ──────────────────────
+# `CompiledFn::call_batch_par` is `output.par_iter_mut()` over a shared `&self`
+# function pointer; `jit::tests::par_batch_*` drive it. `jit::cache` is folded
+# in because it is the same module tree and costs seconds.
+jit::

--- a/.github/tsan-scope.txt
+++ b/.github/tsan-scope.txt
@@ -35,6 +35,16 @@ simplify::dispatch::
 # is precisely the happens-before edge TSan exists to check. `simplify::engine`
 # is the sequential caller of that helper and spawns small-stack threads of its
 # own in `deep_chain_*`; `parse` does the same in `parse_code_on_big_stack`.
+#
+# `parse::` is where this scope pays for its conservatism, and the number is
+# worth knowing before anyone "optimises" it. Measured locally (12 cores,
+# -Zsanitizer=thread, -Z build-std): the whole narrowed unit-test pass is 562 s
+# wall and `parse::tests::a_long_flat_sum_is_not_nesting` alone is 562 s of it —
+# every other test in this file finishes inside the first 12 s. That one test
+# does not spawn anything; it is in scope only because it shares a module with
+# `parse_code_on_big_stack`. Splitting it out would mean scoping by test name,
+# which is the hand-maintained list this file exists to avoid, and it would buy
+# ~9 minutes off a nightly job that used to take 136. Left as is deliberately.
 simplify::stack::
 simplify::engine::
 parse::

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,40 @@ jobs:
       # `simplify_par` / `simplify_redex` on one shared pool, and nested
       # `call_batch_par` from real OS threads. `egraph` is left off — it pulls
       # in egglog, which is single-threaded here and only lengthens the build.
+      #
+      # ── Why this step is not one `--workspace --lib --tests` command ──────
+      #
+      # It was, and the job stopped finishing. Measured from the last green
+      # nightly (run 33299657521): the `alkahest-cas` unit-test binary took
+      # 7 977 s, of which the last ~5 340 s is three tests running alone on an
+      # otherwise idle runner —
+      #
+      #   real::sos::psd::tests::psd_search_does_not_yet_reach_homogeneous_…  ~118 min
+      #   real::sos::psd::tests::psd_search_certifies_robinsons_form_with_…    ~67 min
+      #   real::sos::tests::motzkin_certifies_via_a_reznick_multiplier         ~63 min
+      #
+      # Every other test in the workspace was done 45 minutes in. Those three
+      # are semidefinite-programming searches: a simplex/LP loop over rational
+      # matrices in `real::sos::{lp,linalg,psd,gram}`, reached only from
+      # `real::sos`. They allocate nothing that outlives the call, share no
+      # state with anything, and — the point — never start a second thread.
+      # TSan reports data races; a race needs two threads touching one address.
+      # Instrumenting a single-threaded simplex solver cannot find one. It just
+      # made the shard the longest job in the matrix, and the last two nightlies
+      # were killed mid-run with SIGTERM.
+      #
+      # So: `alkahest-cas`'s *unit* tests are filtered down to the modules where
+      # two threads really do meet, listed in `.github/tsan-scope.txt`.
+      # Nothing else is narrowed — every integration test target and every other
+      # package's unit tests still run in full, because together they are ~70 s.
+      #
+      # What stops the filter from rotting is `alkahest-core/tests/tsan_scope.rs`,
+      # an ordinary test that runs on every PR: it walks the module tree from
+      # `src/lib.rs` and fails if a module whose source spawns a thread or hands
+      # work to Rayon is not covered by the scope file, and fails again if a
+      # scope entry names a module that no longer exists. Below, this step also
+      # refuses to run a filter that matches zero tests — a rename cannot make
+      # the shard pass vacuously.
       - name: ThreadSanitizer
         if: matrix.shard == 'tsan'
         env:
@@ -493,11 +527,43 @@ jobs:
             fi
           done
           echo "TSAN_OPTIONS=$TSAN_OPTIONS"
-          RUSTFLAGS="-Zsanitizer=thread" \
-          cargo +nightly test --workspace --lib --tests \
-            --features parallel \
-            --target x86_64-unknown-linux-gnu \
-            -Z build-std
+
+          mapfile -t SCOPE < <(grep -vE '^[[:space:]]*(#|$)' .github/tsan-scope.txt)
+          if [ "${#SCOPE[@]}" -eq 0 ]; then
+            echo "error: .github/tsan-scope.txt declares no filters" >&2
+            exit 1
+          fi
+          printf 'tsan scope filter: %s\n' "${SCOPE[@]}"
+
+          COMMON=(--features parallel --target x86_64-unknown-linux-gnu -Z build-std)
+          export RUSTFLAGS="-Zsanitizer=thread"
+
+          # 1/4 — build once, so the --list probes below cost nothing.
+          cargo +nightly test -p alkahest-cas --lib "${COMMON[@]}" --no-run
+
+          # 2/4 — a filter that matches nothing would make this shard green
+          # without running anything. Refuse before, not after.
+          for f in "${SCOPE[@]}"; do
+            n=$(cargo +nightly test -p alkahest-cas --lib "${COMMON[@]}" \
+                  -- --list "$f" 2>/dev/null | grep -c ': test$' || true)
+            echo "  $f -> $n tests"
+            if [ "$n" -eq 0 ]; then
+              echo "error: tsan scope filter '$f' matches no test in alkahest-cas." >&2
+              echo "       Fix or remove the entry in .github/tsan-scope.txt." >&2
+              exit 1
+            fi
+          done
+
+          # 3/4 — the narrowed unit tests: everything that can put two threads
+          # on the same data. See .github/tsan-scope.txt for what each entry is.
+          cargo +nightly test -p alkahest-cas --lib "${COMMON[@]}" -- "${SCOPE[@]}"
+
+          # 4/4 — unnarrowed: every integration test target in the workspace
+          # (parallel_stress.rs among them) and every other package's unit
+          # tests. Cheap, and it means a new integration test is covered the
+          # day it lands without anyone editing the scope file.
+          cargo +nightly test --workspace --test '*' "${COMMON[@]}"
+          cargo +nightly test --workspace --exclude alkahest-cas --lib "${COMMON[@]}"
 
       - name: LeakSanitizer
         if: matrix.shard == 'lsan'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+- **The nightly `tsan` shard spent two thirds of its wall clock instrumenting a
+  simplex solver.** It ran the whole workspace under ThreadSanitizer. On the
+  last green run the `alkahest-cas` unit-test binary took 7 977 s, and the last
+  5 291 s of that — 88 minutes, 66% of the job — was three tests running alone
+  on an otherwise idle runner: `psd_search_does_not_yet_reach_homogeneous_…`
+  (~119 min), `psd_search_certifies_robinsons_form_with_a_reznick_multiplier`
+  (~67 min) and `motzkin_certifies_via_a_reznick_multiplier` (~63 min).
+  Everything else in the workspace was finished 45 minutes in. Those three are
+  semidefinite-programming searches in `real::sos`, whose sources contain no
+  occurrence of `thread`, `rayon`, `Mutex`, `Atomic` or `unsafe`. TSan reports
+  data races, and a race needs two threads reaching one address, so
+  instrumenting them could never report anything. It only made this the longest
+  job in the matrix, and the last two nightlies were killed mid-step.
+
+  `alkahest-cas`'s **unit** tests are now filtered to the modules where two
+  threads actually meet — the Rayon simplifiers (`simplify::{parallel,redex,
+  dispatch}`), the segmented-stack thread handoff (`simplify::{stack,engine}`,
+  `parse`), the sharded `ExprPool` index (`kernel::pool`) and
+  `CompiledFn::call_batch_par` (`jit`) — declared in `.github/tsan-scope.txt`.
+  Nothing else is narrowed: every integration test target, `parallel_stress.rs`
+  among them, and every other package's unit tests still run in full, because
+  together they are ~70 s. 2 806 tests become 194; none of the 2 612 dropped
+  lives in a module containing a thread-spawn or Rayon token, and none names a
+  parallel entry point.
+
+  A hand-maintained list of test names would rot, so the list is not the
+  contract. `alkahest-core/tests/tsan_scope.rs` is an ordinary test — Tier 1, on
+  every PR — that walks the module tree from `src/lib.rs` and fails when a
+  module whose source spawns a thread or hands work to Rayon is not covered, and
+  fails again when an entry names a module that no longer exists. The workflow
+  additionally refuses any filter matching zero tests, so a rename cannot make
+  the shard pass vacuously. `RUST_MIN_STACK` and the `TSAN_OPTIONS` symbolizer
+  handling are unchanged.
+
+  Not fixed here, but on the same path: the `lsan` shard also runs the whole
+  workspace, has gone from ~30 min to 152 min over the same period, and hit the
+  6 h job cap once (run 32209848511). Its exclusion argument is not the same one
+  — a single-threaded solver allocates, so LeakSanitizer has something to say
+  about it — so it needs a different fix.
 - **A Lean certificate typechecked while proving a different statement than the
   one the API reported.** `expr_to_lean` rendered an integer literal with
   `to_i64().unwrap_or(0)`, so any value outside `i64` was silently printed as

--- a/alkahest-core/tests/tsan_scope.rs
+++ b/alkahest-core/tests/tsan_scope.rs
@@ -318,6 +318,21 @@ fn tsan_scope_covers_every_module_that_can_start_a_thread() {
         if is_covered(&module, &entries) {
             continue;
         }
+
+        // A module with tests that names a Rayon-backed entry point anywhere in
+        // its code. The file-level condition is the one that decides; the loop
+        // below only exists to name the offending test in the message. Deciding
+        // at file level means a mis-braced body in `test_fn_bodies` can cost a
+        // vague message but never a missed module.
+        let file_calls: Vec<&str> = PARALLEL_ENTRY_POINTS
+            .iter()
+            .copied()
+            .filter(|t| stripped.contains(t))
+            .collect();
+        if file_calls.is_empty() || !stripped.contains("#[test]") {
+            continue;
+        }
+        let mut named = false;
         for (name, body) in test_fn_bodies(&stripped) {
             let calls: Vec<&str> = PARALLEL_ENTRY_POINTS
                 .iter()
@@ -325,12 +340,20 @@ fn tsan_scope_covers_every_module_that_can_start_a_thread() {
                 .filter(|t| body.contains(t))
                 .collect();
             if !calls.is_empty() {
+                named = true;
                 gaps.push(format!(
                     "  {shown}::…::{name}  ({}) calls: {}",
                     file.display(),
                     calls.join(", ")
                 ));
             }
+        }
+        if !named {
+            gaps.push(format!(
+                "  {shown}  ({}) has tests and names: {}",
+                file.display(),
+                file_calls.join(", ")
+            ));
         }
     }
 

--- a/alkahest-core/tests/tsan_scope.rs
+++ b/alkahest-core/tests/tsan_scope.rs
@@ -77,6 +77,21 @@ fn scope_path() -> PathBuf {
     repo_root().join(".github").join("tsan-scope.txt")
 }
 
+/// `false` when this is a published `.crate` rather than the git checkout.
+///
+/// `.github/` is not part of the packaged crate, so a downstream `cargo test`
+/// on a vendored `alkahest-cas` has nothing to check and should not fail. The
+/// probe is the *workflow*, not the scope file: inside the repo the workflow
+/// always exists, so this can never quietly disable the guard where it matters
+/// — a missing or emptied `tsan-scope.txt` still fails loudly below.
+fn in_source_repo() -> bool {
+    repo_root()
+        .join(".github")
+        .join("workflows")
+        .join("ci.yml")
+        .is_file()
+}
+
 /// The filter lines of `.github/tsan-scope.txt`, trailing `::` trimmed.
 fn scope_entries() -> Vec<String> {
     let path = scope_path();
@@ -268,6 +283,10 @@ fn test_fn_bodies(src: &str) -> Vec<(String, String)> {
 
 #[test]
 fn tsan_scope_covers_every_module_that_can_start_a_thread() {
+    if !in_source_repo() {
+        eprintln!("not a git checkout (.github/ absent) — tsan scope guard skipped");
+        return;
+    }
     let entries = scope_entries();
     let mut gaps: Vec<String> = Vec::new();
 
@@ -329,6 +348,10 @@ fn tsan_scope_covers_every_module_that_can_start_a_thread() {
 
 #[test]
 fn tsan_scope_entries_all_name_a_live_module() {
+    if !in_source_repo() {
+        eprintln!("not a git checkout (.github/ absent) — tsan scope guard skipped");
+        return;
+    }
     let entries = scope_entries();
     let modules: BTreeSet<String> = module_files().into_iter().map(|(m, _)| m).collect();
 

--- a/alkahest-core/tests/tsan_scope.rs
+++ b/alkahest-core/tests/tsan_scope.rs
@@ -1,0 +1,352 @@
+//! Keeps the nightly ThreadSanitizer shard's scope honest.
+//!
+//! The `tsan` shard used to run the whole workspace under TSan. That is 133
+//! minutes of instrumented tests of which ~89 are three single-threaded
+//! semidefinite-programming searches in `real::sos` — code that cannot race
+//! because it never starts a second thread. The shard now runs
+//! `alkahest-cas`'s unit tests filtered through `.github/tsan-scope.txt`
+//! (everything else in the workspace still runs in full; see the step comment
+//! in `.github/workflows/ci.yml`).
+//!
+//! A filter list is only safe if it cannot silently stop covering something.
+//! That is this file's job, and it is an ordinary integration test so it runs
+//! on every PR rather than once a night:
+//!
+//! * [`tsan_scope_covers_every_module_that_can_start_a_thread`] walks the
+//!   module tree from `src/lib.rs`, and fails if a module whose source spawns
+//!   a thread or hands work to Rayon is not covered by a scope entry. Add
+//!   `rayon::` to a new module and Tier-1 CI goes red until the scope names
+//!   it.
+//! * [`tsan_scope_entries_all_name_a_live_module`] fails when an entry no
+//!   longer corresponds to a module — the rename case, where a filter would
+//!   otherwise quietly match nothing and the shard would pass vacuously. (The
+//!   workflow independently fails any filter that matches zero *tests*.)
+//!
+//! # What this check does not prove
+//!
+//! It is a syntactic scan, not a call graph. A test in an out-of-scope module
+//! that reaches Rayon through a helper in a *third* module — one that names
+//! neither `rayon::` nor a parallel entry point in its own source — would not
+//! be flagged. The parallel surface is small and entirely public
+//! (`simplify_par`, `simplify_redex`, `simplify_auto`, `call_batch_par`), so
+//! that path is narrow, and [`PARALLEL_ENTRY_POINTS`] catches the direct call.
+//! The residual risk is accepted deliberately; the alternative is instrumenting
+//! 2 700 tests to look for races in a simplex solver.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Source spellings that put a second thread on the CPU.
+///
+/// Deliberately crude and deliberately over-eager: a false positive costs one
+/// line in `.github/tsan-scope.txt`, a false negative costs a race that
+/// nothing looks for.
+const SPAWN_TOKENS: &[&str] = &[
+    "thread::spawn",
+    "thread::scope",
+    "thread::Builder",
+    "spawn_scoped",
+    "rayon::",
+    "par_iter",
+    "par_chunks",
+    "par_bridge",
+    "par_extend",
+    "par_sort",
+];
+
+/// Public functions that run the caller's work on a Rayon pool.
+///
+/// A test naming one of these executes concurrent code even if its own module
+/// is otherwise sequential, so the module has to be in scope.
+const PARALLEL_ENTRY_POINTS: &[&str] = &[
+    "simplify_par",
+    "simplify_redex",
+    "simplify_auto",
+    "call_batch_par",
+];
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("alkahest-core has a parent directory")
+        .to_path_buf()
+}
+
+fn scope_path() -> PathBuf {
+    repo_root().join(".github").join("tsan-scope.txt")
+}
+
+/// The filter lines of `.github/tsan-scope.txt`, trailing `::` trimmed.
+fn scope_entries() -> Vec<String> {
+    let path = scope_path();
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let entries: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|l| l.trim_end_matches("::").to_string())
+        .collect();
+    assert!(
+        !entries.is_empty(),
+        "{} declares no filters; the tsan shard would run nothing",
+        path.display()
+    );
+    entries
+}
+
+fn is_covered(module: &str, entries: &[String]) -> bool {
+    entries
+        .iter()
+        .any(|e| module == e || module.starts_with(&format!("{e}::")))
+}
+
+/// Drop `//` line comments and `/* */` block comments that own their line.
+///
+/// Doc comments are the main source of false positives here — `simplify::rules`
+/// and `simplify::depth` both discuss `simplify_par` in prose without calling
+/// it. Comments that trail code are left alone; a trailing comment mentioning a
+/// spawn token is rare and only ever over-includes.
+fn strip_comments(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut in_block = false;
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        if in_block {
+            if trimmed.contains("*/") {
+                in_block = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        if trimmed.starts_with("/*") {
+            if !trimmed.contains("*/") {
+                in_block = true;
+            }
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// The `mod foo;` declarations in one file, in source order.
+fn child_module_names(src: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in src.lines() {
+        let mut rest = line.trim();
+        if let Some(r) = rest.strip_prefix("pub") {
+            rest = r.trim_start();
+            if rest.starts_with('(') {
+                match rest.find(')') {
+                    Some(i) => rest = rest[i + 1..].trim_start(),
+                    None => continue,
+                }
+            }
+        }
+        let Some(rest) = rest.strip_prefix("mod ") else {
+            continue;
+        };
+        let name = rest.trim();
+        // `mod foo;` only. `mod foo {` is inline and owns no file.
+        let Some(name) = name.strip_suffix(';') else {
+            continue;
+        };
+        let name = name.trim();
+        if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
+/// Every file reachable from `src/lib.rs` by following `mod foo;`, paired with
+/// its module path.
+///
+/// Walking the declarations rather than the directory is what keeps a stray
+/// source file out of the result: `poly/groebner/f4.rs` still sits on disk and
+/// still contains `par_iter`, but `poly/groebner/mod.rs` replaced it with an
+/// inline re-export shim years ago and never compiles it. Demanding TSan
+/// coverage for a file the build ignores would be noise.
+fn module_files() -> Vec<(String, PathBuf)> {
+    let src = repo_root().join("alkahest-core").join("src");
+    let mut found = Vec::new();
+    let mut queue = vec![(String::new(), src.join("lib.rs"))];
+    let mut seen = BTreeSet::new();
+
+    while let Some((path, file)) = queue.pop() {
+        if !seen.insert(file.clone()) {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(&file) else {
+            continue;
+        };
+        let stripped = strip_comments(&text);
+
+        // Where this file's children live: `lib.rs`/`mod.rs` own their own
+        // directory, `foo.rs` owns the sibling directory `foo/`.
+        let stem = file.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        let dir = match stem {
+            "lib" | "mod" => file.parent().expect("file has a parent").to_path_buf(),
+            other => file
+                .parent()
+                .expect("file has a parent")
+                .join(other)
+                .to_path_buf(),
+        };
+
+        for name in child_module_names(&stripped) {
+            let child_path = if path.is_empty() {
+                name.clone()
+            } else {
+                format!("{path}::{name}")
+            };
+            let flat = dir.join(format!("{name}.rs"));
+            let nested = dir.join(&name).join("mod.rs");
+            if flat.is_file() {
+                queue.push((child_path, flat));
+            } else if nested.is_file() {
+                queue.push((child_path, nested));
+            }
+        }
+        found.push((path, file));
+    }
+    found
+}
+
+/// Test functions in `src`, as `(name, body)`.
+///
+/// Brace matching from the `{` that opens the function. Good enough for a
+/// formatted tree — `cargo fmt` runs in CI — and only ever fails by returning
+/// too much body, which over-includes.
+fn test_fn_bodies(src: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let bytes: Vec<&str> = src.lines().collect();
+    for (i, line) in bytes.iter().enumerate() {
+        if line.trim() != "#[test]" {
+            continue;
+        }
+        // The `fn` line may be a few attributes down (`#[should_panic]`, ...).
+        let Some(fn_line) = (i + 1..(i + 8).min(bytes.len()))
+            .find(|&j| bytes[j].trim_start().starts_with("fn ") || bytes[j].contains(" fn "))
+        else {
+            continue;
+        };
+        let name = bytes[fn_line]
+            .split("fn ")
+            .nth(1)
+            .and_then(|r| r.split(['(', '<']).next())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let mut depth = 0i32;
+        let mut started = false;
+        let mut body = String::new();
+        for l in &bytes[fn_line..] {
+            for c in l.chars() {
+                if c == '{' {
+                    depth += 1;
+                    started = true;
+                } else if c == '}' {
+                    depth -= 1;
+                }
+            }
+            body.push_str(l);
+            body.push('\n');
+            if started && depth <= 0 {
+                break;
+            }
+        }
+        out.push((name, body));
+    }
+    out
+}
+
+#[test]
+fn tsan_scope_covers_every_module_that_can_start_a_thread() {
+    let entries = scope_entries();
+    let mut gaps: Vec<String> = Vec::new();
+
+    for (module, file) in module_files() {
+        let Ok(text) = fs::read_to_string(&file) else {
+            continue;
+        };
+        let stripped = strip_comments(&text);
+        let shown = if module.is_empty() {
+            "<crate root>"
+        } else {
+            &module
+        };
+
+        let spawns: Vec<&str> = SPAWN_TOKENS
+            .iter()
+            .copied()
+            .filter(|t| stripped.contains(t))
+            .collect();
+        if !spawns.is_empty() && !is_covered(&module, &entries) {
+            gaps.push(format!(
+                "  {shown}  ({}) spawns threads: {}",
+                file.display(),
+                spawns.join(", ")
+            ));
+            continue;
+        }
+
+        if is_covered(&module, &entries) {
+            continue;
+        }
+        for (name, body) in test_fn_bodies(&stripped) {
+            let calls: Vec<&str> = PARALLEL_ENTRY_POINTS
+                .iter()
+                .copied()
+                .filter(|t| body.contains(t))
+                .collect();
+            if !calls.is_empty() {
+                gaps.push(format!(
+                    "  {shown}::…::{name}  ({}) calls: {}",
+                    file.display(),
+                    calls.join(", ")
+                ));
+            }
+        }
+    }
+
+    assert!(
+        gaps.is_empty(),
+        "these modules can run two threads at once but the nightly \
+         ThreadSanitizer shard would not run their tests:\n{}\n\n\
+         Add the module path to {} (or move the test into a module already \
+         listed there). The shard only instruments what that file names — a \
+         module missing from it is a race nothing in CI looks for.",
+        gaps.join("\n"),
+        scope_path().display(),
+    );
+}
+
+#[test]
+fn tsan_scope_entries_all_name_a_live_module() {
+    let entries = scope_entries();
+    let modules: BTreeSet<String> = module_files().into_iter().map(|(m, _)| m).collect();
+
+    let stale: Vec<&String> = entries
+        .iter()
+        .filter(|e| {
+            !modules
+                .iter()
+                .any(|m| m == *e || m.starts_with(&format!("{e}::")))
+        })
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "{} names modules that do not exist in alkahest-core: {:?}\n\
+         A filter that matches nothing makes the tsan shard pass vacuously. \
+         Delete the entry or fix the path.",
+        scope_path().display(),
+        stale,
+    );
+}


### PR DESCRIPTION
`Nightly (tsan)` has left `main` red. It is not a data race and not a test failure: the job dies with `The runner has received a shutdown signal`, exit **143** — SIGTERM, the runner being reclaimed — with tests passing normally right up to the kill.

## Duration does not predict the kill — this is a mitigation, not a proven fix

I want this stated plainly, because the obvious story is wrong.

| run | date | tsan duration | outcome |
|---|---|---|---|
| 33299657521 | 08-30 | **136 m** | success |
| 33243038570 | 08-29 | **116 m** | success |
| 33370179540 | 08-31 | **50 m** | SIGTERM / 143 |
| 33479773254 | 09-01 | **89 m** | killed, log never uploaded |

Jobs that ran 136 minutes finished; jobs killed at 50 and 89 did not. Nor is it a fleet-wide reclaim wave — on both those nights `Nightly (lsan)` ran **152 m** and both AFL shards ran **126 m** in the same run, all green. Only `tsan` died.

Also worth correcting the record: the 11 failures **before** 08-29 were not reclaims at all. They were a genuine test failure — `holonomic::telescoping2d::tests::chained_product_at_original_bounds_refuses_fast_via_resource_ceiling`, exit 101 — fixed around 08-29. Only the last two nightlies are the SIGTERM case.

What does hold: before ~08-14 this shard took 7–27 minutes and was never reclaimed; the kills appear only after it grew to 110–180 minutes, and both landed inside the `real::sos` tail. Memory telemetry was unobtainable — the 09-01 tsan log is **absent from the run archive entirely**, which is itself consistent with the runner agent dying. So: a strong prior, not a demonstrated root cause. Shortening the shard 6× and removing its heaviest work removes the exposure either way.

## Where the time went, measured

From run 33299657521, the last green one. The test binary ran 7 977 s. Every test except three finished 44 minutes in. The remaining **5 291 s — 88 minutes, 66% of the job** — is three tests alone on an otherwise idle runner:

| test | duration |
|---|---|
| `real::sos::psd::tests::psd_search_does_not_yet_reach_homogeneous_motzkin_times_sum_of_squares` | ~119 min |
| `real::sos::psd::tests::psd_search_certifies_robinsons_form_with_a_reznick_multiplier` | ~67 min |
| `real::sos::tests::motzkin_certifies_via_a_reznick_multiplier` | ~63 min |

`grep -rn "thread\|rayon\|Mutex\|Atomic\|unsafe\|simplify" alkahest-core/src/real/sos/` returns **zero hits across all 8 files**. They cannot start a thread, so TSan has nothing to say about them.

## The change

`.github/tsan-scope.txt` holds 8 **module-path** filters, read by the workflow. Only `alkahest-cas`'s *unit* tests are narrowed — every integration target still runs unfiltered via `--test '*'` (so `parallel_stress.rs` and any future one are covered automatically), as does `--workspace --exclude alkahest-cas --lib`. Those cost ~70 s combined; narrowing them would buy nothing.

**Anti-rot, three independent layers**, because a hand-maintained list of test names would rot:

1. `alkahest-core/tests/tsan_scope.rs` — an ordinary test, so it runs in **Tier 1 on every PR**, not once a night. It walks the module tree by following `mod foo;` from `src/lib.rs` and fails if a module whose source contains a spawn/Rayon token, or whose tests name `simplify_par`/`simplify_redex`/`simplify_auto`/`call_batch_par`, is not covered. It also fails on an entry naming a module that no longer exists.
2. The workflow refuses any filter matching **zero tests**, so a rename cannot make the shard pass vacuously.
3. Integration tests are never filtered, so the purpose-built stress harness cannot be dropped by editing a list.

Module granularity plus a source-scanning guard was chosen over a naming convention because the concurrency surface is small, closed and module-shaped; a convention would need the same scan to enforce it and would additionally require renaming existing tests.

**Rejected, with reasons.** *Two matrix shards*: the build-std + TSan build is the fixed cost, so splitting pays it twice for zero coverage gain, and the split point is the same list — it does not address rot. *Weekly full run*: keeps a job we know does not finish, red one day in seven instead of most days, and the signal it adds is empty by construction. *More concurrency*: libtest already parallelises; the tail is three tests each running long **alone**, so it is Amdahl-bound at zero, and more threads under TSan increases shadow-memory pressure — the leading suspect for the runner dying.

## Coverage: 2 806 → 194 tests

The dropped set was verified programmatically against both criteria:

- dropped tests in a module containing a thread-spawn or Rayon token: **0**
- dropped tests whose body names a parallel entry point: **0**
- dropped tests whose module could not be resolved: **0**

Kept: `simplify::{parallel,redex,dispatch}` (32), `simplify::{stack,engine}` + `parse::` (61), `kernel::pool::` (28), `jit::` (34) = 147 alkahest-cas unit tests, plus 24 alkahest-mlir lib and 23 integration including all 7 `parallel_stress` tests. Dropped is dominated by `integrate` (869), `poly` (209), `holonomic` (187), `lean` (122), `real` (86).

## Proof the shard still catches a race

A scratch test was appended to `simplify/parallel.rs` — two `std::thread::spawn`s doing an unsynchronised write/read through a raw pointer — and run under **exactly the narrowed command**:

```
WARNING: ThreadSanitizer: data race (pid=581547)
  Read of size 8 by thread T175:
    #0 …deliberate_data_race_scratch::{closure#1}  simplify/parallel.rs:611
  Previous write of size 8 by thread T174:
    #0 …{closure#0}  simplify/parallel.rs:604
```

`CARGO_EXIT=66`. Scratch test removed, tree clean. The guard was also negative-tested three ways — dropping `jit::` from scope, adding a bogus entry, and adding a `simplify_par` call in an out-of-scope module — each failing with a pointed message, each restored.

## Verification, and what is not verified

Narrowed TSan unit pass: **562 s / 146 tests**. Notable: `parse::tests::a_long_flat_sum_is_not_nesting` is 562 s of that 562 s — everything else finishes in the first 12 s. It spawns nothing and is in scope only because it shares a module with `parse_code_on_big_stack`. Splitting it out means scoping by test *name*, the thing being avoided, for ~9 minutes off a job that used to take 136. Left in, with the number recorded in the scope file.

`actionlint` and `shellcheck` clean on the new step (5 pre-existing SC2086 findings elsewhere, verified identical against `origin/main`); `bash -n` on every `run:` block; `cargo fmt`, `cargo clippy --all-targets -D warnings` on default **and** `--features parallel`, `cargo test --workspace` all green.

**Not verified:** the full 4-pass step end-to-end under TSan — the box had ~3 GB free disk, so pass 3 ran in full and passes 2 and 4 were validated via `--list` plus a normal-build run. GitHub Actions is obviously unrun until this PR.

`RUST_MIN_STACK`, the `TSAN_OPTIONS` symbolizer loop and `tsan.supp` are untouched — all load-bearing. No `continue-on-error`, no retry, no deleted shard.

## Two findings, not fixed here

1. **`lsan` is on the same path** — same full-workspace command, ~30 → 152 minutes over the same period, and it already hit the 6 h cap once (run 32209848511, cancelled at 360 m). The exclusion argument does **not** transfer: a single-threaded solver still allocates, so LeakSanitizer genuinely has something to say about `real::sos`. It needs a different fix. `asan` is trending up (42→49→69→75 m) but has headroom; `valgrind` is stable; the AFL shards are pinned by their own 2 h caps.
2. **`alkahest-core/src/poly/groebner/f4.rs` is dead source.** `groebner/mod.rs` replaced it with an inline `pub mod f4 { pub use super::buchberger::… }` shim and never declares `mod f4;`, so the file — 200 lines including a Rayon `par_iter` reduction and 4 tests — is not compiled. Found because the guard initially demanded TSan coverage for it; that is why the guard walks `mod` declarations rather than the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Focused nightly ThreadSanitizer checks on concurrency-related test areas for more efficient validation.
  * Added safeguards to detect empty, missing, or outdated ThreadSanitizer coverage.
  * Retained broader integration and package test coverage in the nightly workflow.

* **Documentation**
  * Added changelog notes covering ThreadSanitizer coverage improvements and fixes for Lean certificates, integration checks, and genus reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->