### PR TITLE
fix(matrix): write Cardano's two cube roots as a coordinated pair, and check every spectrum before returning it

### DIFF
--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -69,6 +69,7 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-EIGEN-005", class: "EigenError", cause: Cause::Domain,    remediation: Some("the matrix is defective or the eigenbasis is incomplete") },
     ErrorSpec { code: "E-EIGEN-006", class: "EigenError", cause: Cause::Unsupported, remediation: Some("nullspace elimination failed; try a purely rational or ℚ(i) spectrum") },
     ErrorSpec { code: "E-EIGEN-007", class: "EigenError", cause: Cause::Domain,    remediation: Some("eigenvector matrix is singular; check multiplicities") },
+    ErrorSpec { code: "E-EIGEN-008", class: "SpectrumRefusal", cause: Cause::Domain,    remediation: Some("substitute concrete numbers for any symbolic entries, or use real_roots / numeric eigenvalues for this matrix") },
     // E-LINALG — LinearAlgebraError (symbolic LA coverage)
     ErrorSpec { code: "E-LINALG-001", class: "LinearAlgebraError", cause: Cause::UserInput,   remediation: Some("pass a square n×n matrix") },
     ErrorSpec { code: "E-LINALG-002", class: "LinearAlgebraError", cause: Cause::Unsupported, remediation: Some("nullspace elimination failed; try rational entries") },

--- a/alkahest-core/src/eval/complex_f64.rs
+++ b/alkahest-core/src/eval/complex_f64.rs
@@ -109,6 +109,21 @@ impl ComplexF64 {
             -self.re.sin() * self.im.sinh(),
         )
     }
