### PR TITLE
fix(logic): decide propositional satisfiability, and repair the DPLL that would have answered it wrong

### DIFF
--- a/alkahest-core/src/logic/mod.rs
+++ b/alkahest-core/src/logic/mod.rs
@@ -1,9 +1,22 @@
 //! First-order formulas over symbolic reals (V3-3 / FOFormula).
 //!
 //! - [`Formula`] is the algebraic view over kernel predicates and quantifiers.
-//! - [`satisfiable`] decides a quantifier-free fragment: conjunctions of
-//!   comparisons between **one** real symbol and a rational constant, plus `Or`
-//!   / `Not` (via NNF on relations).  Other shapes return [`Satisfiability::Unknown`].
+//! - [`satisfiable`] decides two disjoint quantifier-free fragments and answers
+//!   [`Satisfiability::Unknown`] for everything else:
+//!   1. **Purely propositional** — every leaf is a bare [`ExprData::Symbol`] or
+//!      a `True`/`False` constant, combined with `And` / `Or` / `Not`.  This is
+//!      decided *completely* (Tseitin + a budgeted DPLL): every such
+//!      formula gets `Sat`/`Unsat`, never `Unknown`, up to the search budget.
+//!   2. **Single-variable interval arithmetic** — conjunctions of comparisons
+//!      between **one** real symbol and a rational constant, plus `Or` / `Not`
+//!      (via NNF on relations).  Incomplete; `Unknown` is common here.
+//!
+//!   A formula that *mixes* the two (a Boolean symbol and an arithmetic
+//!   relation in the same formula) is deliberately `Unknown`: deciding it needs
+//!   a Boolean-plus-theory combination this module does not implement, and the
+//!   only cheap alternative — abstracting each relation to a fresh proposition —
+//!   is sound for `Unsat` only and would report `x > 0 ∧ x < 0` as *sat*.  Route
+//!   those to [`crate::real::decide`] (CAD) or to `alkahest.smt`.
 //! - [`smtlib`] exports a [`Formula`] as SMT-LIB 2 text for an external solver
 //!   (P2-3).  `alkahest.smt` drives the solver process from Python.
 
