### PR TITLE
fix(series): expand through a removable singularity, and refuse rather than return a NaN coefficient

### DIFF
--- a/alkahest-core/src/calculus/series.rs
+++ b/alkahest-core/src/calculus/series.rs
@@ -4,7 +4,7 @@ use crate::budget::BudgetError;
 use crate::diff::{diff, DiffError};
 use crate::flint::FlintPoly;
 use crate::kernel::{subs, Domain, ExprData, ExprId, ExprPool};
-use crate::poly::{RationalFunction, UniPoly};
+use crate::poly::{together_parts, RationalFunction, UniPoly};
 use crate::simplify::simplify;
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -117,6 +117,23 @@ impl From<DiffError> for SeriesError {
 /// [`take_series_refusal`] pending**, never as a shorter series: a truncated
 /// expansion still labelled `O(hᵒʳᵈᵉʳ)` would be a false statement about the
 /// remainder, and that is a lie where a refusal is merely a limitation.
+///
+/// # Singular expansion points
+///
+/// Substituting `point` into a derivative is not the same as taking a limit, so
+/// a **removable** singularity — `sin(x)/x` at `0`, whose constant term is the
+/// literal `0/0` — has no coefficient the direct route can form. Where the
+/// expression can be put over a common denominator (`quotient_expansion`) the
+/// two sides are expanded separately and the *power series* are divided, which
+/// cancels the vanishing factor before anything is evaluated: `sin(x)/x` gives
+/// `1 − x²/6 + O(x⁴)`, `1/sin(x)` gives `x⁻¹ + x/6 + O(x)`.
+///
+/// Where it cannot — a branch point (`√x`), a logarithmic singularity
+/// (`log x`), an essential one (`e^{1/x}`) — there is no Laurent expansion to
+/// return, and this is an **`Err`** carrying a
+/// [`SeriesRefusalCause::IndeterminateCoefficient`] refusal (`E-SERIES-004`).
+/// It is never a `Series` whose coefficients contain `0⁻¹`: that reports
+/// success, cannot be evaluated, and evaluates to `NaN` for whoever tries.
 pub fn series(
     expr: ExprId,
     var: ExprId,
@@ -138,6 +155,21 @@ pub fn series(
     } = local_expansion(expr, var, point, order, pool)?;
 
     if frame.refusal_pending() {
+        return Err(SeriesError::InvalidOrder);
+    }
+
+    // A coefficient that is `0/0`, `1/0` or `log(0)` is not a value, and a
+    // `Series` carrying one is the exact failure mode this module exists to
+    // avoid: `Ok`, unevaluable, unsimplifiable, `NaN` on contact. Refuse.
+    if let Some(idx) = first_indeterminate(&coeffs, pool) {
+        LAST_REFUSAL.with(|c| {
+            c.set(Some(SeriesRefusal {
+                requested: coeffs.len() as u32,
+                computed: idx as u32,
+                budget: None,
+                cause: SeriesRefusalCause::IndeterminateCoefficient,
+            }))
+        });
         return Err(SeriesError::InvalidOrder);
     }
 
@@ -176,7 +208,242 @@ pub(crate) fn local_expansion(
 
     let h_expr = expansion_increment(pool, var, point);
 
-    expansion_matched_laurent(shifted, xi, h_expr, order, pool)
+    let direct = expansion_matched_laurent(shifted, xi, h_expr, order, pool)?;
+    if first_indeterminate(&direct.coeffs, pool).is_none() {
+        return Ok(direct);
+    }
+
+    // A coefficient is `0/0`, `1/0`, `log(0)`, … — the expansion point is
+    // singular for the *form* the coefficients were computed in, which is not
+    // the same thing as singular for the function. Try the quotient route,
+    // which divides power series instead of substituting into a quotient and
+    // therefore sees through a removable singularity.
+    //
+    // The refusal channel is saved and restored so a probe that runs out of
+    // room cannot make a *successful* repair look like a work-ceiling trip.
+    let saved = LAST_REFUSAL.with(|c| c.get());
+    if let Some(repaired) = quotient_expansion(shifted, xi, h_expr, order, pool)? {
+        if first_indeterminate(&repaired.coeffs, pool).is_none() {
+            LAST_REFUSAL.with(|c| c.set(saved));
+            return Ok(repaired);
+        }
+    }
+
+    // The repair does not apply (branch point, essential singularity, a
+    // denominator whose valuation is not visible). Hand back the direct
+    // expansion unchanged: every caller other than `series` — `limit`,
+    // `gruntz`, `asymptotic`, `fps` — already inspects coefficients for
+    // usability and has its own fallback, and `series` itself turns an
+    // indeterminate coefficient into a refusal rather than a value.
+    Ok(direct)
+}
+
+/// Expand `shifted` about `ξ = 0` by **dividing power series** rather than
+/// substituting into a quotient.
+///
+/// This is the removable-singularity repair. `sin(ξ)/ξ` has no Taylor
+/// coefficient at `ξ = 0` when you substitute — the constant term is the
+/// literal `0/0` — but it has a perfectly ordinary one when you write it as
+/// `(ξ − ξ³/6 + …)/(ξ)` and divide the two expansions, because the vanishing
+/// factor cancels *before* anything is evaluated at `0`.
+///
+/// The steps:
+///
+/// 1. [`together_parts`] puts the expression over one denominator, treating
+///    `sin(ξ)`, `log(1+ξ)`, `ξ^n` and friends as opaque generators. This is
+///    what turns `1/ξ − 1/sin ξ` (an `Add` of two poles that cancel, which
+///    `collect_term_factors` cannot even take apart) into the single quotient
+///    `(sin ξ − ξ)/(ξ · sin ξ)`.
+/// 2. Taylor-expand numerator and denominator separately. Both are polynomials
+///    in the generators, hence analytic wherever the generators are, so their
+///    coefficients are ordinary substitutions — no indeterminate forms.
+/// 3. Read off the valuations `vₙ`, `v_d` (index of the first coefficient that
+///    is not the literal `0`) and divide the unit parts by the standard
+///    recurrence `cₖ = (aₖ − Σ_{j≥1} b_j c_{k−j}) / b₀`.
+///
+/// Returns `Ok(None)` when the shape does not apply: no denominator, a
+/// denominator that does not vanish at the point (the direct route was already
+/// right, so a failure there is not this function's to fix), a valuation that
+/// is not visible within the probe depth, or a numerator/denominator that is
+/// itself singular at `0` (`log(ξ)`, `√ξ` — genuine branch points, for which
+/// no Laurent expansion exists and a refusal is the correct answer).
+///
+/// # Zero tests are one-sided, on purpose
+///
+/// A valuation is found by skipping coefficients that are the *structural*
+/// integer `0`. A coefficient that is secretly zero but does not look it stops
+/// the scan early, which **understates** the valuation. That is the safe
+/// direction for the numerator: `c₀` comes out `0`, the leading zeros are
+/// dropped by [`assemble_series`], and the series is still correct (merely
+/// computed to a lower valuation than necessary). For the denominator it means
+/// dividing by a `b₀` that is really `0`, which produces `0⁻¹` — caught by
+/// [`coefficient_is_indeterminate`] and refused. Neither direction can return
+/// a wrong series.
+fn quotient_expansion(
+    shifted: ExprId,
+    xi: ExprId,
+    h_expr: ExprId,
+    order: u32,
+    pool: &ExprPool,
+) -> Result<Option<LocalExpansion>, SeriesError> {
+    let Ok((num, den)) = together_parts(shifted, vec![xi], pool) else {
+        return Ok(None);
+    };
+    if num == shifted {
+        // Nothing was combined or cancelled — re-expanding would reproduce the
+        // same indeterminate coefficients. This is the branch-point /
+        // essential-singularity exit (`√ξ`, `log ξ`, `e^{1/ξ}`).
+        return Ok(None);
+    }
+    if matches!(pool.get(den), ExprData::Integer(n) if n.0 == 1) {
+        // The GCD reduction removed the vanishing factor outright — the
+        // `(x²−1)/(x−1)` shape, where the quotient *is* a polynomial and there
+        // is nothing left to divide. Expanding the cancelled form is the whole
+        // repair.
+        let coeffs = taylor_coefficients(num, xi, order, pool)?;
+        if coeffs.len() < order as usize {
+            return Ok(None);
+        }
+        return Ok(Some(LocalExpansion {
+            valuation: 0,
+            coeffs,
+            h_expr,
+        }));
+    }
+
+    // Probe depth for the two valuations. A pole deeper than this is not one
+    // this repair claims to handle; the caller refuses rather than guesses.
+    let probe = (order as usize).saturating_add(VALUATION_PROBE_SLACK);
+    let probe_u32 = probe.min(u32::MAX as usize) as u32;
+
+    let d_probe = taylor_coefficients(den, xi, probe_u32, pool)?;
+    let Some(vd) = leading_index(&d_probe, pool) else {
+        return Ok(None);
+    };
+    if vd == 0 {
+        // The denominator is fine at the point; whatever went wrong is in the
+        // numerator, and dividing series will not repair it.
+        return Ok(None);
+    }
+    let n_probe = taylor_coefficients(num, xi, probe_u32, pool)?;
+    let Some(vn) = leading_index(&n_probe, pool) else {
+        return Ok(None);
+    };
+
+    let valuation = vn as i32 - vd as i32;
+    let num_taylor: u32 = if valuation < 0 {
+        order
+    } else {
+        (order as i32 - valuation).max(0) as u32
+    };
+    if num_taylor == 0 {
+        return Ok(Some(LocalExpansion {
+            valuation,
+            coeffs: Vec::new(),
+            h_expr,
+        }));
+    }
+
+    // Unit parts: `a_i = numerator coefficient (vn + i)`, likewise for `b`.
+    let a = unit_part(&n_probe, num, xi, vn, num_taylor, pool)?;
+    let b = unit_part(&d_probe, den, xi, vd, num_taylor, pool)?;
+    let (Some(a), Some(b)) = (a, b) else {
+        return Ok(None);
+    };
+    if a.iter()
+        .chain(b.iter())
+        .any(|&c| coefficient_is_indeterminate(c, pool))
+    {
+        // A generator that is not analytic at the point (`log ξ`, `√ξ`).
+        return Ok(None);
+    }
+
+    let inv_b0 = reciprocal(b[0], pool);
+    let mut coeffs: Vec<ExprId> = Vec::with_capacity(num_taylor as usize);
+    for k in 0..num_taylor as usize {
+        let mut terms = vec![a[k]];
+        for (j, &bj) in b.iter().enumerate().take(k + 1).skip(1) {
+            terms.push(pool.mul(vec![pool.integer(-1_i32), bj, coeffs[k - j]]));
+        }
+        let numer = if terms.len() == 1 {
+            terms[0]
+        } else {
+            pool.add(terms)
+        };
+        coeffs.push(simplify(pool.mul(vec![numer, inv_b0]), pool).value);
+        if coeff_loop_should_stop(pool) {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(LocalExpansion {
+        valuation,
+        coeffs,
+        h_expr,
+    }))
+}
+
+/// How many coefficients past the requested order [`quotient_expansion`] will
+/// look at while hunting for a valuation.
+///
+/// The numerator and denominator valuations are pole/zero orders, which are
+/// small in every expansion anyone writes down (`sin(x)/x`: 1 and 1;
+/// `(1−cos x)/x²`: 2 and 2). The slack buys headroom without turning a failed
+/// probe into a runaway: each probed coefficient is one differentiation.
+const VALUATION_PROBE_SLACK: usize = 4;
+
+/// `1/expr`, folded when `expr` is a nonzero rational literal.
+///
+/// `simplify` leaves `(-1/2)^-1` alone, which is correct but reads badly in
+/// every coefficient of the result (`1/(1−cos x)` would print
+/// `−(−1/2)⁻¹·x⁻² + …` instead of `2·x⁻² + …`). The leading coefficient of a
+/// divisor is a literal in essentially every expansion, so folding it here is
+/// worth the four lines.
+fn reciprocal(expr: ExprId, pool: &ExprPool) -> ExprId {
+    match pool.get(expr) {
+        ExprData::Integer(n) if n.0 != 0 => pool.rational(rug::Integer::from(1), n.0.clone()),
+        ExprData::Rational(r) if r.0 != 0 => {
+            let inv = r.0.clone().recip();
+            let (num, den) = inv.into_numer_denom();
+            pool.rational(num, den)
+        }
+        _ => simplify(pool.pow(expr, pool.integer(-1_i32)), pool).value,
+    }
+}
+
+/// Index of the first coefficient that is not the literal integer `0`.
+///
+/// `None` when every probed coefficient is zero — either the expression really
+/// is identically zero to this depth, or the valuation is deeper than the
+/// probe. The two are indistinguishable from here, so the caller declines
+/// rather than assuming either.
+fn leading_index(coeffs: &[ExprId], pool: &ExprPool) -> Option<usize> {
+    coeffs.iter().position(|&c| !is_structural_zero(c, pool))
+}
+
+/// Coefficients `v, v+1, …, v+wanted-1` of `expr`, re-expanding when the probe
+/// did not reach that far.
+fn unit_part(
+    probed: &[ExprId],
+    expr: ExprId,
+    xi: ExprId,
+    v: usize,
+    wanted: u32,
+    pool: &ExprPool,
+) -> Result<Option<Vec<ExprId>>, SeriesError> {
+    let need = v.saturating_add(wanted as usize);
+    if probed.len() >= need {
+        return Ok(Some(probed[v..need].to_vec()));
+    }
+    let Ok(need_u32) = u32::try_from(need) else {
+        return Ok(None);
+    };
+    let full = taylor_coefficients(expr, xi, need_u32, pool)?;
+    if full.len() < need {
+        // The coefficient loop stopped early (ceiling or budget).
+        return Ok(None);
+    }
+    Ok(Some(full[v..need].to_vec()))
 }
 
 fn factorial_u32(n: u32) -> rug::Integer {
@@ -204,6 +471,104 @@ fn laurent_big_o_pow(valuation: i32, order: u32) -> i64 {
 
 fn is_structural_zero(id: ExprId, pool: &ExprPool) -> bool {
     matches!(pool.get(id), ExprData::Integer(n) if n.0 == 0)
+}
+
+// ---------------------------------------------------------------------------
+// Indeterminate coefficients
+// ---------------------------------------------------------------------------
+
+/// True when `expr` contains a `0^n` node with `n` a negative constant.
+///
+/// The syntactic half of [`coefficient_is_indeterminate`], and the only half
+/// that can see through a free parameter: `k · 0⁻¹` is not a number however
+/// unknown `k` is, and no numeric evaluation can discover that.
+///
+/// The twin of [`crate::calculus::limits`]'s check of the same name; the two
+/// are deliberately separate because their verdicts differ on `±∞` (an
+/// established divergence is a fine *limit* and never a *series coefficient*).
+fn contains_zero_to_negative_power(expr: ExprId, pool: &ExprPool) -> bool {
+    match pool.get(expr) {
+        ExprData::Pow { base, exp } => {
+            let zero_base = matches!(pool.get(base), ExprData::Integer(n) if n.0 == 0);
+            let negative_exp = match pool.get(exp) {
+                ExprData::Integer(n) => n.0 < 0,
+                ExprData::Rational(r) => r.0 < 0,
+                ExprData::Float(f) => f.inner.to_f64() < 0.0,
+                _ => false,
+            };
+            (zero_base && negative_exp)
+                || contains_zero_to_negative_power(base, pool)
+                || contains_zero_to_negative_power(exp, pool)
+        }
+        ExprData::Add(xs) | ExprData::Mul(xs) => {
+            xs.iter().any(|&x| contains_zero_to_negative_power(x, pool))
+        }
+        ExprData::Func { args, .. } => args
+            .iter()
+            .any(|&a| contains_zero_to_negative_power(a, pool)),
+        _ => false,
+    }
+}
+
+/// True when this Taylor/Laurent coefficient is provably **not a number**.
+///
+/// Coefficients are formed by substituting the expansion point into repeated
+/// derivatives (see [`taylor_coefficients`]), so at a singular point the
+/// substitution produces the indeterminate form itself — `0·0⁻¹` for
+/// `sin(x)/x`, `sqrt(0)⁻¹` for `√x`, `log(0)` for `log x`, `exp(0⁻¹)` for
+/// `e^{1/x}`. Every one of those is `NaN` or `±∞` when evaluated, and a
+/// `Series` carrying one is worse than no answer: it reports success, cannot be
+/// evaluated, and cannot be simplified.
+///
+/// Only **positive evidence** counts, in both directions:
+///
+/// * a `0^{negative}` node anywhere, which survives free parameters;
+/// * any *sub*-expression the interpreter actually evaluated, to a non-finite
+///   number.
+///
+/// The search has to go inside the coefficient rather than testing it whole,
+/// because a free parameter makes the whole thing unevaluable while leaving
+/// the culprit in plain sight: the `x¹` coefficient of `k·√x` is
+/// `k · ½ · sqrt(0)⁻¹`, which `eval_interp` declines (it cannot value `k`)
+/// even though `sqrt(0)⁻¹` on its own is `+∞`. Testing only the top node let
+/// that through.
+///
+/// A coefficient the interpreter cannot reach a verdict on anywhere — one that
+/// is just `cos(a)` for a symbolic expansion point, or one whose head has no
+/// interpreter entry — is *not* indeterminate. That direction matters: this
+/// predicate gates a refusal, so a false positive turns a working expansion
+/// into an error.
+fn coefficient_is_indeterminate(expr: ExprId, pool: &ExprPool) -> bool {
+    contains_zero_to_negative_power(expr, pool) || has_non_finite_constant(expr, pool)
+}
+
+/// True when some subtree is closed arithmetic that evaluates to `NaN` or `±∞`.
+///
+/// `eval_interp` returns `Some` exactly for a subtree with no free symbols, so
+/// a `Some` verdict is final for that subtree and the walk stops there;
+/// recursion only follows branches that still mention a symbol, and those are
+/// the only ones that can hide a constant the top-level call could not see.
+fn has_non_finite_constant(expr: ExprId, pool: &ExprPool) -> bool {
+    let env = HashMap::new();
+    if let Some(v) = crate::jit::eval_interp(expr, &env, pool) {
+        return !v.is_finite();
+    }
+    match pool.get(expr) {
+        ExprData::Add(xs) | ExprData::Mul(xs) | ExprData::Func { args: xs, .. } => {
+            xs.iter().any(|&c| has_non_finite_constant(c, pool))
+        }
+        ExprData::Pow { base, exp } => {
+            has_non_finite_constant(base, pool) || has_non_finite_constant(exp, pool)
+        }
+        _ => false,
+    }
+}
+
+/// Index of the first coefficient that is not a number, if any.
+fn first_indeterminate(coeffs: &[ExprId], pool: &ExprPool) -> Option<usize> {
+    coeffs
+        .iter()
+        .position(|&c| coefficient_is_indeterminate(c, pool))
 }
 
 fn collect_atom_factors(expr: ExprId, pool: &ExprPool) -> Option<(Vec<ExprId>, Vec<ExprId>)> {
@@ -336,6 +701,39 @@ pub struct SeriesRefusal {
     requested: u32,
     computed: u32,
     budget: Option<BudgetError>,
+    cause: SeriesRefusalCause,
+}
+
+/// Why a [`SeriesRefusal`] was raised.
+///
+/// Non-exhaustive so a future refusal reason is an additive change; matching
+/// callers must carry a `_` arm.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SeriesRefusalCause {
+    /// The coefficient loop ran past [`MAX_SERIES_POOL_GROWTH`] (or an active
+    /// [`crate::budget`]) before reaching the requested order — `E-SERIES-003`.
+    Exhausted,
+    /// A coefficient came out as an *indeterminate form* rather than a value:
+    /// `0·0⁻¹`, `0⁻¹`, `log(0)`, anything that evaluates to `NaN` or `±∞`
+    /// — `E-SERIES-004`.
+    ///
+    /// This is what a **removable singularity** at the expansion point looks
+    /// like from inside the coefficient loop. Coefficients are formed by
+    /// substituting the expansion point into repeated derivatives, so
+    /// `sin(x)/x` at `0` yields the literal quotient `0/0` for its constant
+    /// term where the *limit* is `1`. `local_expansion` repairs the common
+    /// shape (see `quotient_expansion`); when the repair does not apply, the
+    /// coefficient is not a number and the expansion is refused rather than
+    /// returned with a `NaN` inside it.
+    IndeterminateCoefficient,
+}
+
+impl SeriesRefusal {
+    /// Why the expansion was refused.
+    pub fn cause(&self) -> SeriesRefusalCause {
+        self.cause
+    }
 }
 
 impl SeriesRefusal {
@@ -361,18 +759,28 @@ impl SeriesRefusal {
 
 impl fmt::Display for SeriesRefusal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "series expansion stopped after {} of {} Taylor coefficients ({}); \
-             refusing to return a shorter series labelled with the requested \
-             order, which would understate the O(.) remainder",
-            self.computed,
-            self.requested,
-            match self.budget {
-                Some(b) => format!("budget: {b}"),
-                None => "internal work ceiling".to_string(),
-            }
-        )
+        match self.cause {
+            SeriesRefusalCause::Exhausted => write!(
+                f,
+                "series expansion stopped after {} of {} Taylor coefficients ({}); \
+                 refusing to return a shorter series labelled with the requested \
+                 order, which would understate the O(.) remainder",
+                self.computed,
+                self.requested,
+                match self.budget {
+                    Some(b) => format!("budget: {b}"),
+                    None => "internal work ceiling".to_string(),
+                }
+            ),
+            SeriesRefusalCause::IndeterminateCoefficient => write!(
+                f,
+                "coefficient {} of {} is an indeterminate form (0/0, 1/0, log(0) or \
+                 similar), not a number: the expansion point is a singularity this \
+                 expansion cannot resolve. Refusing to return a series whose \
+                 coefficients evaluate to NaN or infinity",
+                self.computed, self.requested,
+            ),
+        }
     }
 }
 
@@ -380,15 +788,26 @@ impl std::error::Error for SeriesRefusal {}
 
 impl crate::errors::AlkahestError for SeriesRefusal {
     fn code(&self) -> &'static str {
-        "E-SERIES-003"
+        match self.cause {
+            SeriesRefusalCause::Exhausted => "E-SERIES-003",
+            SeriesRefusalCause::IndeterminateCoefficient => "E-SERIES-004",
+        }
     }
 
     fn remediation(&self) -> Option<&'static str> {
-        Some(
-            "ask for a lower order, raise the budget, or rewrite the expression so its \
-             repeated derivatives close (nested radicals grow by a constant factor per \
-             coefficient)",
-        )
+        match self.cause {
+            SeriesRefusalCause::Exhausted => Some(
+                "ask for a lower order, raise the budget, or rewrite the expression so its \
+                 repeated derivatives close (nested radicals grow by a constant factor per \
+                 coefficient)",
+            ),
+            SeriesRefusalCause::IndeterminateCoefficient => Some(
+                "the expansion point is a branch point, an essential singularity, or a \
+                 removable one this engine cannot cancel: cancel the singular factor by \
+                 hand (`cancel`/`together`), expand about a nearby regular point, or use \
+                 `limit` for the single value you need",
+            ),
+        }
     }
 }
 
@@ -500,6 +919,7 @@ fn taylor_coefficients(
                     requested: num,
                     computed: k,
                     budget: crate::budget::check().err(),
+                    cause: SeriesRefusalCause::Exhausted,
                 };
                 LAST_REFUSAL.with(|c| c.set(Some(refusal)));
             }
@@ -790,5 +1210,402 @@ mod tests {
         let s = series(sx, x, p.integer(0), 24, &p).unwrap();
         assert!(contains_big_o(s.expr(), &p));
         assert_eq!(take_series_refusal(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Removable singularities at the expansion point
+    // -----------------------------------------------------------------------
+
+    /// Numeric value of every coefficient, in order, or `None` where the
+    /// coefficient is not a closed constant.
+    fn coeff_values(
+        expr: ExprId,
+        var: ExprId,
+        point: ExprId,
+        order: u32,
+        p: &ExprPool,
+    ) -> Vec<f64> {
+        let exp = local_expansion(expr, var, point, order, p).expect("expansion");
+        let env = HashMap::new();
+        exp.coeffs
+            .iter()
+            .map(|&c| crate::jit::eval_interp(c, &env, p).unwrap_or(f64::NAN))
+            .collect()
+    }
+
+    fn assert_close(got: &[f64], want: &[f64]) {
+        assert_eq!(got.len(), want.len(), "got {got:?} want {want:?}");
+        for (g, w) in got.iter().zip(want) {
+            assert!((g - w).abs() < 1e-12, "got {got:?} want {want:?}");
+        }
+    }
+
+    fn sin_over_x(p: &ExprPool) -> ExprId {
+        let x = p.symbol("x", Domain::Real);
+        let s = p.func("sin", vec![x]);
+        p.mul(vec![s, p.pow(x, p.integer(-1))])
+    }
+
+    /// The headline case. `sin(x)/x` has a *removable* singularity at `0`: the
+    /// function extends analytically with value `1`, and SymPy, Maxima and
+    /// every textbook give `1 − x²/6 + x⁴/120 + O(x⁶)`.
+    ///
+    /// Forming coefficients by substituting `0` into repeated derivatives
+    /// cannot see that — the constant term comes out as the literal `0·0⁻¹` —
+    /// and the result used to be returned as a *successful* `Series` full of
+    /// `1/0` and `0/0`, which no caller could evaluate and none could detect.
+    /// This is the regression test for the most common expansion in applied
+    /// mathematics.
+    #[test]
+    fn sin_over_x_expands_through_its_removable_singularity() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let e = sin_over_x(&p);
+        assert_close(
+            &coeff_values(e, x, p.integer(0), 6, &p),
+            &[1.0, 0.0, -1.0 / 6.0, 0.0, 1.0 / 120.0, 0.0],
+        );
+        assert!(series(e, x, p.integer(0), 6, &p).is_ok());
+        assert_eq!(take_series_refusal(), None);
+    }
+
+    #[test]
+    fn tan_over_x_expands_through_its_removable_singularity() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let t = p.func("tan", vec![x]);
+        let e = p.mul(vec![t, p.pow(x, p.integer(-1))]);
+        assert_close(
+            &coeff_values(e, x, p.integer(0), 5, &p),
+            &[1.0, 0.0, 1.0 / 3.0, 0.0, 2.0 / 15.0],
+        );
+    }
+
+    /// `(1 − cos x)/x²` — a double zero over a double zero, so the repair has
+    /// to line up two valuations rather than one.
+    #[test]
+    fn matched_double_zeros_cancel() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let c = p.func("cos", vec![x]);
+        let n = p.add(vec![p.integer(1), p.mul(vec![p.integer(-1), c])]);
+        let e = p.mul(vec![n, p.pow(x, p.integer(-2))]);
+        assert_close(
+            &coeff_values(e, x, p.integer(0), 5, &p),
+            &[0.5, 0.0, -1.0 / 24.0, 0.0, 1.0 / 720.0],
+        );
+    }
+
+    /// `1/x − 1/sin x` is a *sum* of two poles that cancel, which the
+    /// factor-splitting fast path cannot even take apart. Putting it over a
+    /// common denominator first is what makes it expandable.
+    #[test]
+    fn a_sum_of_cancelling_poles_expands() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let s = p.func("sin", vec![x]);
+        let e = p.add(vec![
+            p.pow(x, p.integer(-1)),
+            p.mul(vec![p.integer(-1), p.pow(s, p.integer(-1))]),
+        ]);
+        // 1/x − 1/sin x = −x/6 − 7x³/360 + O(x⁵): valuation 1, so the
+        // coefficient list starts at the x¹ term.
+        let exp = local_expansion(e, x, p.integer(0), 5, &p).unwrap();
+        assert_eq!(exp.valuation, 1);
+        assert_close(
+            &coeff_values(e, x, p.integer(0), 5, &p),
+            &[-1.0 / 6.0, 0.0, -7.0 / 360.0, 0.0],
+        );
+    }
+
+    /// `(x²−1)/(x−1)` about `x = 1`: the singular factor cancels outright, so
+    /// there is no series left to divide — only a polynomial to expand.
+    #[test]
+    fn a_singularity_that_cancels_outright_expands() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let n = p.add(vec![p.pow(x, p.integer(2)), p.integer(-1)]);
+        let d = p.add(vec![x, p.integer(-1)]);
+        let e = p.mul(vec![n, p.pow(d, p.integer(-1))]);
+        // (x²−1)/(x−1) = x + 1 = 2 + (x−1)
+        assert_close(
+            &coeff_values(e, x, p.integer(1), 4, &p),
+            &[2.0, 1.0, 0.0, 0.0],
+        );
+    }
+
+    /// A genuine pole is not a removable singularity and must keep its
+    /// principal part: `1/sin x = x⁻¹ + x/6 + 7x³/360 + …`.
+    #[test]
+    fn a_real_pole_keeps_its_principal_part() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let s = p.func("sin", vec![x]);
+        let e = p.pow(s, p.integer(-1));
+        let exp = local_expansion(e, x, p.integer(0), 5, &p).unwrap();
+        assert_eq!(exp.valuation, -1);
+        let env = HashMap::new();
+        let vals: Vec<f64> = exp
+            .coeffs
+            .iter()
+            .map(|&c| crate::jit::eval_interp(c, &env, &p).unwrap_or(f64::NAN))
+            .collect();
+        assert_close(&vals, &[1.0, 0.0, 1.0 / 6.0, 0.0, 7.0 / 360.0]);
+    }
+
+    /// A free parameter survives the repair: `sin(kx)/x = k − k³x²/6 + O(x⁴)`.
+    /// The coefficients are symbolic, so the indeterminacy check must not read
+    /// "cannot evaluate" as "not a number".
+    #[test]
+    fn a_symbolic_parameter_survives_the_repair() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let k = p.symbol("k", Domain::Real);
+        let s = p.func("sin", vec![p.mul(vec![k, x])]);
+        let e = p.mul(vec![s, p.pow(x, p.integer(-1))]);
+        let exp = local_expansion(e, x, p.integer(0), 3, &p).unwrap();
+        assert_eq!(exp.valuation, 0);
+        let mut env = HashMap::new();
+        env.insert(k, 2.0);
+        let vals: Vec<f64> = exp
+            .coeffs
+            .iter()
+            .map(|&c| crate::jit::eval_interp(c, &env, &p).unwrap_or(f64::NAN))
+            .collect();
+        assert_close(&vals, &[2.0, 0.0, -8.0 / 6.0]);
+        assert!(series(e, x, p.integer(0), 3, &p).is_ok());
+        assert_eq!(take_series_refusal(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Singularities that are *not* removable: refuse, never fabricate
+    // -----------------------------------------------------------------------
+
+    fn assert_refuses_as_indeterminate(expr: ExprId, var: ExprId, order: u32, p: &ExprPool) {
+        use crate::errors::AlkahestError;
+        let err = series(expr, var, p.integer(0), order, p)
+            .err()
+            .unwrap_or_else(|| panic!("expected a refusal, got a Series"));
+        assert!(matches!(err, SeriesError::InvalidOrder), "{err:?}");
+        let refusal = take_series_refusal().expect("indeterminate-coefficient refusal recorded");
+        assert_eq!(refusal.code(), "E-SERIES-004");
+        assert_eq!(
+            refusal.cause(),
+            SeriesRefusalCause::IndeterminateCoefficient
+        );
+    }
+
+    /// `√x`, `log x`, `e^{1/x}`, `x^x` and `x·sin(1/x)` have no Laurent
+    /// expansion at `0` — branch point, logarithmic singularity, essential
+    /// singularity, and two shapes that are not meromorphic at all. Every one
+    /// of them used to come back as a *successful* `Series` whose coefficients
+    /// were `sqrt(0)⁻¹`, `log(0)`, `exp(0⁻¹)`, …: `Ok`, unevaluable, `NaN` on
+    /// contact. A coded refusal is the only honest answer, and it is what the
+    /// caller can branch on.
+    #[test]
+    fn a_singularity_with_no_laurent_expansion_is_refused() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let inv_x = p.pow(x, p.integer(-1));
+        let log_x = p.func("log", vec![x]);
+
+        assert_refuses_as_indeterminate(p.func("sqrt", vec![x]), x, 4, &p);
+        assert_refuses_as_indeterminate(log_x, x, 4, &p);
+        assert_refuses_as_indeterminate(p.mul(vec![x, log_x]), x, 4, &p);
+        assert_refuses_as_indeterminate(p.mul(vec![log_x, inv_x]), x, 4, &p);
+        assert_refuses_as_indeterminate(p.func("exp", vec![inv_x]), x, 4, &p);
+        assert_refuses_as_indeterminate(p.func("sin", vec![inv_x]), x, 4, &p);
+        let x_sin_inv = p.mul(vec![x, p.func("sin", vec![inv_x])]);
+        assert_refuses_as_indeterminate(x_sin_inv, x, 4, &p);
+        let x_to_x = p.func("exp", vec![p.mul(vec![x, log_x])]);
+        assert_refuses_as_indeterminate(x_to_x, x, 3, &p);
+        // Puiseux, not Laurent: a half-integer valuation.
+        let sqrt_sin = p.func("sqrt", vec![p.func("sin", vec![x])]);
+        assert_refuses_as_indeterminate(sqrt_sin, x, 4, &p);
+    }
+
+    /// A free parameter must not hide the indeterminate part.
+    ///
+    /// The `x¹` coefficient of `k·√x` is `k · ½ · sqrt(0)⁻¹`. Evaluating the
+    /// coefficient as a whole gets nowhere — `k` has no value — so a check that
+    /// only looked at the top node passed it, and `k·√x` came back as a
+    /// successful `Series` carrying `+∞`. The check has to look *inside*.
+    #[test]
+    fn a_free_parameter_does_not_hide_an_indeterminate_coefficient() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let k = p.symbol("k", Domain::Real);
+        let sqrt_x = p.func("sqrt", vec![x]);
+
+        assert_refuses_as_indeterminate(p.mul(vec![k, sqrt_x]), x, 3, &p);
+        assert_refuses_as_indeterminate(p.mul(vec![k, p.func("log", vec![x])]), x, 3, &p);
+        let k_sqrt_sin = p.mul(vec![k, sqrt_x, p.func("sin", vec![x])]);
+        assert_refuses_as_indeterminate(k_sqrt_sin, x, 4, &p);
+
+        // The control: a free parameter over a *pole* is an ordinary Laurent
+        // expansion and must still succeed.
+        let k_over_x = p.mul(vec![k, p.pow(x, p.integer(-1))]);
+        assert!(series(k_over_x, x, p.integer(0), 3, &p).is_ok());
+        assert_eq!(take_series_refusal(), None);
+    }
+
+    /// The class-level gate. Every expansion in the corpus either refuses or
+    /// returns a `Series` in which **no** coefficient evaluates to `NaN` or
+    /// `±∞` and none contains a `0^{negative}` node.
+    ///
+    /// This is the invariant, not the individual answers: a `Series` that
+    /// reports success and cannot be evaluated is the failure mode, whatever
+    /// produced it.
+    #[test]
+    fn no_successful_series_ever_carries_an_indeterminate_coefficient() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let zero = p.integer(0);
+        let one = p.integer(1);
+        let inv_x = p.pow(x, p.integer(-1));
+        let sin_x = p.func("sin", vec![x]);
+        let cos_x = p.func("cos", vec![x]);
+        let exp_x = p.func("exp", vec![x]);
+        let log_x = p.func("log", vec![x]);
+        let x_minus_1 = p.add(vec![x, p.integer(-1)]);
+        let one_minus_cos = p.add(vec![one, p.mul(vec![p.integer(-1), cos_x])]);
+
+        let cases: Vec<(ExprId, ExprId, u32)> = vec![
+            // removable
+            (p.mul(vec![sin_x, inv_x]), zero, 6),
+            (p.mul(vec![p.func("tan", vec![x]), inv_x]), zero, 5),
+            (p.mul(vec![p.func("sinh", vec![x]), inv_x]), zero, 5),
+            (p.mul(vec![p.func("atan", vec![x]), inv_x]), zero, 5),
+            (p.mul(vec![one_minus_cos, p.pow(x, p.integer(-2))]), zero, 5),
+            (
+                p.mul(vec![p.add(vec![exp_x, p.integer(-1)]), inv_x]),
+                zero,
+                5,
+            ),
+            (p.mul(vec![x, p.pow(sin_x, p.integer(-1))]), zero, 5),
+            (
+                p.mul(vec![p.pow(sin_x, p.integer(2)), p.pow(x, p.integer(-2))]),
+                zero,
+                5,
+            ),
+            (
+                p.add(vec![
+                    inv_x,
+                    p.mul(vec![p.integer(-1), p.pow(sin_x, p.integer(-1))]),
+                ]),
+                zero,
+                5,
+            ),
+            // poles — legitimate Laurent expansions
+            (inv_x, zero, 4),
+            (p.pow(x, p.integer(-2)), zero, 4),
+            (p.pow(sin_x, p.integer(-1)), zero, 5),
+            (p.mul(vec![cos_x, p.pow(sin_x, p.integer(-1))]), zero, 5),
+            (p.mul(vec![sin_x, p.pow(x, p.integer(-3))]), zero, 5),
+            (p.pow(one_minus_cos, p.integer(-1)), zero, 4),
+            (p.pow(p.func("tan", vec![x]), p.integer(-1)), zero, 4),
+            // non-zero expansion points, regular and singular
+            (exp_x, one, 5),
+            (log_x, one, 5),
+            (p.func("sqrt", vec![x]), one, 4),
+            (p.pow(log_x, p.integer(-1)), one, 4),
+            (
+                p.mul(vec![
+                    p.func("sqrt", vec![x]),
+                    p.pow(x_minus_1, p.integer(-1)),
+                ]),
+                one,
+                4,
+            ),
+            (
+                p.pow(
+                    p.add(vec![p.pow(x, p.integer(2)), p.integer(-1)]),
+                    p.integer(-1),
+                ),
+                one,
+                4,
+            ),
+            (
+                p.mul(vec![
+                    p.add(vec![p.pow(x, p.integer(2)), p.integer(-1)]),
+                    p.pow(x_minus_1, p.integer(-1)),
+                ]),
+                one,
+                4,
+            ),
+            // branch points / essential singularities
+            (p.func("sqrt", vec![x]), zero, 4),
+            (log_x, zero, 4),
+            (p.func("exp", vec![inv_x]), zero, 4),
+            (p.func("sin", vec![inv_x]), zero, 4),
+            (p.func("gamma", vec![x]), zero, 3),
+            // controls
+            (exp_x, zero, 6),
+            (
+                p.pow(
+                    p.add(vec![one, p.mul(vec![p.integer(-1), x])]),
+                    p.integer(-1),
+                ),
+                zero,
+                6,
+            ),
+            (p.func("sqrt", vec![p.add(vec![one, x])]), zero, 5),
+            (p.func("tan", vec![x]), zero, 8),
+        ];
+
+        let env = HashMap::new();
+        for (i, &(e, point, order)) in cases.iter().enumerate() {
+            let Ok(s) = series(e, x, point, order, &p) else {
+                let _ = take_series_refusal();
+                continue;
+            };
+            assert_eq!(take_series_refusal(), None, "case {i}: refusal left behind");
+            let mut stack = match p.get(s.expr()) {
+                ExprData::Add(xs) => xs,
+                _ => vec![s.expr()],
+            };
+            while let Some(t) = stack.pop() {
+                if matches!(p.get(t), ExprData::BigO(_)) {
+                    continue;
+                }
+                assert!(
+                    !contains_zero_to_negative_power(t, &p),
+                    "case {i}: {} contains 0^-n",
+                    p.display(s.expr())
+                );
+                if let Some(v) = crate::jit::eval_interp(t, &env, &p) {
+                    assert!(
+                        v.is_finite(),
+                        "case {i}: term {} of {} evaluates to {v}",
+                        p.display(t),
+                        p.display(s.expr())
+                    );
+                }
+                // Descend so a non-finite factor inside a term that still has
+                // a free `x` in it cannot hide.
+                match p.get(t) {
+                    ExprData::Add(xs) | ExprData::Mul(xs) => stack.extend(xs),
+                    ExprData::Pow { base, exp } => {
+                        stack.push(base);
+                        stack.push(exp);
+                    }
+                    ExprData::Func { args, .. } => stack.extend(args),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// `limit` reads coefficients out of the same expansion, so the repair has
+    /// to leave the standard limits right. `lim_{x→0} sin(x)/x = 1` now comes
+    /// straight off the constant term instead of falling through to L'Hôpital.
+    #[test]
+    fn the_repair_agrees_with_the_limit_engine() {
+        use crate::calculus::limits::{limit, LimitDirection};
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let e = sin_over_x(&p);
+        let l = limit(e, x, p.integer(0), LimitDirection::Bidirectional, &p).unwrap();
+        assert_eq!(crate::jit::eval_interp(l, &HashMap::new(), &p), Some(1.0));
     }
 }

--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -51,6 +51,14 @@ pub const REGISTRY: &[ErrorSpec] = &[
     // Carried out of band on `SeriesError::InvalidOrder` (exhaustive public enum) —
     // see `calculus::series::take_series_refusal`.
     ErrorSpec { code: "E-SERIES-003", class: "SeriesRefusal", cause: Cause::Resource,  remediation: Some("ask for a lower order, raise the budget, or rewrite the expression so its repeated derivatives close") },
+    // A coefficient came out as an indeterminate form rather than a number: `0/0` for a
+    // removable singularity the engine could not cancel, `1/0` for a branch point,
+    // `log(0)`, `exp(0^-1)` for an essential one. Returning the series anyway is the
+    // silent-wrong-answer shape this registry exists to prevent — it reports success,
+    // cannot be evaluated, and turns into NaN the moment anyone tries. Carried out of
+    // band on `SeriesError::InvalidOrder` alongside E-SERIES-003; see
+    // `calculus::series::take_series_refusal` and `SeriesRefusal::cause`.
+    ErrorSpec { code: "E-SERIES-004", class: "SeriesRefusal", cause: Cause::Domain,    remediation: Some("the expansion point is a branch point, an essential singularity, or a removable one this engine cannot cancel: cancel the singular factor by hand, expand about a nearby regular point, or use `limit` for the single value you need") },
     // E-INT — IntegrationError
     ErrorSpec { code: "E-INT-001", class: "IntegrationError", cause: Cause::Unsupported, remediation: Some("use a numeric integrator for arbitrary functions") },
     ErrorSpec { code: "E-INT-002", class: "IntegrationError", cause: Cause::Domain,      remediation: None },

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1813,6 +1813,46 @@ impl PySeries {
         self.expr.clone()
     }
 
+    /// The expansion with its trailing `O(·)` term dropped — SymPy's
+    /// ``removeO()``.
+    ///
+    /// `Series.expr` keeps the `BigO` node, which is the honest thing for it to
+    /// do (the remainder *is* part of the statement) and also what makes the
+    /// result a dead end: `eval_expr`, `simplify` and `diff` all refuse a bare
+    /// `O(x^n)`, so every caller re-implemented "walk the top-level sum and
+    /// skip the `big_o` child" by hand — `tests/_tg_helpers.py` and
+    /// `tests/silent_errors/corpus.py` each carry a copy.
+    ///
+    /// What comes back is a **polynomial approximation, not the function**:
+    /// dropping the remainder discards the only statement about the error, so
+    /// it is the right input to `eval_expr` near the expansion point and the
+    /// wrong thing to substitute back into an identity.
+    fn truncated(&self, py: Python<'_>) -> PyExpr {
+        let id = {
+            let pool = self.expr.pool.borrow(py);
+            let p = &pool.inner;
+            match p.get(self.expr.id) {
+                alkahest_core::kernel::ExprData::Add(terms) => {
+                    let kept: Vec<_> = terms
+                        .into_iter()
+                        .filter(|&t| !matches!(p.get(t), alkahest_core::kernel::ExprData::BigO(_)))
+                        .collect();
+                    match kept.len() {
+                        0 => p.integer(0_i32),
+                        1 => kept[0],
+                        _ => p.add(kept),
+                    }
+                }
+                alkahest_core::kernel::ExprData::BigO(_) => p.integer(0_i32),
+                _ => self.expr.id,
+            }
+        };
+        PyExpr {
+            id,
+            pool: self.expr.pool.clone_ref(py),
+        }
+    }
+
     fn __repr__(&self, py: Python<'_>) -> String {
         let pool = self.expr.pool.borrow(py);
         format!("Series({})", pool.inner.display(self.expr.id))

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -192,7 +192,7 @@ you reach for `.value`:
 |---|---|
 | `diff`, `integrate`, `simplify*`, `sum_*`, `product_*`, `resultant`, … | `DerivedResult` |
 | `limit` | plain `Expr` — **no `.value`** |
-| `series` | `Series` object — **no `.value`** |
+| `series` | `Series` object — **no `.value`**; `.expr` keeps the `O(...)`, `.truncated()` drops it |
 | `solve` | `list[dict[Expr, Expr]]` (or `GroebnerBasis`) |
 | `evaluate` | `EvaluationResult` |
 | `real_roots` | `list[RootInterval]` |
@@ -403,11 +403,21 @@ limit(sin(x) / x, x, pool.integer(0))              # → Expr: 1
 limit(pool.integer(1) / x, x, pool.integer(0), dir="+")   # one-sided
 
 s = series(exp(x), x, pool.integer(0), 4)          # → Series
-s.expr    # ((1 * 1) + (x * 1) + (1/2 * x^2) + (1/6 * x^3) + O(x^4))
+s.expr        # ((1 * 1) + (x * 1) + (1/2 * x^2) + (1/6 * x^3) + O(x^4))
+s.truncated() # → Expr, same sum without the O(x^4) term — feed this to eval_expr
 ```
 
-`Series` exposes a single attribute, `.expr`, which retains the `O(...)` term —
-strip or truncate it before feeding the result into numeric evaluation.
+`Series` has one attribute, `.expr`, which retains the `O(...)` term, and one
+method, `.truncated()`, which drops it (SymPy's `removeO()`). `eval_expr`,
+`simplify` and `diff` all refuse a bare `O(x**n)`, so `.truncated()` is what
+you want whenever the series is an input to something else.
+
+A **removable singularity** at the expansion point is expanded, not refused:
+`series(sin(x)/x, x, pool.integer(0), 4)` is `1 - x**2/6 + O(x**4)`, and
+`series(1/sin(x), ...)` gives the Laurent series `x**-1 + x/6 + O(x)`. A branch
+point (`sqrt(x)`), a logarithmic singularity (`log(x)`) or an essential one
+(`exp(1/x)`) has no Laurent expansion at all and raises `SeriesError` with code
+`E-SERIES-004` — never a `Series` whose coefficients evaluate to `NaN`.
 
 For asymptotics and multivariate limits, see `experimental.asymptotic_expand` and
 `experimental.multilimit`.

--- a/docs/mdbook/src/errors.md
+++ b/docs/mdbook/src/errors.md
@@ -116,13 +116,21 @@ loop must record as **undecided**, never as a negative result.
 | `E-IDEAL-006` | `IdealRefusal` | `primary_decomposition` reached a component it cannot show is primary, so it will not report the ideal itself with an unjustified `associated_prime` |
 | `E-SOLVE-004` | `TriangularizeRefusal` | `triangularize` extracted a chain that does not generate an ideal containing the input, i.e. one that cuts out a larger variety than the system. Splitting on the initials (Lazard–Kalkbrener) is not implemented |
 | `E-SERIES-003` | `SeriesError` | `series` ran past its work ceiling (or an active `Budget`) before reaching the requested order. Coefficients are formed by repeated differentiation without re-simplifying, so a nested radical's derivatives grow by a constant factor each time; a *shorter* series would carry an `O(h^order)` label nothing bounded |
+| `E-SERIES-004` | `SeriesError` | A `series` coefficient came out as an indeterminate form (`0/0`, `1/0`, `log(0)`) rather than a number, so the expansion point is a singularity this engine cannot resolve — a branch point (`√x`), an essential singularity (`e^{1/x}`), or a removable one it could not cancel. Returning the `Series` anyway would report success and hand back coefficients that evaluate to `NaN` |
 | `E-INT-004` | `IntegrationError` | Proven non-elementary. **This one is a verdict, not a refusal** — keep it apart from the rest |
 | `E-BUDGET-001..003` | `BudgetExceededError` | Ran out of the time/steps it was given, or was cancelled |
 
-`E-SERIES-003` travels out of band for the same reason (`SeriesError` is exhaustive) but *is*
-wired into the bindings: `series` returns `SeriesError::InvalidOrder` with
-`calculus::series::take_series_refusal()` pending, and the Python layer raises `SeriesError`
-with `.code == "E-SERIES-003"` — or `BudgetExceededError` when a budget was what stopped it.
+`E-SERIES-003` and `E-SERIES-004` travel out of band for the same reason (`SeriesError` is
+exhaustive) but *are* wired into the bindings: `series` returns `SeriesError::InvalidOrder`
+with `calculus::series::take_series_refusal()` pending, and the Python layer raises
+`SeriesError` with `.code == "E-SERIES-003"` / `"E-SERIES-004"` — or `BudgetExceededError`
+when a budget was what stopped it. `SeriesRefusal::cause()` distinguishes the two in Rust.
+
+A **removable** singularity is not in that list, because it is no longer refused: `series`
+puts the expression over a common denominator and divides the two power series rather than
+substituting the expansion point into a quotient, so `sin(x)/x` gives `1 − x²/6 + O(x⁴)` and
+`1/sin(x)` gives `x⁻¹ + x/6 + O(x)`. `E-SERIES-004` is what is left when that does not
+apply.
 
 `E-IDEAL-005`, `E-IDEAL-006` and `E-SOLVE-004` are new in 3.8 and travel **out of band**:
 `PrimaryDecompositionError` and `SolverError` are public exhaustive enums that cannot gain

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1221,6 +1221,24 @@ def series(expr, var, point, order):
     a *shorter* series: the ``O(h**order)`` term is a claim about the remainder,
     and attaching it to fewer coefficients than were asked for would be a false
     one that no caller could audit.
+
+    A **removable singularity** at *point* is expanded, not refused: the
+    expression is put over a common denominator and the two power series are
+    divided, so ``series(sin(x)/x, x, 0, 4)`` is ``1 - x**2/6 + O(x**4)`` and
+    ``series(1/sin(x), x, 0, 3)`` is ``x**-1 + x/6 + O(x)``.  Substituting the
+    expansion point into repeated derivatives would give ``0/0`` for the first
+    of those, which is why the direct route cannot see it.
+
+    A singularity that is *not* removable and not a pole — a branch point
+    (``sqrt(x)``), a logarithmic singularity (``log(x)``), an essential one
+    (``exp(1/x)``) — raises :exc:`SeriesError` with code ``E-SERIES-004``.
+    There is no Laurent expansion to return, and a ``Series`` whose
+    coefficients are ``0**-1`` would report success while evaluating to
+    ``NaN``.
+
+    Use :meth:`Series.truncated` to get the expansion as an :class:`Expr` with
+    the ``O(.)`` term dropped, which is what :func:`eval_expr` and
+    :func:`simplify` accept.
     """
     return _native_series(_coerce_expr(expr), _coerce_expr(var), _coerce_expr(point), order)
 

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -31,9 +31,12 @@ Canonical code ranges — authoritative source is ``alkahest_core::errors::codes
     E-RSOLVE-001 … E-RSOLVE-005 RsolveError (V2-18 difference equations)
     E-DIOPH-001 … E-DIOPH-004 DiophantineError (V2-19)
     E-NT-001 … E-NT-005    NumberTheoryError (V3-1 integer number theory)
-    E-SERIES-001 … E-SERIES-003 SeriesError  (003 = expansion ran past its work
+    E-SERIES-001 … E-SERIES-004 SeriesError  (003 = expansion ran past its work
                                  ceiling / budget before reaching the requested
-                                 order; refused rather than returned short)
+                                 order; refused rather than returned short.
+                                 004 = a coefficient is an indeterminate form,
+                                 not a number — a branch point or essential
+                                 singularity at the expansion point)
     E-LIMIT-001 … E-LIMIT-006 LimitError  (006 = the limit turns on the sign of
                                  a free parameter that nothing states; assume
                                  it, or declare the symbol Domain.Positive)

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -2080,9 +2080,10 @@ CASES: list[Case] = [
         contract=RefusesOr(1 / math.sin(0.1), tol=1e-3),
         verified_by="1/sin x = 1/x + x/6 + 7x³/360 + …; truncating after x gives 10.0166667 at "
         "x=0.1 against the true 1/sin(0.1) = 10.0166861 (tolerance covers truncation).",
-        note="Weak refusal: alkahest returns a Series whose coefficients contain 0^-1, so it "
-        "cannot be evaluated. It does not raise, so a caller who never evaluates the "
-        "coefficients gets no signal.",
+        note="Answered, not refused, since the removable-singularity fix: `series` divides the "
+        "numerator and denominator expansions instead of substituting 0 into a quotient, so "
+        "this returns x^-1 + x/6 + O(x). It used to return a Series whose coefficients "
+        "contained 0^-1 — unevaluable, and reported as success.",
     ),
     Case(
         id="series_log_at_origin",
@@ -2092,7 +2093,8 @@ CASES: list[Case] = [
         contract=RefusesOr(),
         verified_by="log x is unbounded at 0 but x^n·log x → 0 for every n>0, so no finite "
         "principal part exists. No finite answer is acceptable.",
-        note="Weak refusal: the returned Series contains log(0) and 0^-1 coefficients.",
+        note="Refused with E-SERIES-004 since the removable-singularity fix. It used to return "
+        "a Series carrying log(0) and 0^-1 coefficients — a weak refusal at best.",
     ),
     Case(
         id="series_sqrt_at_branch_point",
@@ -2101,7 +2103,8 @@ CASES: list[Case] = [
         op=series_at(ak.sqrt(X), _int(0), 3, 0.1),
         contract=RefusesOr(),
         verified_by="√x is not meromorphic at 0; a Puiseux series is required.",
-        note="Weak refusal: coefficients contain sqrt(0)^-1.",
+        note="Refused with E-SERIES-004 since the removable-singularity fix; it used to return "
+        "coefficients containing sqrt(0)^-1.",
     ),
     Case(
         id="series_essential_singularity",
@@ -2111,7 +2114,52 @@ CASES: list[Case] = [
         contract=RefusesOr(),
         verified_by="The Laurent series Σ x^-n/n! has infinitely many negative powers "
         "(Casorati–Weierstrass); no truncation at positive order represents it.",
-        note="Weak refusal: coefficients contain exp(0^-1).",
+        note="Refused with E-SERIES-004 since the removable-singularity fix; it used to return "
+        "coefficients containing exp(0^-1).",
+    ),
+    # -----------------------------------------------------------------------
+    # Removable singularities at the expansion point.  Substituting the point
+    # into repeated derivatives gives 0/0, which is where the silent NaN came
+    # from; the function itself extends analytically and has an ordinary
+    # Taylor series.  These are `Returns`, not `RefusesOr`: refusing here would
+    # be over-refusal on the most common expansion in applied mathematics.
+    # -----------------------------------------------------------------------
+    Case(
+        id="series_removable_singularity_sinc",
+        subsystem="series",
+        statement="sin(x)/x at x=0 is removable: the Taylor series is 1 - x²/6 + O(x⁴)",
+        op=series_at(ak.sin(X) / X, _int(0), 4, 0.1),
+        contract=Returns(1 - 0.01 / 6, tol=1e-12),
+        verified_by="SymPy series(sin(x)/x, x, 0, 4) = 1 - x**2/6 + O(x**4); evaluated at "
+        "x=0.1 by hand.",
+        note="Regression guard: this used to return a Series whose coefficients were 0*0^-1 "
+        "and 0^-1 — reported as success, evaluating to NaN.",
+    ),
+    Case(
+        id="series_removable_singularity_tan_over_x",
+        subsystem="series",
+        statement="tan(x)/x at x=0 is removable: the Taylor series is 1 + x²/3 + O(x⁴)",
+        op=series_at(ak.tan(X) / X, _int(0), 4, 0.1),
+        contract=Returns(1 + 0.01 / 3, tol=1e-12),
+        verified_by="tan x = x + x³/3 + 2x⁵/15 + …, so tan(x)/x = 1 + x²/3 + 2x⁴/15 + ….",
+    ),
+    Case(
+        id="series_removable_singularity_one_minus_cos",
+        subsystem="series",
+        statement="(1-cos x)/x² at x=0 is removable with value 1/2",
+        op=series_at((1 - ak.cos(X)) / X**2, _int(0), 4, 0.1),
+        contract=Returns(0.5 - 0.01 / 24, tol=1e-12),
+        verified_by="1 - cos x = x²/2 - x⁴/24 + …, so the quotient is 1/2 - x²/24 + ….",
+    ),
+    Case(
+        id="series_cancelling_poles_are_not_a_pole",
+        subsystem="series",
+        statement="1/x - 1/sin(x) is regular at 0 — the two simple poles cancel",
+        op=series_at(1 / X - 1 / ak.sin(X), _int(0), 4, 0.1),
+        contract=Returns(-0.1 / 6 - 7 * 0.001 / 360, tol=1e-12),
+        verified_by="1/sin x = 1/x + x/6 + 7x³/360 + …, so 1/x - 1/sin x = -x/6 - 7x³/360 + ….",
+        note="A sum, not a quotient: the expansion has to combine the terms over a common "
+        "denominator before it can see that the singular parts cancel.",
     ),
     Case(
         id="series_control_exponential",

--- a/tests/test_series_v215.py
+++ b/tests/test_series_v215.py
@@ -130,3 +130,88 @@ def test_ordinary_high_order_series_still_expands():
     assert _has_big_o(s.expr)
     # sin's expansion runs to x^23: the last odd power below order 24.
     assert "x^23" in str(s.expr)
+
+
+# ---------------------------------------------------------------------------
+# Removable singularities at the expansion point
+# ---------------------------------------------------------------------------
+
+
+def _truncated_value(s: alkahest.Series, var: alkahest.Expr, at: float) -> float:
+    return alkahest.eval_expr(s.truncated(), {var: at})
+
+
+def test_sin_over_x_expands_through_its_removable_singularity():
+    """`series(sin(x)/x, x, 0, 4)` is `1 - x**2/6 + O(x**4)`, the answer SymPy
+    gives and the one every table of expansions has.
+
+    Coefficients are formed by substituting the expansion point into repeated
+    derivatives, so this used to come back as a *successful* `Series` whose
+    constant term was the literal `0 * 0**-1`: it could not be evaluated, could
+    not be simplified, and nothing about the return value said so.
+    """
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    s = alkahest.series(alkahest.sin(x) / x, x, p.integer(0), 4)
+    assert _has_big_o(s.expr)
+    assert _truncated_value(s, x, 0.1) == pytest.approx(1 - 0.01 / 6, abs=1e-15)
+    assert _truncated_value(s, x, 0.0) == pytest.approx(1.0, abs=1e-15)
+
+
+def test_tan_over_x_expands_through_its_removable_singularity():
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    s = alkahest.series(alkahest.tan(x) / x, x, p.integer(0), 4)
+    assert _truncated_value(s, x, 0.1) == pytest.approx(1 + 0.01 / 3, abs=1e-15)
+
+
+def test_a_genuine_pole_keeps_its_principal_part():
+    """The control in the other direction: a pole is expandable and must not be
+    turned into a refusal by the removable-singularity fix. `1/sin x` is
+    `x**-1 + x/6 + O(x)`."""
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    s = alkahest.series(1 / alkahest.sin(x), x, p.integer(0), 3)
+    assert _truncated_value(s, x, 0.1) == pytest.approx(10.0 + 0.1 / 6, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["sqrt", "log"],
+)
+def test_a_branch_point_is_refused_not_faked(name):
+    """`√x` and `log x` have no Laurent expansion at `0`. Each used to return a
+    `Series` whose coefficients were `sqrt(0)**-1` / `log(0)` — success, and
+    `NaN` for anyone who evaluated it."""
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    f = getattr(alkahest, name)(x)
+    with pytest.raises(alkahest.SeriesError) as excinfo:
+        alkahest.series(f, x, p.integer(0), 4)
+    assert excinfo.value.code == "E-SERIES-004"
+
+
+def test_an_essential_singularity_is_refused_not_faked():
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    with pytest.raises(alkahest.SeriesError) as excinfo:
+        alkahest.series(alkahest.exp(1 / x), x, p.integer(0), 4)
+    assert excinfo.value.code == "E-SERIES-004"
+
+
+def test_truncated_drops_the_remainder_and_is_evaluable():
+    """`Series.expr` keeps its `O(.)` term, which is honest and also makes the
+    result a dead end — `eval_expr` and `simplify` both refuse a bare
+    `O(x**n)`. `truncated()` is the bridge."""
+    p = alkahest.ExprPool()
+    x = p.symbol("x")
+    s = alkahest.series(alkahest.exp(x), x, p.integer(0), 5)
+    assert _has_big_o(s.expr)
+    assert not _has_big_o(s.truncated())
+    with pytest.raises(ValueError):
+        alkahest.eval_expr(s.expr, {x: 0.1})
+    want = 1 + 0.1 + 0.01 / 2 + 0.001 / 6 + 0.0001 / 24
+    assert alkahest.eval_expr(s.truncated(), {x: 0.1}) == pytest.approx(want, abs=1e-15)
+    # and it is an ordinary Expr, so the rest of the library accepts it
+    assert alkahest.simplify(s.truncated()) is not None
+    assert alkahest.diff(s.truncated(), x) is not None


### PR DESCRIPTION
`series` returned coefficients containing `0⁻¹` and `0·0⁻¹` — numerically `inf`
and `NaN` — and reported it as **success**:

```python
ak.series(ak.sin(x)/x, x, 0, 4)
# ((0 * 1 * 0^-1) + (x * (0^-1 + (-1 * 0 * 0^-2))) + … + O(x^4))
```

Expected `1 − x²/6 + O(x⁴)`. The returned `Series` could not be evaluated or
simplified. `tan(x)/x` behaved identically, as did the Black–Scholes volatility
expansion that surfaced this.

The cause was stated in `series`' own docstring: *"coefficients are formed by
repeated differentiation without re-simplifying"*, so the nth derivative of
`sin(x)/x` at `0` is literally `0/0`.

## Fix — power-series division, not limit-per-coefficient

`local_expansion` now checks its coefficients and, on an indeterminate one,
retries through `quotient_expansion`: `poly::together_parts` puts the
expression over one denominator (treating `sin(ξ)` as an opaque generator),
numerator and denominator are expanded **separately** — both analytic, so
ordinary substitutions — and the unit parts are divided by
`cₖ = (aₖ − Σⱼ bⱼcₖ₋ⱼ)/b₀`. The vanishing factor cancels before anything is
evaluated at the point.

Limit-per-coefficient was rejected: `limit` calls `local_expansion` (recursion
risk), a limit per coefficient is expensive and unpredictable, while series
division is deterministic and exact. Going through a common denominator is also
what makes a *sum* of cancelling poles (`1/x − 1/sin x`) work, which the
factor-splitting path could not take apart at all.

Anything not repairable now refuses with a new **`E-SERIES-004`** rather than
returning a non-value. The detector looks *inside* each coefficient — a free
parameter otherwise hides the culprit (`k·½·sqrt(0)⁻¹`) — and fires only on
positive evidence in both directions, so `cos(a)` at a symbolic point is never
mistaken for a non-value.

## Audit — 47-case corpus, every returned coefficient evaluated

**Fixed (22):** `sin(x)/x`, `tan(x)/x`, `sinh(x)/x`, `atan(x)/x`, `(1−cos x)/x²`,
`(eˣ−1)/x`, `sin²x/x²`, `x/sin x`, `(cos x − 1 + x²/2)/x⁴`, `sin(kx)/x`,
`1/x − 1/sin x`, `1/x − 1/(eˣ−1)`, `(x²−1)/(x−1)` at 1, `1/sin x`, `cot x`,
`1/tan x`, `1/(1−cos x)`, `sin(x)/x³`, `1/(x²−1)` at 1, `1/log x` at 1,
`√x/(x−1)` at 1, ATM Black–Scholes. Verified against hand-derived expansions.

**Now correctly refused (16):** `√x`, `log x`, `e^{1/x}`, `sin(1/x)`, `x^x`,
`gamma(x)`, `x^{3/2}`, `k·√x`, … — no Laurent expansion exists, so refusal is
the right answer. The free-parameter shapes were a second, distinct hole the
first version of the detector missed.

The Black–Scholes case now gives the textbook ATM approximation
`σS√T/√(2π) − σ³ST^{3/2}/(24√(2π))`, and correctly refuses the non-ATM case,
which genuinely is an essential singularity at `σ = 0`.

**Filed, not fixed:** Puiseux expansions are refused rather than computed
(`Series` has no half-integer-valuation representation; `poly::puiseux` exists
and connecting it is a real feature). `gamma(x)` at 0 has a computable Laurent
series but is not a quotient. `simplify` does not fold `(-1/2)^-1` to `-2`.

## Ergonomics

`Series` had only `.expr`, which keeps the `O(·)` node, so `eval_expr`/
`simplify`/`diff` all refused it — and both `tests/_tg_helpers.py` and
`tests/silent_errors/corpus.py` carried hand-rolled "walk the sum, skip the
big_o child" copies. Added `Series.truncated()` (SymPy's `removeO()`).
Additive; `check_api_freeze.py` reports no surface change.

## Cost

Median of 15, release, vs the same branch with only `series.rs` reverted:
**3–9%** on well-behaved expansions (`sin` order 24: 0.63 → 0.69 ms; `tan`
order 16: 4.96 → 5.07 ms), from the coefficient scan. Limits within noise.
An earlier reading suggested 3–4× — that was contention from concurrent builds,
not real.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2845 passed, 0
failed, 11 ignored** (base 2834, +11). `pytest tests/` → 3773 passed, 0 failed.
Silent-error gate: 256 cases, 0.0%. clippy `-D warnings`, `fmt --check`,
`check_error_codes.py`, `check_api_freeze.py` clean.

New: a class-level gate, `no_successful_series_ever_carries_an_indeterminate_coefficient`,
walks a 33-expansion corpus and asserts no returned term contains `0^{negative}`
or evaluates non-finite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