+    /// `acos z = π/2 + i·Log(iz + √(1 − z²))`, principal branch.
+    ///
+    /// Present because `matrix::eigen`'s casus-irreducibilis form —
+    /// `2√(−p/3)·cos((acos c + 2πk)/3)`, the *correct* closed form for a cubic
+    /// with three real roots — is otherwise a spectrum
+    /// [`crate::matrix::spectrum`]'s check cannot evaluate, and an unevaluable
+    /// spectrum is no information rather than a confirmation.
+    fn acos(self) -> Result<Self, EvalError> {
+        let one = Self::new(1.0, 0.0);
+        let i = Self::new(0.0, 1.0);
+        let root = one.add(Self::new(-1.0, 0.0).mul(self.mul(self))).sqrt()?;
+        let ln = i.mul(self).add(root).ln()?;
+        Ok(Self::new(std::f64::consts::FRAC_PI_2, 0.0).add(i.mul(ln)))
+    }
+
     fn principal_arg(self) -> Result<f64, EvalError> {
         // Principal arg is undefined at 0 and discontinuous on the negative real axis.
         if self.im == 0.0 && self.re <= 0.0 {
@@ -187,6 +202,7 @@ fn eval_node(
                 "exp" => Ok(x.exp()),
                 "log" => x.ln(),
                 "sqrt" => x.sqrt(),
+                "acos" => x.acos(),
                 "re" => Ok(ComplexF64::new(x.re, 0.0)),
                 "im" => Ok(ComplexF64::new(x.im, 0.0)),
                 "conjugate" => Ok(ComplexF64::new(x.re, -x.im)),
@@ -246,6 +262,24 @@ mod tests {
         let expr = pool.pow(pool.integer(-1_i32), pool.rational(1, 2));
         let v = eval_complex_f64(expr, &pool, &HashMap::new()).unwrap();
         assert!((v.re).abs() < 1e-12 && (v.im - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn acos_matches_the_real_branch_inside_the_unit_interval() {
+        let pool = crate::kernel::ExprPool::new();
+        let expr = pool.func("acos", vec![pool.rational(1, 2)]);
+        let v = eval_complex_f64(expr, &pool, &HashMap::new()).unwrap();
+        assert!((v.re - std::f64::consts::FRAC_PI_3).abs() < 1e-12, "{v:?}");
+        assert!(v.im.abs() < 1e-12, "{v:?}");
+    }
+
+    #[test]
+    fn acos_continues_off_the_real_interval() {
+        let pool = crate::kernel::ExprPool::new();
+        // cos(acos 2) must be 2 again, whatever branch the continuation picks.
+        let expr = pool.func("cos", vec![pool.func("acos", vec![pool.integer(2_i32)])]);
+        let v = eval_complex_f64(expr, &pool, &HashMap::new()).unwrap();
+        assert!((v.re - 2.0).abs() < 1e-12 && v.im.abs() < 1e-12, "{v:?}");
     }
 
     #[test]

--- a/alkahest-core/src/matrix/eigen.rs
+++ b/alkahest-core/src/matrix/eigen.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
-use crate::matrix::{zero_test, Matrix};
+use crate::matrix::{spectrum, zero_test, Matrix};
 use crate::poly::error::ConversionError;
 use crate::poly::unipoly::UniPoly;
 use crate::poly::{factor_univariate_z, FactorError};
@@ -85,7 +85,16 @@ pub enum EigenError {
     CharPolyConversion(ConversionError),
     /// FLINT factorization failed.
     Factorization(FactorError),
-    /// The characteristic polynomial has an irreducible factor of degree greater than three.
+    /// No *usable* closed form for a factor of this degree.
+    ///
+    /// Covers two refusals. Either the characteristic polynomial has an
+    /// irreducible factor of degree greater than three, for which this module
+    /// has no formula at all; or a closed form was produced and then failed
+    /// `matrix::spectrum::confirm_spectrum`, which is the stronger
+    /// statement that the radicals do not describe the spectrum on the branches
+    /// anything will read them on. `EigenError` is a public exhaustive enum and
+    /// cannot grow a variant for the second, so it travels out of band — see
+    /// [`crate::matrix::take_spectrum_refusal`], which carries `E-EIGEN-008`.
     UnsupportedIrreducibleDegree { degree: usize },
     /// Algebraic and geometric multiplicity disagree (Jordan block situation).
     NonDiagonalizable,
@@ -103,8 +112,9 @@ impl fmt::Display for EigenError {
             EigenError::Factorization(e) => write!(f, "factorization failed: {e}"),
             EigenError::UnsupportedIrreducibleDegree { degree } => write!(
                 f,
-                "characteristic polynomial has an irreducible factor of degree {degree}; \
-                 closed-form eigenvalues are only available up to degree 3"
+                "no usable closed form for a characteristic factor of degree {degree}: \
+                 either the factor is irreducible of degree > 3, for which there is no \
+                 formula here, or its radicals did not check out as the spectrum"
             ),
             EigenError::NonDiagonalizable => {
                 write!(
@@ -149,7 +159,7 @@ impl crate::errors::AlkahestError for EigenError {
             ),
             EigenError::Factorization(_) => None,
             EigenError::UnsupportedIrreducibleDegree { .. } => {
-                Some("degree-4+ irreducible characteristic factors require a CAS / algebraic-numbers extension")
+                Some("degree-4+ irreducible characteristic factors require a CAS / algebraic-numbers extension; for a spectrum that did not verify, substitute concrete entries or use numeric root finding")
             }
             EigenError::NonDiagonalizable => {
                 Some("use Jordan-form tooling or restrict to diagonalizable matrices")
@@ -192,7 +202,47 @@ pub fn characteristic_polynomial_lambda_minus_m(
 }
 
 /// multiset of eigenvalue Expr → algebraic multiplicity
+///
+/// # The returned list is checked before it is returned
+///
+/// Every closed form here is a radical, and a radical is not a number until a
+/// branch is chosen. `matrix::spectrum::confirm_spectrum` evaluates
+/// `Π(z − λ)` and `det(zI − A)` at sampled `z` and refuses when they differ, so
+/// a spectrum that is only correct under some convention the expression does
+/// not record cannot leave this function. See
+/// `real_cbrt_of_rational_plus_sqrt` for the case that motivated it.
+///
+/// A list that cannot be evaluated at all is *no information* rather than a
+/// refusal — the classification `integrate`'s antiderivative gates and
+/// `limit`'s value gate use — because refusing it would discard every
+/// symbolic-entry spectrum on the strength of an evaluator's function table.
 pub fn eigenvalues(m: &Matrix, pool: &ExprPool) -> Result<Vec<(ExprId, usize)>, EigenError> {
+    // No `UnsupportedIrreducibleDegree` this call returns may inherit the
+    // `E-EIGEN-008` of an earlier one on the same thread — cf.
+    // [`zero_test::forget_refusal`].
+    spectrum::forget_refusal();
+    let pairs = eigenvalues_unchecked(m, pool)?;
+    // Flatten to a list with multiplicity: the identity being tested is between
+    // two degree-`n` polynomials, so every root has to appear as often as it is
+    // claimed to.
+    let mut flat: Vec<ExprId> = Vec::new();
+    for &(lam, mult) in &pairs {
+        for _ in 0..mult {
+            flat.push(lam);
+        }
+    }
+    match spectrum::confirm_spectrum(m, &flat, pool) {
+        Ok(_) => Ok(pairs),
+        Err(refusal) => {
+            let degree = flat.len();
+            spectrum::record_refusal(refusal);
+            Err(EigenError::UnsupportedIrreducibleDegree { degree })
+        }
+    }
+}
+
+/// [`eigenvalues`] without the spectrum check — the formula layer on its own.
+fn eigenvalues_unchecked(m: &Matrix, pool: &ExprPool) -> Result<Vec<(ExprId, usize)>, EigenError> {
     let (poly_e, lam) = characteristic_polynomial_lambda_minus_m(m, pool)?;
     match eigenvalues_from_char_poly(poly_e, lam, pool) {
         Ok(v) => Ok(v),
@@ -800,8 +850,93 @@ fn rational_to_expr(r: &Rational, pool: &ExprPool) -> ExprId {
     }
 }
 
+/// The **real** cube root of `w = r ± √d` (`minus` selects the sign), as an
+/// expression whose every cube-root base is non-negative.
+///
+/// # The bug this exists to prevent
+///
+/// Cardano's `t = A + B` solves `t³ + p·t + q` only for the pair with
+/// `A·B = −p/3`; of the nine `(A, B)` pairs of cube roots, three qualify. The
+/// obvious spelling — `(−q/2 + √Δ)^{1/3}` and `(−q/2 − √Δ)^{1/3}`, two
+/// independent `Pow` nodes — does not record that constraint, and it is
+/// violated exactly when both radicands are negative, which happens for every
+/// `Δ > 0` cubic with `q > 0 > p`. Read on principal branches each radical
+/// picks up its own `e^{iπ/3}`, so `A·B` is off by `e^{2iπ/3}` and neither
+/// `A + B` nor the conjugate pair built from it is a root of anything.
+///
+/// `λ³ + 3λ² + 2λ + 1` is the smallest case: `p = −1`, `q = 1`, `Δ = 23/108`,
+/// and both radicands are negative. The three returned expressions were right
+/// under the real-cube-root convention — the real one evaluated to
+/// `−2.324718`, residual `8.9e-16` — and wrong under principal branches, where
+/// `|p(λ)| = 2.29`. The library implements the real-cube-root convention
+/// **nowhere**: `eval_expr` answers `E-EVAL-009` for `x^{1/3}` at negative `x`,
+/// and `eval_complex_f64` answers the principal value. So `eigenvals` reported
+/// success and returned three values that were unusable to one evaluator and
+/// wrong to the other.
+///
+/// # The fix
+///
+/// Pull the sign out of the radical instead of asking a branch convention to
+/// carry it: for `w < 0`, `∛w = −∛|w|`, and `|w|` is written as the same
+/// `rational ∓ √d` with both terms negated. Every base then sits on the
+/// positive real axis, where the real and principal cube roots coincide, so
+/// the emitted expression means the same thing to `eval_expr`, to
+/// `eval_complex_f64` and to Cardano. `A·B = ∛(w₊·w₋) = ∛(−p³/27) = −p/3`
+/// holds because both factors are now genuinely real.
+///
+/// Deciding the sign needs no numerics: `d ≥ 0` and everything else is exactly
+/// rational, so `r + √d ≥ 0` iff `r ≥ 0` or `d ≥ r²`, and `r − √d ≥ 0` iff
+/// `r ≥ 0` and `d ≤ r²`.
+fn real_cbrt_of_rational_plus_sqrt(
+    r: &Rational,
+    d: &Rational,
+    minus: bool,
+    pool: &ExprPool,
+) -> ExprId {
+    let third = pool.rational(rug::Integer::from(1), rug::Integer::from(3));
+    let neg_one = pool.integer(-1_i32);
+    let sqrt_d = simplify(pool.func("sqrt", vec![rational_to_expr(d, pool)]), pool).value;
+    let neg_sqrt_d = simplify(pool.mul(vec![neg_one, sqrt_d]), pool).value;
+
+    let r_sq = r.clone() * r.clone();
+    let nonneg = if minus {
+        *r >= 0 && *d <= r_sq
+    } else {
+        *r >= 0 || *d >= r_sq
+    };
+
+    // `|w|`: `w` itself when it is non-negative, and `−w` — the same two terms
+    // with both signs flipped — when it is not.
+    let (rational_part, radical_part) = if nonneg {
+        (r.clone(), if minus { neg_sqrt_d } else { sqrt_d })
+    } else {
+        (
+            Rational::from(0) - r.clone(),
+            if minus { sqrt_d } else { neg_sqrt_d },
+        )
+    };
+    let magnitude = simplify(
+        pool.pow(
+            pool.add(vec![rational_to_expr(&rational_part, pool), radical_part]),
+            third,
+        ),
+        pool,
+    )
+    .value;
+    if nonneg {
+        magnitude
+    } else {
+        simplify(pool.mul(vec![neg_one, magnitude]), pool).value
+    }
+}
+
 /// Roots of an irreducible cubic `c₀ + c₁λ + c₂λ² + c₃λ³` via depression +
 /// trigonometric Cardano (three real roots) or radical Cardano (one real root).
+///
+/// The `Δ > 0` branch emits **real** cube roots — see
+/// `real_cbrt_of_rational_plus_sqrt` — so that the two radicals Cardano pairs
+/// are coordinated by construction rather than by a convention the expression
+/// does not carry.
 fn cubic_roots(p: &UniPoly, pool: &ExprPool) -> Result<[ExprId; 3], EigenError> {
     let c = p.coefficients();
     if c.len() != 4 {
@@ -872,32 +1007,12 @@ fn cubic_roots(p: &UniPoly, pool: &ExprPool) -> Result<[ExprId; 3], EigenError> 
         }
         out
     } else {
-        // One real root via Cardano: A = ∛(−q/2 + √Δ), B = ∛(−q/2 − √Δ), t₀ = A+B.
-        let sqrt_delta = simplify(
-            pool.func("sqrt", vec![rational_to_expr(&delta, pool)]),
-            pool,
-        )
-        .value;
-        let neg_half_q = rational_to_expr(&(Rational::from(0) - half_q), pool);
-        let a_cbrt = simplify(
-            pool.pow(
-                pool.add(vec![neg_half_q, sqrt_delta]),
-                pool.rational(rug::Integer::from(1), rug::Integer::from(3)),
-            ),
-            pool,
-        )
-        .value;
-        let b_cbrt = simplify(
-            pool.pow(
-                pool.add(vec![
-                    neg_half_q,
-                    pool.mul(vec![pool.integer(-1_i32), sqrt_delta]),
-                ]),
-                pool.rational(rug::Integer::from(1), rug::Integer::from(3)),
-            ),
-            pool,
-        )
-        .value;
+        // One real root via Cardano: A = ∛(−q/2 + √Δ), B = ∛(−q/2 − √Δ), t₀ = A+B,
+        // on the **real** cube root of each radicand — see `real_cbrt_of_rational_plus_sqrt`
+        // for why the two radicals cannot be written as independent principal powers.
+        let neg_half_q = Rational::from(0) - half_q.clone();
+        let a_cbrt = real_cbrt_of_rational_plus_sqrt(&neg_half_q, &delta, false, pool);
+        let b_cbrt = real_cbrt_of_rational_plus_sqrt(&neg_half_q, &delta, true, pool);
         let t0 = simplify(pool.add(vec![a_cbrt, b_cbrt]), pool).value;
         // Complex conjugate pair: −(A+B)/2 ± i √3 (A−B)/2.
         let half = pool.rational(rug::Integer::from(1), rug::Integer::from(2));
@@ -1691,6 +1806,190 @@ mod tests {
 
     fn pool() -> ExprPool {
         ExprPool::new()
+    }
+
+    /// Companion matrix of `λ³ + 3λ² + 2λ + 1`, irreducible over ℚ, with
+    /// `Δ = 23/108 > 0` and `q = 1 > 0 > p = −1` — the sign pattern that makes
+    /// both Cardano radicands negative.
+    fn cardano_companion(p: &ExprPool) -> Matrix {
+        let z = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        Matrix::new(vec![
+            vec![z, z, p.integer(-1_i32)],
+            vec![one, z, p.integer(-2_i32)],
+            vec![z, one, p.integer(-3_i32)],
+        ])
+        .unwrap()
+    }
+
+    /// The confirmed bug: three radical eigenvalues that were roots only under
+    /// the real-cube-root convention, which nothing in the library implements.
+    ///
+    /// Before: `(−1/2 ± √(23/108))^{1/3}` — a cube root of a negative — so
+    /// `eval_expr` answered `E-EVAL-009` and the principal-branch residual was
+    /// `|p(λ)| = 2.29`. After: every cube-root base is positive, the values are
+    /// the roots on the same branch everything reads them on.
+    #[test]
+    fn cardano_eigenvalues_are_roots_on_principal_branches() {
+        let p = pool();
+        let m = cardano_companion(&p);
+        let vals = eigenvalues(&m, &p).expect("the irreducible cubic still has a closed form");
+        let flat: Vec<ExprId> = vals
+            .iter()
+            .flat_map(|&(l, mult)| std::iter::repeat_n(l, mult))
+            .collect();
+        assert_eq!(flat.len(), 3);
+
+        // `p(λ) = λ³ + 3λ² + 2λ + 1` at each returned value, read principally.
+        let env = std::collections::HashMap::new();
+        for &lam in &flat {
+            let v = crate::eval::eval_complex_f64(lam, &p, &env)
+                .unwrap_or_else(|e| panic!("{} is unevaluable: {e}", p.display(lam)));
+            let (re, im) = (v.re, v.im);
+            // λ³ + 3λ² + 2λ + 1 by hand, to keep the check independent of the pool.
+            let sq = (re * re - im * im, 2.0 * re * im);
+            let cu = (sq.0 * re - sq.1 * im, sq.0 * im + sq.1 * re);
+            let rr = cu.0 + 3.0 * sq.0 + 2.0 * re + 1.0;
+            let ri = cu.1 + 3.0 * sq.1 + 2.0 * im;
+            assert!(
+                rr.hypot(ri) < 1e-9,
+                "{} evaluates to {re} + {im}i, residual {}",
+                p.display(lam),
+                rr.hypot(ri)
+            );
+        }
+
+        // The real root is the one the trio must contain.
+        assert!(
+            flat.iter().any(|&lam| {
+                let v = crate::eval::eval_complex_f64(lam, &p, &env).unwrap();
+                v.im.abs() < 1e-9 && (v.re + 2.324_717_957_244_746).abs() < 1e-9
+            }),
+            "the real root −2.32471796 must be among the three"
+        );
+    }
+
+    /// The property the prime directive asks for, stated directly: a `Result`
+    /// that says `Ok` may not carry a value the library cannot turn into a
+    /// number.
+    ///
+    /// "The library" means the evaluator appropriate to the value's domain.
+    /// `eval_interp` — what `eval_expr` calls — is real-valued, and a complex
+    /// eigenvalue is spelled with the crate's own `sqrt(−1)`, so a genuinely
+    /// non-real λ is `E-EVAL-009` there by construction and always has been;
+    /// that is the domain, not this defect. The real root has no such excuse,
+    /// and before the fix it raised `E-EVAL-009` too.
+    #[test]
+    fn a_returned_cardano_spectrum_is_never_unevaluable() {
+        let p = pool();
+        let m = cardano_companion(&p);
+        let env = std::collections::HashMap::new();
+        match eigenvalues(&m, &p) {
+            Err(_) => { /* a coded refusal is always allowed */ }
+            Ok(vals) => {
+                let mut real_valued = 0;
+                for (lam, _) in vals {
+                    let interp =
+                        crate::jit::eval_interp_checked(lam, &std::collections::HashMap::new(), &p);
+                    let complex = crate::eval::eval_complex_f64(lam, &p, &env)
+                        .expect("every eigenvalue must be a complex number");
+                    if complex.im.abs() < 1e-9 {
+                        real_valued += 1;
+                        assert!(
+                            interp.is_ok(),
+                            "eigenvals reported success carrying the *real* value `{}`, \
+                             which `eval_expr` cannot turn into a number: {:?}",
+                            p.display(lam),
+                            interp.err()
+                        );
+                    }
+                }
+                assert_eq!(real_valued, 1, "this cubic has exactly one real root");
+            }
+        }
+    }
+
+    /// Cardano's pairing constraint, checked on the emitted radicals rather
+    /// than on the roots: `A·B = −p/3` is what selects three of the nine
+    /// `(A, B)` pairs, and it is the identity the old independent-principal
+    /// form broke.
+    #[test]
+    fn the_two_cardano_radicals_are_a_coordinated_pair() {
+        let p = pool();
+        // λ³ + 3λ² + 2λ + 1 depresses to t³ − t + 1: p = −1, so A·B = 1/3.
+        let a = real_cbrt_of_rational_plus_sqrt(
+            &Rational::from((-1, 2)),
+            &Rational::from((23, 108)),
+            false,
+            &p,
+        );
+        let b = real_cbrt_of_rational_plus_sqrt(
+            &Rational::from((-1, 2)),
+            &Rational::from((23, 108)),
+            true,
+            &p,
+        );
+        let env = std::collections::HashMap::new();
+        let va = crate::eval::eval_complex_f64(a, &p, &env).expect("A is evaluable");
+        let vb = crate::eval::eval_complex_f64(b, &p, &env).expect("B is evaluable");
+        let prod = (va.re * vb.re - va.im * vb.im, va.re * vb.im + va.im * vb.re);
+        assert!(
+            (prod.0 - 1.0 / 3.0).abs() < 1e-12 && prod.1.abs() < 1e-12,
+            "A·B = {} + {}i, must be 1/3",
+            prod.0,
+            prod.1
+        );
+    }
+
+    /// The three-real-roots branch emits `acos`, not cube roots, and has never
+    /// had the pairing problem — but it must still pass the same gate, or the
+    /// gate is only checking the cases it was written for.
+    #[test]
+    fn the_casus_irreducibilis_branch_is_confirmed_too() {
+        let p = pool();
+        // Companion matrix of λ³ − 3λ + 1 (Δ < 0: three real roots).
+        let z = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let m = Matrix::new(vec![
+            vec![z, z, p.integer(-1_i32)],
+            vec![one, z, p.integer(3_i32)],
+            vec![z, one, z],
+        ])
+        .unwrap();
+        let vals = eigenvalues(&m, &p).expect("casus irreducibilis still solves");
+        let flat: Vec<ExprId> = vals
+            .iter()
+            .flat_map(|&(l, mult)| std::iter::repeat_n(l, mult))
+            .collect();
+        let check = crate::matrix::spectrum::confirm_spectrum(&m, &flat, &p)
+            .expect("the trigonometric form is a correct spectrum");
+        assert!(
+            check.is_confirmed(),
+            "the trigonometric roots must be *confirmed*, not merely unevaluated: {check:?}"
+        );
+    }
+
+    /// A spectrum that does not check out is refused, and the refusal names
+    /// itself. Driven through the check directly because the formula layer no
+    /// longer produces one.
+    #[test]
+    fn a_spectrum_that_fails_the_check_is_refused_with_its_own_code() {
+        use crate::errors::AlkahestError;
+        let p = pool();
+        let m = cardano_companion(&p);
+        // The old, uncoordinated form: two independent principal cube roots.
+        let third = p.rational(1, 3);
+        let sqrt_d = p.func("sqrt", vec![p.rational(23, 108)]);
+        let half = p.rational(-1, 2);
+        let a = p.pow(p.add(vec![half, sqrt_d]), third);
+        let b = p.pow(
+            p.add(vec![half, p.mul(vec![p.integer(-1_i32), sqrt_d])]),
+            third,
+        );
+        let t0 = simplify(p.add(vec![a, b, p.integer(-1_i32)]), &p).value;
+        let refusal = crate::matrix::spectrum::confirm_spectrum(&m, &[t0, t0, t0], &p)
+            .expect_err("independent principal cube roots are not the spectrum");
+        assert_eq!(refusal.code(), "E-EIGEN-008");
     }
 
     #[test]

--- a/alkahest-core/src/matrix/mod.rs
+++ b/alkahest-core/src/matrix/mod.rs
@@ -17,6 +17,7 @@ pub mod linear_algebra;
 pub mod normal_form;
 mod smith;
 mod smith_poly;
+pub mod spectrum;
 pub(crate) mod zero_test;
 
 pub use eigen::{
@@ -32,6 +33,7 @@ pub use normal_form::{
     hermite_form, hermite_form_poly, smith_form, smith_form_poly, IntegerMatrix, NormalFormError,
     PolyMatrixQ, RatUniPoly,
 };
+pub use spectrum::{take_spectrum_refusal, SpectrumRefusal};
 pub use zero_test::{take_zero_test_refusal, ZeroTestRefusal};
 
 // ---------------------------------------------------------------------------

--- a/alkahest-core/src/matrix/spectrum.rs
+++ b/alkahest-core/src/matrix/spectrum.rs
@@ -1,0 +1,480 @@
+//! The canonical "are these actually the eigenvalues?" check.
+//!
+//! `Π_i (z − λ_i)` and `det(zI − A)` are the same polynomial in `z` when the
+//! `λ_i` really are the spectrum of `A`, so evaluating both at a few sampled
+//! `z` (and, for symbolic entries, a few sampled parameter values) either
+//! confirms the list or refutes it.
+//!
+//! # Why a closed-form spectrum needs checking at all
+//!
+//! Because a radical is not a number until a branch is chosen, and the formula
+//! that produced it may need a *coordinated* choice that the expression does
+//! not record. Cardano's solution of `t³ + p·t + q` is
+//!
+//! ```text
+//!     t = A + B,   A³ = −q/2 + √Δ,   B³ = −q/2 − √Δ,   Δ = (q/2)² + (p/3)³
+//! ```
+//!
+//! but only for the pair `(A, B)` satisfying `A·B = −p/3`; there are nine
+//! `(A, B)` pairs and only three are roots. Writing the two cube roots as
+//! independent principal-branch powers `(…)^{1/3}` throws that constraint
+//! away, and when both radicands are negative — `Δ > 0` with `q > 0 > p` —
+//! each picks up its own `e^{iπ/3}`, `A·B` acquires a factor `e^{2iπ/3}`, and
+//! the three expressions are roots of nothing. That is not hypothetical: it is
+//! what `matrix::eigen::cubic_roots` emitted for `λ³ + 3λ² + 2λ + 1` until the
+//! real-cube-root form replaced it, and `p(λ)` at the returned values was
+//! `2.29`, not `0`.
+//!
+//! The generator is now written so its own convention is the principal one
+//! (see [`crate::matrix::eigen`]), which is what makes those values usable;
+//! this module is the independent check that says so, kept separate from the
+//! formula it checks on the principle that a gate is not allowed to be its own
+//! witness.
+//!
+//! # What each verdict means
+//!
+//! | outcome | meaning |
+//! |---|---|
+//! | `SpectrumCheck::Confirmed` | the identity held at every sample that could be evaluated |
+//! | `SpectrumCheck::Unevaluated` | nothing could be evaluated — **no information** |
+//! | `Err(`[`SpectrumRefusal`]`)` | the identity was evaluated and **failed** |
+//!
+//! `Unevaluated` is deliberately not a refusal *here*: an expression this
+//! module's evaluator does not model is a property of the expression, not
+//! evidence against the spectrum, and the same classification is what
+//! `integrate`'s antiderivative gates and `limit`'s value gate use. Callers
+//! that need a positive confirmation before building on the list — `dsolve`'s
+//! Putzer expansion, which turns a bad spectrum into a page-long candidate —
+//! ask for `SpectrumCheck::Confirmed` explicitly.
+
+use crate::eval::{eval_complex_f64, ComplexF64};
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::matrix::Matrix;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Complex helpers
+// ---------------------------------------------------------------------------
+//
+// `ComplexF64` exposes its parts but not its arithmetic, and the determinant
+// below needs four operations on it. They are three lines each.
+
+fn cadd(a: ComplexF64, b: ComplexF64) -> ComplexF64 {
+    ComplexF64::new(a.re + b.re, a.im + b.im)
+}
+
+fn csub(a: ComplexF64, b: ComplexF64) -> ComplexF64 {
+    ComplexF64::new(a.re - b.re, a.im - b.im)
+}
+
+fn cmul(a: ComplexF64, b: ComplexF64) -> ComplexF64 {
+    ComplexF64::new(a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re)
+}
+
+fn cdiv(a: ComplexF64, b: ComplexF64) -> ComplexF64 {
+    let d = b.re * b.re + b.im * b.im;
+    ComplexF64::new(
+        (a.re * b.re + a.im * b.im) / d,
+        (a.im * b.re - a.re * b.im) / d,
+    )
+}
+
+fn cabs(a: ComplexF64) -> f64 {
+    a.re.hypot(a.im)
+}
+
+fn cfinite(a: ComplexF64) -> bool {
+    a.re.is_finite() && a.im.is_finite()
+}
+
+/// `det` by Gaussian elimination with partial pivoting; `None` when the matrix
+/// is singular to working precision, which is no information about the
+/// identity being tested rather than a value of zero.
+fn complex_det(m: &mut [Vec<ComplexF64>]) -> Option<ComplexF64> {
+    let n = m.len();
+    let mut det = ComplexF64::ONE;
+    for k in 0..n {
+        let mut piv = k;
+        for r in (k + 1)..n {
+            if cabs(m[r][k]) > cabs(m[piv][k]) {
+                piv = r;
+            }
+        }
+        if cabs(m[piv][k]) < 1e-13 {
+            return None;
+        }
+        if piv != k {
+            m.swap(piv, k);
+            det = cmul(det, ComplexF64::new(-1.0, 0.0));
+        }
+        det = cmul(det, m[k][k]);
+        for r in (k + 1)..n {
+            let f = cdiv(m[r][k], m[k][k]);
+            // `r > k`, so the pivot row and the row being cleared are in
+            // different halves and can be borrowed at once.
+            let (above, from_r) = m.split_at_mut(r);
+            let pivot_row = &above[k];
+            for (dst, &src) in from_r[0].iter_mut().zip(pivot_row.iter()).skip(k) {
+                *dst = csub(*dst, cmul(f, src));
+            }
+        }
+    }
+    if cfinite(det) {
+        Some(det)
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The refusal
+// ---------------------------------------------------------------------------
+
+/// A closed-form spectrum that is not the spectrum it claims to be.
+///
+/// # Why this is not an error variant
+///
+/// [`EigenError`](crate::matrix::EigenError) and
+/// [`LinearAlgebraError`](crate::matrix::LinearAlgebraError) are public
+/// *exhaustive* enums, so growing either a `SpectrumUnverified` variant is a
+/// major semver break — and so is marking them `#[non_exhaustive]` to allow one
+/// later. A correctness fix inside a patch release cannot spend a major
+/// version, so the refusal travels out of band instead: the refusing routine
+/// returns `UnsupportedIrreducibleDegree { degree }`, whose reworded text
+/// states exactly the disjunction that is known ("no *usable* closed form for a
+/// factor of this degree"), and the real cause is recorded here for
+/// [`take_spectrum_refusal`] to hand to the bindings, which raise its own
+/// `E-EIGEN-008`.
+///
+/// This is the pattern [`crate::matrix::take_zero_test_refusal`] uses for
+/// undecided zero tests inside `MatrixError::SingularMatrix`, and
+/// `crate::calculus::series::take_series_refusal` for truncated expansions
+/// inside `SeriesError::InvalidOrder`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpectrumRefusal {
+    lambdas: Vec<String>,
+    probe: (f64, f64),
+    product: (f64, f64),
+    determinant: (f64, f64),
+}
+
+impl SpectrumRefusal {
+    /// The candidate eigenvalues, rendered, in the order they were checked.
+    pub fn lambdas(&self) -> &[String] {
+        &self.lambdas
+    }
+
+    /// The `z` at which `Π(z − λ)` and `det(zI − A)` were found to differ.
+    pub fn probe(&self) -> (f64, f64) {
+        self.probe
+    }
+}
+
+impl fmt::Display for SpectrumRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "the closed-form eigenvalues [{}] are not roots of the characteristic \
+             polynomial when their radicals are read on principal branches: at \
+             z = {} + {}i, Π(z − λ) = {} + {}i but det(zI − A) = {} + {}i. \
+             Refusing rather than returning a spectrum whose correctness depends \
+             on a branch convention nothing in the expression records",
+            self.lambdas.join(", "),
+            self.probe.0,
+            self.probe.1,
+            self.product.0,
+            self.product.1,
+            self.determinant.0,
+            self.determinant.1,
+        )
+    }
+}
+
+impl std::error::Error for SpectrumRefusal {}
+
+impl crate::errors::AlkahestError for SpectrumRefusal {
+    fn code(&self) -> &'static str {
+        "E-EIGEN-008"
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        Some("substitute concrete numbers for any symbolic entries, or use real_roots / numeric eigenvalues for this matrix")
+    }
+}
+
+thread_local! {
+    /// The refusal behind the `UnsupportedIrreducibleDegree` the current thread
+    /// is about to return, when that error is a failed spectrum check rather
+    /// than a degree this module never had a formula for.
+    static LAST_REFUSAL: RefCell<Option<SpectrumRefusal>> = const { RefCell::new(None) };
+}
+
+/// Take the spectrum refusal recorded by the most recent eigen call on this
+/// thread, if it made one. Clears it.
+pub fn take_spectrum_refusal() -> Option<SpectrumRefusal> {
+    LAST_REFUSAL.with(|c| c.borrow_mut().take())
+}
+
+pub(crate) fn record_refusal(r: SpectrumRefusal) {
+    LAST_REFUSAL.with(|c| *c.borrow_mut() = Some(r));
+}
+
+/// Drop any refusal left on this thread, so a later, unrelated
+/// `UnsupportedIrreducibleDegree` cannot inherit `E-EIGEN-008`.
+pub(crate) fn forget_refusal() {
+    LAST_REFUSAL.with(|c| *c.borrow_mut() = None);
+}
+
+// ---------------------------------------------------------------------------
+// The check
+// ---------------------------------------------------------------------------
+
+/// What [`confirm_spectrum`] was able to establish.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SpectrumCheck {
+    /// `Π(z − λ) = det(zI − A)` held at every one of `samples` evaluated probes.
+    Confirmed { samples: usize },
+    /// Neither the entries nor the eigenvalues could be turned into numbers at
+    /// any sample, so nothing was tested. No information either way.
+    Unevaluated,
+}
+
+impl SpectrumCheck {
+    pub(crate) fn is_confirmed(self) -> bool {
+        matches!(self, SpectrumCheck::Confirmed { .. })
+    }
+}
+
+/// Parameter values to substitute for free symbols, chosen to be unrelated and
+/// away from the small integers that make accidental agreement likely.
+const PARAM_SETS: [&[f64]; 2] = [&[1.7, 0.6, 2.3, 1.1, 0.4], &[0.37, 1.9, 0.83, 2.7, 1.3]];
+/// `z` values at which the two polynomials are compared. Off the real axis and
+/// away from any small-integer eigenvalue.
+const PROBES: [(f64, f64); 3] = [(0.53, 0.29), (-1.17, 0.71), (2.31, -0.43)];
+
+/// Check that `lambdas` (listed with multiplicity, so `lambdas.len() == a.rows`)
+/// is the spectrum of `a`.
+///
+/// The comparison is `Π_i (z − λ_i)` against `det(zI − A)`, a polynomial
+/// identity of degree `n` in `z`; agreement at three probes is not a proof, but
+/// disagreement at one is a refutation, and refutation is the direction that
+/// matters here.
+pub(crate) fn confirm_spectrum(
+    a: &Matrix,
+    lambdas: &[ExprId],
+    pool: &ExprPool,
+) -> Result<SpectrumCheck, SpectrumRefusal> {
+    let n = a.rows;
+    if n != a.cols || lambdas.len() != n {
+        // Not a shape this check is about; the caller's own arity errors say so.
+        return Ok(SpectrumCheck::Unevaluated);
+    }
+
+    let mut params: Vec<ExprId> = Vec::new();
+    for &e in a.entries() {
+        collect_free_symbols(e, pool, &mut params);
+    }
+    for &l in lambdas {
+        collect_free_symbols(l, pool, &mut params);
+    }
+    params.sort_by_key(|&s| pool.display(s).to_string());
+
+    let mut checked = 0usize;
+    for ps in PARAM_SETS {
+        let mut env: HashMap<ExprId, ComplexF64> = HashMap::new();
+        bind_constants(pool, &mut env, a, lambdas);
+        for (i, &p) in params.iter().enumerate() {
+            env.insert(p, ComplexF64::new(ps[i % ps.len()], 0.0));
+        }
+        let Some(entries) = a
+            .entries()
+            .iter()
+            .map(|&e| eval_complex_f64(e, pool, &env).ok().filter(|&v| cfinite(v)))
+            .collect::<Option<Vec<_>>>()
+        else {
+            continue;
+        };
+        let Some(lam) = lambdas
+            .iter()
+            .map(|&l| eval_complex_f64(l, pool, &env).ok().filter(|&v| cfinite(v)))
+            .collect::<Option<Vec<_>>>()
+        else {
+            continue;
+        };
+        for (zr, zi) in PROBES {
+            let z = ComplexF64::new(zr, zi);
+            let mut m: Vec<Vec<ComplexF64>> = (0..n)
+                .map(|i| {
+                    (0..n)
+                        .map(|j| {
+                            let e = entries[i * n + j];
+                            let neg = ComplexF64::new(-e.re, -e.im);
+                            if i == j {
+                                cadd(z, neg)
+                            } else {
+                                neg
+                            }
+                        })
+                        .collect()
+                })
+                .collect();
+            let Some(det) = complex_det(&mut m) else {
+                continue;
+            };
+            let prod = lam
+                .iter()
+                .fold(ComplexF64::ONE, |acc, &l| cmul(acc, csub(z, l)));
+            let scale = cabs(det).max(cabs(prod)).max(1.0);
+            if cabs(csub(det, prod)) > 1e-7 * scale {
+                return Err(SpectrumRefusal {
+                    lambdas: lambdas
+                        .iter()
+                        .map(|&l| pool.display(l).to_string())
+                        .collect(),
+                    probe: (zr, zi),
+                    product: (prod.re, prod.im),
+                    determinant: (det.re, det.im),
+                });
+            }
+            checked += 1;
+        }
+    }
+
+    if checked == 0 {
+        Ok(SpectrumCheck::Unevaluated)
+    } else {
+        Ok(SpectrumCheck::Confirmed { samples: checked })
+    }
+}
+
+/// Bind the named constants the eigen formulas emit but that
+/// [`eval_complex_f64`] has no value for.
+///
+/// `pi` is a plain [`ExprData::Symbol`] in this crate, so the casus
+/// irreducibilis form `2√(−p/3)·cos((acos c + 2πk)/3)` would otherwise be
+/// unevaluable — and, worse, `pi` would be collected as a free *parameter* and
+/// given a sample value, turning a correct spectrum into a spurious refusal.
+/// Binding it here is what lets the three-real-roots branch be confirmed rather
+/// than merely tolerated.
+fn bind_constants(
+    pool: &ExprPool,
+    env: &mut HashMap<ExprId, ComplexF64>,
+    a: &Matrix,
+    lambdas: &[ExprId],
+) {
+    let mut all: Vec<ExprId> = Vec::new();
+    for &e in a.entries() {
+        collect_named_constants(e, pool, &mut all);
+    }
+    for &l in lambdas {
+        collect_named_constants(l, pool, &mut all);
+    }
+    for s in all {
+        env.insert(s, ComplexF64::new(std::f64::consts::PI, 0.0));
+    }
+}
+
+fn is_pi(expr: ExprId, pool: &ExprPool) -> bool {
+    matches!(pool.get(expr), ExprData::Symbol { name, .. } if name == "pi")
+}
+
+fn collect_named_constants(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
+    walk_symbols(expr, pool, &mut |s, pool| {
+        if is_pi(s, pool) && !out.contains(&s) {
+            out.push(s);
+        }
+    });
+}
+
+/// Symbols that are genuine free parameters: neither `pi` nor the imaginary
+/// unit, both of which have values and must not be sampled.
+fn collect_free_symbols(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
+    walk_symbols(expr, pool, &mut |s, pool| {
+        if !is_pi(s, pool) && !pool.is_imaginary_unit(s) && !out.contains(&s) {
+            out.push(s);
+        }
+    });
+}
+
+fn walk_symbols(expr: ExprId, pool: &ExprPool, f: &mut impl FnMut(ExprId, &ExprPool)) {
+    match pool.get(expr) {
+        ExprData::Symbol { .. } => f(expr, pool),
+        ExprData::Add(args) | ExprData::Mul(args) | ExprData::Func { args, .. } => {
+            for a in args {
+                walk_symbols(a, pool, f);
+            }
+        }
+        ExprData::Pow { base, exp } => {
+            walk_symbols(base, pool, f);
+            walk_symbols(exp, pool, f);
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    fn mat(rows: usize, entries: Vec<ExprId>, pool: &ExprPool) -> Matrix {
+        let mut m = Matrix::zeros(rows, rows, pool);
+        for i in 0..rows {
+            for j in 0..rows {
+                m.set(i, j, entries[i * rows + j]);
+            }
+        }
+        m
+    }
+
+    #[test]
+    fn a_correct_rational_spectrum_is_confirmed() {
+        let p = ExprPool::new();
+        // diag(2, 5): the spectrum is {2, 5}.
+        let z = p.integer(0_i32);
+        let m = mat(2, vec![p.integer(2_i32), z, z, p.integer(5_i32)], &p);
+        let out = confirm_spectrum(&m, &[p.integer(2_i32), p.integer(5_i32)], &p).unwrap();
+        assert!(out.is_confirmed(), "{out:?}");
+    }
+
+    #[test]
+    fn a_wrong_spectrum_is_refuted() {
+        let p = ExprPool::new();
+        let z = p.integer(0_i32);
+        let m = mat(2, vec![p.integer(2_i32), z, z, p.integer(5_i32)], &p);
+        let err = confirm_spectrum(&m, &[p.integer(2_i32), p.integer(6_i32)], &p)
+            .expect_err("{2, 6} is not the spectrum of diag(2, 5)");
+        assert_eq!(
+            <SpectrumRefusal as crate::errors::AlkahestError>::code(&err),
+            "E-EIGEN-008"
+        );
+        assert!(err.lambdas().len() == 2, "{err}");
+    }
+
+    #[test]
+    fn an_unevaluable_spectrum_is_no_information_not_a_refusal() {
+        let p = ExprPool::new();
+        let z = p.integer(0_i32);
+        let m = mat(2, vec![p.integer(2_i32), z, z, p.integer(5_i32)], &p);
+        // `zeta` has no entry in the complex evaluator, so neither λ is a number.
+        let opaque = p.func("zeta", vec![p.integer(3_i32)]);
+        let out = confirm_spectrum(&m, &[opaque, opaque], &p).unwrap();
+        assert_eq!(out, SpectrumCheck::Unevaluated);
+    }
+
+    #[test]
+    fn pi_is_a_constant_not_a_sampled_parameter() {
+        let p = ExprPool::new();
+        // A matrix whose spectrum is {π, 0}: `[[π, 0], [0, 0]]`.
+        let pi = p.symbol("pi", Domain::Real);
+        let z = p.integer(0_i32);
+        let m = mat(2, vec![pi, z, z, z], &p);
+        let out = confirm_spectrum(&m, &[pi, z], &p).unwrap();
+        assert!(
+            out.is_confirmed(),
+            "π must be bound to 3.14159…, not sampled: {out:?}"
+        );
+    }
+}

--- a/alkahest-core/src/ode/dsolve/system.rs
+++ b/alkahest-core/src/ode/dsolve/system.rs
@@ -342,133 +342,32 @@ fn spectrum(a: &Matrix, pool: &ExprPool) -> Result<Vec<ExprId>, DsolveSystemErro
 
 /// Cross-check the eigenvalue list before anything is built on it.
 ///
-/// `Π_i (z − λ_i)` must equal `det(zI − A)` — a polynomial identity, so testing
-/// it at a few sampled `z` (and a few sampled parameter values) either confirms
-/// it or refutes it.
+/// Delegates to `matrix::spectrum::confirm_spectrum`, which is the
+/// canonical form of this check and lives beside the routine that produces the
+/// spectrum — one copy, checked by one set of tests, rather than a second that
+/// drifts.  What stays here is the *policy*.
 ///
-/// This is not paranoia about arithmetic.  `matrix::eigenvalues` answers an
-/// irreducible cubic with Cardano radicals, and Cardano's formula is only
-/// correct on a *coordinated* choice of cube-root branches: written as two
-/// independent radicals `(−q/2 ± √Δ)^{1/3}`, each evaluated on its own
-/// principal branch, the constraint `AB = −p/3` fails and the three expressions
-/// are not roots of the polynomial they came from.  Building `e^{At}` on such a
-/// list produces a page-long candidate that the substitution gate then refuses
-/// — correctly, but slowly and under an error that says "verification failed"
-/// when the truth is "these are not the eigenvalues".
+/// Putzer's algorithm turns a wrong eigenvalue list into a page-long `e^{At}`
+/// candidate that the substitution gate then refuses — correctly, but slowly,
+/// and under an error saying "verification failed" when the truth is "these are
+/// not the eigenvalues".  So a system is solved only on a spectrum that was
+/// positively **confirmed**, and an unevaluable one is refused here.
+/// `matrix::eigenvalues` is deliberately laxer: it has no expansion to protect,
+/// and refusing an unevaluable spectrum there would discard every correct
+/// symbolic answer whose radicals the numeric evaluator happens not to model.
 fn confirm_spectrum(
     a: &Matrix,
     lambdas: &[ExprId],
     pool: &ExprPool,
 ) -> Result<(), DsolveSystemError> {
-    let n = a.rows;
-    let mut params: Vec<ExprId> = Vec::new();
-    for &e in a.entries() {
-        collect_symbols(e, pool, &mut params);
-    }
-    for &l in lambdas {
-        collect_symbols(l, pool, &mut params);
-    }
-    params.sort_by_key(|&s| pool.display(s).to_string());
-    const PARAM_SETS: [&[f64]; 2] = [&[1.7, 0.6, 2.3, 1.1, 0.4], &[0.37, 1.9, 0.83, 2.7, 1.3]];
-    const PROBES: [(f64, f64); 3] = [(0.53, 0.29), (-1.17, 0.71), (2.31, -0.43)];
-
-    let mut checked = 0usize;
-    for ps in PARAM_SETS {
-        let mut env: HashMap<ExprId, C64> = HashMap::new();
-        for (i, &p) in params.iter().enumerate() {
-            env.insert(p, C64::real(ps[i % ps.len()]));
-        }
-        let Some(entries) = a
-            .entries()
-            .iter()
-            .map(|&e| eval_complex(e, &env, pool).filter(|v| v.is_finite()))
-            .collect::<Option<Vec<_>>>()
-        else {
-            continue;
-        };
-        let Some(lam) = lambdas
-            .iter()
-            .map(|&l| eval_complex(l, &env, pool).filter(|v| v.is_finite()))
-            .collect::<Option<Vec<_>>>()
-        else {
-            continue;
-        };
-        for (zr, zi) in PROBES {
-            let z = C64::new(zr, zi);
-            // det(zI − A)
-            let mut m: Vec<Vec<C64>> = (0..n)
-                .map(|i| {
-                    (0..n)
-                        .map(|j| {
-                            let e = entries[i * n + j].mul(C64::real(-1.0));
-                            if i == j {
-                                z.add(e)
-                            } else {
-                                e
-                            }
-                        })
-                        .collect()
-                })
-                .collect();
-            let Some(det) = complex_det(&mut m) else {
-                continue;
-            };
-            let prod = lam.iter().fold(C64::real(1.0), |acc, &l| acc.mul(z.sub(l)));
-            let scale = det.abs().max(prod.abs()).max(1.0);
-            if det.sub(prod).abs() > 1e-7 * scale {
-                return Err(DsolveSystemError::UnsupportedSpectrum(format!(
-                    "the closed-form eigenvalues of the coefficient matrix are not roots \
-                     of its characteristic polynomial when evaluated on principal \
-                     branches (Π(z−λ) and det(zI−A) differ at z = {zr} + {zi}i).  This is \
-                     the Cardano branch-coordination problem for an irreducible cubic; no \
-                     answer is returned rather than one built on a spectrum that does not \
-                     check out"
-                )));
-            }
-            checked += 1;
-        }
-    }
-    if checked == 0 {
-        return Err(DsolveSystemError::UnsupportedSpectrum(
+    match crate::matrix::spectrum::confirm_spectrum(a, lambdas, pool) {
+        Ok(check) if check.is_confirmed() => Ok(()),
+        Ok(_) => Err(DsolveSystemError::UnsupportedSpectrum(
             "the eigenvalues of the coefficient matrix could not be evaluated at any \
              sample, so nothing confirms they are its spectrum"
                 .to_string(),
-        ));
-    }
-    Ok(())
-}
-
-/// Determinant by Gaussian elimination with partial pivoting, in place.
-fn complex_det(m: &mut [Vec<C64>]) -> Option<C64> {
-    let n = m.len();
-    let mut det = C64::real(1.0);
-    for col in 0..n {
-        let mut piv = col;
-        for r in (col + 1)..n {
-            if m[r][col].abs() > m[piv][col].abs() {
-                piv = r;
-            }
-        }
-        if m[piv][col].abs() < 1e-14 {
-            return Some(C64::real(0.0));
-        }
-        if piv != col {
-            m.swap(col, piv);
-            det = det.mul(C64::real(-1.0));
-        }
-        det = det.mul(m[col][col]);
-        for r in (col + 1)..n {
-            let f = m[r][col].div(m[col][col]);
-            for c in col..n {
-                let sub = f.mul(m[col][c]);
-                m[r][c] = m[r][c].sub(sub);
-            }
-        }
-    }
-    if det.is_finite() {
-        Some(det)
-    } else {
-        None
+        )),
+        Err(refusal) => Err(DsolveSystemError::UnsupportedSpectrum(refusal.to_string())),
     }
 }
 

--- a/alkahest-core/src/ode/dsolve/verify.rs
+++ b/alkahest-core/src/ode/dsolve/verify.rs
@@ -841,9 +841,6 @@ impl C64 {
     pub(crate) fn real(re: f64) -> Self {
         C64 { re, im: 0.0 }
     }
-    pub(crate) fn new(re: f64, im: f64) -> Self {
-        C64 { re, im }
-    }
     pub(crate) fn is_finite(self) -> bool {
         self.re.is_finite() && self.im.is_finite()
     }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1127,6 +1127,18 @@ fn eigen_error_to_py(e: EigenError) -> PyErr {
             });
         }
     }
+    // `UnsupportedIrreducibleDegree` likewise covers two: a degree there is no
+    // formula for (`E-EIGEN-004`), and a closed form that was produced and then
+    // failed the `Π(z−λ) = det(zI−A)` check (`E-EIGEN-008`) — the radicals do
+    // not describe the spectrum on the branches anything will read them on.
+    if matches!(e, EigenError::UnsupportedIrreducibleDegree { .. }) {
+        if let Some(r) = alkahest_core::matrix::take_spectrum_refusal() {
+            return Python::with_gil(|py| {
+                let exc_type = py.get_type_bound::<PyEigenError>();
+                make_structured_err(py, &exc_type, &r)
+            });
+        }
+    }
     Python::with_gil(|py| {
         let exc_type = py.get_type_bound::<PyEigenError>();
         make_structured_err(py, &exc_type, &e)
@@ -1140,6 +1152,18 @@ fn linear_algebra_error_to_py(e: LinearAlgebraError) -> PyErr {
     // variant of its own.
     if matches!(e, LinearAlgebraError::UnsupportedField) {
         if let Some(r) = alkahest_core::matrix::take_zero_test_refusal() {
+            return Python::with_gil(|py| {
+                let exc_type = py.get_type_bound::<PyLinearAlgebraError>();
+                make_structured_err(py, &exc_type, &r)
+            });
+        }
+    }
+    // `jordan_form`, `matrix_exp` and `diagonalize` all reach the spectrum
+    // through `eigenvalues`, and `map_eigen_err` carries its
+    // `UnsupportedIrreducibleDegree` across unchanged; so does the out-of-band
+    // refusal behind it. See `eigen_error_to_py`.
+    if matches!(e, LinearAlgebraError::UnsupportedIrreducibleDegree { .. }) {
+        if let Some(r) = alkahest_core::matrix::take_spectrum_refusal() {
             return Python::with_gil(|py| {
                 let exc_type = py.get_type_bound::<PyLinearAlgebraError>();
                 make_structured_err(py, &exc_type, &r)

--- a/docs/mdbook/src/errors.md
+++ b/docs/mdbook/src/errors.md
@@ -110,6 +110,7 @@ loop must record as **undecided**, never as a negative result.
 |---|---|---|
 | `E-LINALG-010` | `LinearAlgebraError` | An entry's vanishing could be proven neither zero nor non-zero, so `rank` / `rref` / `nullspace` / `eigenvects` / `jordan_form` declined to pick a branch |
 | `E-MAT-004` | `MatrixError` | Same, for a determinant: `inverse()` will not divide by something it cannot show is non-zero |
+| `E-EIGEN-008` | `EigenError` / `LinearAlgebraError` | The closed-form eigenvalues were produced and then failed their own check: `Π(z − λ)` and `det(zI − A)` disagree at a sampled `z`, so the radicals are not the spectrum on the branches anything reads them on. `eigenvals` / `eigenvects` / `diagonalize` / `jordan_form` / `matrix_exp` refuse rather than return them |
 | `E-CAD-001` | `CadError` | `decide` is outside its fragment, or the only candidate solutions lie at an irrational boundary point it cannot test exactly |
 | `E-SOS-002` | `SosError` | No positivity certificate of this shape at this degree — a statement about the search, not a proof that none exists. **Record it as `unknown`, never as "not SOS" or "the inequality is false":** `p` may be SOS outside the LP subcone searched, SOS at a higher `basis_degree`, or non-negative without being SOS (Motzkin). `E-SOS-003`, which carries a witness point, is the only SOS *refutation*. See [Positivity certificates](./positivity.md#three-outcomes-deliberately-kept-apart) |
 | `E-IDEAL-005` | `IdealRefusal` | `radical` cannot certify `√I` for this ideal. Only monomial, principal and zero-dimensional ideals — and anything whose primary decomposition is certified — are answered; the alternative is asserting `√I = I` with nothing behind it |
@@ -123,6 +124,12 @@ loop must record as **undecided**, never as a negative result.
 wired into the bindings: `series` returns `SeriesError::InvalidOrder` with
 `calculus::series::take_series_refusal()` pending, and the Python layer raises `SeriesError`
 with `.code == "E-SERIES-003"` — or `BudgetExceededError` when a budget was what stopped it.
+
+`E-EIGEN-008` travels out of band on the same arrangement: `EigenError` and
+`LinearAlgebraError` are exhaustive, so the refusal is returned inside
+`UnsupportedIrreducibleDegree` — whose text now states the disjunction it covers — with
+`matrix::take_spectrum_refusal()` pending, and the Python bindings raise `EigenError` /
+`LinearAlgebraError` carrying `.code == "E-EIGEN-008"` and the offending `λ` list.
 
 `E-IDEAL-005`, `E-IDEAL-006` and `E-SOLVE-004` are new in 3.8 and travel **out of band**:
 `PrimaryDecompositionError` and `SolverError` are public exhaustive enums that cannot gain

--- a/docs/sphinx/api/errors.rst
+++ b/docs/sphinx/api/errors.rst
@@ -116,6 +116,14 @@ Exception subclasses
    an :exc:`EigenError` carrying code ``E-LINALG-010``: the code names what
    could not be decided, not the wrapper it arrived in.
 
+   ``E-EIGEN-008`` arrives the same way. Closed-form eigenvalues are radicals,
+   and a radical is not a number until a branch is chosen, so every list is
+   checked against ``det(zI - A)`` at sampled ``z`` before it is returned. When
+   the two disagree the radicals are not the spectrum on the branches anything
+   reads them on, and ``eigenvals`` / ``eigenvects`` / ``diagonalize`` /
+   ``jordan_form`` / ``matrix_exp`` refuse. **This is "these are not the
+   eigenvalues", not "this matrix has none".**
+
 .. exception:: CadError
 
    Code prefix ``E-CAD-*``. Real quantifier elimination (:func:`decide`).


### PR DESCRIPTION
`Matrix.eigenvals()` on an irreducible cubic returned three expressions that
**are not roots**, and that the library's own evaluator refused.

On the companion matrix of `λ³ + 3λ² + 2λ + 1`:

| | before | after |
|---|---|---|
| `\|p(λ)\|` at the three returned values | **2.2944788, 1.5048698, 1.5048698** | **2.2e-16, 0.0, 0.0** |
| `eval_expr` on the real root | `E-EVAL-009` (undefined) | `−2.324717957244746` |

## Cause

`t = A + B` solves `t³ + pt + q` only for the pair satisfying `A·B = −p/3`.
Two independent `Pow` nodes `(−q/2 ± √Δ)^(1/3)` do not record that constraint,
and it fails exactly when both radicands are negative (`Δ > 0`, `q > 0 > p`):
each radical picks up its own `e^{iπ/3}`, so `A·B` is off by `e^{2iπ/3}`.

## Fix

Pull the sign **out** of the radical instead of asking a convention to carry
it: for `w < 0`, `∛w = −∛|w|`, and `|w|` is the same two terms negated. Every
cube-root base then sits on the positive real axis, where the real and
principal cube roots coincide — so the expression means the same thing to
`eval_expr`, to `eval_complex_f64`, and to Cardano. The sign is decided
**exactly** (`Δ ≥ 0` and the rest is rational, so `r + √d ≥ 0` iff `r ≥ 0` or
`d ≥ r²`) — no numerics.

A `cbrt` head was rejected: it would need `eval_expr`, `eval_interp`, the
complex evaluator, `simplify`, `diff`, printing and PyO3 to all agree, and a
half-implemented convention is worse than a refusal. `RootSum` was rejected
because it trades a wrong value for an unusable one.

## Standing gate

`matrix/spectrum.rs` is a new canonical `Π(z−λ) = det(zI−A)` check (3 complex
probes × 2 parameter sets); `eigenvalues` refuses via `E-EIGEN-008` when it
fails. It lives beside the formula, not inside it — a gate may not be its own
witness. `ode::dsolve::system`'s private copy now delegates to it, and two bugs
in that copy are fixed in the shared one:

1. **`pi` was sampled as a free parameter** and bound to `1.7` (π is a plain
   `Symbol` here, so `collect_symbols` picked it up), turning the correct
   casus-irreducibilis form into a spurious refusal blaming Cardano.
2. A near-singular probe reported `det = 0` instead of declining.

`eval_complex_f64` gains `acos` (principal branch) so the three-real-roots
branch is *confirmed* rather than tolerated. `acos` was deliberately **not**
added to `eval::eval_f64` — the 3.9.0 notes document that the antiderivative
gates depend on that table staying small.

## Blast radius

`eigen.rs` is the only place in the crate building a `^(1/3)` root.
`eigenvects`/`diagonalize`/`jordan_form`/`matrix_exp` are downstream and
unchanged in behaviour on this matrix (all returned `E-LINALG-010` before and
after — the zero test cannot decide a pivot of nested radicals).
`minimal_polynomial`, `rational_canonical_form`, `real_roots` and `solve` never
form radicals and are unaffected. Quartics take no Ferrari path (`E-EIGEN-004`).
`dsolve_system` on the Cardano companion now **solves** where its own gate
previously refused.

`E-EIGEN-008` travels out of band via `matrix::take_spectrum_refusal()` —
`EigenError`/`LinearAlgebraError` are public exhaustive enums, so a new variant
would be a semver break. Same pattern as `E-LINALG-010`/`E-SERIES-003`.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2845 passed, 0
failed, 11 ignored** (base 2834, +11). clippy `-D warnings`, `cargo fmt
--check`, `check_error_codes.py`, `check_api_freeze.py` all clean.
`pytest tests/` → 3186 passed, 0 failed.

Known, deliberately not fixed here: `ode/dsolve/verify.rs` has the same
`pi`-as-a-free-parameter bug in its substitution gate. Fixing it makes *more*
dsolve answers pass verification and needs its own corpus measurement rather
than riding along on a `matrix/` fix. It is a false refusal, never a wrong
answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the complex inverse cosine function, including correct principal-branch behavior.
  - Added validation for calculated eigenvalues to ensure they match the matrix spectrum.
  - Added a specific diagnostic for eigenvalue expressions that cannot be verified.

- **Bug Fixes**
  - Improved cubic eigenvalue results by coordinating real radical expressions and avoiding inconsistent branches.
  - Python bindings now surface detailed spectrum-validation errors instead of generic failures.

- **Documentation**
  - Documented the new eigenvalue diagnostic, its behavior, and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->