### PR TITLE
feat(solve): accept rational equations, and exclude the roots clearing them invents

### DIFF
--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -124,7 +124,7 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-DIFFALG-001", class: "DiffAlgError", cause: Cause::Unsupported, remediation: Some("ensure the DAE is polynomial in its state and derivative symbols") },
     ErrorSpec { code: "E-DIFFALG-002", class: "DiffAlgError", cause: Cause::UserInput,   remediation: Some("declare all jet variables; remove transcendental functions") },
     ErrorSpec { code: "E-DIFFALG-003", class: "DiffAlgError", cause: Cause::UserInput, remediation: None },
-    ErrorSpec { code: "E-SOLVE-001", class: "SolverError", cause: Cause::UserInput,   remediation: Some("ensure all equations are polynomial in the declared variables") },
+    ErrorSpec { code: "E-SOLVE-001", class: "SolverError", cause: Cause::UserInput,   remediation: Some("ensure all equations are polynomial or rational in the declared variables") },
     ErrorSpec { code: "E-SOLVE-002", class: "SolverError", cause: Cause::Unsupported, remediation: Some("only degree ≤ 2 univariate solving is implemented; Gröbner basis is still returned") },
     ErrorSpec { code: "E-SOLVE-003", class: "SolverError", cause: Cause::UserInput,   remediation: Some("provide one equation per variable") },
     // `triangularize` extracts one polynomial per main variable, so two basis
