### PR TITLE
docs(release): date the 3.9.0 section and point the install examples at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.9.0 — 2026-09-02
+
 - **A definite integral whose antiderivative is not defined on the interval of
   integration was answered rather than refused.** The FTC needs `F` continuous
   on `[a, b]`; `engine::antiderivative_jump` is the guard that looks at `F`
@@ -1877,7 +1879,6 @@
   Nothing in `integrate/` was touched: emitting Fresnel or `Li₂` forms from
   `∫sin(x²)dx`, `∫log(x)/(1+x)dx` and friends is a separate change.
 
-## 3.9.0 — 2026-08-14
 
 Everything in this section landed **after `v3.8.0` was tagged and published**,
 so none of it is in the released 3.8.0 wheel. It is the result of acting on a

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Probe your environment after install: `alkahest.capabilities()["features"]` and 
 
 ### Opt-in Linux wheels: `+jit` and `+full` (PyTorch-style)
 
-**Why a separate index or direct wheel URL:** feature-heavy wheels use a PEP 440 **local version** (for example `3.8.0+jit` or `3.8.0+full`). Those builds **must not** be mixed into the main PyPI project’s simple API for the same reason PyTorch publishes CUDA wheels on `download.pytorch.org`: otherwise `pip install alkahest` could resolve a `+jit` / `+full` build as “newer” than `3.8.0` and pull LLVM (or a much larger binary) when you wanted the default wheel.
+**Why a separate index or direct wheel URL:** feature-heavy wheels use a PEP 440 **local version** (for example `3.9.0+jit` or `3.9.0+full`). Those builds **must not** be mixed into the main PyPI project’s simple API for the same reason PyTorch publishes CUDA wheels on `download.pytorch.org`: otherwise `pip install alkahest` could resolve a `+jit` / `+full` build as “newer” than `3.9.0` and pull LLVM (or a much larger binary) when you wanted the default wheel.
 
 There is **no** `pip install alkahest[jit]` / `alkahest[full]` that swaps the native extension: **pip extras only add Python dependencies**, not alternate binaries for the same wheel slot.
 
@@ -76,13 +76,13 @@ There is **no** `pip install alkahest[jit]` / `alkahest[full]` that swaps the na
 Direct-install examples (adjust tag and filename after checking the release assets):
 
 ```bash
-pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.8.0/alkahest-3.8.0+full-cp311-cp311-linux_x86_64.whl"
-pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.8.0/alkahest-3.8.0+jit-cp311-cp311-linux_x86_64.whl"
+pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.9.0/alkahest-3.9.0+full-cp311-cp311-linux_x86_64.whl"
+pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.9.0/alkahest-3.9.0+jit-cp311-cp311-linux_x86_64.whl"
 ```
 
 These wheels vendor LLVM (for JIT) and related `.so` files under `site-packages/alkahest.libs/`. If `import alkahest` fails with a missing `libffi-*.so` or `libLLVM-*.so`, prepend that directory to `LD_LIBRARY_PATH` (or install matching system packages). Release CI uses the same `LD_LIBRARY_PATH` step when smoke-testing wheels.
 
-If your client chokes on `+` in the URL, use percent-encoding (`3.8.0%2Bfull` in the filename segment).
+If your client chokes on `+` in the URL, use percent-encoding (`3.9.0%2Bfull` in the filename segment).
 
 After installing the **default** wheel, `alkahest.jit_is_available()` is `True` (Cranelift). After **`+jit`** it is also `True` (LLVM, in place of Cranelift); **`+full`** carries both backends. Gröbner-backed APIs such as `alkahest.solve` are available in **all** wheels since `groebner` became a default feature.
 
@@ -91,7 +91,7 @@ After installing the **default** wheel, `alkahest.jit_is_available()` is `True` 
 **Target layout (roadmap):** a small **extra index** URL (PEP 503) hosting only `+jit` / `+full` wheels, mirroring PyTorch’s `--extra-index-url` workflow:
 
 ```bash
-pip install 'alkahest==3.8.0+full' --extra-index-url https://EXAMPLE/alkahest-extras/simple
+pip install 'alkahest==3.9.0+full' --extra-index-url https://EXAMPLE/alkahest-extras/simple
 ```
 
 ### From source


### PR DESCRIPTION
`v3.9.0` has never been tagged — the newest release is **v3.8.0** (2026-08-13), while `Cargo.toml` and `pyproject.toml` have read `3.9.0` since shortly after it.

So the 66 entries that accumulated under `## Unreleased` are 3.9.0 material too, and the existing `## 3.9.0 — 2026-08-14` heading sat *below* them, predating most of their content. Tagging without noticing would have shipped release notes dated three weeks before the work they describe.

This folds the two together under a single `## 3.9.0 — 2026-09-02` heading and leaves `## Unreleased` empty for the next cycle.

**The rollover is verified content-identical** — stripping section headers and blank lines leaves the file unchanged, so no entry was moved, dropped or reworded.

README's install examples and wheel URLs still pointed at `v3.8.0`; updated to `3.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the 3.9.0 release date in the changelog.
  - Added a changelog entry for a definite-integral verification fix.
  - Added performance notes to the 3.9.0 release information.
  - Updated Linux wheel installation examples and references to version 3.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->