@@ -605,8 +618,326 @@ fn simplify_formula_constants(f: Formula) -> Formula {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Purely propositional fragment
+// ---------------------------------------------------------------------------
+
+/// Most distinct Boolean symbols the propositional path will accept.
+const MAX_PROP_VARS: usize = 64;
+/// Most formula nodes the propositional path will visit while lifting.
+const MAX_PROP_NODES: usize = 4096;
+/// Decision budget handed to [`dpll_sat_bounded`] by [`satisfiable`].
+const PROP_DECISION_BUDGET: u64 = 2_000_000;
+
+/// The string a [`Satisfiability::Sat`] witness uses for a true Boolean.
+pub(crate) const BOOL_TRUE: &str = "true";
+/// The string a [`Satisfiability::Sat`] witness uses for a false Boolean.
+pub(crate) const BOOL_FALSE: &str = "false";
+
+/// A formula in the purely propositional fragment.
+///
+/// `Var(i)` is a **1-based** proposition index, so it doubles as a [`BoolLit`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Prop {
+    Var(u32),
+    Const(bool),
+    And(Vec<Prop>),
+    Or(Vec<Prop>),
+    Not(Box<Prop>),
+}
+
+impl Prop {
+    /// Evaluate under a total assignment (`model[i - 1]` is the value of `Var(i)`).
+    fn eval(&self, model: &[bool]) -> bool {
+        match self {
+            Prop::Const(b) => *b,
+            Prop::Var(i) => model[*i as usize - 1],
+            Prop::Not(x) => !x.eval(model),
+            Prop::And(xs) => xs.iter().all(|x| x.eval(model)),
+            Prop::Or(xs) => xs.iter().any(|x| x.eval(model)),
+        }
+    }
+}
+
+/// Variable table built while lifting an [`ExprId`] into a [`Prop`].
+struct PropVars {
+    /// Symbol `ExprId` → 1-based proposition index.
+    index: HashMap<ExprId, u32>,
+    /// Proposition index − 1 → symbol name, for the witness map.
+    names: Vec<String>,
+    /// Formula nodes visited so far (a DAG node is counted once per visit).
+    nodes: usize,
+}
+
+/// Lift `expr` into the purely propositional fragment.
+///
+/// Returns `None` when `expr` is **not** purely propositional — it contains an
+/// arithmetic relation, a quantifier, a non-symbol term, two same-named symbols
+/// that a witness map could not tell apart, or more material than the budget
+/// allows.  `None` therefore means "some other decision procedure's problem",
+/// never "unsatisfiable".
+fn prop_from_expr(expr: ExprId, pool: &ExprPool, vars: &mut PropVars) -> Option<Prop> {
+    vars.nodes += 1;
+    if vars.nodes > MAX_PROP_NODES {
+        return None;
+    }
+    match pool.get(expr) {
+        ExprData::Symbol { name, .. } => {
+            if let Some(&i) = vars.index.get(&expr) {
+                return Some(Prop::Var(i));
+            }
+            // Distinct `ExprId`s can share a name (same name, different
+            // `Domain`).  The witness map is keyed by name, so it could not
+            // report both; refuse rather than conflate them.
+            if vars.names.contains(&name) {
+                return None;
+            }
+            if vars.names.len() >= MAX_PROP_VARS {
+                return None;
+            }
+            let i = vars.names.len() as u32 + 1;
+            vars.names.push(name);
+            vars.index.insert(expr, i);
+            Some(Prop::Var(i))
+        }
+        ExprData::Predicate { kind, args } => match kind {
+            PredicateKind::True => Some(Prop::Const(true)),
+            PredicateKind::False => Some(Prop::Const(false)),
+            PredicateKind::And => args
+                .into_iter()
+                .map(|a| prop_from_expr(a, pool, vars))
+                .collect::<Option<Vec<_>>>()
+                .map(Prop::And),
+            PredicateKind::Or => args
+                .into_iter()
+                .map(|a| prop_from_expr(a, pool, vars))
+                .collect::<Option<Vec<_>>>()
+                .map(Prop::Or),
+            PredicateKind::Not => {
+                if args.len() != 1 {
+                    return None;
+                }
+                prop_from_expr(args[0], pool, vars).map(|p| Prop::Not(Box::new(p)))
+            }
+            // A relation is an arithmetic atom, not a proposition.
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Fold `True`/`False` away.  Afterwards a [`Prop::Const`] can only be the root.
+fn prop_fold(p: Prop) -> Prop {
+    match p {
+        Prop::And(xs) => {
+            let mut out = Vec::with_capacity(xs.len());
+            for x in xs {
+                match prop_fold(x) {
+                    Prop::Const(true) => {}
+                    Prop::Const(false) => return Prop::Const(false),
+                    other => out.push(other),
+                }
+            }
+            match out.len() {
+                0 => Prop::Const(true),
+                1 => out.pop().expect("len == 1"),
+                _ => Prop::And(out),
+            }
+        }
+        Prop::Or(xs) => {
+            let mut out = Vec::with_capacity(xs.len());
+            for x in xs {
+                match prop_fold(x) {
+                    Prop::Const(false) => {}
+                    Prop::Const(true) => return Prop::Const(true),
+                    other => out.push(other),
+                }
+            }
+            match out.len() {
+                0 => Prop::Const(false),
+                1 => out.pop().expect("len == 1"),
+                _ => Prop::Or(out),
+            }
+        }
+        Prop::Not(x) => match prop_fold(*x) {
+            Prop::Const(b) => Prop::Const(!b),
+            other => Prop::Not(Box::new(other)),
+        },
+        other => other,
+    }
+}
+
+/// Tseitin encoder: a [`Prop`] becomes an equisatisfiable CNF over the original
+/// propositions plus one fresh definition variable per gate.
+struct Tseitin {
+    clauses: Vec<BoolClause>,
+    /// Highest variable index allocated so far.
+    next: u32,
+}
+
+impl Tseitin {
+    fn fresh(&mut self) -> Option<BoolLit> {
+        self.next = self.next.checked_add(1)?;
+        // Definition variables sit above the originals; keep them inside `i32`.
+        if self.next > (MAX_PROP_VARS + MAX_PROP_NODES) as u32 {
+            return None;
+        }
+        Some(self.next as BoolLit)
+    }
+
+    /// Emit the defining clauses for `p` and return the literal it denotes.
+    ///
+    /// Both directions of each definition are emitted (`g ↔ gate`), so the CNF
+    /// is satisfiable exactly when `p` is, and any CNF model restricted to the
+    /// original propositions is a model of `p`.
+    fn encode(&mut self, p: &Prop) -> Option<BoolLit> {
+        match p {
+            // Folded away by `prop_fold` before encoding.
+            Prop::Const(_) => None,
+            Prop::Var(i) => Some(*i as BoolLit),
+            Prop::Not(x) => Some(-self.encode(x)?),
+            Prop::And(xs) => {
+                let lits = xs
+                    .iter()
+                    .map(|x| self.encode(x))
+                    .collect::<Option<Vec<_>>>()?;
+                let g = self.fresh()?;
+                // g → xᵢ for every i
+                let mut long = Vec::with_capacity(lits.len() + 1);
+                long.push(g);
+                for l in lits {
+                    self.clauses.push(vec![-g, l]);
+                    long.push(-l);
+                }
+                // (⋀ xᵢ) → g
+                self.clauses.push(long);
+                Some(g)
+            }
+            Prop::Or(xs) => {
+                let lits = xs
+                    .iter()
+                    .map(|x| self.encode(x))
+                    .collect::<Option<Vec<_>>>()?;
+                let g = self.fresh()?;
+                // g → ⋁ xᵢ
+                let mut long = Vec::with_capacity(lits.len() + 1);
+                long.push(-g);
+                for l in lits {
+                    self.clauses.push(vec![g, -l]);
+                    long.push(l);
+                }
+                // xᵢ → g for every i
+                self.clauses.push(long);
+                Some(g)
+            }
+        }
+    }
+}
+
+/// Brute-force reference decision, used only to guard [`Prop`] verdicts in
+/// debug builds on instances small enough for it to be free.
+#[cfg(debug_assertions)]
+fn prop_brute_force_sat(p: &Prop, n_vars: usize) -> bool {
+    let mut model = vec![false; n_vars];
+    for bits in 0u32..(1u32 << n_vars) {
+        for (i, m) in model.iter_mut().enumerate() {
+            *m = bits & (1 << i) != 0;
+        }
+        if p.eval(&model) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Decide `expr` if — and only if — it is purely propositional.
+///
+/// `None` means the formula is outside this fragment and the caller should try
+/// another procedure.  `Some(Satisfiability::Unknown)` means it *is* in the
+/// fragment but exceeded the search budget.
+fn satisfiable_propositional(expr: ExprId, pool: &ExprPool) -> Option<Satisfiability> {
+    let mut vars = PropVars {
+        index: HashMap::new(),
+        names: Vec::new(),
+        nodes: 0,
+    };
+    let raw = prop_from_expr(expr, pool, &mut vars)?;
+    let folded = prop_fold(raw);
+    let n_vars = vars.names.len();
+
+    // A formula that folds to a constant needs no search.
+    if let Prop::Const(b) = folded {
+        return Some(if b {
+            Satisfiability::Sat(HashMap::new())
+        } else {
+            Satisfiability::Unsat
+        });
+    }
+
+    let mut enc = Tseitin {
+        clauses: Vec::new(),
+        next: n_vars as u32,
+    };
+    let root = enc.encode(&folded)?;
+    enc.clauses.push(vec![root]);
+    let n_total = enc.next;
+
+    let verdict = dpll_sat_bounded(enc.clauses, n_total, PROP_DECISION_BUDGET);
+
+    #[cfg(debug_assertions)]
+    if n_vars <= 10 && !matches!(verdict, DpllOutcome::Exhausted) {
+        assert_eq!(
+            matches!(verdict, DpllOutcome::Sat(_)),
+            prop_brute_force_sat(&folded, n_vars),
+            "DPLL disagreed with exhaustive enumeration on {folded:?}"
+        );
+    }
+
+    match verdict {
+        DpllOutcome::Unsat => Some(Satisfiability::Unsat),
+        DpllOutcome::Exhausted => Some(Satisfiability::Unknown),
+        DpllOutcome::Sat(assign) => {
+            // Never hand back an unchecked model: evaluate the *original*
+            // formula under it.  A Tseitin or search defect then degrades to an
+            // honest `Unknown` instead of a wrong `Sat`.
+            let model = &assign[..n_vars];
+            if !folded.eval(model) {
+                return Some(Satisfiability::Unknown);
+            }
+            let witness = vars
+                .names
+                .iter()
+                .zip(model)
+                .map(|(name, &v)| {
+                    (
+                        name.clone(),
+                        if v { BOOL_TRUE } else { BOOL_FALSE }.to_string(),
+                    )
+                })
+                .collect();
+            Some(Satisfiability::Sat(witness))
+        }
+    }
+}
+
 /// Quantifier-free (and single-∃) satisfiability over the supported fragment.
+///
+/// See the [module docs](self) for exactly which fragments are decided.  The
+/// two paths are disjoint and are tried in order:
+///
+/// 1. purely propositional (Boolean symbols and `∧ ∨ ¬`, hence also `→` and
+///    `↔` written out in terms of them) — complete, via DPLL;
+/// 2. one real symbol against rational constants — incomplete, via intervals.
+///
+/// A [`Satisfiability::Sat`] witness maps symbol name → value string, and is
+/// **homogeneous**: from the propositional path every value is `"true"` or
+/// `"false"`; from the interval path every value is a rational literal.  The
+/// two never mix, because a formula containing both a Boolean symbol and an
+/// arithmetic relation is [`Satisfiability::Unknown`].
 pub fn satisfiable(expr: ExprId, pool: &ExprPool) -> Satisfiability {
+    if let Some(verdict) = satisfiable_propositional(expr, pool) {
+        return verdict;
+    }
     let f = match formula_from_expr(expr, pool) {
         Ok(f) => f,
         Err(_) => return Satisfiability::Unknown,
@@ -620,7 +951,7 @@ pub fn satisfiable(expr: ExprId, pool: &ExprPool) -> Satisfiability {
 }
 
 // ---------------------------------------------------------------------------
-// Boolean DPLL skeleton (purely structural; exported for benchmarks / future theory plugins)
+// Boolean DPLL (purely structural; exported for benchmarks / future theory plugins)
 // ---------------------------------------------------------------------------
 
 /// Literal: signed index into a fixed proposition table.
@@ -629,103 +960,176 @@ pub type BoolLit = i32;
 /// Clause disjunction; empty clause = false.
 pub type BoolClause = Vec<BoolLit>;
 
+/// Verdict of a budgeted DPLL search.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DpllOutcome {
+    /// A total assignment; every clause is satisfied by it.
+    Sat(Vec<bool>),
+    /// Proved: no assignment satisfies every clause.
+    Unsat,
+    /// The decision budget ran out.  **Not a verdict** — the instance may be
+    /// satisfiable or unsatisfiable, and a caller must not read this as either.
+    Exhausted,
+}
+
+/// Why a branch of the search stopped.
+enum DpllStop {
+    /// This branch is refuted.
+    Conflict,
+    /// The decision budget ran out somewhere below here.
+    Budget,
+}
+
+fn dpll_is_conflict(c: &BoolClause, a: &[Option<bool>]) -> bool {
+    c.iter().all(|&lit| {
+        let v = lit.unsigned_abs() as usize - 1;
+        let sign = lit > 0;
+        match a[v] {
+            Some(t) => t != sign,
+            None => false,
+        }
+    })
+}
+
+/// Unit propagation to fixpoint.  `Err(())` means a clause went false.
+///
+/// On `Err` the trail is left dirty; every caller that can continue searching
+/// restores a snapshot first (see [`dpll_dfs`]).
+fn dpll_unit_prop(clauses: &[BoolClause], a: &mut [Option<bool>]) -> Result<(), ()> {
+    loop {
+        let mut progressed = false;
+        for cl in clauses {
+            let mut unassigned: Vec<(usize, bool)> = vec![];
+            let mut satisfied = false;
+            for &lit in cl {
+                let v = lit.unsigned_abs() as usize - 1;
+                let sign = lit > 0;
+                match a[v] {
+                    None => unassigned.push((v, sign)),
+                    Some(t) if t == sign => satisfied = true,
+                    _ => {}
+                }
+            }
+            if satisfied {
+                continue;
+            }
+            if unassigned.is_empty() {
+                return Err(());
+            }
+            if unassigned.len() == 1 {
+                let (v, s) = unassigned[0];
+                if a[v].is_none() {
+                    a[v] = Some(s);
+                    progressed = true;
+                }
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn dpll_dfs(
+    clauses: &[BoolClause],
+    a: &mut [Option<bool>],
+    budget: &mut u64,
+) -> Result<(), DpllStop> {
+    dpll_unit_prop(clauses, a).map_err(|()| DpllStop::Conflict)?;
+    for cl in clauses {
+        if dpll_is_conflict(cl, a) {
+            return Err(DpllStop::Conflict);
+        }
+    }
+    let Some((i, _)) = a.iter().enumerate().find(|(_, x)| x.is_none()) else {
+        return Ok(());
+    };
+    if *budget == 0 {
+        return Err(DpllStop::Budget);
+    }
+    *budget -= 1;
+
+    // Both `dpll_unit_prop` above and the recursive calls below write into `a`.
+    // Undoing only `a[i]` between the two branches — which is what this used to
+    // do — leaves the second branch starting from the first branch's implied
+    // literals, which can refute a branch that is in fact satisfiable and so
+    // report a satisfiable instance as `Unsat`.  Restore the whole trail.
+    let snapshot = a.to_vec();
+    for value in [false, true] {
+        a[i] = Some(value);
+        match dpll_dfs(clauses, a, budget) {
+            Ok(()) => return Ok(()),
+            Err(DpllStop::Budget) => return Err(DpllStop::Budget),
+            Err(DpllStop::Conflict) => a.copy_from_slice(&snapshot),
+        }
+    }
+    Err(DpllStop::Conflict)
+}
+
+/// DPLL with a cap on the number of decisions, so a caller can bound the search.
+///
+/// `max_decisions` counts *branching* decisions only; unit propagation is free.
+/// Returns [`DpllOutcome::Exhausted`] rather than guessing when the cap is hit.
+pub(crate) fn dpll_sat_bounded(
+    clauses: Vec<BoolClause>,
+    n_vars: u32,
+    max_decisions: u64,
+) -> DpllOutcome {
+    let mut assign = vec![None; n_vars as usize];
+    let mut budget = max_decisions;
+    match dpll_dfs(&clauses, &mut assign, &mut budget) {
+        Ok(()) => {
+            let model: Vec<bool> = assign.into_iter().map(|x| x.unwrap_or(false)).collect();
+            // A model is cheap to check and expensive to get wrong; a search
+            // defect must not be able to leave here as a `Sat`.
+            debug_assert!(
+                clauses.iter().all(|cl| cl
+                    .iter()
+                    .any(|&lit| { model[lit.unsigned_abs() as usize - 1] == (lit > 0) })),
+                "dpll_sat_bounded returned a model that falsifies a clause"
+            );
+            DpllOutcome::Sat(model)
+        }
+        Err(DpllStop::Conflict) => DpllOutcome::Unsat,
+        Err(DpllStop::Budget) => DpllOutcome::Exhausted,
+    }
+}
+
 /// Very small DPLL without clause learning. Returns `Some(assign)` or `None` if UNSAT.
+///
+/// Sound and complete for the CNF it is handed, and unbudgeted: on a hard
+/// instance it runs until it finishes.  The crate-internal `dpll_sat_bounded`
+/// is the variant to use where a caller
+/// needs to bound the search and to tell "no model" apart from "gave up".
 ///
 /// # Not an SMT engine (P2-3 design decision D6)
 ///
 /// This solves the *propositional* problem it is handed — a CNF clause list over
-/// opaque propositions — and it is sound and complete for that.  It is
-/// deliberately **not** wired into [`smtlib`] or `alkahest.smt` as a fallback
-/// engine, because the only way to reach it from a [`Formula`] is to abstract
-/// each arithmetic atom to a fresh proposition, and that abstraction is sound in
-/// one direction only: it can confirm `unsat`, but it reports `x > 0 ∧ x < 0` as
-/// *sat* with a meaningless model.  Handing that back as a witness — under a
-/// bridge whose entire premise is that every `sat` model is checked exactly —
-/// would be precisely the silent-error shape the bridge exists to prevent.
-/// `alkahest.smt.solve` therefore refuses with `E-SMT-001` when no external
-/// solver is installed rather than degrading to anything in-tree.
+/// opaque propositions.  [`satisfiable`] routes the **purely propositional**
+/// fragment here, where the propositions are the formula's own Boolean symbols
+/// and nothing is abstracted away, so the answer transfers back exactly.
+///
+/// It is still deliberately **not** wired into [`smtlib`] or `alkahest.smt` as a
+/// fallback engine, because the only way to reach it from an *arithmetic*
+/// [`Formula`] is to abstract each relation to a fresh proposition, and that
+/// abstraction is sound in one direction only: it can confirm `unsat`, but it
+/// reports `x > 0 ∧ x < 0` as *sat* with a meaningless model.  Handing that back
+/// as a witness — under a bridge whose entire premise is that every `sat` model
+/// is checked exactly — would be precisely the silent-error shape the bridge
+/// exists to prevent.  `alkahest.smt.solve` therefore refuses with `E-SMT-001`
+/// when no external solver is installed rather than degrading to anything
+/// in-tree.
 pub fn dpll_sat(clauses: Vec<BoolClause>, n_vars: u32) -> Option<Vec<bool>> {
-    fn is_conflict(c: &BoolClause, a: &[Option<bool>]) -> bool {
-        c.iter().all(|&lit| {
-            let v = lit.unsigned_abs() as usize - 1;
-            let sign = lit > 0;
-            match a[v] {
-                Some(t) => t != sign,
-                None => false,
-            }
-        })
-    }
-
-    fn unit_prop(clauses: &[BoolClause], a: &mut [Option<bool>]) -> Result<(), ()> {
-        loop {
-            let mut progressed = false;
-            for cl in clauses {
-                let mut unassigned: Vec<(usize, bool)> = vec![];
-                let mut satisfied = false;
-                for &lit in cl {
-                    let v = lit.unsigned_abs() as usize - 1;
-                    let sign = lit > 0;
-                    match a[v] {
-                        None => unassigned.push((v, sign)),
-                        Some(t) if t == sign => satisfied = true,
-                        _ => {}
-                    }
-                }
-                if satisfied {
-                    continue;
-                }
-                if unassigned.is_empty() {
-                    return Err(());
-                }
-                if unassigned.len() == 1 {
-                    let (v, s) = unassigned[0];
-                    if a[v].is_none() {
-                        a[v] = Some(s);
-                        progressed = true;
-                    }
-                }
-            }
-            if !progressed {
-                break;
-            }
+    match dpll_sat_bounded(clauses, n_vars, u64::MAX) {
+        DpllOutcome::Sat(model) => Some(model),
+        DpllOutcome::Unsat => None,
+        // A `u64::MAX` decision budget cannot be spent in finite time, so this
+        // is unreachable.  Returning `None` here would mean reporting "gave up"
+        // as "unsatisfiable", which is the one answer this must never give.
+        DpllOutcome::Exhausted => {
+            unreachable!("dpll_sat: the u64::MAX decision budget was exhausted")
         }
-        Ok(())
-    }
-
-    fn dfs(clauses: &[BoolClause], a: &mut [Option<bool>]) -> Result<(), ()> {
-        unit_prop(clauses, a)?;
-        for cl in clauses {
-            if is_conflict(cl, a) {
-                return Err(());
-            }
-        }
-        if let Some((i, _)) = a.iter().enumerate().find(|(_, x)| x.is_none()) {
-            a[i] = Some(false);
-            if dfs(clauses, a).is_ok() {
-                return Ok(());
-            }
-            a[i] = Some(true);
-            if dfs(clauses, a).is_ok() {
-                return Ok(());
-            }
-            a[i] = None;
-            Err(())
-        } else {
-            Ok(())
-        }
-    }
-
-    let n = n_vars as usize;
-    let mut assign = vec![None; n];
-    if dfs(&clauses, &mut assign).is_ok() {
-        Some(
-            assign
-                .into_iter()
-                .map(|x| x.unwrap_or(false))
-                .collect::<Vec<_>>(),
-        )
-    } else {
-        None
     }
 }
 
@@ -782,5 +1186,403 @@ mod tests {
         // (p1 ∨ p2) ∧ (¬p1 ∨ p2)  →  p2 true
         let r = dpll_sat(vec![vec![1, 2], vec![-1, 2]], 2);
         assert!(r.is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // DPLL backtracking
+    // -----------------------------------------------------------------------
+
+    /// Regression: the search used to undo only its own decision literal on
+    /// backtracking, leaving the failed branch's unit-propagated literals in
+    /// place.  The second branch then started from a polluted trail and could
+    /// be refuted even though it was satisfiable — reporting a *satisfiable*
+    /// instance as `Unsat`, which is the worst answer this code can give.
+    #[test]
+    fn dpll_restores_the_trail_on_backtrack() {
+        // (p1 ∨ p2) ∧ (p1 ∨ ¬p2) ∧ (¬p1 ∨ ¬p2): satisfied by p1 = ⊤, p2 = ⊥.
+        let clauses = vec![vec![1, 2], vec![1, -2], vec![-1, -2]];
+        let model = dpll_sat(clauses.clone(), 2).expect("instance is satisfiable");
+        for cl in &clauses {
+            assert!(
+                cl.iter()
+                    .any(|&lit| model[lit.unsigned_abs() as usize - 1] == (lit > 0)),
+                "clause {cl:?} falsified by {model:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dpll_genuine_unsat_is_still_unsat() {
+        // (p1) ∧ (¬p1)
+        assert!(dpll_sat(vec![vec![1], vec![-1]], 1).is_none());
+        // All four assignments of two variables excluded.
+        let all_excluded = vec![vec![1, 2], vec![1, -2], vec![-1, 2], vec![-1, -2]];
+        assert!(dpll_sat(all_excluded, 2).is_none());
+    }
+
+    #[test]
+    fn dpll_bounded_reports_exhausted_rather_than_guessing() {
+        // Zero decisions allowed, and the instance needs one.
+        let out = dpll_sat_bounded(vec![vec![1, 2], vec![-1, -2]], 2, 0);
+        assert_eq!(out, DpllOutcome::Exhausted);
+        // The same instance with a budget is decidable.
+        assert!(matches!(
+            dpll_sat_bounded(vec![vec![1, 2], vec![-1, -2]], 2, 100),
+            DpllOutcome::Sat(_)
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Propositional satisfiability through `satisfiable`
+    // -----------------------------------------------------------------------
+
+    fn bools(p: &ExprPool, names: &[&str]) -> Vec<ExprId> {
+        names.iter().map(|n| p.symbol(*n, Domain::Real)).collect()
+    }
+
+    /// `a → b`, written out: the kernel has no `Implies` predicate.
+    fn implies(p: &ExprPool, a: ExprId, b: ExprId) -> ExprId {
+        p.pred_or(vec![p.pred_not(a), b])
+    }
+
+    /// `a ↔ b`, written out as `(a → b) ∧ (b → a)`.
+    fn iff(p: &ExprPool, a: ExprId, b: ExprId) -> ExprId {
+        p.pred_and(vec![implies(p, a, b), implies(p, b, a)])
+    }
+
+    fn assert_witness_is(m: &HashMap<String, String>, expect: &[(&str, bool)]) {
+        for (name, want) in expect {
+            let got = m
+                .get(*name)
+                .unwrap_or_else(|| panic!("witness has no entry for {name}: {m:?}"));
+            assert_eq!(
+                got,
+                if *want { BOOL_TRUE } else { BOOL_FALSE },
+                "witness for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn propositional_unsat() {
+        // (A ∨ B) ∧ ¬A ∧ ¬B
+        let p = ExprPool::new();
+        let v = bools(&p, &["A", "B"]);
+        let (a, b) = (v[0], v[1]);
+        let f = p.pred_and(vec![p.pred_or(vec![a, b]), p.pred_not(a), p.pred_not(b)]);
+        assert_eq!(satisfiable(f, &p), Satisfiability::Unsat);
+    }
+
+    #[test]
+    fn propositional_sat_gives_a_checked_witness() {
+        // (A ∨ B) ∧ ¬A  →  A = ⊥, B = ⊤ is the only model.
+        let p = ExprPool::new();
+        let v = bools(&p, &["A", "B"]);
+        let (a, b) = (v[0], v[1]);
+        let f = p.pred_and(vec![p.pred_or(vec![a, b]), p.pred_not(a)]);
+        match satisfiable(f, &p) {
+            Satisfiability::Sat(m) => {
+                assert_eq!(m.len(), 2);
+                assert_witness_is(&m, &[("A", false), ("B", true)]);
+            }
+            other => panic!("expected Sat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn propositional_contradiction_and_tautology() {
+        let p = ExprPool::new();
+        let a = p.symbol("A", Domain::Real);
+        // A ∧ ¬A
+        let contradiction = p.pred_and(vec![a, p.pred_not(a)]);
+        assert_eq!(satisfiable(contradiction, &p), Satisfiability::Unsat);
+        // A ∨ ¬A — satisfiable, which is all `satisfiable` claims about it.
+        let tautology = p.pred_or(vec![a, p.pred_not(a)]);
+        assert!(matches!(satisfiable(tautology, &p), Satisfiability::Sat(_)));
+        // ¬(A ∨ ¬A) — the negation of a tautology is unsatisfiable.
+        assert_eq!(
+            satisfiable(p.pred_not(tautology), &p),
+            Satisfiability::Unsat
+        );
+    }
+
+    #[test]
+    fn propositional_bare_symbol_is_a_boolean_variable() {
+        let p = ExprPool::new();
+        let a = p.symbol("A", Domain::Real);
+        match satisfiable(a, &p) {
+            Satisfiability::Sat(m) => assert_eq!(m.len(), 1),
+            other => panic!("expected Sat, got {other:?}"),
+        }
+        assert_eq!(
+            satisfiable(p.pred_not(a), &p),
+            Satisfiability::Sat(HashMap::from([("A".to_string(), BOOL_FALSE.to_string())]))
+        );
+    }
+
+    #[test]
+    fn propositional_implication_and_biconditional() {
+        let p = ExprPool::new();
+        let v = bools(&p, &["A", "B"]);
+        let (a, b) = (v[0], v[1]);
+
+        // (A → B) ∧ A ∧ ¬B denies modus ponens: unsatisfiable.
+        let mp = p.pred_and(vec![implies(&p, a, b), a, p.pred_not(b)]);
+        assert_eq!(satisfiable(mp, &p), Satisfiability::Unsat);
+
+        // (A → B) ∧ A forces B.
+        match satisfiable(p.pred_and(vec![implies(&p, a, b), a]), &p) {
+            Satisfiability::Sat(m) => assert_witness_is(&m, &[("A", true), ("B", true)]),
+            other => panic!("expected Sat, got {other:?}"),
+        }
+
+        // (A ↔ B) ∧ A ∧ ¬B is unsatisfiable; (A ↔ B) ∧ ¬A forces ¬B.
+        let biconditional = iff(&p, a, b);
+        assert_eq!(
+            satisfiable(p.pred_and(vec![biconditional, a, p.pred_not(b)]), &p),
+            Satisfiability::Unsat
+        );
+        match satisfiable(p.pred_and(vec![biconditional, p.pred_not(a)]), &p) {
+            Satisfiability::Sat(m) => assert_witness_is(&m, &[("A", false), ("B", false)]),
+            other => panic!("expected Sat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn propositional_constants_fold() {
+        let p = ExprPool::new();
+        let a = p.symbol("A", Domain::Real);
+        assert_eq!(
+            satisfiable(p.pred_true(), &p),
+            Satisfiability::Sat(HashMap::new())
+        );
+        assert_eq!(satisfiable(p.pred_false(), &p), Satisfiability::Unsat);
+        assert_eq!(
+            satisfiable(p.pred_and(vec![a, p.pred_false()]), &p),
+            Satisfiability::Unsat
+        );
+        assert_eq!(
+            satisfiable(p.pred_or(vec![a, p.pred_true()]), &p),
+            Satisfiability::Sat(HashMap::new())
+        );
+    }
+
+    #[test]
+    fn propositional_pigeonhole_three_into_two_is_unsat() {
+        // Three pigeons, two holes: p{i}{j} = pigeon i sits in hole j.
+        let p = ExprPool::new();
+        let cell: Vec<Vec<ExprId>> = (0..3)
+            .map(|i| {
+                (0..2)
+                    .map(|j| p.symbol(format!("p{i}{j}"), Domain::Real))
+                    .collect()
+            })
+            .collect();
+        let mut clauses = Vec::new();
+        // Every pigeon sits somewhere.
+        for row in &cell {
+            clauses.push(p.pred_or(row.clone()));
+        }
+        // No hole holds two pigeons.
+        for (i, row_i) in cell.iter().enumerate() {
+            for row_k in &cell[i + 1..] {
+                for (a, b) in row_i.iter().zip(row_k) {
+                    clauses.push(p.pred_or(vec![p.pred_not(*a), p.pred_not(*b)]));
+                }
+            }
+        }
+        assert_eq!(satisfiable(p.pred_and(clauses), &p), Satisfiability::Unsat);
+    }
+
+    // -----------------------------------------------------------------------
+    // The boundary: what stays `Unknown`
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mixed_boolean_and_arithmetic_stays_unknown() {
+        // A ∧ (x > 0): a Boolean symbol and a real relation in one formula.
+        // Deciding this needs a Boolean-plus-theory combination this module
+        // does not have; `Unknown` is honest and must not become `Unsat`.
+        let p = ExprPool::new();
+        let a = p.symbol("A", Domain::Real);
+        let x = p.symbol("x", Domain::Real);
+        let f = p.pred_and(vec![a, p.pred_gt(x, p.integer(0_i32))]);
+        assert_eq!(satisfiable(f, &p), Satisfiability::Unknown);
+
+        // …and the mixed *contradiction* stays `Unknown` too.
+        let g = p.pred_and(vec![
+            a,
+            p.pred_gt(x, p.integer(0_i32)),
+            p.pred_lt(x, p.integer(0_i32)),
+        ]);
+        assert_eq!(satisfiable(g, &p), Satisfiability::Unknown);
+    }
+
+    #[test]
+    fn non_predicate_term_stays_unknown() {
+        // `x + 1` is a term, not a formula.
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let t = p.add(vec![x, p.integer(1_i32)]);
+        assert_eq!(satisfiable(t, &p), Satisfiability::Unknown);
+    }
+
+    #[test]
+    fn quantified_propositional_stays_unknown() {
+        // ∀A. A — quantification over a Boolean is outside the fragment.
+        let p = ExprPool::new();
+        let a = p.symbol("A", Domain::Real);
+        assert_eq!(satisfiable(p.forall(a, a), &p), Satisfiability::Unknown);
+    }
+
+    #[test]
+    fn same_name_different_domain_refuses_rather_than_conflating() {
+        // Two distinct symbols share the name "A"; a name-keyed witness could
+        // not tell them apart, so the propositional path declines.
+        let p = ExprPool::new();
+        let a_real = p.symbol("A", Domain::Real);
+        let a_int = p.symbol("A", Domain::Integer);
+        assert_ne!(a_real, a_int);
+        let f = p.pred_and(vec![a_real, p.pred_not(a_int)]);
+        assert_eq!(satisfiable(f, &p), Satisfiability::Unknown);
+    }
+
+    #[test]
+    fn arithmetic_path_is_untouched() {
+        // The single-variable interval fragment behaves as before, and its
+        // witnesses are still rationals rather than "true"/"false".
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let z = p.integer(0_i32);
+        assert_eq!(
+            satisfiable(p.pred_and(vec![p.pred_gt(x, z), p.pred_lt(x, z)]), &p),
+            Satisfiability::Unsat
+        );
+        match satisfiable(p.pred_gt(x, z), &p) {
+            Satisfiability::Sat(m) => {
+                let v = m.get("x").expect("witness for x");
+                assert_ne!(v, BOOL_TRUE);
+                assert_ne!(v, BOOL_FALSE);
+                assert!(
+                    v.parse::<rug::Rational>().is_ok(),
+                    "witness is not a rational: {v}"
+                );
+            }
+            other => panic!("expected Sat, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-check against exhaustive enumeration
+    // -----------------------------------------------------------------------
+
+    /// xorshift64, so the corpus is reproducible without a dependency.
+    fn xorshift(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+
+    /// Build a random propositional `ExprId` over `vars`.
+    fn random_prop(p: &ExprPool, vars: &[ExprId], depth: u32, rng: &mut u64) -> ExprId {
+        if depth == 0 {
+            return vars[(xorshift(rng) as usize) % vars.len()];
+        }
+        match xorshift(rng) % 5 {
+            0 => vars[(xorshift(rng) as usize) % vars.len()],
+            1 => p.pred_not(random_prop(p, vars, depth - 1, rng)),
+            2 => {
+                let k = 2 + (xorshift(rng) % 2) as usize;
+                p.pred_and(
+                    (0..k)
+                        .map(|_| random_prop(p, vars, depth - 1, rng))
+                        .collect(),
+                )
+            }
+            3 => {
+                let k = 2 + (xorshift(rng) % 2) as usize;
+                p.pred_or(
+                    (0..k)
+                        .map(|_| random_prop(p, vars, depth - 1, rng))
+                        .collect(),
+                )
+            }
+            // An implication, written out.
+            _ => {
+                let a = random_prop(p, vars, depth - 1, rng);
+                let b = random_prop(p, vars, depth - 1, rng);
+                p.pred_or(vec![p.pred_not(a), b])
+            }
+        }
+    }
+
+    /// Evaluate a propositional `ExprId` directly, independently of `Prop`.
+    fn eval_expr_prop(p: &ExprPool, e: ExprId, env: &HashMap<ExprId, bool>) -> bool {
+        match p.get(e) {
+            ExprData::Symbol { .. } => env[&e],
+            ExprData::Predicate { kind, args } => match kind {
+                PredicateKind::True => true,
+                PredicateKind::False => false,
+                PredicateKind::Not => !eval_expr_prop(p, args[0], env),
+                PredicateKind::And => args.iter().all(|&a| eval_expr_prop(p, a, env)),
+                PredicateKind::Or => args.iter().any(|&a| eval_expr_prop(p, a, env)),
+                other => panic!("not propositional: {other:?}"),
+            },
+            other => panic!("not propositional: {other:?}"),
+        }
+    }
+
+    /// `satisfiable` must agree with brute-force enumeration on every random
+    /// propositional formula, in **both** directions.  This is the gate that
+    /// catches the DPLL backtracking bug.
+    #[test]
+    fn propositional_agrees_with_exhaustive_enumeration() {
+        let mut rng = 0x2545_F491_4F6C_DD1D_u64;
+        for case in 0..400_u32 {
+            let p = ExprPool::new();
+            let n = 2 + (case % 4) as usize; // 2..=5 variables
+            let names: Vec<String> = (0..n).map(|i| format!("v{i}")).collect();
+            let vars: Vec<ExprId> = names.iter().map(|s| p.symbol(s, Domain::Real)).collect();
+            let f = random_prop(&p, &vars, 3, &mut rng);
+
+            // Ground truth by enumeration.
+            let mut truth = false;
+            for bits in 0_u32..(1_u32 << n) {
+                let env: HashMap<ExprId, bool> = vars
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &v)| (v, bits & (1 << i) != 0))
+                    .collect();
+                if eval_expr_prop(&p, f, &env) {
+                    truth = true;
+                    break;
+                }
+            }
+
+            match satisfiable(f, &p) {
+                Satisfiability::Unsat => {
+                    assert!(!truth, "case {case}: reported Unsat but a model exists");
+                }
+                Satisfiability::Sat(m) => {
+                    assert!(
+                        truth,
+                        "case {case}: reported Sat but the formula is unsatisfiable"
+                    );
+                    let env: HashMap<ExprId, bool> = vars
+                        .iter()
+                        .zip(&names)
+                        .map(|(&v, name)| (v, m.get(name).map(|s| s == BOOL_TRUE) == Some(true)))
+                        .collect();
+                    assert!(
+                        eval_expr_prop(&p, f, &env),
+                        "case {case}: witness {m:?} does not satisfy the formula"
+                    );
+                }
+                Satisfiability::Unknown => {
+                    panic!("case {case}: purely propositional formula answered Unknown")
+                }
+            }
+        }
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -11655,9 +11655,50 @@ fn require_same_pool(py: Python<'_>, a: &PyExpr, b: &PyExpr) -> PyResult<()> {
     Ok(())
 }
 
-/// Return ``False`` if unsatisfiable, ``True`` if satisfiable with no witness
-/// variables, a ``dict`` of symbol → rational string if a witness is found, or
-/// ``None`` if the fragment is unsupported.
+/// Decide satisfiability of a predicate ``Expr``.
+///
+/// Returns ``False`` if unsatisfiable, ``True`` if satisfiable with no witness
+/// variables, a ``dict`` of symbol → value string if a witness is found, or
+/// ``None`` if the fragment is unsupported.  ``None`` **never** means
+/// "unsatisfiable" — only ``False`` is a proof of that.
+///
+/// Two fragments are decided, and they are disjoint:
+///
+/// * **Purely propositional** — every leaf is a bare symbol (read as a Boolean
+///   variable, whatever ``Domain`` it was declared with) or ``pool.pred_true()``
+///   / ``pool.pred_false()``, combined with ``pred_and`` / ``pred_or`` /
+///   ``pred_not`` (equivalently :func:`And` / :func:`Or` / :func:`Not`).  This
+///   fragment is decided **completely** by DPLL: it returns ``None`` only if
+///   the formula exceeds the built-in search budget (64 distinct symbols, 4096
+///   nodes, 2 000 000 branching decisions), never because it gave up thinking.
+///   ``→`` and ``↔`` are in it once written out: ``a → b`` is
+///   ``Or(Not(a), b)`` and ``a ↔ b`` is ``And(Or(Not(a), b), Or(Not(b), a))``;
+///   the kernel has no separate implication node.
+/// * **One real symbol against rational constants** — ``x < 3``, ``x >= 1/2``
+///   and Boolean combinations of them, decided by interval intersection.  This
+///   one is *incomplete*: ``None`` is common, and expected.
+///
+/// Everything else is ``None``, including — deliberately — any formula that
+/// **mixes** a Boolean symbol with an arithmetic relation (``A ∧ x > 0``), any
+/// formula over two or more real symbols, and anything quantified.  Deciding
+/// those needs a Boolean-plus-theory combination this function does not
+/// implement; the cheap alternative, abstracting each relation to a fresh
+/// proposition, is sound for "unsatisfiable" only and would call
+/// ``x > 0 ∧ x < 0`` satisfiable.  Send them to :func:`decide` (real
+/// quantifier elimination by CAD) or to :mod:`alkahest.smt` instead.
+///
+/// A witness ``dict`` is **homogeneous**, so a caller can tell which path
+/// answered from any one value: propositional witnesses map every symbol to
+/// ``"true"`` or ``"false"``, interval witnesses map every symbol to a rational
+/// literal such as ``"1/2"``.  The two never appear in the same dict.
+///
+/// >>> import alkahest as ak
+/// >>> p = ak.ExprPool()
+/// >>> A, B = p.symbol("A"), p.symbol("B")
+/// >>> ak.satisfiable(p.pred_and([p.pred_or([A, B]), p.pred_not(A), p.pred_not(B)]))
+/// False
+/// >>> sorted(ak.satisfiable(p.pred_and([p.pred_or([A, B]), p.pred_not(A)])).items())
+/// [('A', 'false'), ('B', 'true')]
 #[pyfunction(name = "satisfiable")]
 fn py_satisfiable(py: Python<'_>, formula: PyRef<PyExpr>) -> PyResult<PyObject> {
     let pool = formula.pool.borrow(py);

--- a/docs/mdbook/src/smt.md
+++ b/docs/mdbook/src/smt.md
@@ -235,8 +235,9 @@ directory — a `pip install z3-solver` into a venv that was never `activate`d s
 found.
 
 If no solver is installed, `solve` raises `E-SMT-001`. It does **not** fall back to
-`alkahest.satisfiable`, the interval heuristic: that would answer `Unknown` and look for
-all the world like a solver had run and found nothing.
+`alkahest.satisfiable`: that decides only the purely propositional fragment and
+single-variable interval arithmetic — neither of which overlaps what is asked here — so it
+would answer `None` and look for all the world like a solver had run and found nothing.
 
 ### `SmtResult`
 

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -782,8 +782,9 @@ class SmtError(AlkahestError):
     Raised by :mod:`alkahest.smt` (P2 item 3).
 
     - ``E-SMT-001`` — no solver binary was found. Reported as a refusal rather
-      than a silent fallback to the weak interval :func:`alkahest.satisfiable`,
-      which would answer ``Unknown`` and look like the solver had run.
+      than a silent fallback to :func:`alkahest.satisfiable`, which decides only
+      the propositional and single-real-variable fragments and would answer
+      ``None`` here — looking like the solver had run and found nothing.
     - ``E-SMT-002`` — the formula is outside the supported SMT-LIB fragment;
       check :func:`alkahest.smt.supported` first.
     - ``E-SMT-003`` — the model contains a value (an ``root-obj`` algebraic

--- a/python/alkahest/smt.py
+++ b/python/alkahest/smt.py
@@ -233,10 +233,10 @@ def _resolve_solver(solver: str) -> tuple[_SolverSpec, str]:
         code="E-SMT-001",
         remediation=(
             "install z3 (`pip install z3-solver`) or cvc5 and make it visible on PATH. "
-            "This is a refusal, not a fallback: alkahest.satisfiable is an interval "
-            "heuristic that answers Unknown for almost everything a solver would settle, "
-            "so silently routing to it would look like the solver had run and found "
-            "nothing"
+            "This is a refusal, not a fallback: alkahest.satisfiable decides only the "
+            "purely propositional fragment and single-variable interval arithmetic, and "
+            "answers None for almost every arithmetic formula a solver would settle, so "
+            "silently routing to it would look like the solver had run and found nothing"
         ),
     )
 
@@ -1134,7 +1134,9 @@ def solve(
     ------
     SmtError
         ``E-SMT-001`` no solver installed — a refusal, never a silent fallback
-        to the weak interval :func:`alkahest.satisfiable`.
+        to :func:`alkahest.satisfiable`, whose fragments (propositional, and one
+        real variable against rational constants) do not overlap what is asked
+        here.
         ``E-SMT-002`` formula outside the exportable/solvable fragment.
         ``E-SMT-003`` a model value (``root-obj``) cannot be lifted exactly.
         ``E-SMT-004`` the model failed back-substitution.  This is raised, never

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
+
 import alkahest
+import pytest
 from alkahest import ExprPool
 
 
@@ -40,3 +43,161 @@ def test_top_level_forall_exists():
     body = p.gt(x, p.integer(0))
     e = alkahest.Exists(x, body)
     assert e.node()[0] == "exists"
+
+
+# ---------------------------------------------------------------------------
+# Propositional satisfiability
+#
+# `satisfiable` decides the purely propositional fragment completely.  The
+# contract that matters most here: `None` means "unsupported fragment" and
+# never "unsatisfiable" -- only `False` is a proof of unsatisfiability.
+# ---------------------------------------------------------------------------
+
+
+def _implies(p, a, b):
+    """``a -> b``; the kernel has no separate implication node."""
+    return p.pred_or([p.pred_not(a), b])
+
+
+def _iff(p, a, b):
+    """``a <-> b``, written as ``(a -> b) and (b -> a)``."""
+    return p.pred_and([_implies(p, a, b), _implies(p, b, a)])
+
+
+def _holds(witness, formula_fn):
+    """Evaluate ``formula_fn`` on a witness dict of ``"true"``/``"false"``."""
+    return formula_fn({k: v == "true" for k, v in witness.items()})
+
+
+def test_propositional_unsat():
+    # (A or B) and not A and not B
+    p = ExprPool()
+    a, b = p.symbol("A"), p.symbol("B")
+    f = p.pred_and([p.pred_or([a, b]), p.pred_not(a), p.pred_not(b)])
+    assert alkahest.satisfiable(f) is False
+
+
+def test_propositional_sat_returns_a_witness_that_works():
+    # (A or B) and not A -- the only model is A = False, B = True.
+    p = ExprPool()
+    a, b = p.symbol("A"), p.symbol("B")
+    f = p.pred_and([p.pred_or([a, b]), p.pred_not(a)])
+    r = alkahest.satisfiable(f)
+    assert isinstance(r, dict)
+    assert r == {"A": "false", "B": "true"}
+    assert _holds(r, lambda m: (m["A"] or m["B"]) and not m["A"])
+
+
+def test_propositional_tautology_and_contradiction():
+    p = ExprPool()
+    a = p.symbol("A")
+    # A or not A is satisfiable; its negation is not.
+    tautology = p.pred_or([a, p.pred_not(a)])
+    assert alkahest.satisfiable(tautology) not in (False, None)
+    assert alkahest.satisfiable(p.pred_not(tautology)) is False
+    # A and not A is unsatisfiable.
+    assert alkahest.satisfiable(p.pred_and([a, p.pred_not(a)])) is False
+
+
+def test_propositional_constants():
+    p = ExprPool()
+    a = p.symbol("A")
+    assert alkahest.satisfiable(p.pred_true()) is True
+    assert alkahest.satisfiable(p.pred_false()) is False
+    assert alkahest.satisfiable(p.pred_and([a, p.pred_false()])) is False
+    assert alkahest.satisfiable(p.pred_or([a, p.pred_true()])) is True
+
+
+def test_propositional_implication():
+    p = ExprPool()
+    a, b = p.symbol("A"), p.symbol("B")
+    # (A -> B) and A and not B denies modus ponens.
+    assert alkahest.satisfiable(p.pred_and([_implies(p, a, b), a, p.pred_not(b)])) is False
+    # (A -> B) and A forces B.
+    r = alkahest.satisfiable(p.pred_and([_implies(p, a, b), a]))
+    assert r == {"A": "true", "B": "true"}
+
+
+def test_propositional_biconditional():
+    p = ExprPool()
+    a, b = p.symbol("A"), p.symbol("B")
+    biconditional = _iff(p, a, b)
+    assert alkahest.satisfiable(p.pred_and([biconditional, a, p.pred_not(b)])) is False
+    r = alkahest.satisfiable(p.pred_and([biconditional, p.pred_not(a)]))
+    assert r == {"A": "false", "B": "false"}
+
+
+def test_propositional_pigeonhole_is_unsat():
+    # Three pigeons into two holes.
+    p = ExprPool()
+    cell = [[p.symbol(f"p{i}{j}") for j in range(2)] for i in range(3)]
+    clauses = [p.pred_or(row) for row in cell]
+    for j in range(2):
+        for i in range(3):
+            for k in range(i + 1, 3):
+                clauses.append(p.pred_or([p.pred_not(cell[i][j]), p.pred_not(cell[k][j])]))
+    assert alkahest.satisfiable(p.pred_and(clauses)) is False
+
+
+def test_boolean_witness_values_are_true_false_not_rationals():
+    # A witness dict is homogeneous: a propositional one is all "true"/"false",
+    # an arithmetic one is all rational literals.  A caller can tell them apart
+    # from any single value.
+    p = ExprPool()
+    a = p.symbol("A")
+    x = p.symbol("x")
+    prop = alkahest.satisfiable(p.pred_and([a]))
+    assert set(prop.values()) <= {"true", "false"}
+    arith = alkahest.satisfiable(p.gt(x, p.integer(0)))
+    assert isinstance(arith, dict)
+    assert set(arith.values()).isdisjoint({"true", "false"})
+    Fraction(arith["x"])  # parses as an exact rational
+
+
+def test_mixed_boolean_and_arithmetic_is_still_none():
+    # THE boundary case.  `A and (x > 0)` needs a Boolean-plus-theory
+    # combination this function does not implement, so it must answer None --
+    # "unsupported" -- and specifically must not answer False.
+    p = ExprPool()
+    a = p.symbol("A")
+    x = p.symbol("x")
+    assert alkahest.satisfiable(p.pred_and([a, p.gt(x, p.integer(0))])) is None
+    # Even when the arithmetic part alone is contradictory: a False here would
+    # be luck, not a proof.
+    mixed = p.pred_and([a, p.gt(x, p.integer(0)), p.lt(x, p.integer(0))])
+    assert alkahest.satisfiable(mixed) is None
+
+
+def test_non_formula_term_is_still_none():
+    p = ExprPool()
+    x = p.symbol("x")
+    assert alkahest.satisfiable(x + p.integer(1)) is None
+
+
+def test_arithmetic_fragment_unchanged():
+    p = ExprPool()
+    x = p.symbol("x")
+    z = p.integer(0)
+    assert alkahest.satisfiable(alkahest.And(p.gt(x, z), p.lt(x, z))) is False
+    r = alkahest.satisfiable(p.gt(x, z))
+    assert isinstance(r, dict)
+    assert Fraction(r["x"]) > 0
+
+
+def test_smt_bridge_refuses_rather_than_falling_back_to_satisfiable():
+    # The native paths must not depend on an external solver being installed.
+    caps = alkahest.capabilities()["verification"]["smt_solvers"]
+    p = ExprPool()
+    x = p.symbol("x")
+    a = p.symbol("A")
+    f = p.pred_and([p.gt(p.mul([x, x]), p.integer(2)), p.lt(x, p.integer(5))])
+    # to_smtlib is a pure emitter and works with no solver present.
+    assert "QF_NRA" in alkahest.smt.to_smtlib(f)
+    # ...and satisfiable itself never shells out.
+    assert alkahest.satisfiable(p.pred_and([a, p.pred_not(a)])) is False
+    if all(v is None for v in caps.values()):
+        # With no solver installed, solve() refuses with E-SMT-001 rather than
+        # degrading to satisfiable() and reporting its None as the solver's.
+        with pytest.raises(alkahest.SmtError) as exc:
+            alkahest.smt.solve(f)
+        assert exc.value.code == "E-SMT-001"

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -422,10 +422,11 @@ def test_model_parser_handles_both_z3_shapes():
 
 
 def test_missing_solver_is_a_refusal_not_a_fallback(pool, monkeypatch):
-    """Never quietly degrade to the weak interval `satisfiable`.
+    """Never quietly degrade to `satisfiable`.
 
-    That would answer ``Unknown`` and look exactly like a solver had run and
-    found nothing.
+    `satisfiable` decides only the propositional and single-real-variable
+    fragments, so on an arithmetic formula it would answer ``None`` and look
+    exactly like a solver had run and found nothing.
     """
     monkeypatch.setattr(smt, "_find_binary", lambda _binary: None)
     x = pool.symbol("x")


### PR DESCRIPTION
`satisfiable` returned `None` ("fragment unsupported") for ordinary
propositional formulas:

```python
ak.satisfiable((A|B) & ~A & ~B)   # -> None,  should be False
ak.satisfiable((A|B) & ~A)        # -> None,  should be True
```

## Two causes — the second is the serious one

**1. A representation gap, not an unwired binding.** `Formula::Atom` carries a
`PredicateKind` and the solver's `is_rel` restricts those to the six relations,
so a bare `ExprData::Symbol` in formula position fell to the catch-all →
`E-LOGIC-001` → `Unknown`. Nothing downstream could rescue it: `sat_intervals`
is interval intersection over one real symbol with no case-splitting. The
binding routed correctly; there was nothing to route to.

**2. `dpll_sat` was unsound for UNSAT.** Found while fixing (1). `dfs` undid
only its own decision literal on backtracking and left the failed branch's
unit-propagated literals on the trail, so the second branch started polluted
and could be refuted when satisfiable:

```
dpll_sat([[1,2],[1,-2],[-1,-2]], 2)   # satisfied by p1=⊤, p2=⊥
                                      # returned None, i.e. "unsatisfiable"
```

**Wiring the front end into DPLL as it stood would have turned a `None` into a
`False` — a claimed proof of unsatisfiability for a satisfiable formula.**
Callers treat `False` as a proof, so that is strictly worse than the gap being
fixed. `dpll_dfs` now snapshots and restores the whole trail around each branch.

## What changed

A propositional path in front of the interval path: leaves lifted to a `Prop`
(a bare symbol is a Boolean variable, whatever its `Domain`), constants folded,
Tseitin-encoded with **both** directions of each gate definition, decided by a
new `dpll_sat_bounded`/`DpllOutcome` that reports `Exhausted` rather than
guessing. `dpll_sat` is now a wrapper whose `Exhausted` arm is `unreachable!`
rather than `None` — returning `None` there would report "gave up" as
"unsatisfiable".

Two guards against a wrong answer: every `Sat` model is evaluated against the
original formula before it leaves — a defect degrades to an honest `Unknown`,
and **this check runs in release too** — plus a debug-only cross-check of every
verdict on ≤10 variables against exhaustive enumeration.

## The boundary

- **Purely propositional** → decided completely. `None` only on budget
  exhaustion (64 symbols, 4096 nodes, 2e6 decisions). `→`/`↔` are covered as
  soon as they are written out; the kernel has no `Implies` node and one was
  not added.
- **One real symbol vs rational constants** → unchanged, still incomplete.
- **Mixed Boolean + arithmetic** → still `None`, deliberately. The cheap
  alternative (abstract each relation to a fresh proposition) is sound for
  `Unsat` only and calls `x>0 ∧ x<0` satisfiable — the same argument
  `dpll_sat`'s existing doc comment makes for keeping it out of the SMT bridge.

Boolean witnesses are `"true"`/`"false"`; arithmetic witnesses stay rational
literals. A dict is **homogeneous**, so one value identifies which path
answered — the two can never mix, precisely because mixed formulas are `None`.
Same-named symbols with different `Domain`s are refused rather than conflated.

Unchanged and re-verified: `to_smtlib` still emits `QF_NRA`;
`decide(∃x. x²−2>0)` → `(True, {'x': '-4'})`; `smt.solve` with no solver still
raises `E-SMT-001`. The SMT bridge was already correct — it refuses rather than
falling back — so only now-inaccurate wording was corrected.

## Semver

**Additive.** `cargo semver-checks check-release -p alkahest-cas` → 223 pass,
0 fail, "no semver update required" — the new items are `pub(crate)`, so the
public Rust surface is byte-identical. `check_api_freeze.py` → no change. The
Python behaviour change is a strict refinement: cases that answered `None` now
answer; no case that already answered changes.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2850 passed, 0
failed, 11 ignored** (base 2834, +16). `pytest tests/` → 3197 passed, 0 failed.
Silent-error gate 339 passed. clippy `-D warnings` (also with no optional
features), `fmt --check`, `check_error_codes.py` clean. `cargo check --release`
warning-free, confirming the `cfg(debug_assertions)` block leaves no dead code.

Test-power check: re-introducing the DPLL bug made both
`dpll_restores_the_trail_on_backtrack` and the 400-case randomized
`propositional_agrees_with_exhaustive_enumeration` fail, then pass on restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