@@ -134,6 +134,12 @@ pub const REGISTRY: &[ErrorSpec] = &[
     // point until it exists.  Travels inside `SolverError::NotPolynomial` — see
     // `solver::regular_chains::TriangularizeRefusal`.
     ErrorSpec { code: "E-SOLVE-004", class: "TriangularizeRefusal", cause: Cause::Unsupported, remediation: Some("this ideal needs a splitting triangular decomposition (Lazard–Kalkbrener on the initials), which is not implemented; use GroebnerBasis::compute or primary_decomposition instead") },
+    // A rational equation whose denominator is identically zero (`1/(x − x)`)
+    // denotes no function, so it has no solution set.  Clearing it would
+    // multiply through by zero and turn every point into a "solution".  Like
+    // `E-SOLVE-004`, it travels inside `SolverError::NotPolynomial` — see
+    // `solver::UndefinedEquation`.
+    ErrorSpec { code: "E-SOLVE-005", class: "UndefinedEquation", cause: Cause::UserInput,   remediation: Some("a denominator simplifies to zero, so the equation denotes no function; check the equation for a subtraction that cancels") },
     ErrorSpec { code: "E-SOLVE-010", class: "SolverError", cause: Cause::Resource,    remediation: Some("check GPU availability; pass device_id=None to fall back to CPU") },
     ErrorSpec { code: "E-SOLVE-011", class: "SolverError", cause: Cause::Resource,    remediation: Some("CRT reconstruction failed; try adding more equations or use CPU path") },
     // E-IDEAL — PrimaryDecompositionError (ideal/primary.rs) and IdealRefusal

--- a/alkahest-core/src/solver/mod.rs
+++ b/alkahest-core/src/solver/mod.rs
@@ -1294,7 +1294,7 @@ pub fn collect_parameters(equations: &[ExprId], vars: &[ExprId], pool: &ExprPool
 ///
 /// That step is **not** an equivalence: `N/D = 0` means `N = 0 ∧ D ≠ 0`, and a
 /// root of `N` at which `D` vanishes is not a solution.  Such roots are removed
-/// again by [`exclude_pole_roots`], which decides `D ≠ 0` exactly where it can
+/// again by `exclude_pole_roots`, which decides `D ≠ 0` exactly where it can
 /// (rational arithmetic, the ambient assumptions, ball arithmetic) and
 /// otherwise records a `D ≠ 0` hypothesis through [`take_solve_side_conditions`]
 /// rather than assuming it.  Surviving roots are additionally substituted into

--- a/alkahest-core/src/solver/mod.rs
+++ b/alkahest-core/src/solver/mod.rs
@@ -34,6 +34,7 @@
 pub mod diophantine;
 pub mod homotopy;
 pub mod polyhedral;
+mod rational;
 pub mod regular_chains;
 pub mod transcendental;
 mod verify;
@@ -88,7 +89,8 @@ pub enum SolutionSet {
 /// Errors from the polynomial system solver.
 #[derive(Debug, Clone)]
 pub enum SolverError {
-    /// An equation is not a polynomial in the given variables.
+    /// An equation is not a polynomial (nor a rational function) in the given
+    /// variables.
     NotPolynomial(String),
     /// Back-substitution would require solving a degree > 2 univariate — not yet
     /// implemented for general algebraic numbers.
@@ -128,7 +130,7 @@ impl AlkahestError for SolverError {
     fn remediation(&self) -> Option<&'static str> {
         match self {
             SolverError::NotPolynomial(_) => Some(
-                "ensure all equations are polynomial in the declared variables; \
+                "ensure all equations are polynomial or rational in the declared variables; \
                  transcendental functions are not supported",
             ),
             SolverError::HighDegree(_) => Some(
@@ -140,6 +142,91 @@ impl AlkahestError for SolverError {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Everywhere-undefined equations, reported out of band
+// ---------------------------------------------------------------------------
+
+/// The solver declined because an equation's denominator is **identically**
+/// zero — `1/(x − x)`.
+///
+/// Such an equation denotes no function, so it has no solution set at all;
+/// clearing it would multiply through by zero and make every point a
+/// "solution", which is the one outcome worth going out of the way to prevent.
+///
+/// # Why this is not an error variant
+///
+/// [`SolverError`] is a public *exhaustive* enum, so growing it a variant is a
+/// major semver break for every downstream `match`. The refusal therefore
+/// travels inside [`SolverError::NotPolynomial`] and is recovered here, exactly
+/// as [`regular_chains::TriangularizeRefusal`] does for `E-SOLVE-004`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UndefinedEquation {
+    detail: String,
+}
+
+impl UndefinedEquation {
+    /// What was found to be identically zero.
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+impl fmt::Display for UndefinedEquation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "equation is undefined everywhere: {}", self.detail)
+    }
+}
+
+impl std::error::Error for UndefinedEquation {}
+
+impl AlkahestError for UndefinedEquation {
+    fn code(&self) -> &'static str {
+        "E-SOLVE-005"
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        Some(
+            "a denominator simplifies to zero, so the equation denotes no function; \
+             check the equation for a subtraction that cancels",
+        )
+    }
+}
+
+thread_local! {
+    /// The refusal behind the `SolverError::NotPolynomial` this thread is about
+    /// to return, when that variant is a carrier rather than what it usually
+    /// means.
+    static LAST_UNDEFINED_EQUATION: std::cell::RefCell<Option<UndefinedEquation>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Drop any recorded refusal, so a later unrelated `NotPolynomial` — a
+/// genuinely transcendental equation, say — is never re-attributed to it.
+fn forget_undefined_equation() {
+    LAST_UNDEFINED_EQUATION.with(|c| *c.borrow_mut() = None);
+}
+
+/// Build the carrier error and stash the refusal behind it.
+pub(crate) fn refuse_undefined_equation(detail: &str) -> SolverError {
+    let refusal = UndefinedEquation {
+        detail: detail.to_string(),
+    };
+    let message = refusal.to_string();
+    LAST_UNDEFINED_EQUATION.with(|c| *c.borrow_mut() = Some(refusal));
+    SolverError::NotPolynomial(message)
+}
+
+/// Take the refusal behind the error that just came back, if there was one.
+///
+/// Bindings call this when [`solve_polynomial_system`] returns
+/// `SolverError::NotPolynomial` and raise the refusal's own `E-SOLVE-005` when
+/// it is present, so the caller is told the equation is undefined rather than
+/// merely non-polynomial. Consuming, so one refusal is reported once;
+/// thread-local.
+pub fn take_undefined_equation() -> Option<UndefinedEquation> {
+    LAST_UNDEFINED_EQUATION.with(|c| c.borrow_mut().take())
 }
 
 // ---------------------------------------------------------------------------
@@ -924,6 +1011,252 @@ fn refine_solutions(
     kept
 }
 
+// ---------------------------------------------------------------------------
+// Poles: undoing the equivalence that clearing denominators broke
+// ---------------------------------------------------------------------------
+
+/// What could be established about a cleared denominator at a candidate root.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PoleStatus {
+    /// Proved non-zero — the root survives with no hypothesis attached.
+    Nonzero,
+    /// Proved zero (or the denominator is not even defined there): the root is
+    /// spurious and is removed.  This is a *positive* finding, so an empty
+    /// solution list that follows from it is a real "no solution".
+    Vanishes,
+    /// A number, but one the enclosure could not separate from zero.  Treated
+    /// as vanishing — the safe direction — but recorded, because unlike
+    /// [`PoleStatus::Vanishes`] it is not a proof and must not be allowed to
+    /// underwrite the claim "this system has no solutions".
+    Indeterminate,
+    /// Still mentions a free parameter, so it cannot be decided at all.  The
+    /// root is kept under a stated non-vanishing hypothesis.
+    Undecided,
+}
+
+/// Decide whether a domain condition, already specialised at a candidate root,
+/// vanishes there.
+///
+/// Four sources are consulted in order of strength: exact rational arithmetic,
+/// the structural zero test, the ambient assumptions (`R1 > 0` settles `R1 ≠ 0`
+/// outright, which is why declaring a resistance positive removes a side
+/// condition), and finally rigorous ball arithmetic.
+fn domain_status(e: ExprId, pool: &ExprPool) -> PoleStatus {
+    if let Some(v) = rational_value(e, pool) {
+        return if v == 0 {
+            PoleStatus::Vanishes
+        } else {
+            PoleStatus::Nonzero
+        };
+    }
+    if is_certain_zero(e, pool) {
+        return PoleStatus::Vanishes;
+    }
+    match crate::simplify::assumptions::assumed_sign(e, pool) {
+        Some(crate::simplify::assumptions::Sign::Zero) => return PoleStatus::Vanishes,
+        Some(_) => return PoleStatus::Nonzero,
+        None => {}
+    }
+    match verify::CBallEval::default().eval(e, pool) {
+        Ok(ball) if ball.excludes_zero() => PoleStatus::Nonzero,
+        // A number whose enclosure straddles zero.  For a denominator that
+        // really vanishes this is the *exact* answer arriving as a tight ball
+        // around zero; for one that does not it would need to be smaller than
+        // 2^-180, which no root of the systems this solver accepts is.
+        Ok(_) => PoleStatus::Indeterminate,
+        // `0^-1` inside the denominator itself: the root is outside the
+        // equation's domain either way.
+        Err(verify::VerifyGap::Undefined) => PoleStatus::Vanishes,
+        Err(verify::VerifyGap::Unsupported) => PoleStatus::Undecided,
+    }
+}
+
+/// Rebuild `expr` with each `vars[i]` replaced by `values[i]`.
+///
+/// Memoised on [`ExprId`], so a shared sub-expression is rewritten once: the
+/// input is a DAG and its tree expansion is not what anyone wants to walk.
+fn substitute_solution(
+    expr: ExprId,
+    vars: &[ExprId],
+    values: &[ExprId],
+    pool: &ExprPool,
+    memo: &mut std::collections::HashMap<ExprId, ExprId>,
+) -> ExprId {
+    if let Some(&hit) = memo.get(&expr) {
+        return hit;
+    }
+    if let Some(i) = vars.iter().position(|&v| v == expr) {
+        memo.insert(expr, values[i]);
+        return values[i];
+    }
+    let out = match pool.get(expr) {
+        ExprData::Add(args) => {
+            let new: Vec<ExprId> = args
+                .iter()
+                .map(|&a| substitute_solution(a, vars, values, pool, memo))
+                .collect();
+            pool.add(new)
+        }
+        ExprData::Mul(args) => {
+            let new: Vec<ExprId> = args
+                .iter()
+                .map(|&a| substitute_solution(a, vars, values, pool, memo))
+                .collect();
+            pool.mul(new)
+        }
+        ExprData::Pow { base, exp } => {
+            let b = substitute_solution(base, vars, values, pool, memo);
+            let e = substitute_solution(exp, vars, values, pool, memo);
+            pool.pow(b, e)
+        }
+        ExprData::Func { name, args } => {
+            let new: Vec<ExprId> = args
+                .iter()
+                .map(|&a| substitute_solution(a, vars, values, pool, memo))
+                .collect();
+            pool.func(&name, new)
+        }
+        _ => expr,
+    };
+    memo.insert(expr, out);
+    out
+}
+
+/// The verdict of substituting a candidate back into the caller's own equations.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum OriginalCheck {
+    /// Nothing could be held against it.
+    Survives,
+    /// The residual is *separated* from zero: a proof that this is not a root.
+    Refuted,
+    /// The expression has no value at the candidate (`1/0`, `0/0`) — or its
+    /// reciprocal's argument merely could not be separated from zero, which
+    /// reads the same from here.  A drop either way, but not a proof.
+    Undefined,
+}
+
+/// Substitute a candidate into the **original** rational equations — the ones
+/// the caller wrote, before anything was multiplied through.
+///
+/// Independent of the denominator test above and deliberately so: this walks
+/// the caller's own expression, so a mistake in clearing denominators shows up
+/// here rather than being confirmed by its own output.  One-sided in the same
+/// direction as [`refine_solutions`] — a candidate is only ever dropped, never
+/// rescued, and a residual ball that straddles zero proves nothing and lets the
+/// candidate through.
+fn check_against_original(
+    sol: &Solution,
+    equations: &[ExprId],
+    vars: &[ExprId],
+    pool: &ExprPool,
+) -> OriginalCheck {
+    let mut memo = std::collections::HashMap::new();
+    let mut evaluator = verify::CBallEval::default();
+    let mut verdict = OriginalCheck::Survives;
+    for &eq in equations {
+        let at_root = substitute_solution(eq, vars, sol, pool, &mut memo);
+        match evaluator.eval(at_root, pool) {
+            Ok(ball) if ball.excludes_zero() => return OriginalCheck::Refuted,
+            Ok(_) => {}
+            Err(verify::VerifyGap::Undefined) => verdict = OriginalCheck::Undefined,
+            // A free parameter: nothing can be concluded, and nothing is.
+            Err(verify::VerifyGap::Unsupported) => {}
+        }
+    }
+    verdict
+}
+
+/// Remove the roots that clearing denominators invented, and state the
+/// hypotheses under which the rest stand.
+///
+/// `N/D = 0` is equivalent to `N = 0 ∧ D ≠ 0`; the solver was handed only
+/// `N = 0`, so every root it produced has to be re-tested against the
+/// `domains` polynomial that says where its equation has a value at all
+/// (see [`rational`] — that is *not* the same thing as the product of the
+/// denominators). `x/(x−1) = 1/(x−1)` clears to `(x−1)² = 0` and its only root
+/// `x = 1` is removed here, which is the whole reason this step exists:
+/// returning it would be a wrong answer.
+///
+/// Three outcomes, all visible to the caller:
+///
+/// * **Proved non-zero** — the root is returned unconditionally.
+/// * **Proved zero** — the root is dropped.  Because this is a proof, an empty
+///   result is a genuine "no solution".
+/// * **Undecidable** (the condition still mentions a free parameter, so whether
+///   it vanishes depends on values nobody supplied) — the root is returned
+///   under a `≠ 0` hypothesis recorded through [`assume_nonzero`] and reported
+///   by [`take_solve_side_conditions`].  It is never assumed silently.
+///
+/// Returns the surviving roots and whether any drop was
+/// [`PoleStatus::Indeterminate`] rather than proved; the caller must not
+/// report "no solutions" on the strength of one of those.
+fn exclude_pole_roots(
+    solutions: Vec<Solution>,
+    domains: &[GbPoly],
+    equations: &[ExprId],
+    all_vars: &[ExprId],
+    n_solve: usize,
+    pool: &ExprPool,
+) -> (Vec<Solution>, bool) {
+    if domains.is_empty() {
+        return (solutions, false);
+    }
+    let solve_vars: Vec<ExprId> = all_vars[..n_solve].to_vec();
+    let mut kept = Vec::with_capacity(solutions.len());
+    let mut unproved_drop = false;
+
+    for sol in solutions {
+        // Name exponent slot `i` by the solved value for an unknown, and by
+        // the parameter itself for everything past them.
+        let mut at_root: Vec<ExprId> = sol.clone();
+        at_root.extend_from_slice(&all_vars[n_solve..]);
+
+        let mut hypotheses: Vec<ExprId> = Vec::new();
+        let mut excluded = false;
+        for d in domains {
+            let Some(value) = gbpoly_to_expr(d, &at_root, pool) else {
+                // `at_root` names every indeterminate by construction, so this
+                // is unreachable; refusing the root is the safe reading.
+                excluded = true;
+                unproved_drop = true;
+                break;
+            };
+            match domain_status(value, pool) {
+                PoleStatus::Nonzero => {}
+                PoleStatus::Vanishes => {
+                    excluded = true;
+                    break;
+                }
+                PoleStatus::Indeterminate => {
+                    excluded = true;
+                    unproved_drop = true;
+                    break;
+                }
+                PoleStatus::Undecided => hypotheses.push(value),
+            }
+        }
+        if excluded {
+            continue;
+        }
+        match check_against_original(&sol, equations, &solve_vars, pool) {
+            OriginalCheck::Survives => {}
+            OriginalCheck::Refuted => continue,
+            OriginalCheck::Undefined => {
+                // The product-of-denominators test above did not object, so the
+                // two enclosures disagree.  Dropping is the safe reading, but
+                // it is not the proof `Vanishes` would have been.
+                unproved_drop = true;
+                continue;
+            }
+        }
+        for h in hypotheses {
+            assume_nonzero(h);
+        }
+        kept.push(sol);
+    }
+    (kept, unproved_drop)
+}
+
 /// Free symbols in `equations` that are not among the declared solve `vars`,
 /// in stable [`ExprId`] order (via [`collect_free_vars`]'s `BTreeSet`).
 ///
@@ -944,7 +1277,7 @@ pub fn collect_parameters(equations: &[ExprId], vars: &[ExprId], pool: &ExprPool
     params.into_iter().collect()
 }
 
-/// Solve a polynomial system in the declared unknowns.
+/// Solve a polynomial — or **rational** — system in the declared unknowns.
 ///
 /// `equations` — list of `ExprId` each representing `p = 0`.
 /// `vars` — unknowns to solve for (order used for `GbPoly` exponent vectors).
@@ -952,6 +1285,20 @@ pub fn collect_parameters(equations: &[ExprId], vars: &[ExprId], pool: &ExprPool
 /// Symbols that appear in `equations` but are absent from `vars` are treated as
 /// free parameters: solutions may be expressions in those symbols (e.g.
 /// `x² − y = 0` in `[x]` yields `x = ±√y`).
+///
+/// # Rational equations
+///
+/// An equation may be a ratio of polynomials — `(Vo − Vin)/R1 + Vo·s·C`, the
+/// shape every admittance equation in nodal analysis has.  Each is put over a
+/// common denominator and the numerator system is solved.
+///
+/// That step is **not** an equivalence: `N/D = 0` means `N = 0 ∧ D ≠ 0`, and a
+/// root of `N` at which `D` vanishes is not a solution.  Such roots are removed
+/// again by [`exclude_pole_roots`], which decides `D ≠ 0` exactly where it can
+/// (rational arithmetic, the ambient assumptions, ball arithmetic) and
+/// otherwise records a `D ≠ 0` hypothesis through [`take_solve_side_conditions`]
+/// rather than assuming it.  Surviving roots are additionally substituted into
+/// the equations as the caller wrote them, before anything was cleared.
 ///
 /// Returns a [`SolutionSet`] with symbolic `ExprId` values for each solution
 /// (parallel to `vars` only — parameters are not included in solution tuples).
@@ -981,17 +1328,29 @@ pub fn solve_polynomial_system(
     pool: &ExprPool,
 ) -> Result<SolutionSet, SolverError> {
     // Hypotheses describe *this* call; a caller reading them after it must
-    // never see one left behind by an earlier solve.
+    // never see one left behind by an earlier solve.  Same for the refusal
+    // channel: a stale one would re-label an unrelated `NotPolynomial`.
     let _ = take_solve_side_conditions();
+    forget_undefined_equation();
     let n_solve = vars.len();
     let params = collect_parameters(&equations, &vars, pool);
     let mut all_vars = vars;
     all_vars.extend(params);
     let n_vars = all_vars.len();
 
+    // Each equation is put over a common denominator; the numerators are the
+    // system the Gröbner machinery below actually sees, and `domains` carries
+    // what has to be non-zero for each numerator to speak for its equation.
+    // For polynomial input the domain is `1` and nothing about this call
+    // changes.
     let mut polys: Vec<GbPoly> = Vec::with_capacity(equations.len());
+    let mut domains: Vec<GbPoly> = Vec::new();
     for eq in &equations {
-        polys.push(expr_to_gbpoly(*eq, &all_vars, pool)?);
+        let cleared = rational::clear_denominators(*eq, &all_vars, pool)?;
+        if !cleared.is_polynomial() {
+            domains.push(cleared.domain);
+        }
+        polys.push(cleared.numer);
     }
 
     let gb = GroebnerBasis::compute(polys.clone(), MonomialOrder::Lex);
@@ -1018,7 +1377,16 @@ pub fn solve_polynomial_system(
             // "this system has no solutions" — so decline instead.
             return None;
         }
-        Some(SolutionSet::Finite(refined))
+        // Clearing denominators enlarged the solution set; take the excess
+        // back out.  An empty list *is* the right answer here — `1/(x−1) =
+        // x/(x−1)` genuinely has none — but only when every drop was proved,
+        // so a merely-undecided one falls through to the basis instead.
+        let (kept, unproved_drop) =
+            exclude_pole_roots(refined, &domains, &equations, &all_vars, n_solve, pool);
+        if kept.is_empty() && unproved_drop {
+            return None;
+        }
+        Some(SolutionSet::Finite(kept))
     };
 
     match try_backsolve_generators(gens, &all_vars, n_solve, pool)? {
@@ -1043,6 +1411,15 @@ pub fn solve_polynomial_system(
             if let Some(set) = finish(solutions) {
                 return Ok(set);
             }
+        }
+    }
+    // The basis being returned is the *numerator* ideal, whose variety contains
+    // points the original equations are not even defined at.  Nobody filtered
+    // them, because no solution list was produced to filter; say so rather than
+    // hand back a basis that quietly means something wider than it looks.
+    for d in &domains {
+        if let Some(e) = gbpoly_to_expr(d, &all_vars, pool) {
+            assume_nonzero(e);
         }
     }
     Ok(SolutionSet::Parametric(gb))
@@ -1553,5 +1930,321 @@ mod tests {
         let yv = eval_interp(sols[0][1], &env, &pool).expect("eval y");
         assert!((xv - 2.0).abs() < 1e-10);
         assert!((yv - 2.0).abs() < 1e-10);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rational equations: clearing denominators, and taking the excess back out
+    // -----------------------------------------------------------------------
+
+    /// `a − b` as an expression.
+    fn minus(a: ExprId, b: ExprId, pool: &ExprPool) -> ExprId {
+        pool.add(vec![a, pool.mul(vec![pool.integer(-1_i32), b])])
+    }
+
+    /// `a / b` written the way a caller writes it: `a · b⁻¹`.
+    fn over(a: ExprId, b: ExprId, pool: &ExprPool) -> ExprId {
+        pool.mul(vec![a, pool.pow(b, pool.integer(-1_i32))])
+    }
+
+    /// The RC divider in the form nodal analysis produces it. Solving it at all
+    /// is the point: this was `E-SOLVE-001` until rational equations were
+    /// accepted, and the caller had to clear `1/R1` by hand.
+    #[test]
+    fn rc_divider_solves_in_admittance_form() {
+        let pool = ExprPool::new();
+        let vo = pool.symbol("Vo", Domain::Real);
+        let vin = pool.symbol("Vin", Domain::Real);
+        let r1 = pool.symbol("R1", Domain::Real);
+        let c = pool.symbol("C", Domain::Real);
+        let s = pool.symbol("s", Domain::Real);
+
+        // (Vo − Vin)/R1 + Vo·s·C = 0
+        let eq = pool.add(vec![
+            over(minus(vo, vin, &pool), r1, &pool),
+            pool.mul(vec![vo, s, c]),
+        ]);
+        let SolutionSet::Finite(sols) = solve_polynomial_system(vec![eq], vec![vo], &pool).unwrap()
+        else {
+            panic!("expected a finite solution set");
+        };
+        assert_eq!(sols.len(), 1);
+
+        // Vo = Vin/(1 + s·R1·C).  At Vin = 1, s = 7, R1 = 2, C = 5 that is 1/71.
+        let env: HashMap<ExprId, f64> = [(vin, 1.0), (s, 7.0), (r1, 2.0), (c, 5.0)]
+            .into_iter()
+            .collect();
+        let got = eval_interp(sols[0][0], &env, &pool).expect("numeric value");
+        assert!((got - 1.0 / 71.0).abs() < 1e-12, "got {got}");
+
+        // The answer holds for R1 ≠ 0, and says so.
+        let conds = take_solve_side_conditions();
+        assert!(
+            conds.contains(&crate::deriv::log::SideCondition::NonZero(r1)),
+            "the cleared denominator R1 must be reported: {conds:?}"
+        );
+    }
+
+    /// A resistance declared positive settles its own non-vanishing, so the
+    /// hypothesis is discharged rather than reported.
+    #[test]
+    fn a_positive_denominator_needs_no_hypothesis() {
+        let pool = ExprPool::new();
+        let vo = pool.symbol("Vo", Domain::Real);
+        let vin = pool.symbol("Vin", Domain::Real);
+        let r1 = pool.symbol("R1", Domain::Positive);
+        let c = pool.symbol("C", Domain::Real);
+        let s = pool.symbol("s", Domain::Real);
+        let eq = pool.add(vec![
+            over(minus(vo, vin, &pool), r1, &pool),
+            pool.mul(vec![vo, s, c]),
+        ]);
+        let SolutionSet::Finite(sols) = solve_polynomial_system(vec![eq], vec![vo], &pool).unwrap()
+        else {
+            panic!("expected a finite solution set");
+        };
+        assert_eq!(sols.len(), 1);
+        let conds = take_solve_side_conditions();
+        assert!(
+            !conds.contains(&crate::deriv::log::SideCondition::NonZero(r1)),
+            "R1 > 0 already excludes R1 = 0: {conds:?}"
+        );
+    }
+
+    /// Two-node modified nodal analysis: two rational equations, two unknowns,
+    /// five symbolic parameters.
+    #[test]
+    fn two_node_mna_system() {
+        let pool = ExprPool::new();
+        let v1 = pool.symbol("V1", Domain::Real);
+        let v2 = pool.symbol("V2", Domain::Real);
+        let vin = pool.symbol("Vin", Domain::Real);
+        let r1 = pool.symbol("R1", Domain::Real);
+        let r2 = pool.symbol("R2", Domain::Real);
+        let c = pool.symbol("C", Domain::Real);
+        let s = pool.symbol("s", Domain::Real);
+
+        // (V1 − Vin)/R1 + (V1 − V2)/R2 = 0
+        let node1 = pool.add(vec![
+            over(minus(v1, vin, &pool), r1, &pool),
+            over(minus(v1, v2, &pool), r2, &pool),
+        ]);
+        // (V2 − V1)/R2 + V2·s·C = 0
+        let node2 = pool.add(vec![
+            over(minus(v2, v1, &pool), r2, &pool),
+            pool.mul(vec![v2, s, c]),
+        ]);
+
+        let SolutionSet::Finite(sols) =
+            solve_polynomial_system(vec![node1, node2], vec![v1, v2], &pool).unwrap()
+        else {
+            panic!("expected a finite solution set");
+        };
+        assert_eq!(sols.len(), 1);
+
+        // V2 = Vin/(1 + s·C·(R1+R2)) and V1 = V2·(1 + s·C·R2).
+        // Vin = 1, R1 = 2, R2 = 3, C = 5, s = 7  →  V2 = 1/176, V1 = 53/88.
+        let env: HashMap<ExprId, f64> = [(vin, 1.0), (r1, 2.0), (r2, 3.0), (c, 5.0), (s, 7.0)]
+            .into_iter()
+            .collect();
+        let got1 = eval_interp(sols[0][0], &env, &pool).expect("V1");
+        let got2 = eval_interp(sols[0][1], &env, &pool).expect("V2");
+        assert!((got1 - 53.0 / 88.0).abs() < 1e-12, "V1 = {got1}");
+        assert!((got2 - 1.0 / 176.0).abs() < 1e-12, "V2 = {got2}");
+
+        let conds = take_solve_side_conditions();
+        assert!(
+            !conds.is_empty(),
+            "R1 and R2 were divided by; that has to be visible"
+        );
+    }
+
+    /// `x/(x−1) = 1/(x−1)` clears to `(x−1)² = 0`. Its root `x = 1` is exactly
+    /// where the original equation reads `1/0 = 1/0`, so it is **not** a
+    /// solution — returning it would be a wrong answer, not a rough edge.
+    #[test]
+    fn a_root_that_kills_the_denominator_is_not_returned() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let xm1 = minus(x, pool.integer(1_i32), &pool);
+        let eq = minus(
+            over(x, xm1, &pool),
+            over(pool.integer(1_i32), xm1, &pool),
+            &pool,
+        );
+        match solve_polynomial_system(vec![eq], vec![x], &pool).unwrap() {
+            SolutionSet::Finite(sols) => assert!(
+                sols.is_empty(),
+                "x = 1 is a pole of both sides, not a solution: {sols:?}"
+            ),
+            SolutionSet::NoSolution => {}
+            SolutionSet::Parametric(_) => panic!("expected a decided answer"),
+        }
+    }
+
+    /// `1/x = 0` has no solution. Not `x = ∞`, and not the `x = 0` a careless
+    /// cancellation would produce.
+    #[test]
+    fn a_reciprocal_is_never_zero() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let eq = pool.pow(x, pool.integer(-1_i32));
+        match solve_polynomial_system(vec![eq], vec![x], &pool).unwrap() {
+            SolutionSet::NoSolution => {}
+            SolutionSet::Finite(sols) => {
+                assert!(sols.is_empty(), "1/x = 0 has no solution: {sols:?}")
+            }
+            SolutionSet::Parametric(_) => panic!("expected a decided answer"),
+        }
+    }
+
+    /// `x²/x = 0` is the case reducing to lowest terms gets wrong: cancelling
+    /// gives `x = 0`, but the original expression is `0/0` there.
+    #[test]
+    fn a_removable_singularity_is_still_not_a_solution() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let eq = over(pool.pow(x, pool.integer(2_i32)), x, &pool);
+        match solve_polynomial_system(vec![eq], vec![x], &pool).unwrap() {
+            SolutionSet::Finite(sols) => {
+                assert!(sols.is_empty(), "x = 0 makes it read 0/0: {sols:?}")
+            }
+            SolutionSet::NoSolution => {}
+            SolutionSet::Parametric(_) => panic!("expected a decided answer"),
+        }
+    }
+
+    /// `1/(1/x − 1) = 0` has no solution, and the reason is the one a "product
+    /// of the denominators" reading loses.
+    ///
+    /// The reciprocal swaps the halves — `(n/d)⁻¹ = d/n` — so the inner
+    /// denominator `x` becomes the outer *numerator* and the requirement
+    /// `x ≠ 0` leaves the denominator product entirely. What is left, `1 − x`,
+    /// is perfectly non-zero at `x = 0`, so the cleared numerator's only root
+    /// sails through and `x = 0` comes back as a solution of an equation that
+    /// has no value there.
+    #[test]
+    fn a_condition_hidden_by_a_reciprocal_is_not_lost() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let inner = minus(
+            pool.pow(x, pool.integer(-1_i32)),
+            pool.integer(1_i32),
+            &pool,
+        );
+        let eq = pool.pow(inner, pool.integer(-1_i32));
+        match solve_polynomial_system(vec![eq], vec![x], &pool).unwrap() {
+            SolutionSet::Finite(sols) => assert!(
+                sols.is_empty(),
+                "1/x is undefined at x = 0, so the whole equation is: {sols:?}"
+            ),
+            SolutionSet::NoSolution => {}
+            SolutionSet::Parametric(_) => panic!("expected a decided answer"),
+        }
+    }
+
+    /// One equation's root is another's pole: the system has no solution even
+    /// though the cleared numerator system has a perfectly good one.
+    #[test]
+    fn a_pole_of_a_sibling_equation_excludes_the_root() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let y = pool.symbol("y", Domain::Real);
+        let one = pool.integer(1_i32);
+        let ym1 = minus(y, one, &pool);
+        // (x − 1)/(y − 1) = 0,  y − 1 = 0
+        let eq1 = over(minus(x, one, &pool), ym1, &pool);
+        match solve_polynomial_system(vec![eq1, ym1], vec![x, y], &pool).unwrap() {
+            SolutionSet::Finite(sols) => assert!(
+                sols.is_empty(),
+                "(1,1) is a pole of the first equation: {sols:?}"
+            ),
+            SolutionSet::NoSolution => {}
+            SolutionSet::Parametric(_) => panic!("expected a decided answer"),
+        }
+    }
+
+    /// A rational equation whose roots are genuine keeps all of them; the pole
+    /// it does have is simply not one of them.
+    #[test]
+    fn genuine_roots_of_a_rational_equation_survive() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let one = pool.integer(1_i32);
+        // (x² − 4)/(x − 1) = 0  →  x = ±2
+        let num = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-4_i32)]);
+        let eq = over(num, minus(x, one, &pool), &pool);
+        let SolutionSet::Finite(sols) = solve_polynomial_system(vec![eq], vec![x], &pool).unwrap()
+        else {
+            panic!("expected a finite solution set");
+        };
+        assert_eq!(sols.len(), 2);
+        let mut vals: Vec<f64> = sols.iter().map(|s| eval_no_env(s[0], &pool)).collect();
+        vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert!((vals[0] + 2.0).abs() < 1e-10 && (vals[1] - 2.0).abs() < 1e-10);
+        // No parameter is involved, so nothing had to be assumed.
+        assert!(take_solve_side_conditions().is_empty());
+    }
+
+    /// Widening to rational functions must not widen to transcendental ones:
+    /// `exp(x) − 2` keeps refusing, with the code it always had.
+    #[test]
+    fn a_transcendental_still_refuses_with_its_own_code() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let eq = pool.add(vec![pool.func("exp", vec![x]), pool.integer(-2_i32)]);
+        let Err(err) = solve_polynomial_system(vec![eq], vec![x], &pool) else {
+            panic!("a transcendental must not be solved by the polynomial path");
+        };
+        assert!(matches!(err, SolverError::NotPolynomial(_)), "{err}");
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-SOLVE-001");
+    }
+
+    /// An equation whose denominator is identically zero denotes no function;
+    /// clearing it would multiply by zero and make every point a "solution".
+    #[test]
+    fn an_everywhere_undefined_equation_is_refused() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let zero = minus(x, x, &pool);
+        let eq = pool.pow(zero, pool.integer(-1_i32));
+        let Err(err) = solve_polynomial_system(vec![eq], vec![x], &pool) else {
+            panic!("an everywhere-undefined equation must not be solved");
+        };
+        assert!(matches!(err, SolverError::NotPolynomial(_)), "{err}");
+        let refusal = take_undefined_equation().expect("refusal recorded out of band");
+        assert_eq!(crate::errors::AlkahestError::code(&refusal), "E-SOLVE-005");
+    }
+
+    /// A genuinely transcendental refusal must never be re-attributed to the
+    /// undefined-equation carrier left behind by an earlier call.
+    #[test]
+    fn an_undefined_equation_refusal_does_not_leak_into_the_next_solve() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let zero = minus(x, x, &pool);
+        let bad = pool.pow(zero, pool.integer(-1_i32));
+        assert!(solve_polynomial_system(vec![bad], vec![x], &pool).is_err());
+
+        let trans = pool.add(vec![pool.func("exp", vec![x]), pool.integer(-2_i32)]);
+        assert!(solve_polynomial_system(vec![trans], vec![x], &pool).is_err());
+        assert!(
+            take_undefined_equation().is_none(),
+            "exp(x) − 2 is not an undefined equation"
+        );
+    }
+
+    /// Polynomial input takes exactly the path it always did: no denominator,
+    /// no exclusion step, no hypothesis invented.
+    #[test]
+    fn polynomial_input_records_no_denominator_hypothesis() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let eq = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-4_i32)]);
+        let SolutionSet::Finite(sols) = solve_polynomial_system(vec![eq], vec![x], &pool).unwrap()
+        else {
+            panic!("expected a finite solution set");
+        };
+        assert_eq!(sols.len(), 2);
+        assert!(take_solve_side_conditions().is_empty());
     }
 }

--- a/alkahest-core/src/solver/rational.rs
+++ b/alkahest-core/src/solver/rational.rs
@@ -1,0 +1,451 @@
+//! Clearing denominators: turning a **rational**-function equation into the
+//! polynomial numerator the Gröbner solver can take, plus the condition that
+//! says where that numerator is allowed to speak for it.
+//!
+//! Every admittance equation in circuit analysis has the shape `(V₁ − V₂)/R`
+//! or `V/(s·L)`, so refusing anything with a negative exponent refuses symbolic
+//! nodal analysis outright.  Multiplying up is easy; the part that has to be
+//! got right is that **it is not an equivalence**:
+//!
+//! ```text
+//!     N(x)/D(x) = 0     ⟺     N(x) = 0  ∧  D(x) ≠ 0
+//! ```
+//!
+//! The right-hand conjunct is dropped by the multiplication, and a root of `N`
+//! at which the equation is undefined is *not* a solution of it.
+//! `x/(x−1) = 1/(x−1)` clears to `(x−1)² = 0`, whose only root `x = 1` is
+//! precisely the point where the original equation reads `1/0 = 1/0`.
+//! Returning it would be a wrong answer, not a cosmetic one, so
+//! [`super::exclude_pole_roots`] removes it again downstream, using the
+//! `domain` polynomial this module returns alongside the numerator.
+//!
+//! # The domain polynomial, and why it is not "the denominator"
+//!
+//! The obvious candidate — the product of the denominators multiplied through —
+//! is **wrong**, and wrong in the direction that returns a spurious root.  A
+//! reciprocal swaps the two halves: `(n/d)⁻¹ = d/n`, so an inner *denominator*
+//! becomes an outer *numerator* and drops out of the product entirely.  In
+//! `1/(1/x − 1)` the requirement `x ≠ 0` disappears exactly that way, leaving
+//! `1 − x` as the only recorded condition and `x = 0` — a point where the
+//! expression has no value — looking like a solution.
+//!
+//! So what is carried is the **domain**: the product of everything that has to
+//! be non-zero for the expression to denote a number at all, accumulated
+//! through the recursion with
+//!
+//! ```text
+//!     rec(e) = (n, d, dom)   such that   dom(p) ≠ 0  ⟹  e is defined at p,
+//!                                                       d(p) ≠ 0,
+//!                                                       and e(p) = n(p)/d(p)
+//! ```
+//!
+//! and the one rule that adds to `dom` is the negative power: `(n/d)^−k`
+//! requires `n ≠ 0` on top of whatever the base already required.  For
+//! `1/(1/x − 1)` that yields `dom = x·(1 − x)`, which is precisely the pair of
+//! points the expression is undefined at.
+//!
+//! # Why nothing is reduced to lowest terms
+//!
+//! Cancelling `N/D` is tempting and is *not* sound on its own.  Writing
+//! `D = g·D′` and `N = g·N′`, the original solution set is
+//! `{N′ = 0} ∩ {g ≠ 0} ∩ {D′ ≠ 0}`, while the reduced one is
+//! `{N′ = 0} ∩ {D′ ≠ 0}` — larger by exactly the removable singularities that
+//! happen to be zeros of `N′`.  `x²/x = 0` is the smallest example: cancelling
+//! gives `x = 0`, but the original expression is `0/0` there and the equation
+//! has no solution at all.  Keeping `dom` uncancelled keeps that conjunct
+//! available.
+
+use super::SolverError;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::poly::groebner::GbPoly;
+use rug::Rational;
+use std::collections::BTreeMap;
+
+/// One equation rewritten as `numer = 0`, valid where `domain ≠ 0`.
+///
+/// Both polynomials are over the solver's full indeterminate list (unknowns
+/// followed by parameters).  `domain` is never the zero polynomial: an equation
+/// that is undefined everywhere is refused before this is built.
+#[derive(Debug, Clone)]
+pub(crate) struct ClearedEquation {
+    /// The numerator — what the Gröbner solver is actually given.
+    pub numer: GbPoly,
+    /// Everything that has to be non-zero for the equation to have a value,
+    /// as one product and **not** reduced against `numer`.  A candidate root at
+    /// which this vanishes is not a solution of the equation the caller wrote.
+    pub domain: GbPoly,
+}
+
+impl ClearedEquation {
+    /// True when nothing was multiplied through — the input was already a
+    /// polynomial, is defined everywhere, and no exclusion step is owed.
+    pub fn is_polynomial(&self) -> bool {
+        is_one(&self.domain)
+    }
+}
+
+/// Is `p` the constant polynomial `1`?
+fn is_one(p: &GbPoly) -> bool {
+    p.terms.len() == 1
+        && p.terms
+            .iter()
+            .all(|(exp, c)| exp.iter().all(|&e| e == 0) && *c == 1)
+}
+
+/// Put `expr` over a common denominator as polynomials in `vars`.
+///
+/// `vars` is the solver's full indeterminate list: unknowns first, then the
+/// free parameters.  Anything that is still not polynomial once the division
+/// nodes have been accounted for — `exp(x)`, a symbolic exponent, a symbol
+/// absent from `vars` — is refused with the same
+/// [`SolverError::NotPolynomial`] the polynomial-only conversion raised, so a
+/// transcendental input keeps its existing verdict and its existing code.
+pub(crate) fn clear_denominators(
+    expr: ExprId,
+    vars: &[ExprId],
+    pool: &ExprPool,
+) -> Result<ClearedEquation, SolverError> {
+    let n = vars.len();
+    let (numer, _denom, domain) = rec(expr, vars, n, pool)?;
+    Ok(ClearedEquation { numer, domain })
+}
+
+/// `(numerator, denominator, domain)` of `expr`, maintaining the invariant
+/// stated in the module documentation: wherever `domain` is non-zero, `expr` is
+/// defined, `denominator` is non-zero, and `expr = numerator / denominator`.
+///
+/// Neither `denominator` nor `domain` is ever the zero polynomial — the only
+/// way either could become one is a negative power of an identically-zero base,
+/// which is refused.
+fn rec(
+    expr: ExprId,
+    vars: &[ExprId],
+    n_vars: usize,
+    pool: &ExprPool,
+) -> Result<(GbPoly, GbPoly, GbPoly), SolverError> {
+    let one = || GbPoly::constant(Rational::from(1), n_vars);
+
+    if let Some(idx) = vars.iter().position(|&v| v == expr) {
+        let mut exp = vec![0u32; n_vars];
+        exp[idx] = 1;
+        let mut terms = BTreeMap::new();
+        terms.insert(exp, Rational::from(1));
+        return Ok((GbPoly { terms, n_vars }, one(), one()));
+    }
+
+    enum Node {
+        IntConst(rug::Integer),
+        RatConst(Rational),
+        FloatConst(f64),
+        FreeSymbol(String),
+        Add(Vec<ExprId>),
+        Mul(Vec<ExprId>),
+        Pow(ExprId, ExprId),
+        Func(String),
+        Other,
+    }
+
+    let node = pool.with(expr, |data| match data {
+        ExprData::Integer(n) => Node::IntConst(n.0.clone()),
+        ExprData::Rational(r) => Node::RatConst(r.0.clone()),
+        ExprData::Float(f) => Node::FloatConst(f.inner.to_f64()),
+        ExprData::Symbol { name, .. } => Node::FreeSymbol(name.clone()),
+        ExprData::Add(args) => Node::Add(args.clone()),
+        ExprData::Mul(args) => Node::Mul(args.clone()),
+        ExprData::Pow { base, exp } => Node::Pow(*base, *exp),
+        ExprData::Func { name, .. } => Node::Func(name.clone()),
+        _ => Node::Other,
+    });
+
+    match node {
+        Node::IntConst(n) => Ok((GbPoly::constant(Rational::from(n), n_vars), one(), one())),
+        Node::RatConst(r) => Ok((GbPoly::constant(r, n_vars), one(), one())),
+        Node::FloatConst(v) => {
+            let r = Rational::from_f64(v).unwrap_or_else(|| Rational::from(0));
+            Ok((GbPoly::constant(r, n_vars), one(), one()))
+        }
+        Node::FreeSymbol(name) => Err(SolverError::NotPolynomial(format!(
+            "free symbol '{name}' not in variable list"
+        ))),
+        Node::Add(args) => {
+            // `n₁/d₁ + n₂/d₂ = (n₁·d₂ + n₂·d₁)/(d₁·d₂)`, left-folded.  A sum is
+            // defined exactly where both summands are, so the domains multiply
+            // and nothing new is required.
+            //
+            // The `is_one` guards are not micro-optimisation: without them a
+            // purely polynomial equation would pay several full polynomial
+            // multiplications by the constant `1` per summand, which is a cost
+            // the polynomial path never used to have.
+            let mut num = GbPoly::zero(n_vars);
+            let mut den = one();
+            let mut dom = one();
+            for a in args {
+                let (n2, d2, dom2) = rec(a, vars, n_vars, pool)?;
+                let scaled = if is_one(&den) { n2 } else { n2.mul(&den) };
+                num = if is_one(&d2) { num } else { num.mul(&d2) }.add(&scaled);
+                if !is_one(&d2) {
+                    den = den.mul(&d2);
+                }
+                dom = combine_domains(dom, dom2);
+            }
+            Ok((num, den, dom))
+        }
+        Node::Mul(args) => {
+            let mut num = one();
+            let mut den = one();
+            let mut dom = one();
+            for a in args {
+                let (n2, d2, dom2) = rec(a, vars, n_vars, pool)?;
+                num = num.mul(&n2);
+                if !is_one(&d2) {
+                    den = den.mul(&d2);
+                }
+                dom = combine_domains(dom, dom2);
+            }
+            Ok((num, den, dom))
+        }
+        Node::Pow(base, exp_id) => {
+            let exp_node = pool.with(exp_id, |d| match d {
+                ExprData::Integer(n) => Some(n.0.clone()),
+                _ => None,
+            });
+            let Some(n) = exp_node else {
+                return Err(SolverError::NotPolynomial(
+                    "symbolic or non-integer exponent".to_string(),
+                ));
+            };
+            // Exponent vectors are `u32`. Expanding past that range would wrap
+            // in a release build — silently returning a polynomial that is not
+            // the input's — so refuse instead. Nothing computable is excluded:
+            // a single term of degree 2³² is already far past what any Gröbner
+            // basis over these polynomials could be asked to do.
+            let too_wide = "integer exponent too large to expand";
+            let Some(n_val) = n.to_i64() else {
+                return Err(SolverError::NotPolynomial(too_wide.to_string()));
+            };
+            if u32::try_from(n_val.unsigned_abs()).is_err() {
+                return Err(SolverError::NotPolynomial(too_wide.to_string()));
+            }
+            let (bn, bd, bdom) = rec(base, vars, n_vars, pool)?;
+            if n_val >= 0 {
+                // A non-negative power is defined wherever its base is.
+                let k = n_val as u64;
+                let den = if is_one(&bd) { bd } else { pow_poly(&bd, k) };
+                Ok((pow_poly(&bn, k), den, bdom))
+            } else {
+                // `(n/d)^−k = d^k / n^k`: the base's numerator becomes the
+                // denominator, so `n ≠ 0` joins the domain — this is the only
+                // rule that adds to it, and the one the "product of the
+                // denominators" reading gets wrong.  A base that is identically
+                // zero makes the equation undefined everywhere rather than
+                // merely non-polynomial.
+                if bn.is_zero() {
+                    return Err(super::refuse_undefined_equation(
+                        "a denominator is identically zero",
+                    ));
+                }
+                let k = n_val.unsigned_abs();
+                let dom = combine_domains(bdom, bn.clone());
+                Ok((pow_poly(&bd, k), pow_poly(&bn, k), dom))
+            }
+        }
+        Node::Func(name) => Err(SolverError::NotPolynomial(format!(
+            "function '{name}' is not a polynomial"
+        ))),
+        Node::Other => Err(SolverError::NotPolynomial(
+            "unsupported expression node".to_string(),
+        )),
+    }
+}
+
+/// `a·b`, skipping the multiplication when either side is the constant `1`.
+///
+/// Two conditions hold together exactly when their product is non-zero, so a
+/// domain is one polynomial rather than a list — there is no way for a nested
+/// requirement to be dropped on the way up.
+fn combine_domains(a: GbPoly, b: GbPoly) -> GbPoly {
+    if is_one(&b) {
+        a
+    } else if is_one(&a) {
+        b
+    } else {
+        a.mul(&b)
+    }
+}
+
+/// `p^k` by binary exponentiation.
+fn pow_poly(p: &GbPoly, k: u64) -> GbPoly {
+    let mut result = GbPoly::constant(Rational::from(1), p.n_vars);
+    let mut cur = p.clone();
+    let mut rem = k;
+    while rem > 0 {
+        if rem & 1 == 1 {
+            result = result.mul(&cur);
+        }
+        rem >>= 1;
+        if rem > 0 {
+            let cur2 = cur.clone();
+            cur = cur.mul(&cur2);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+    use crate::solver::expr_to_gbpoly;
+
+    /// `terms` of the polynomial `expr` denotes, for comparing against a
+    /// numerator or a domain without going through a display form.
+    fn poly(expr: ExprId, vars: &[ExprId], pool: &ExprPool) -> BTreeMap<Vec<u32>, Rational> {
+        expr_to_gbpoly(expr, vars, pool).unwrap().terms
+    }
+
+    /// `clear_denominators` agrees with the polynomial-only conversion on
+    /// polynomial input, and reports that nothing was cleared.
+    #[test]
+    fn a_polynomial_clears_to_itself_over_one() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.add(vec![pool.pow(x, pool.integer(2_i32)), pool.integer(-1_i32)]);
+        let c = clear_denominators(e, &[x], &pool).unwrap();
+        assert!(c.is_polynomial(), "no denominator was introduced");
+        assert_eq!(c.numer.terms, poly(e, &[x], &pool));
+    }
+
+    #[test]
+    fn reciprocal_moves_to_the_denominator() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.pow(x, pool.integer(-1_i32));
+        let c = clear_denominators(e, &[x], &pool).unwrap();
+        assert!(!c.is_polynomial());
+        assert_eq!(c.numer.terms, poly(pool.integer(1_i32), &[x], &pool));
+        assert_eq!(c.domain.terms, poly(x, &[x], &pool));
+    }
+
+    /// A reciprocal swaps numerator and denominator, so an inner denominator
+    /// becomes an outer numerator and would vanish from any "product of the
+    /// denominators" bookkeeping.  `1/(1/x − 1)` is undefined at `x = 0` *and*
+    /// at `x = 1`, and the domain has to name both — the first is the one a
+    /// denominator product loses, and losing it hands back `x = 0` as a root.
+    #[test]
+    fn a_reciprocal_of_a_quotient_keeps_the_inner_condition() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let inner = pool.add(vec![
+            pool.pow(x, pool.integer(-1_i32)),
+            pool.integer(-1_i32),
+        ]);
+        let c = clear_denominators(pool.pow(inner, pool.integer(-1_i32)), &[x], &pool).unwrap();
+        // numerator x, domain x·(1 − x)
+        assert_eq!(c.numer.terms, poly(x, &[x], &pool));
+        let one_minus_x = pool.add(vec![
+            pool.integer(1_i32),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        let expected = pool.mul(vec![x, one_minus_x]);
+        assert_eq!(c.domain.terms, poly(expected, &[x], &pool));
+    }
+
+    /// A zeroth power of an undefined base is still undefined: `(1/x)^0` says
+    /// nothing about `x = 0`, but the expression does not denote a number there.
+    #[test]
+    fn a_zeroth_power_does_not_erase_its_bases_domain() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let recip = pool.pow(x, pool.integer(-1_i32));
+        let c = clear_denominators(pool.pow(recip, pool.integer(0_i32)), &[x], &pool).unwrap();
+        assert!(!c.is_polynomial(), "x ≠ 0 is still required");
+        assert_eq!(c.domain.terms, poly(x, &[x], &pool));
+    }
+
+    /// The domain is deliberately **not** reduced against the numerator:
+    /// `x²/x` must keep `x` as an exclusion condition, or `x = 0` comes back as
+    /// a solution of an equation that reads `0/0` there.
+    #[test]
+    fn a_removable_singularity_is_still_a_domain_condition() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.mul(vec![
+            pool.pow(x, pool.integer(2_i32)),
+            pool.pow(x, pool.integer(-1_i32)),
+        ]);
+        let c = clear_denominators(e, &[x], &pool).unwrap();
+        let x2 = pool.pow(x, pool.integer(2_i32));
+        assert_eq!(c.numer.terms, poly(x2, &[x], &pool));
+        assert_eq!(c.domain.terms, poly(x, &[x], &pool));
+    }
+
+    /// `x/(x−1) − 1/(x−1)` clears to the numerator `(x−1)²` with the domain
+    /// `(x−1)²`: both the spurious root and the condition that refutes it are
+    /// present.
+    #[test]
+    fn a_common_denominator_survives_in_both_halves() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let xm1 = pool.add(vec![x, pool.integer(-1_i32)]);
+        let inv = pool.pow(xm1, pool.integer(-1_i32));
+        let e = pool.add(vec![
+            pool.mul(vec![x, inv]),
+            pool.mul(vec![pool.integer(-1_i32), inv]),
+        ]);
+        let c = clear_denominators(e, &[x], &pool).unwrap();
+        let sq = pool.pow(xm1, pool.integer(2_i32));
+        let expected = poly(sq, &[x], &pool);
+        assert_eq!(c.numer.terms, expected);
+        assert_eq!(c.domain.terms, expected);
+    }
+
+    #[test]
+    fn a_transcendental_keeps_its_refusal() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let e = pool.add(vec![pool.func("exp", vec![x]), pool.integer(-2_i32)]);
+        let err = clear_denominators(e, &[x], &pool).unwrap_err();
+        assert!(matches!(err, SolverError::NotPolynomial(_)), "{err}");
+        assert_eq!(
+            err.to_string(),
+            "not a polynomial: function 'exp' is not a polynomial"
+        );
+        assert_eq!(crate::errors::AlkahestError::code(&err), "E-SOLVE-001");
+    }
+
+    /// An exponent past the `u32` exponent-vector range must refuse, not wrap:
+    /// a wrapped exponent is a different polynomial wearing the input's name.
+    #[test]
+    fn an_exponent_wider_than_the_exponent_vector_is_refused() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        for e in [5_000_000_000_i64, -5_000_000_000_i64] {
+            let expr = pool.pow(x, pool.integer(e));
+            let err = clear_denominators(expr, &[x], &pool).unwrap_err();
+            assert!(matches!(err, SolverError::NotPolynomial(_)), "{err}");
+            assert!(err.to_string().contains("too large"), "{err}");
+        }
+        // The ordinary range is untouched.
+        let ok = pool.pow(x, pool.integer(-3_i32));
+        assert!(clear_denominators(ok, &[x], &pool).is_ok());
+    }
+
+    #[test]
+    fn an_identically_zero_denominator_is_refused() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // 1/(x − x)
+        let zero = pool.add(vec![x, pool.mul(vec![pool.integer(-1_i32), x])]);
+        let e = pool.pow(zero, pool.integer(-1_i32));
+        let err = clear_denominators(e, &[x], &pool).unwrap_err();
+        // The refusal travels inside `NotPolynomial` (the enum is public and
+        // exhaustive) and carries its own code out of band.
+        assert!(matches!(err, SolverError::NotPolynomial(_)), "{err}");
+        let refusal = crate::solver::take_undefined_equation().expect("refusal recorded");
+        assert_eq!(crate::errors::AlkahestError::code(&refusal), "E-SOLVE-005");
+        assert!(
+            crate::solver::take_undefined_equation().is_none(),
+            "consuming"
+        );
+    }
+}

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -14877,7 +14877,29 @@ fn py_solve_numerical(
 
 /// `alkahest.solve(equations, vars, *, numeric=False, method="groebner")`
 ///
-/// Solve a zero-dimensional polynomial system.
+/// Solve a zero-dimensional polynomial — or **rational** — system.
+///
+/// Rational equations
+/// ------------------
+/// An equation may be a ratio of polynomials in *vars*, which is the form nodal
+/// analysis produces: ``solve([(Vo - Vin)/R1 + Vo*s*C], [Vo])`` →
+/// ``Vin/(1 + s*R1*C)``. Each equation is put over a common denominator and the
+/// numerator system is solved.
+///
+/// Clearing a denominator is **not** an equivalence — ``N/D = 0`` means
+/// ``N = 0 and D != 0`` — so every root is re-tested against the denominators
+/// that were multiplied through, and one that makes any of them vanish is
+/// dropped: ``solve([x/(x-1) - 1/(x-1)], [x])`` returns ``[]``, not ``x = 1``.
+/// Where the denominator still mentions a free parameter the question is not
+/// decidable, and the root is returned under a ``D != 0`` hypothesis listed by
+/// :func:`alkahest.solve_side_conditions` rather than under a silent assumption.
+/// Surviving roots are also substituted into the equations **as you wrote
+/// them**, before anything was cleared.
+///
+/// An equation whose denominator is identically zero (``1/(x - x)``) denotes no
+/// function at all and raises ``SolverError`` with ``.code == "E-SOLVE-005"``.
+/// Transcendental equations outside the closed-form slice keep refusing with
+/// ``E-SOLVE-001``.
 ///
 /// Parameters
 /// ----------
@@ -15077,6 +15099,15 @@ fn capture_solve_side_conditions(pool: &alkahest_core::ExprPool) {
 /// **assumed** in order to return the solutions it did — one string per
 /// condition, e.g. ``"a ≠ 0"``.
 ///
+/// Two things land here. A leading coefficient the back-substitution divided by
+/// without being able to decide it, and — for a rational equation — a
+/// denominator that was cleared and whose vanishing at the returned root could
+/// not be decided either. ``solve([(Vo - Vin)/R1 + Vo*s*C], [Vo])`` lists
+/// ``R1 ≠ 0``: at ``R1 = 0`` the equation you wrote has no value at all, so the
+/// answer is the answer *for* ``R1 ≠ 0``. Declaring the symbol positive
+/// (``pool.symbol("R1", "positive")``) discharges that condition instead of
+/// reporting it.
+///
 /// ``solve([a*x - b], [x])`` returns ``b/a``, which is the solution *for
 /// ``a ≠ 0``*: at ``a = 0`` the equation reads ``-b = 0``, so there is either no
 /// solution (``b ≠ 0``) or every ``x`` (``b = 0``), and neither of those is
@@ -15114,6 +15145,17 @@ fn finite_solutions_to_py(
     match result {
         Err(e) => Python::with_gil(|py2| {
             let exc_type = py2.get_type_bound::<PySolverError>();
+            // An equation whose denominator is identically zero is reported as
+            // `NotPolynomial` (the enum is public and exhaustive) with the real
+            // reason recorded out of band — the same arrangement `triangularize`
+            // uses for `E-SOLVE-004`. Recover it so the refusal raises its own
+            // `E-SOLVE-005` instead of `E-SOLVE-001`, which means something else:
+            // a well-defined equation that is merely not rational in the unknowns.
+            if matches!(e, alkahest_core::SolverError::NotPolynomial(_)) {
+                if let Some(r) = alkahest_core::solver::take_undefined_equation() {
+                    return Err(make_structured_err(py2, &exc_type, &r));
+                }
+            }
             Err(make_structured_err(py2, &exc_type, &e))
         }),
         Ok(SolutionSet::NoSolution) => Ok(pyo3::types::PyList::empty_bound(py).into()),

--- a/alkahest-skill/alkahest.md
+++ b/alkahest-skill/alkahest.md
@@ -597,6 +597,25 @@ for s in solutions:
 # Certified enclosures / residuals: solve_numerical(eqs, vars, ...)
 ```
 
+**Rational equations** (`method="groebner"` only). Equations may be ratios of
+polynomials in the unknowns, which is the form nodal analysis produces — no need to
+clear `1/R` by hand:
+
+```python
+solve([(Vo - Vin)/R1 + Vo*s*C], [Vo])     # → [{Vo: Vin*(1 + R1*C*s)**-1}]
+alkahest.solve_side_conditions()          # → ['(1 + (R1 * C * s)) ≠ 0', 'R1 ≠ 0']
+```
+
+Clearing a denominator is not an equivalence — `N/D = 0` means `N = 0 and D != 0` — so
+roots at a pole are excluded again: `solve([x/(x-1) - 1/(x-1)], [x])` is `[]`, not
+`x = 1`; `solve([1/x], [x])` is `[]`; `solve([x*x/x], [x])` is `[]` (`0/0` at `x = 0`);
+and `solve([1/(1/x - 1)], [x])` is `[]` (`1/x` has no value at `x = 0`). Where the
+condition still mentions a free parameter the question is undecidable and the root is
+returned under a `≠ 0` hypothesis listed by `solve_side_conditions()` — read it, and
+treat an unstated condition as absent rather than assumed. `1/(x - x)` raises
+`E-SOLVE-005`. `method="homotopy"` and `solve_numerical` remain polynomial-only
+(`E-SOLVE-001`).
+
 ### Coefficient fields for elimination: `Q(params)` (M9, experimental)
 
 `GroebnerBasis.compute(polys, vars, params=[...])` puts the listed symbols in the **coefficient field** instead of the ring — they never enter the monomial order or generate S-pairs. This is the difference between eliminating states from `Q[states, Y, params]` and `Q(params)[states, Y]`: for a differential-elimination / structural-identifiability problem (states eliminated from an ODE model's jet equations, rate constants left symbolic), the parametric route can be an order of magnitude faster and produce far fewer basis generators than treating the parameters as ring variables — see `docs/mdbook/src/solving.md` for measured numbers on a worked example.

--- a/docs/mdbook/src/errors.md
+++ b/docs/mdbook/src/errors.md
@@ -87,9 +87,10 @@ Raised when a mathematical side condition is violated.
 
 | Code | Cause | Remediation |
 |---|---|---|
-| `E-SOLVE-001` | System is inconsistent | No solutions exist |
+| `E-SOLVE-001` | An equation is not polynomial *or rational* in the declared variables — a transcendental function, a symbolic exponent, or a symbol the conversion could not place | Restate it as a ratio of polynomials in the unknowns and parameters. (An *inconsistent* system is not an error: it returns an empty list) |
 | `E-SOLVE-002` | High-degree univariate factor (> 2) | Symbolic solution not supported; use numerical solve |
 | `E-SOLVE-003` | Gröbner basis did not terminate | Increase node/iteration limits |
+| `E-SOLVE-005` | An equation's denominator is identically zero (`1/(x - x)`), so it denotes no function and has no solution set | Check the equation for a subtraction that cancels |
 
 ### PrimaryDecompositionError (E-IDEAL-*)
 
@@ -147,6 +148,13 @@ real code is available from `ideal::take_ideal_refusal()` /
 `radical` and `primary_decomposition` raise `AlkahestError` with `.code == "E-IDEAL-005"` /
 `"E-IDEAL-006"`, and `triangularize` raises `SolverError` with `.code == "E-SOLVE-004"`.
 `AlkahestError` subclasses `ValueError`, so code that catches `ValueError` is unaffected.
+
+`E-SOLVE-005` uses the same channel for the same reason: `solve` returns
+`SolverError::NotPolynomial` with `solver::take_undefined_equation()` pending, and the
+Python binding raises `SolverError` with `.code == "E-SOLVE-005"`. It means the equation's
+denominator vanishes identically, so it is not a rational function of anything and there is
+no solution set to report — distinct from `E-SOLVE-001`, which means the equation is a
+perfectly good function that is merely not polynomial or rational in the declared unknowns.
 
 The takers are *consuming*, which is what keeps the carrier variant honest: a genuinely
 non-polynomial equation still reports `E-SOLVE-001`, because no refusal is pending for it.

--- a/docs/mdbook/src/solving.md
+++ b/docs/mdbook/src/solving.md
@@ -1,6 +1,7 @@
 # Polynomial system solving
 
-Alkahest solves systems of polynomial equations symbolically using Gröbner bases.
+Alkahest solves systems of polynomial — and rational — equations symbolically using
+Gröbner bases.
 
 ## solve
 
@@ -47,6 +48,90 @@ for sol in solutions:
 `solve` returns an empty list for inconsistent systems and a `GroebnerBasis` handle for parametric families (infinite solution sets).
 
 Pass `numeric=True` to return float values directly: `solve(eqs, vars, numeric=True)`.
+
+## Rational equations
+
+An equation may be a ratio of polynomials in the declared unknowns. This is the form
+nodal analysis produces — every admittance term is a reciprocal — so writing the
+circuit equation directly is the point:
+
+```python
+Vo, Vin, R1, C, s = (pool.symbol(n) for n in ("Vo", "Vin", "R1", "C", "s"))
+
+solve([(Vo - Vin) / R1 + Vo * s * C], [Vo])
+# → [{Vo: Vin * (1 + R1*C*s)**-1}]
+
+solve_side_conditions()
+# → ['(1 + (R1 * C * s)) ≠ 0', 'R1 ≠ 0']
+```
+
+Each equation is put over a common denominator and the numerator system is solved.
+
+### Spurious roots
+
+Clearing a denominator is **not** an equivalence:
+
+```text
+N/D = 0     ⟺     N = 0  and  D ≠ 0
+```
+
+Multiplying up drops the second conjunct, and the root it leaves behind is not a
+near-miss — it is the one point where the equation has no value at all. `x/(x-1) =
+1/(x-1)` clears to `(x-1)**2 = 0`, whose only root is `x = 1`, which is exactly where
+both sides read `1/0`:
+
+```python
+solve([x / (x - 1) - 1 / (x - 1)], [x])   # → []   (not x = 1)
+solve([1 / x], [x])                       # → []   (a reciprocal is never zero)
+solve([x * x / x], [x])                   # → []   (0/0 at x = 0)
+solve([1 / (1 / x - 1)], [x])             # → []   (1/x has no value at x = 0)
+```
+
+So every candidate root is re-tested against the condition that says where the equation
+has a value at all, and one that makes it vanish is dropped. The test is exact where it
+can be — rational arithmetic, then the ambient assumptions, then rigorous ball
+arithmetic — and surviving roots are additionally substituted into the equations **as
+you wrote them**, before anything was cleared.
+
+Two things that condition is deliberately *not*:
+
+- It is not the *cancelled* denominator. `x**2/x` reduces to `x`, whose root `x = 0` is
+  precisely the point the original expression is `0/0` at, so the uncancelled form is
+  what gets carried.
+- It is not the product of the denominators either. A reciprocal swaps the two halves —
+  `(n/d)**-1 = d/n` — so an inner *denominator* becomes an outer *numerator* and would
+  drop out of such a product. In `1/(1/x - 1)` the requirement `x != 0` disappears
+  exactly that way, leaving `1 - x` (non-zero at `x = 0`) as the only recorded condition
+  and `x = 0` looking like a root. What is carried instead is the **domain**: everything
+  that has to be non-zero for the expression to denote a number, which for that example
+  is `x*(1 - x)` — both of the points it is undefined at.
+
+### When the exclusion is undecidable
+
+With symbolic parameters, whether a denominator vanishes at a root may be undecidable —
+`R1 ≠ 0` is not something the solver gets to assume. The root is returned under a
+stated hypothesis instead, listed by `solve_side_conditions()` alongside the
+non-vanishing leading coefficients the back-substitution divided by. Declaring the
+symbol positive discharges the condition rather than reporting it:
+
+```python
+R1 = pool.symbol("R1", "positive")
+solve([(Vo - Vin) / R1 + Vo * s * C], [Vo])
+solve_side_conditions()          # → ['(1 + (C * s * R1)) ≠ 0']   — no 'R1 ≠ 0'
+```
+
+An empty list means every divisor was *proved* non-zero, not that none was looked at.
+
+When no finite solution list can be produced and a `GroebnerBasis` comes back instead,
+that basis is the **numerator** ideal — no root of it has been tested against the
+denominators — and the cleared denominators are reported as side conditions so the
+distinction is visible.
+
+An equation whose denominator is identically zero (`1/(x - x)`) denotes no function at
+all and raises `SolverError` with `.code == "E-SOLVE-005"` rather than being cleared.
+
+`method="homotopy"` and `solve_numerical` are **not** covered by this: they take
+polynomial systems only, and a rational equation still raises `E-SOLVE-001` there.
 
 ## GroebnerBasis
 

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1824,8 +1824,11 @@ if "solve" in dir():
         return [sol for sol in result if _solution_respects_assumptions(sol, assumptions)]
 
     def solve(equations, vars, *, numeric=False, method="groebner", domain=None, assumptions=None):
-        """Solve a zero-dimensional polynomial system (see native ``solve`` for
-        the base behavior of *equations*, *vars*, *numeric*, and *method*).
+        """Solve a zero-dimensional polynomial or rational system (see native
+        ``solve`` for the base behavior of *equations*, *vars*, *numeric*, and
+        *method*, including how roots at a cleared denominator's zero are
+        excluded and how the undecidable ones are reported through
+        :func:`solve_side_conditions`).
 
         Parameters
         ----------

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -940,6 +940,65 @@ def _solve_states_no_unnecessary_hypothesis(
     return op
 
 
+def _roots_of(equation: ak.Expr, unknown: ak.Expr) -> list[float]:
+    """Every value ``solve`` returns for *unknown*, as floats."""
+    sols = ak.solve([equation], [unknown])
+    if not isinstance(sols, list):
+        raise ak.SolverError("solve returned an ideal, not a solution list")
+    out: list[float] = []
+    for sol in sols:
+        value = sol[unknown]
+        out.append(
+            float(value) if isinstance(value, (int, float)) else float(ak.eval_expr(value, {}))
+        )
+    return out
+
+
+def _solve_returns_a_pole_as_a_root(
+    equation: ak.Expr, unknown: ak.Expr, pole: float
+) -> Callable[[], float]:
+    """Answer = how many returned roots sit at *pole*, where the equation is undefined.
+
+    ``x/(x−1) = 1/(x−1)`` has no solution: at ``x = 1`` both sides read ``1/0``,
+    and nowhere else are they unequal.  Multiplying up turns it into
+    ``(x−1)² = 0``, whose only root is exactly that point — so a solver that
+    clears denominators and stops has a clean, plausible, wrong answer waiting
+    for it.  Counting the returned roots that land on the pole keeps the answer
+    a finite number.
+    """
+
+    def op() -> float:
+        return float(sum(1 for r in _roots_of(equation, unknown) if abs(r - pole) <= 1e-9))
+
+    return op
+
+
+def _solve_root_count(equation: ak.Expr, unknown: ak.Expr) -> Callable[[], float]:
+    """Answer = how many roots ``solve`` returns for a rational equation."""
+
+    def op() -> float:
+        return float(len(_roots_of(equation, unknown)))
+
+    return op
+
+
+def _solve_finds_all_of(
+    equation: ak.Expr, unknown: ak.Expr, expected: tuple[float, ...]
+) -> Callable[[], float]:
+    """Answer = how many of *expected* ``solve`` actually returned.
+
+    The control for the pole cases: excluding a root because a denominator
+    vanishes there must not degenerate into excluding roots, and refusing the
+    whole equation must not pass either.
+    """
+
+    def op() -> float:
+        got = _roots_of(equation, unknown)
+        return float(sum(1 for e in expected if any(abs(r - e) <= 1e-9 for r in got)))
+
+    return op
+
+
 def _undisclosed_expansion_limit(base: ak.Expr, exponent: int) -> Callable[[], float]:
     """Answer = 1.0 if a bounded expansion no-oped without saying so, else 0.0.
 
@@ -3913,6 +3972,86 @@ CASES: list[Case] = [
             "non-zero by inspection, so no side condition is needed. At b = 6 the solution is 3. "
             "The control for the case above — a library that emits a hypothesis unconditionally "
             "would pass that one and fail this."
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    # Spurious roots from clearing a denominator.
+    #
+    # `N/D = 0` means `N = 0 and D != 0`.  Multiplying up drops the second
+    # conjunct, and the root it leaves behind is not a near-miss — it is the one
+    # point where the equation has no value at all.  Every one of these has a
+    # confident wrong answer available to a solver that stops after clearing.
+    # -----------------------------------------------------------------------
+    Case(
+        id="solve_rational_does_not_return_a_root_at_a_pole",
+        subsystem="solving",
+        statement="x/(x−1) = 1/(x−1) has no solution; x = 1 is a pole of both sides",
+        op=_solve_returns_a_pole_as_a_root(X / (X - _int(1)) - _int(1) / (X - _int(1)), X, 1.0),
+        contract=RefusesOr(0.0),
+        verified_by=(
+            "By hand: for x ≠ 1 the equation is x/(x−1) = 1/(x−1), i.e. x = 1 after "
+            "multiplying by the non-zero (x−1) — which contradicts x ≠ 1. At x = 1 neither "
+            "side is defined. So the solution set is empty. SymPy's solve returns [] for "
+            "the same input. Clearing denominators gives (x−1)² = 0 whose root is 1, so a "
+            "solver that stops there reports the one point that is excluded."
+        ),
+        note="Refusing to accept the rational form at all also scores 0 — that was the "
+        "behaviour before rational equations were supported.",
+    ),
+    Case(
+        id="solve_reciprocal_equals_zero_has_no_solution",
+        subsystem="solving",
+        statement="1/x = 0 has no solution — not x = 0, and not x = ∞",
+        op=_solve_root_count(_int(1) / X, X),
+        contract=RefusesOr(0.0),
+        verified_by=(
+            "By hand: 1/x = 0 would need 1 = 0 after multiplying by x, which is false for "
+            "every x; and x = 0 is not in the domain. A reciprocal is never zero. The trap "
+            "is a solver that cancels x against the numerator and reports x = 0."
+        ),
+    ),
+    Case(
+        id="solve_removable_singularity_is_not_a_solution",
+        subsystem="solving",
+        statement="x²/x = 0 has no solution: at x = 0 the expression is 0/0",
+        op=_solve_root_count(X * X / X, X),
+        contract=RefusesOr(0.0),
+        verified_by=(
+            "By hand: for x ≠ 0 the expression equals x, which is non-zero there; at x = 0 "
+            "it is 0/0 and has no value. So no x satisfies it. This is the case that "
+            "reducing to lowest terms gets wrong — cancelling gives x = 0, a point the "
+            "original expression is not defined at, so the cancelled form must not be the "
+            "one the exclusion test is run against."
+        ),
+    ),
+    Case(
+        id="solve_nested_reciprocal_keeps_the_inner_domain_condition",
+        subsystem="solving",
+        statement="1/(1/x − 1) = 0 has no solution: 1/x is undefined at x = 0",
+        op=_solve_root_count(_int(1) / (_int(1) / X - _int(1)), X),
+        contract=RefusesOr(0.0),
+        verified_by=(
+            "By hand: the expression is defined only for x ∉ {0, 1}, and there it equals "
+            "x/(1−x), which is zero only at x = 0 — a point outside its domain. So the "
+            "solution set is empty. SymPy's solve returns [] for the same input. The trap is "
+            "specific: a reciprocal swaps numerator and denominator, so the inner denominator "
+            "x becomes the outer numerator and the condition x ≠ 0 vanishes from any "
+            "product-of-denominators bookkeeping. What is left, 1 − x, is non-zero at x = 0, "
+            "so the cleared numerator's only root passes every check that is not the domain."
+        ),
+    ),
+    Case(
+        id="solve_control_rational_equation_keeps_its_real_roots",
+        subsystem="solving",
+        statement="(x²−4)/(x−1) = 0 has the roots ±2; excluding poles must not exclude them",
+        op=_solve_finds_all_of((X * X - _int(4)) / (X - _int(1)), X, (-2.0, 2.0)),
+        contract=Returns(2.0),
+        verified_by=(
+            "By hand: the numerator vanishes at x = ±2 and the denominator is 1 and −3 "
+            "there, so both are genuine solutions; the pole at x = 1 is not a root of the "
+            "numerator and never was a candidate. The control for the three cases above — "
+            "a library that refuses every rational equation, or drops every root it cannot "
+            "prove non-singular, passes those and fails this."
         ),
     ),
     Case(

--- a/tests/test_solve_rational.py
+++ b/tests/test_solve_rational.py
@@ -1,0 +1,193 @@
+"""``solve`` on rational-function equations — the form nodal analysis produces.
+
+Two things are being tested and they pull in opposite directions.  Accepting
+``(Vo - Vin)/R1 + Vo*s*C`` at all is the feature: every admittance term in
+circuit analysis is a reciprocal, and requiring the caller to clear denominators
+by hand is what blocked symbolic nodal/MNA analysis.  But clearing a denominator
+is not an equivalence — ``N/D = 0`` means ``N = 0 and D != 0`` — so the roots it
+invents have to come back out again, and a root returned at a pole would be a
+wrong answer rather than a rough edge.
+"""
+
+from __future__ import annotations
+
+import alkahest as ak
+import pytest
+
+pytest.importorskip("alkahest", reason="native extension required")
+
+
+@pytest.fixture
+def pool():
+    return ak.ExprPool()
+
+
+def _values(sols, var):
+    """The returned roots for *var*, as floats."""
+    return sorted(float(ak.eval_expr(s[var], {})) for s in sols)
+
+
+# ---------------------------------------------------------------------------
+# The gap this closes
+# ---------------------------------------------------------------------------
+
+
+def test_rc_divider_in_admittance_form(pool):
+    """``(Vo - Vin)/R1 + Vo*s*C = 0`` → ``Vo = Vin/(1 + s*R1*C)``.
+
+    This raised ``E-SOLVE-001`` ("negative exponent -1 in polynomial") until
+    rational equations were accepted, and the workaround was to multiply through
+    by ``R1`` by hand.
+    """
+    Vo, Vin, R1, C, s = (pool.symbol(n) for n in ("Vo", "Vin", "R1", "C", "s"))
+    sols = ak.solve([(Vo - Vin) / R1 + Vo * s * C], [Vo])
+    assert len(sols) == 1
+    env = {Vin: 1.0, s: 7.0, R1: 2.0, C: 5.0}
+    assert float(ak.eval_expr(sols[0][Vo], env)) == pytest.approx(1.0 / 71.0)
+
+
+def test_rc_divider_agrees_with_the_hand_cleared_form(pool):
+    """Clearing ``1/R1`` by hand and letting the solver do it give the same answer."""
+    Vo, Vin, R1, C, s = (pool.symbol(n) for n in ("Vo", "Vin", "R1", "C", "s"))
+    env = {Vin: 3.0, s: 2.0, R1: 11.0, C: 0.5}
+    rational = ak.solve([(Vo - Vin) / R1 + Vo * s * C], [Vo])
+    cleared = ak.solve([(Vo - Vin) + Vo * s * C * R1], [Vo])
+    assert len(rational) == len(cleared) == 1
+    assert float(ak.eval_expr(rational[0][Vo], env)) == pytest.approx(
+        float(ak.eval_expr(cleared[0][Vo], env))
+    )
+
+
+def test_two_node_mna_system(pool):
+    """Two rational equations, two unknowns, five symbolic parameters."""
+    V1, V2, Vin = (pool.symbol(n) for n in ("V1", "V2", "Vin"))
+    R1, R2, C, s = (pool.symbol(n) for n in ("R1", "R2", "C", "s"))
+    node1 = (V1 - Vin) / R1 + (V1 - V2) / R2
+    node2 = (V2 - V1) / R2 + V2 * s * C
+
+    sols = ak.solve([node1, node2], [V1, V2])
+    assert len(sols) == 1
+    # V2 = Vin/(1 + s*C*(R1+R2)) and V1 = V2*(1 + s*C*R2).
+    env = {Vin: 1.0, R1: 2.0, R2: 3.0, C: 5.0, s: 7.0}
+    assert float(ak.eval_expr(sols[0][V2], env)) == pytest.approx(1.0 / 176.0)
+    assert float(ak.eval_expr(sols[0][V1], env)) == pytest.approx(53.0 / 88.0)
+
+
+# ---------------------------------------------------------------------------
+# Spurious roots — the correctness burden
+# ---------------------------------------------------------------------------
+
+
+def test_a_root_at_a_pole_is_not_returned(pool):
+    """``x/(x-1) = 1/(x-1)`` clears to ``(x-1)**2 = 0``; ``x = 1`` is not a solution."""
+    x = pool.symbol("x")
+    assert ak.solve([x / (x - 1) - 1 / (x - 1)], [x]) == []
+
+
+def test_a_reciprocal_is_never_zero(pool):
+    """``1/x = 0`` has no solution — not ``x = 0``, not ``x = inf``."""
+    x = pool.symbol("x")
+    assert ak.solve([1 / x], [x]) == []
+
+
+def test_a_removable_singularity_is_not_a_solution(pool):
+    """``x**2/x = 0`` is ``0/0`` at ``x = 0``, so it has no solution.
+
+    The case that reducing to lowest terms gets wrong: cancelling gives
+    ``x = 0``, a point the expression as written has no value at.
+    """
+    x = pool.symbol("x")
+    assert ak.solve([x * x / x], [x]) == []
+
+
+def test_a_condition_hidden_by_a_reciprocal_is_not_lost(pool):
+    """``1/(1/x - 1) = 0`` has no solution: ``1/x`` is undefined at ``x = 0``.
+
+    A reciprocal swaps numerator and denominator, so the inner denominator
+    ``x`` becomes the outer numerator and ``x != 0`` drops out of any
+    product-of-denominators bookkeeping. What survives, ``1 - x``, is
+    perfectly non-zero at ``x = 0``, so the cleared numerator's only root
+    sails straight through unless the *domain* is what gets carried.
+    """
+    x = pool.symbol("x")
+    assert ak.solve([1 / (1 / x - 1)], [x]) == []
+
+
+def test_a_pole_of_a_sibling_equation_excludes_the_root(pool):
+    """The numerator system has the root (1, 1); the first equation has a pole there."""
+    x, y = pool.symbol("x"), pool.symbol("y")
+    assert ak.solve([(x - 1) / (y - 1), y - 1], [x, y]) == []
+
+
+def test_genuine_roots_of_a_rational_equation_survive(pool):
+    """Excluding poles must not degenerate into excluding roots."""
+    x = pool.symbol("x")
+    sols = ak.solve([(x * x - 4) / (x - 1)], [x])
+    assert _values(sols, x) == pytest.approx([-2.0, 2.0])
+    # Nothing parametric is involved, so nothing had to be assumed.
+    assert ak.solve_side_conditions() == []
+
+
+# ---------------------------------------------------------------------------
+# Undecidable exclusions are stated, never assumed
+# ---------------------------------------------------------------------------
+
+
+def test_a_cleared_parametric_denominator_is_reported(pool):
+    """Whether ``R1`` vanishes is nobody's to decide here, so it is stated."""
+    Vo, Vin, R1, C, s = (pool.symbol(n) for n in ("Vo", "Vin", "R1", "C", "s"))
+    ak.solve([(Vo - Vin) / R1 + Vo * s * C], [Vo])
+    conditions = ak.solve_side_conditions()
+    assert any(str(c).startswith("R1 ") for c in conditions), conditions
+
+
+def test_a_positive_denominator_discharges_its_own_hypothesis(pool):
+    """A resistance declared positive cannot be zero, so no hypothesis is reported."""
+    Vo, Vin, C, s = (pool.symbol(n) for n in ("Vo", "Vin", "C", "s"))
+    R1 = pool.symbol("R1", "positive")
+    sols = ak.solve([(Vo - Vin) / R1 + Vo * s * C], [Vo])
+    assert len(sols) == 1
+    assert not any(str(c).startswith("R1 ") for c in ak.solve_side_conditions())
+
+
+# ---------------------------------------------------------------------------
+# What is still refused
+# ---------------------------------------------------------------------------
+
+
+def test_an_everywhere_undefined_equation_is_refused(pool):
+    """``1/(x - x)`` denotes no function, so it has no solution set to report."""
+    x = pool.symbol("x")
+    with pytest.raises(ak.SolverError) as exc:
+        ak.solve([1 / (x - x)], [x])
+    assert exc.value.code == "E-SOLVE-005"
+
+
+def test_a_transcendental_outside_the_closed_form_slice_still_refuses(pool):
+    """Widening to rational functions does not widen to transcendental ones."""
+    x, y = pool.symbol("x"), pool.symbol("y")
+    with pytest.raises(ak.SolverError) as exc:
+        ak.solve([ak.exp(x) + ak.sin(y), x - y], [x, y])
+    assert exc.value.code == "E-SOLVE-001"
+
+
+def test_a_rational_transcendental_is_refused_not_cleared(pool):
+    """A denominator around a transcendental is still not a rational function."""
+    x = pool.symbol("x")
+    with pytest.raises(ak.SolverError) as exc:
+        ak.solve([1 / (ak.exp(x) - 2) - 1], [x])
+    assert exc.value.code == "E-SOLVE-001"
+
+
+# ---------------------------------------------------------------------------
+# Regression: the polynomial path is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_polynomial_input_is_unchanged(pool):
+    x, y = pool.symbol("x"), pool.symbol("y")
+    assert _values(ak.solve([x * x - 4], [x]), x) == pytest.approx([-2.0, 2.0])
+    assert ak.solve_side_conditions() == []
+    (sol,) = ak.solve([x + y - 1, x - y], [x, y])
+    assert float(ak.eval_expr(sol[x], {})) == pytest.approx(0.5)
+    assert float(ak.eval_expr(sol[y], {})) == pytest.approx(0.5)


### PR DESCRIPTION
`solve` rejected any equation with a negative exponent:

```python
ak.solve([(Vo - Vin)/R1 + Vo*s*C], [Vo])
# E-SOLVE-001: not a polynomial: negative exponent -1 in polynomial
```

Every admittance equation in circuit analysis has that shape (`1/R`, `1/(sL)`),
so this single restriction blocked symbolic nodal/MNA analysis — the main
symbolic-math use case in analog and semiconductor work. Clearing denominators
by hand worked and gave the right answer, which is a poor interface.

## What changed

Each equation is put over a common denominator, the numerator system is solved,
and the roots that clearing invented are removed again.

**The exclusion condition is the *domain*, not "the denominator".** This was the
real trap, and the first implementation was silently wrong until edge-testing
caught it: a reciprocal swaps the halves (`(n/d)⁻¹ = d/n`), so an inner
denominator becomes an outer *numerator* and drops out of the product of
denominators. In `1/(1/x − 1)` the requirement `x ≠ 0` disappears exactly that
way, leaving `1 − x` as the only recorded condition and `x = 0` looking like a
root.

`solver/rational.rs` now returns `(num, den, dom)` with the invariant

> `dom(p) ≠ 0` ⟹ the expression is defined at `p`, `den(p) ≠ 0`, and it equals
> `num(p)/den(p)`

and the negative power is the only rule that adds to `dom`. Nothing is reduced
to lowest terms either — `x²/x` cancels to `x`, whose root is precisely the
`0/0` point.

## Excluding spurious roots, including when it is undecidable

Per candidate root the domain polynomial is specialised and classified by four
sources in increasing strength — exact rational arithmetic, the structural zero
test, `assumed_sign` (the assumptions system), then rigorous ball arithmetic:

- **Proved non-zero** → returned unconditionally.
- **Proved zero / undefined** → dropped. Because it is a proof, an empty result
  is a genuine "no solution".
- **Undecidable** (still mentions a free parameter) → returned under a `≠ 0`
  hypothesis recorded via the existing `solve_side_conditions()` channel, never
  assumed silently. Declaring `R1` positive discharges it instead.
- **Indeterminate** (a concrete number whose 192-bit enclosure straddles zero)
  → dropped in the safe direction, but tracked; if the result is empty *and* any
  drop was of this kind, the solver declines to a `GroebnerBasis` rather than
  claiming "no solutions".

Surviving roots are substituted into the equations **as written**, before
clearing — an independent check that does not read back the cleared form's own
output.

## Results

| | before | after |
|---|---|---|
| RC divider | `E-SOLVE-001` | `Vo = Vin/(1 + R1·C·s)`, conditions `['(1 + R1·C·s) ≠ 0', 'R1 ≠ 0']` |
| 2-node MNA | `E-SOLVE-001` | `V2 = Vin/(1+sC(R1+R2))`, `V1 = V2(1+sCR2)`; numerically `1/176`, `53/88` |

Traps: `x/(x−1) = 1/(x−1)` → `[]` (**not** `x = 1`); `1/x = 0` → `[]`;
`x²/x` → `[]`; `1/(1/x−1)` → `[]`. Control: `(x²−4)/(x−1)` → `±2`, no
conditions. `1/(x−x)` → new `E-SOLVE-005`.

## Semver

**Additive.** Two new public items (`solver::UndefinedEquation`,
`solver::take_undefined_equation`); no signature, variant or removal changes.
A `SolverError` variant was deliberately *not* added — it is a public
exhaustive enum in `alkahest_cas::stable` — so `E-SOLVE-005` travels inside
`NotPolynomial` with the refusal recovered out of band, the arrangement
`E-SOLVE-004` already uses. `check_api_freeze.py` → no surface change.

## `solve_numerical` — same restriction, deliberately not fixed

`homotopy.rs` calls `expr_to_gbpoly` with only the declared vars, so it rejects
negative exponents and parameters alike. `clear_denominators` would drop in for
the conversion, but the exclusion story does not: homotopy returns numerically
certified points, so "this root is at a pole" can only ever be a non-separation
result, never a proof — the opposite of the discipline used here. Left alone and
documented as polynomial-only.

## Known limitations

A genuine root whose domain value is a nonzero algebraic number smaller than
~2⁻¹⁸⁰ would be dropped — ruled out only by height bounds, not by proof. It is
the incomplete-not-wrong direction and is documented in the code. Side
conditions are not simplified, so they can be redundant (`['a ≠ 0',
'(a * -1 * -1 * a^-1) ≠ 0']`) — correct but verbose.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2856 passed, 0
failed, 11 ignored** (base 2834, +22). `pytest tests/` → 3205 passed, 0 failed.
Silent-error gate 256 cases, 0.0% (solving corpus 43 → 48). clippy
`-D warnings`, `fmt --check`, `check_error_codes.py`, `check_api_freeze.py`
clean. 19 Rust + 15 Python tests added, plus 5 silent-error traps including a
control that fails a solver which simply drops everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Gröbner solver now supports rational equations, including equations with nested fractions and denominators.
  - Invalid roots caused by zero denominators are excluded from results.
  - Unresolved denominator restrictions are reported as side conditions.
  - Added a dedicated error for equations with identically zero denominators.

- **Bug Fixes**
  - Prevents spurious solutions introduced when clearing denominators.

- **Documentation**
  - Updated solver guidance and error references for rational equations and denominator restrictions.

- **Tests**
  - Added coverage for rational systems, poles, removable singularities, and undefined equations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->