### PR TITLE
fix(ball): stop an enclosure that cannot bound a value from reporting that it excludes it

### DIFF
--- a/alkahest-core/src/ball/mod.rs
+++ b/alkahest-core/src/ball/mod.rs
@@ -151,24 +151,63 @@ impl ArbBall {
 
     /// True if the ball is a single point (radius = 0).
     pub fn is_exact(&self) -> bool {
-        self.rad == 0
+        self.mid.is_finite() && self.rad == 0
+    }
+
+    /// True when the ball carries **no information**: a NaN midpoint or
+    /// radius, an infinite radius, or a midpoint that overflowed to `±∞`.
+    ///
+    /// Such a ball is read as the whole real line, which is the only sound
+    /// reading available. The alternative — leaving NaN in place — makes
+    /// `lo()`/`hi()` NaN, and every comparison against a NaN is false, so
+    /// [`Self::contains`] would answer "no" for the very value the ball is
+    /// supposed to enclose. That is an enclosure claiming not to enclose, and
+    /// it is worse than a merely useless bound: a caller cross-checking a
+    /// symbolic identity against `contains` would read it as a refutation.
+    fn is_indeterminate(&self) -> bool {
+        self.mid.is_nan() || self.rad.is_nan() || !self.mid.is_finite() || self.rad.is_infinite()
+    }
+
+    /// Replace an indeterminate ball by the canonical `[0 ± ∞]`.
+    ///
+    /// Every arithmetic operation funnels its result through this, so a NaN
+    /// produced by an indeterminate operand (`0 · ∞` in the radius of a
+    /// product, `∞ − ∞` in the midpoint of a sum) widens to "unknown" instead
+    /// of escaping as a ball whose endpoints are NaN.
+    fn sanitized(self) -> Self {
+        if self.is_indeterminate() {
+            return ArbBall::infinity(self.prec);
+        }
+        self
     }
 
     /// True if `v` is contained in `[mid - rad, mid + rad]`.
+    ///
+    /// An indeterminate ball (see `is_indeterminate`) is the whole real line,
+    /// so it contains every `v`.
     pub fn contains(&self, v: f64) -> bool {
+        if self.is_indeterminate() {
+            return true;
+        }
         let v = Float::with_val(self.prec, v);
         let lo = Float::with_val(self.prec, &self.mid - &self.rad);
         let hi = Float::with_val(self.prec, &self.mid + &self.rad);
         v >= lo && v <= hi
     }
 
-    /// Lower bound of the interval.
+    /// Lower bound of the interval (`-∞` when the ball is indeterminate).
     pub fn lo(&self) -> Float {
+        if self.is_indeterminate() {
+            return Float::with_val(self.prec, f64::NEG_INFINITY);
+        }
         Float::with_val(self.prec, &self.mid - &self.rad)
     }
 
-    /// Upper bound of the interval.
+    /// Upper bound of the interval (`+∞` when the ball is indeterminate).
     pub fn hi(&self) -> Float {
+        if self.is_indeterminate() {
+            return Float::with_val(self.prec, f64::INFINITY);
+        }
         Float::with_val(self.prec, &self.mid + &self.rad)
     }
 
@@ -184,15 +223,44 @@ impl ArbBall {
 
     // ── arithmetic ───────────────────────────────────────────────────────
 
-    /// Grow radius by a rounding-error term: `eps * |mid| * 2^{-prec}`.
+    /// Grow the radius outward by four ulps of the ball's own **outer**
+    /// magnitude, `(|mid| + rad) · 2^{-(prec-2)}`.
+    ///
+    /// The rules that build a ball from `f(lo)` and `f(hi)` accumulate up to
+    /// four round-to-nearest steps — one on each endpoint, one on `(hi+lo)/2`
+    /// and one on `(hi-lo)/2` — each worth half an ulp *of the endpoint*, not
+    /// of the midpoint. Scaling by `|mid|` alone therefore under-covers
+    /// whenever the ball is wide relative to its centre, and covers nothing at
+    /// all for a ball centred on zero. Four ulps of `|mid| + rad` dominates all
+    /// four steps in every case, and matches the `2^{-(prec-2)}` convention
+    /// [`crate::validated::inflate`] already uses.
     fn add_rounding_error(&mut self) {
-        if self.mid.is_infinite() || self.mid.is_nan() {
+        if self.mid.is_infinite() || self.mid.is_nan() || self.rad.is_nan() {
+            // `mid` is reset too: `∞ ± ∞` and `NaN ± ∞` both have NaN
+            // endpoints, which is the failure this guard exists to prevent.
+            self.mid = Float::new(self.prec);
             self.rad = Float::with_val(self.prec, f64::INFINITY);
             return;
         }
-        let scale = Float::with_val(self.prec, &self.mid).abs()
-            * Float::with_val(self.prec, 2.0_f64.powi(-(self.prec as i32)));
+        let magnitude = Float::with_val(self.prec, self.mid.abs_ref()) + self.rad.clone();
+        let scale = magnitude * Float::with_val(self.prec, 2.0_f64.powi(-(self.prec as i32) + 2));
         self.rad += &scale;
+    }
+
+    /// The interval `[min, max]` as a ball, rounded **outward**.
+    ///
+    /// `(min+max)/2` and `(max-min)/2` are both round-to-nearest, so building a
+    /// ball from them without a bump can produce an enclosure *narrower* than
+    /// the interval it was built from — by a sub-ulp margin, but a bound that
+    /// is short by an ulp is not a bound. Every corner-evaluation rule below
+    /// goes through here.
+    fn from_min_max(min: &Float, max: &Float, prec: u32) -> Self {
+        let work = prec + 32;
+        let mid = Float::with_val(prec, Float::with_val(work, min + max) / 2u32);
+        let rad = Float::with_val(prec, Float::with_val(work, max - min) / 2u32).abs();
+        let mut out = ArbBall { mid, rad, prec };
+        out.add_rounding_error();
+        out.sanitized()
     }
 }
 
@@ -216,12 +284,12 @@ impl std::ops::Add for ArbBall {
     fn add(self, rhs: Self) -> Self {
         let prec = self.prec.max(rhs.prec);
         let mid = Float::with_val(prec, &self.mid + &rhs.mid);
-        let mut rad = Float::with_val(prec, &self.rad + &rhs.rad);
-        // Rounding error: 1 ulp
-        let eps = Float::with_val(prec, mid.abs_ref())
-            * Float::with_val(prec, 2.0_f64.powi(-(prec as i32)));
-        rad += eps;
-        ArbBall { mid, rad, prec }
+        // The radius sum is accumulated at extra precision and rounded once, so
+        // `add_rounding_error`'s four ulps cover the rounding of *both* fields.
+        let rad = Float::with_val(prec, Float::with_val(prec + 32, &self.rad + &rhs.rad));
+        let mut out = ArbBall { mid, rad, prec };
+        out.add_rounding_error();
+        out.sanitized()
     }
 }
 
@@ -230,11 +298,10 @@ impl std::ops::Sub for ArbBall {
     fn sub(self, rhs: Self) -> Self {
         let prec = self.prec.max(rhs.prec);
         let mid = Float::with_val(prec, &self.mid - &rhs.mid);
-        let mut rad = Float::with_val(prec, &self.rad + &rhs.rad);
-        let eps = Float::with_val(prec, mid.abs_ref())
-            * Float::with_val(prec, 2.0_f64.powi(-(prec as i32)));
-        rad += eps;
-        ArbBall { mid, rad, prec }
+        let rad = Float::with_val(prec, Float::with_val(prec + 32, &self.rad + &rhs.rad));
+        let mut out = ArbBall { mid, rad, prec };
+        out.add_rounding_error();
+        out.sanitized()
     }
 }
 
@@ -245,15 +312,21 @@ impl std::ops::Mul for ArbBall {
         // |a*b| ≤ |a|*|b|
         // rad(a*b) = |mid_a|*rad_b + |mid_b|*rad_a + rad_a*rad_b
         let mid = Float::with_val(prec, &self.mid * &rhs.mid);
-        let ma = Float::with_val(prec, self.mid.abs_ref());
-        let mb = Float::with_val(prec, rhs.mid.abs_ref());
-        let mut rad = Float::with_val(prec, &ma * &rhs.rad)
-            + Float::with_val(prec, &mb * &self.rad)
-            + Float::with_val(prec, &self.rad * &rhs.rad);
-        let eps = Float::with_val(prec, mid.abs_ref())
-            * Float::with_val(prec, 2.0_f64.powi(-(prec as i32)));
-        rad += eps;
-        ArbBall { mid, rad, prec }
+        let work = prec + 32;
+        let ma = Float::with_val(work, self.mid.abs_ref());
+        let mb = Float::with_val(work, rhs.mid.abs_ref());
+        // Five roundings if this is done at `prec`; done at `prec + 32` and
+        // rounded once, it is covered by `add_rounding_error` like every other
+        // rule.
+        let rad = Float::with_val(
+            prec,
+            Float::with_val(work, &ma * &rhs.rad)
+                + Float::with_val(work, &mb * &self.rad)
+                + Float::with_val(work, &self.rad * &rhs.rad),
+        );
+        let mut out = ArbBall { mid, rad, prec };
+        out.add_rounding_error();
+        out.sanitized()
     }
 }
 
@@ -265,6 +338,7 @@ impl std::ops::Neg for ArbBall {
             rad: self.rad,
             prec: self.prec,
         }
+        .sanitized()
     }
 }
 
@@ -302,20 +376,25 @@ impl std::ops::Div for ArbBall {
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap()
             .clone();
-        let sum = Float::with_val(prec, &min + &max);
-        let diff = Float::with_val(prec, &max - &min);
-        let new_mid = sum / 2_f64;
-        let rad = diff / 2_f64;
-        Some(ArbBall {
-            mid: new_mid,
-            rad,
-            prec,
-        })
+        Some(ArbBall::from_min_max(&min, &max, prec))
     }
 }
 
 impl ArbBall {
-    /// Integer power: `self^n` (n ≥ 0).
+    /// Integer power `self^n`, enclosed from the interval's **endpoints**.
+    ///
+    /// `x ↦ xⁿ` is monotone on each side of the origin, so the range of `xⁿ`
+    /// over `[lo, hi]` is the hull of `loⁿ` and `hiⁿ` — together with `0`,
+    /// which is attained when `n` is even and the interval straddles the
+    /// origin. That is the *exact* range, so the only widening needed is for
+    /// rounding.
+    ///
+    /// Repeated ball multiplication, which this replaces, forgets that the two
+    /// factors of `x·x` are the same number and pays the dependency problem
+    /// once per squaring: `[-1, 1]²` came out as `[-2, 4]` rather than `[0, 1]`,
+    /// and `[2, 3]⁶` as an interval straddling zero — after which `[2,3]^-6`
+    /// had **no finite enclosure at all**, for a function whose range there is
+    /// `[1/729, 1/64]`. Both answers were sound; neither was usable.
     pub fn powi(&self, n: i64) -> Self {
         if n == 0 {
             return ArbBall::from_f64(1.0, self.prec);
@@ -326,18 +405,26 @@ impl ArbBall {
             return (ArbBall::from_f64(1.0, self.prec) / pos)
                 .unwrap_or_else(|| ArbBall::infinity(self.prec));
         }
-        // Fast exponentiation by squaring
-        let mut result = ArbBall::from_f64(1.0, self.prec);
-        let mut base = self.clone();
-        let mut exp = n as u64;
-        while exp > 0 {
-            if exp & 1 == 1 {
-                result = result * base.clone();
-            }
-            base = base.clone() * base.clone();
-            exp >>= 1;
+        let prec = self.prec;
+        let (lo, hi) = (self.lo(), self.hi());
+        let Ok(exp) = u32::try_from(n) else {
+            // Nothing real is being asked for at this size; refuse to guess.
+            return ArbBall::infinity(prec);
+        };
+        if !(lo.is_finite() && hi.is_finite()) {
+            return ArbBall::infinity(prec);
         }
-        result
+        // Corner powers at extra precision so their own round-to-nearest is far
+        // below the outward bump added at the end.
+        let work = prec + 32;
+        let a = Float::with_val(work, Float::with_val(work, &lo).pow(exp));
+        let b = Float::with_val(work, Float::with_val(work, &hi).pow(exp));
+        let (mut min, max) = if a <= b { (a, b) } else { (b, a) };
+        if exp % 2 == 0 && lo <= 0 && hi >= 0 {
+            // The even power dips to 0 in the interior of the interval.
+            min = Float::new(work);
+        }
+        ArbBall::from_min_max(&min, &max, prec)
     }
 
     pub fn pow_f(&self, exp: &ArbBall) -> Self {
@@ -377,15 +464,7 @@ impl ArbBall {
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap()
             .clone();
-        let sum = Float::with_val(prec, &min + &max);
-        let diff = Float::with_val(prec, &max - &min);
-        let new_mid = sum / 2_f64;
-        let rad = diff / 2_f64;
-        ArbBall {
-            mid: new_mid,
-            rad,
-            prec,
-        }
+        ArbBall::from_min_max(&min, &max, prec)
     }
 
     pub fn sin(&self) -> Self {
@@ -413,18 +492,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().exp());
         let hi = Float::with_val(prec, self.hi().exp());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // `lo`/`hi` are themselves rounded to `prec`; without this the ball is
-        // exact-looking (`rad == 0`) for an exact input, which is a false
-        // rigorous claim about a transcendental value.
-        b.add_rounding_error();
-        b
+        ArbBall::from_min_max(&lo, &hi, prec)
     }
 
     pub fn log(&self) -> Option<Self> {
@@ -434,18 +502,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().ln());
         let hi = Float::with_val(prec, self.hi().ln());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; without this a ball built from an
-        // exact input reports `rad == 0`, falsely claiming an irrational result
-        // is exactly representable.
-        b.add_rounding_error();
-        Some(b)
+        Some(ArbBall::from_min_max(&lo, &hi, prec))
     }
 
     pub fn sqrt(&self) -> Option<Self> {
@@ -455,18 +512,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().sqrt());
         let hi = Float::with_val(prec, self.hi().sqrt());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; without this a ball built from an
-        // exact input reports `rad == 0`, falsely claiming an irrational result
-        // is exactly representable.
-        b.add_rounding_error();
-        Some(b)
+        Some(ArbBall::from_min_max(&lo, &hi, prec))
     }
 
     /// tan([m-r, m+r]) — Lipschitz constant: sec²(m+r) (may blow up near π/2).
@@ -509,16 +555,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().sinh());
         let hi = Float::with_val(prec, self.hi().sinh());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; see `exp`.
-        b.add_rounding_error();
-        b
+        ArbBall::from_min_max(&lo, &hi, prec)
     }
 
     pub fn cosh(&self) -> Self {
@@ -555,16 +592,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().tanh());
         let hi = Float::with_val(prec, self.hi().tanh());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; see `exp`.
-        b.add_rounding_error();
-        b
+        ArbBall::from_min_max(&lo, &hi, prec)
     }
 
     pub fn asin(&self) -> Option<Self> {
@@ -574,18 +602,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().asin());
         let hi = Float::with_val(prec, self.hi().asin());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; without this a ball built from an
-        // exact input reports `rad == 0`, falsely claiming an irrational result
-        // is exactly representable.
-        b.add_rounding_error();
-        Some(b)
+        Some(ArbBall::from_min_max(&lo, &hi, prec))
     }
 
     pub fn acos(&self) -> Option<Self> {
@@ -614,16 +631,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().atan());
         let hi = Float::with_val(prec, self.hi().atan());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; see `exp`.
-        b.add_rounding_error();
-        b
+        ArbBall::from_min_max(&lo, &hi, prec)
     }
 
     /// asinh([m-r, m+r]) — monotone increasing on all of ℝ.
@@ -631,16 +639,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().asinh());
         let hi = Float::with_val(prec, self.hi().asinh());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; see `exp`.
-        b.add_rounding_error();
-        b
+        ArbBall::from_min_max(&lo, &hi, prec)
     }
 
     /// acosh([m-r, m+r]) — monotone increasing on `[1, ∞)`. Returns `None` if
@@ -652,18 +651,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().acosh());
         let hi = Float::with_val(prec, self.hi().acosh());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; without this a ball built from an
-        // exact input reports `rad == 0`, falsely claiming an irrational result
-        // is exactly representable.
-        b.add_rounding_error();
-        Some(b)
+        Some(ArbBall::from_min_max(&lo, &hi, prec))
     }
 
     /// atanh([m-r, m+r]) — monotone increasing on `(-1, 1)`. Returns `None` if
@@ -675,18 +663,7 @@ impl ArbBall {
         let prec = self.prec;
         let lo = Float::with_val(prec, self.lo().atanh());
         let hi = Float::with_val(prec, self.hi().atanh());
-        let sum = Float::with_val(prec, &lo + &hi);
-        let diff = Float::with_val(prec, &hi - &lo);
-        let mut b = ArbBall {
-            mid: sum / 2_f64,
-            rad: diff / 2_f64,
-            prec,
-        };
-        // Endpoints are rounded to `prec`; without this a ball built from an
-        // exact input reports `rad == 0`, falsely claiming an irrational result
-        // is exactly representable.
-        b.add_rounding_error();
-        Some(b)
+        Some(ArbBall::from_min_max(&lo, &hi, prec))
     }
 
     pub fn erf(&self) -> Self {
@@ -920,6 +897,7 @@ impl ArbBall {
                 rad: max_abs / 2_f64,
                 prec,
             }
+            .sanitized()
         } else {
             let mid = Float::with_val(prec, self.mid.clone().abs());
             let rad = self.rad.clone();
@@ -1674,6 +1652,128 @@ mod tests {
         let z = AcbBall::from_f64(3.0, 4.0, 128);
         let m = z.modulus();
         assert!(m.contains(5.0));
+    }
+}
+
+#[cfg(test)]
+mod indeterminate_ball_tests {
+    use super::*;
+
+    const PREC: u32 = 128;
+
+    /// An indeterminate operand must widen the result to the whole real line,
+    /// never to a ball with NaN endpoints.
+    ///
+    /// `[0 ± ∞] · [0 ± r]` computed a radius of `|0|·∞ + |0|·r + ∞·r`, whose
+    /// first term is `0 · ∞ = NaN`. Every comparison against a NaN is false, so
+    /// `contains` then answered `false` for *every* real number — an enclosure
+    /// claiming not to enclose. That is strictly worse than a useless bound: a
+    /// caller cross-checking a symbolic identity reads `false` as a refutation.
+    #[test]
+    fn an_indeterminate_operand_never_produces_nan_endpoints() {
+        let unknown = ArbBall::infinity(PREC);
+        let zero_centred = ArbBall::from_midpoint_radius(0.0, 0.5, PREC);
+
+        let products = [
+            unknown.clone() * zero_centred.clone(),
+            zero_centred * unknown.clone(),
+            unknown.clone() * unknown.clone(),
+            unknown.clone() + unknown.clone(),
+            unknown.clone() - unknown.clone(),
+            unknown.powi(2),
+            unknown.powi(-2),
+            unknown.abs_ball(),
+            unknown.sin(),
+            unknown.exp(),
+        ];
+        for (i, p) in products.iter().enumerate() {
+            assert!(!p.lo().is_nan(), "case {i}: lo is NaN");
+            assert!(!p.hi().is_nan(), "case {i}: hi is NaN");
+            assert!(p.lo() <= 0 && p.hi() >= 0, "case {i}: not the whole line");
+            for probe in [0.0, 1.0, -5.0, 1e300] {
+                assert!(p.contains(probe), "case {i}: refuses to contain {probe}");
+            }
+        }
+    }
+
+    /// `powi` must enclose the range from the interval's endpoints, not by
+    /// repeated ball multiplication.
+    ///
+    /// Squaring a ball as a product forgets that both factors are the same
+    /// number, so `[-1,1]²` widened to `[-2,4]` and `[2,3]⁶` straddled zero —
+    /// after which `[2,3]^-6` had no finite enclosure at all.
+    #[test]
+    fn powi_encloses_from_the_endpoints() {
+        // [-1, 1]² is exactly [0, 1].
+        let pm1 = ArbBall::from_midpoint_radius(0.0, 1.0, PREC);
+        let sq = pm1.powi(2);
+        assert!(
+            sq.lo() >= -1e-30,
+            "even power must not dip below 0: {}",
+            sq.lo()
+        );
+        assert!(sq.hi() >= 1.0, "1 is attained at both endpoints");
+        // Tight: within a few ulps of 1, not the [-2, 4] the squaring loop gave.
+        assert!(Float::with_val(PREC, sq.hi() - 1u32) < 1e-30);
+
+        // [2, 3]^-6 is exactly [1/729, 1/64].
+        let two_three = ArbBall::from_midpoint_radius(2.5, 0.5, PREC);
+        let inv6 = two_three.powi(-6);
+        assert!(
+            inv6.lo().is_finite() && inv6.hi().is_finite(),
+            "no finite enclosure"
+        );
+        // `1/64` is exact in binary and is attained at x = 2, so `hi` must
+        // reach it. `1/729` is not, so the comparison is against a `Float`, not
+        // against an `f64` literal that is itself a whole 1e-19 off.
+        let one_over_729 = Float::with_val(PREC + 64, 1u32) / 729u32;
+        assert!(inv6.lo() <= one_over_729 && inv6.hi() >= 1.0 / 64.0);
+        assert!(
+            inv6.lo() > 0.0 && inv6.hi() < 0.02,
+            "enclosure is not tight: {inv6}"
+        );
+
+        // Odd powers stay monotone across the origin.
+        let cube = ArbBall::from_midpoint_radius(-2.325, 1.0, PREC).powi(3);
+        assert!(cube.hi() < 0, "(-3.325, -1.325)³ is negative throughout");
+        // (-3.325)³ = -36.75486…, (-1.325)³ = -2.326203…
+        assert!(cube.lo() <= -36.75 && cube.lo() >= -36.76);
+        assert!(cube.hi() >= -2.3263 && cube.hi() <= -2.326);
+    }
+
+    /// The range of `x^n` over a box must contain every sampled value.
+    ///
+    /// The samples and their powers are computed in `Float` at `PREC + 64`, not
+    /// in `f64`: the enclosure is tight to a few ulps at `PREC`, so an `f64`
+    /// reference value would be the less accurate of the two and the comparison
+    /// would be measuring the reference's rounding, not the ball's soundness.
+    #[test]
+    fn powi_encloses_dense_samples() {
+        const WORK: u32 = PREC + 64;
+        for &(mid, rad) in &[
+            (0.0_f64, 1.0_f64),
+            (-2.325, 1.0),
+            (2.5, 0.5),
+            (0.5, 0.5),
+            (-0.25, 0.75),
+            (3.0, 0.0),
+        ] {
+            let b = ArbBall::from_midpoint_radius(mid, rad, PREC);
+            let (lo, hi) = (Float::with_val(WORK, b.lo()), Float::with_val(WORK, b.hi()));
+            for n in [1_u32, 2, 3, 4, 5, 6, 7] {
+                let p = b.powi(n as i64);
+                let (plo, phi) = (Float::with_val(WORK, p.lo()), Float::with_val(WORK, p.hi()));
+                for k in 0..=64u32 {
+                    let t = Float::with_val(WORK, &lo)
+                        + Float::with_val(WORK, Float::with_val(WORK, &hi - &lo) * k) / 64u32;
+                    let v = Float::with_val(WORK, t.clone().pow(n));
+                    assert!(
+                        plo <= v && v <= phi,
+                        "x^{n} over [{mid}±{rad}] misses {v} at x = {t}"
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/docs/mdbook/src/ball-arithmetic.md
+++ b/docs/mdbook/src/ball-arithmetic.md
@@ -90,6 +90,33 @@ result = interval_eval(expr, {
 
 `interval_eval` guarantees that the output ball contains the true value for any input in the given input balls, accounting for all rounding in the intermediate computation.
 
+## The indeterminate ball
+
+Some expressions have no finite enclosure over the ball you asked about — `1/x`
+where the ball straddles `0`, or an intermediate result whose enclosure lost so
+much to the dependency problem that a later reciprocal became unbounded. The
+answer in that case is `[-inf, inf]`: the whole real line, which is true and
+carries no information.
+
+```python
+r = interval_eval(pool.integer(1) / x, {x: ArbBall(0.0, 1.0)})
+r.lo, r.hi        # (-inf, inf)
+r.contains(5.0)   # True — it contains everything
+```
+
+Two consequences worth knowing:
+
+* **Check `lo`/`hi` for finiteness before believing a bound.** An infinite
+  endpoint is the API saying "I could not bound this", and it is the only way
+  it says so — `interval_eval` does not raise for it.
+* **`contains` is `True` for an indeterminate ball, never `False`.** This is
+  the direction that matters: `contains` is what a caller uses to
+  cross-check a symbolic identity, and a `False` there is read as a
+  *refutation*. "No information" must never be reported as "that value is
+  outside the enclosure", so no ball ever has NaN endpoints — a NaN produced by
+  an indeterminate operand (`0 · ∞` in the radius of a product, `∞ − ∞` in the
+  midpoint of a sum) widens to the whole line instead of escaping.
+
 ## AcbBall
 
 Complex ball arithmetic for expressions over ℂ:

--- a/docs/mdbook/src/validated-bounds.md
+++ b/docs/mdbook/src/validated-bounds.md
@@ -109,11 +109,18 @@ whose enclosure has a determined one, and samples the centres of the rest.
 | `x²−2` on `[-10,10]` | 2 | + → + | `"false"` |
 | `(x²−2)(x²+1)` on `[-2,2]` | 2 | + → + | `"false"` |
 | `x−y` on `[-1,1]²` | a whole line | — | `"false"` |
-| `(x−1)²` on `[0,2]` | 1 (double) | + → + | `"undecided"` |
+| `(x−1)²` on `[0,2]` | 1 (double) | + → + | `"false"` |
+| `(x−1)²` on `[0,3/2]` | 1 (double) | + → + | `"undecided"` |
 
-The last row is the honest limit. A double root never changes sign, so no
-witness pair exists; `"undecided"` is the answer, and it is not upgraded to
-`"false"` on the strength of an enclosure that merely touches zero.
+The last two rows are the honest limit, and the difference between them is
+worth understanding. A double root never changes sign, so the intermediate
+value theorem has nothing to work with either time. What settles `[0,2]` is the
+*other* proof: `1` is the exact midpoint of that box, and substituting it
+symbolically gives a literal `0`, so a point of the box is **proven** to be a
+root and no continuity argument is needed. On `[0,3/2]` the root is at no
+distinguished point and no dyadic bisection ever lands on it, so nothing is
+proven and `"undecided"` is the answer — never upgraded to `"false"` on the
+strength of an enclosure that merely touches zero.
 
 ### Inequalities that are tight at an endpoint
 
@@ -164,9 +171,17 @@ enclosure that merely touches zero.
 Taylor models reach the **elementary fragment**: `exp`, `log`, `sqrt`, `sin`,
 `cos`, `tan`, `asin`, `acos`, `atan`, `sinh`, `cosh`, `tanh`, `asinh`,
 `acosh`, `atanh`, `abs`, plus arithmetic and integer/rational powers — and,
-since 3.9.0, `erf` and `erfc`. Outside it are `bessel_j0`, `bessel_j1`,
-`digamma`, `lambert_w`, `gamma`, the elliptic integrals, `floor` and `ceil`,
-and so is any two-argument function such as `atan2`.
+since 3.9.0, `erf` and `erfc` — and it reaches beyond it: `gamma`, `digamma`,
+`trigamma`, `lambert_w`, `bessel_j0`, `bessel_j1`, `dilog`, `Si`, `Ci`, `Shi`,
+`Chi`, `Ei`, `li`, `fresnels` and `fresnelc` all carry a rule with a rigorous
+remainder as well. Outside it are the elliptic integrals, `floor`, `ceil`,
+`sign`, `round` and `heaviside` — none of which is differentiable, so no
+Lagrange remainder exists for them at any order — and so is any two-argument
+function such as `atan2`.
+
+Do not read that list as fixed. `taylor_model` and `bounds_supported` are
+derived by *running* the Taylor evaluator, so the query below is the answer and
+this paragraph is only a summary of it.
 
 The three inverse hyperbolics carry the domain restriction their branch has:
 `acosh` needs the whole box strictly above `1` and `atanh` needs it strictly
@@ -180,20 +195,23 @@ instead of discovering it by hitting `E-VALIDATED-001`:
 
 ```python
 ak.bounds_supported(ak.sin(x) * ak.exp(x))     # truthy
-answer = ak.bounds_supported(ak.bessel_j0(x))
-bool(answer), answer.functions                  # (False, ['bessel_j0'])
-answer.blocker                                  # "function `bessel_j0`"
+answer = ak.bounds_supported(ak.floor(x))
+bool(answer), answer.functions                  # (False, ['floor'])
+answer.blocker                                  # "function `floor`"
 
 # Per primitive, in the agent contract:
 {row["name"] for row in ak.capabilities()["primitives"] if row["taylor_model"]}
 ```
 
-**`numeric_ball` is not this flag.** It reports pointwise ball arithmetic,
-which `bessel_j0`, `digamma`, `lambert_w` and `floor` all have; a Taylor model
-additionally needs a rule with a rigorous Lagrange remainder, which they do
-not. Both bits are honest — they answer different questions. `taylor_model`
-and `bounds_supported` are derived by *running* the Taylor evaluator, not from
-a maintained list, so neither can drift from what `bound_on_box` accepts.
+**`numeric_ball` is not this flag.** It reports pointwise ball arithmetic; a
+Taylor model additionally needs a rule with a rigorous Lagrange remainder, and
+the two bits move independently. `floor` is the clean example: its ball rule is
+exact — `floor` of a ball straddling an integer returns an interval covering
+both values — and it still has `taylor_model = False`, because it has no
+derivative to bound. The elliptic integrals have neither. Both bits are honest,
+and they answer different questions. `taylor_model` and `bounds_supported` are
+derived by *running* the Taylor evaluator, not from a maintained list, so
+neither can drift from what `bound_on_box` accepts.
 
 A `True` answer means "will not be refused with `E-VALIDATED-001`". It is not
 a promise of success: a covered function can still hit a domain violation or

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -1100,6 +1100,53 @@ def _perron_connection_constant(polys: list[tuple[int, ...]], terms: list[int]) 
     return float(r.connection_constant)
 
 
+# ---------------------------------------------------------------------------
+# Validated numerics / ball arithmetic
+#
+# This layer's whole value proposition is that a returned interval *contains*
+# the true value, so the answer scored here is the containment claim itself:
+# the op asks the enclosure whether it holds an independently computed truth,
+# and ``False`` — an enclosure that does not enclose — is exactly the silent
+# error, because nothing in the returned object distinguishes it from a sound
+# one.  Truths come from a closed form or from mpmath at 50 digits; each
+# literal is derived in the case's ``verified_by``.
+# ---------------------------------------------------------------------------
+
+
+def _encloses(build: Callable[[], Any], truth: float) -> Callable[[], bool]:
+    """Answer = does the returned ``Enclosure`` contain *truth*?"""
+
+    def op() -> bool:
+        r = build()
+        return bool(r.lower <= truth <= r.upper)
+
+    return op
+
+
+def _ball_encloses(expr: ak.Expr, binding: dict[Any, Any], truth: float) -> Callable[[], bool]:
+    """Answer = does ``interval_eval``'s ball claim to contain *truth*?
+
+    ``ArbBall.contains`` is the documented way to read the guarantee, so a
+    ``False`` here is the library contradicting its own contract — and it is a
+    *directed* lie: a caller cross-checking a symbolic identity against it reads
+    ``False`` as a refutation rather than as "no information".
+    """
+
+    def op() -> bool:
+        return bool(ak.interval_eval(expr, binding).contains(truth))
+
+    return op
+
+
+def _ball_upper(expr: ak.Expr, binding: dict[Any, Any]) -> Callable[[], float]:
+    """Answer = the ball's upper endpoint, for the cases where no bound exists."""
+
+    def op() -> float:
+        return float(ak.interval_eval(expr, binding).hi)
+
+    return op
+
+
 CASES: list[Case] = [
     # ── real quantifier elimination ──────────────────────────────────────────
     #
@@ -4498,6 +4545,419 @@ CASES: list[Case] = [
             "Control for the refusal the changelog claims: the polynomial part is "
             "declined rather than quietly discarded, which would have produced a "
             "clean, plausible, wrong function."
+        ),
+    ),
+    # ── validated bounds and ball arithmetic ────────────────────────────────
+    #
+    # The archetype for this layer is not a wrong number, it is a wrong
+    # *interval*.  An enclosure that does not enclose is a false lemma every
+    # downstream derivation inherits, and it is indistinguishable from a sound
+    # one at the call site.
+    Case(
+        id="ball_indeterminate_product_still_encloses",
+        subsystem="ball",
+        statement="interval_eval((x^-3)^2) over x in [-3.325, -1.325] must contain 2.325^-6",
+        op=_ball_encloses(
+            (X ** _int(-3)) ** _int(2),
+            {X: ak.ArbBall(-2.325, 1.0)},
+            0.006331864446927654,
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "x^-6 is even and decreasing in |x|, so on |x| in [1.325, 3.325] its range is "
+            "[3.325^-6, 1.325^-6] = [7.400313e-4, 0.1848012] (mpmath, 50 digits), and the "
+            "midpoint value 2.325^-6 = 6.331864e-3 lies inside it. Every sound enclosure of "
+            "this expression over this box therefore contains that number: `contains` may "
+            "answer False only for values outside [7.4e-4, 0.185], which this is not."
+        ),
+        note=(
+            "Two failures meet here. x^3 by repeated ball squaring lost the sign of the box "
+            "and came out straddling zero, so 1/x^3 was the indeterminate ball [0 +- inf]; "
+            "squaring *that* computed a radius of 0*inf = NaN, and every comparison against a "
+            "NaN endpoint is false, so `contains` answered False for every real number, the "
+            "true value included. Powering from the endpoints fixes the first, and NaN no "
+            "longer escapes any operation, which fixes the second. "
+            "ball_removable_quotient_across_zero_still_encloses is the case that still reaches "
+            "the NaN path, by a route no precision improvement can close."
+        ),
+    ),
+    Case(
+        id="ball_control_reciprocal_power_encloses",
+        subsystem="ball",
+        statement="interval_eval(x^-6) over x in [2, 3] must bracket [1/729, 1/64] tightly",
+        op=lambda: bool(
+            ak.interval_eval(X ** _int(-6), {X: ak.ArbBall(2.5, 0.5)}).lo
+            <= (1.0 / 729.0) * (1 + 1e-12)
+            and ak.interval_eval(X ** _int(-6), {X: ak.ArbBall(2.5, 0.5)}).hi >= 1.0 / 64.0
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "x^-6 is decreasing on [2, 3], so its range there is exactly [3^-6, 2^-6] = "
+            "[1/729, 1/64], attained at the two endpoints. 1/64 is exact in binary, so the "
+            "upper bound is compared with no slack; 1/729 is not, and the returned enclosure "
+            "is tighter than an f64 can express, so that comparison carries a 1e-12 relative "
+            "slack -- far below the 1e-3 width of the interval and far above the 1e-16 the "
+            "f64 literal is off by."
+        ),
+        note=(
+            "Also the tightness control. The enclosure used to be [-inf, inf] here, because "
+            "x^6 computed by repeated ball squaring straddled zero and its reciprocal was "
+            "therefore unbounded: sound, and completely useless."
+        ),
+    ),
+    Case(
+        id="ball_reciprocal_across_zero_is_not_a_bound",
+        subsystem="ball",
+        statement="1/x over x in [-1, 1] has no finite enclosure -- 0 is in the box",
+        op=_ball_upper(_int(1) / X, {X: ak.ArbBall(0.0, 1.0)}),
+        contract=RefusesOr(),
+        verified_by=(
+            "1/x is unbounded on every neighbourhood of 0 and undefined at it, so no finite "
+            "interval contains its range on [-1, 1]. Any finite number returned here would be "
+            "a bound that is not one."
+        ),
+        note=(
+            "Passes via a weak refusal: the ball comes back as [-inf, inf] rather than as an "
+            "exception. That is the honest 'no information' answer for ball arithmetic, but a "
+            "caller has to look at the value to notice."
+        ),
+    ),
+    Case(
+        id="ball_removable_quotient_across_zero_still_encloses",
+        subsystem="ball",
+        statement="sin(x)/x over x in [-0.5, 0.5] must not claim to exclude 0.9588510772",
+        op=_ball_encloses(ak.sin(X) / X, {X: ak.ArbBall(0.0, 0.5)}, 0.958851077208406),
+        contract=Returns(True),
+        verified_by=(
+            "sin(0.5)/0.5 = 0.95885107720840600... (mpmath, 50 digits) is the value the "
+            "expression takes at a point of the ball, so no sound enclosure over that ball can "
+            "exclude it. Pointwise ball arithmetic cannot resolve the 0/0 at the centre, so "
+            "the only correct answers are 'the whole line' or a refusal -- never 'that value "
+            "is outside'."
+        ),
+        note=(
+            "Same NaN mechanism as ball_indeterminate_product_still_encloses reached from the "
+            "other side: 1/x is indeterminate and sin(x) has midpoint 0, so the product's "
+            "radius was |0| * inf = NaN."
+        ),
+    ),
+    Case(
+        id="ball_sqrt_of_a_ball_straddling_zero_refuses",
+        subsystem="ball",
+        statement="sqrt of the ball [-1, 1] is not real -- refuse rather than take the real part",
+        op=lambda: float(ak.ArbBall(0.0, 1.0).sqrt().lo),
+        contract=RefusesOr(),
+        verified_by=(
+            "sqrt is undefined on the negative half of [-1, 1], so no real enclosure of it "
+            "exists there. The plausible wrong answer is [0, 1]: the image of the part of the "
+            "ball where sqrt happens to be defined, which silently shrinks the domain."
+        ),
+    ),
+    Case(
+        id="ball_floor_straddling_an_integer_covers_both_values",
+        subsystem="ball",
+        statement="floor over x in [0.75, 1.25] takes both 0 and 1, so the ball is >= 1 wide",
+        op=lambda: float(
+            ak.interval_eval(ak.floor(X), {X: ak.ArbBall(1.0, 0.25)}).hi
+            - ak.interval_eval(ak.floor(X), {X: ak.ArbBall(1.0, 0.25)}).lo
+        ),
+        contract=Returns(1.0, tol=1e-12),
+        verified_by=(
+            "floor(0.75) = 0 and floor(1.25) = 1, so the range is exactly {0, 1} and the "
+            "narrowest sound interval is [0, 1], of width 1. Evaluating the midpoint and "
+            "adding the input radius -- the Lipschitz shortcut that works for sin and exp -- "
+            "would give width 0.5 around floor(1) = 1, an interval that misses 0 entirely."
+        ),
+    ),
+    Case(
+        id="ball_unsupported_primitive_refuses",
+        subsystem="ball",
+        statement="sign(x) has no ball rule; interval_eval must refuse rather than use f64",
+        op=lambda: float(ak.interval_eval(ak.sign(X), {X: ak.ArbBall(0.5, 0.25)}).hi),
+        contract=RefusesOr(),
+        verified_by=(
+            "capabilities() reports numeric_ball = False for `sign`. The dangerous answer is "
+            "the f64 one, sign(0.5) = 1 as an exact ball: right on this box, wrong on any box "
+            "straddling 0, with nothing in the result to say which case the caller got."
+        ),
+    ),
+    Case(
+        id="validated_integral_removable_log_quotient",
+        subsystem="validated",
+        statement="int_0^1 log(1+x)/x dx = pi^2/12; the enclosure must contain it",
+        op=_encloses(
+            lambda: ak.verified_integral(ak.log(_int(1) + X) / X, X, 0.0, 1.0),
+            math.pi**2 / 12,
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "Expanding log(1+x)/x = sum_{n>=1} (-1)^(n+1) x^(n-1)/n and integrating term by "
+            "term gives sum (-1)^(n+1)/n^2 = eta(2) = pi^2/12 = 0.8224670334241132.... The "
+            "integrand is singular only as an *expression*; it extends continuously by 1 at "
+            "x = 0, so refusing here would be a coverage regression rather than a lie."
+        ),
+    ),
+    Case(
+        id="validated_integral_removable_at_a_grid_point",
+        subsystem="validated",
+        statement="int_0^2 (x^2-1)/(x-1) dx = 4, integrating the continuous extension x+1",
+        op=_encloses(
+            lambda: ak.verified_integral((X * X - _int(1)) / (X - _int(1)), X, 0.0, 2.0),
+            4.0,
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "(x^2-1)/(x-1) = x+1 for every x != 1, and int_0^2 (x+1) dx = [x^2/2 + x]_0^2 = 4 "
+            "exactly. The singular point x = 1 is the midpoint of the interval, so it lies on "
+            "the bisection grid -- the easy half of the removable-singularity path, and the "
+            "control for the pole cases below."
+        ),
+    ),
+    Case(
+        id="validated_integral_pole_inverse_square",
+        subsystem="validated",
+        statement="int_0^2 (x-1)^-2 dx diverges (double pole at x = 1)",
+        op=lambda: float(
+            ak.verified_integral(_int(1) / (X - _int(1)) ** _int(2), X, 0.0, 2.0).lower
+        ),
+        contract=Raises("E-VALIDATED-003"),
+        verified_by=(
+            "int (x-1)^-2 dx = -1/(x-1), so the naive FTC gives -1 - 1 = -2 -- a clean, "
+            "plausible, negative number for the integral of a strictly positive function. The "
+            "true value is +infinity: the integrand is ~ t^-2 on both sides of 1. This is the "
+            "archetype the whole gate is named for, asked of the rigorous integrator."
+        ),
+    ),
+    Case(
+        id="validated_integral_simple_pole_off_the_bisection_grid",
+        subsystem="validated",
+        statement="int_0^1 dx/(x - 1/3) diverges; 1/3 is never a dyadic bisection point",
+        op=lambda: float(ak.verified_integral(_int(1) / (X - _rat(1, 3)), X, 0.0, 1.0).lower),
+        contract=Raises("E-VALIDATED-003"),
+        verified_by=(
+            "The one-sided integrals are -inf and +inf, so the integral does not converge; its "
+            "Cauchy principal value is log(2) = 0.6931471805..., which is the plausible wrong "
+            "answer. 1/3 has no finite binary expansion, so no bisection of [0, 1] ever lands "
+            "on it: the singular point has to be found by the Newton search on the denominator "
+            "and then rejected, because the numerator 1 does not vanish there."
+        ),
+    ),
+    Case(
+        id="validated_integral_double_zero_denominator_refused",
+        subsystem="validated",
+        statement="int_-1^1 sin(x)/x^2 dx diverges: the denominator has a double zero",
+        op=lambda: float(ak.verified_integral(ak.sin(X) / (X * X), X, -1.0, 1.0).lower),
+        contract=Raises("E-VALIDATED-003"),
+        verified_by=(
+            "sin(x)/x^2 = 1/x - x/6 + ... near 0, so neither one-sided integral converges. The "
+            "odd symmetry makes 0 the plausible wrong answer, and it is exactly what a routine "
+            "that cancelled one power of x without checking the order would report. The "
+            "removable-singularity path must decline because D' = 2x vanishes at the singular "
+            "point, which is what separates this from sin(x)/x."
+        ),
+    ),
+    Case(
+        id="validated_integral_integrable_endpoint_singularity_refused",
+        subsystem="validated",
+        statement="int_0^1 -log(x) dx = 1 converges, but is not a removable N/D quotient",
+        op=lambda: float(ak.verified_integral(_int(-1) * ak.log(X), X, 0.0, 1.0).lower),
+        contract=RefusesOr(1.0),
+        verified_by=(
+            "int_0^1 -log x dx = [x - x log x]_0^1 = 1 exactly (the x log x term tends to 0). "
+            "The integral exists, so 1 is a correct answer if it can be certified; today it "
+            "cannot -- log's enclosure reaches 0 at the endpoint and the integrand is not a "
+            "0/0 quotient -- and the refusal is honest. Any *other* finite number is a lie."
+        ),
+        note=(
+            "Documented limitation (docs/mdbook/src/validated-bounds.md, 'What is still "
+            "refused'). Paired with validated_integral_removable_log_quotient, the nearest "
+            "convergent neighbour, which must keep working."
+        ),
+    ),
+    Case(
+        id="validated_bound_interior_pole_refuses",
+        subsystem="validated",
+        statement="the range of 1/x over [-1, 1] is not a bounded interval",
+        op=lambda: float(ak.bound_on_box(_int(1) / X, [(X, -1.0, 1.0)]).upper),
+        contract=Raises("E-VALIDATED-003"),
+        verified_by=(
+            "1/x is unbounded above and below on [-1, 1] and undefined at 0, so no finite "
+            "[lo, hi] encloses its range. A branch-and-bound that quietly dropped the "
+            "sub-boxes it could not model would report the range over the rest -- a "
+            "comfortable finite interval, with nothing saying part of the domain was skipped."
+        ),
+    ),
+    Case(
+        id="validated_bound_unsupported_primitive_refuses",
+        subsystem="validated",
+        statement="floor has a ball rule but no Taylor model; bound_on_box must refuse",
+        op=lambda: float(ak.bound_on_box(ak.floor(X), [(X, 0.0, 2.5)]).upper),
+        contract=Raises("E-VALIDATED-001"),
+        verified_by=(
+            "capabilities() reports numeric_ball = True and taylor_model = False for `floor`, "
+            "and floor is not differentiable, so no Lagrange remainder exists for it at any "
+            "order. Falling back to the pointwise ball rule would produce a rigorous-looking "
+            "range that is really just an evaluation over the box hull, with none of the "
+            "subdivision guarantees the caller of bound_on_box is relying on."
+        ),
+    ),
+    Case(
+        id="validated_bound_starved_budget_still_encloses",
+        subsystem="validated",
+        statement="bound_on_box(exp, [-5,5], max_subdivisions=0) is wide but must contain e^5",
+        op=_encloses(
+            lambda: ak.bound_on_box(ak.exp(X), [(X, -5.0, 5.0)], max_subdivisions=0),
+            148.4131591025766,
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "exp(5) = 148.41315910257660342... (mpmath, 50 digits) is attained at the right "
+            "endpoint, so it is in the range and must be in any enclosure of it. Exhausting "
+            "the work budget is documented as *not* an error -- the result comes back with "
+            "budget_exhausted = True and is still sound -- and this case is what makes that "
+            "promise testable rather than aspirational."
+        ),
+    ),
+    Case(
+        id="validated_integral_starved_budget_still_encloses",
+        subsystem="validated",
+        statement="int_0^5 e^x dx = e^5 - 1 must be enclosed even with zero subdivisions",
+        op=_encloses(
+            lambda: ak.verified_integral(ak.exp(X), X, 0.0, 5.0, max_subdivisions=0),
+            147.4131591025766,
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "int_0^5 e^x dx = e^5 - 1 = 147.41315910257660342... exactly. With no subdivisions "
+            "the single Taylor model over the whole interval gives a very wide interval; wide "
+            "is fine, not-containing is not."
+        ),
+    ),
+    Case(
+        id="validated_bound_tan_up_to_the_pole",
+        subsystem="validated",
+        statement="tan on [1, 1.5707963267948966] reaches 1.6331239353195370e16",
+        op=_encloses(
+            lambda: ak.bound_on_box(ak.tan(X), [(X, 1.0, 1.5707963267948966)]),
+            1.633123935319537e16,
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "The f64 literal 1.5707963267948966 is exactly "
+            "1.5707963267948965579989817342720925808, which is 6.123234e-17 *below* pi/2, so "
+            "tan is finite on the closed box and tan of that endpoint is "
+            "1.6331239353195369756e16 (mpmath, 60 digits). A bound therefore exists, and it "
+            "is enormous -- which is the point: a routine that clipped, overflowed or bisected "
+            "away from the endpoint would report a comfortable finite maximum for a function "
+            "that is 10^16 at the edge of the box."
+        ),
+    ),
+    Case(
+        id="validated_no_roots_control_root_free_box",
+        subsystem="validated",
+        statement="x^2 + 1 has no real root, so verified_no_roots on [-5, 5] is 'true'",
+        op=lambda: str(ak.verified_no_roots(X * X + _int(1), [(X, -5.0, 5.0)])),
+        contract=Returns("true"),
+        verified_by=(
+            "x^2 + 1 >= 1 > 0 for every real x. The control for the three-valued predicate: a "
+            "verdict function that answered 'undecided' to everything would be perfectly sound "
+            "and perfectly useless, and only a positive case catches that."
+        ),
+    ),
+    Case(
+        id="validated_no_roots_even_count_still_false",
+        subsystem="validated",
+        statement="x^2 - 2 has two roots in [-2, 2] and both endpoints are positive",
+        op=lambda: str(ak.verified_no_roots(X * X - _int(2), [(X, -2.0, 2.0)])),
+        contract=Returns("false"),
+        verified_by=(
+            "+-sqrt(2) = +-1.41421356... both lie in [-2, 2], while f(-2) = f(2) = 2 > 0. An "
+            "endpoint-only sign test sees no change and would answer 'true' -- a *certified* "
+            "claim that a box containing two roots is root-free, which is the worst shape a "
+            "verdict can have."
+        ),
+    ),
+    Case(
+        id="validated_no_roots_double_root_at_the_centre",
+        subsystem="validated",
+        statement="(x-1)^2 has a root at the centre of [0, 2] and never changes sign",
+        op=lambda: str(ak.verified_no_roots((X - _int(1)) ** _int(2), [(X, 0.0, 2.0)])),
+        contract=Returns("false"),
+        verified_by=(
+            "(1-1)^2 = 0, so x = 1 is a root of even multiplicity and it is the exact midpoint "
+            "of [0, 2]. There is no sign change anywhere, so the intermediate value theorem "
+            "cannot see it; the verdict has to come from exact substitution at a distinguished "
+            "point of the box."
+        ),
+    ),
+    Case(
+        id="validated_sign_tangent_at_the_endpoint_true",
+        subsystem="validated",
+        statement="Cusa-Huygens: x(2 + cos x) - 3 sin x >= 0 on [0, 1.5], tight at x = 0",
+        op=lambda: str(
+            ak.verified_sign(
+                X * (_int(2) + ak.cos(X)) - _int(3) * ak.sin(X), [(X, 0.0, 1.5)], "nonnegative"
+            )
+        ),
+        contract=Returns("true"),
+        verified_by=(
+            "Taylor at 0: x(2 + cos x) - 3 sin x = x^5/60 - x^7/1260 + ..., leading coefficient "
+            "1/60 > 0, and a 2001-point mpmath sweep of [0, 1.5] at 60 digits finds no "
+            "negative value. The margin vanishes at x = 0, so every range enclosure straddles "
+            "zero however fine the subdivision; only the endpoint expansion with a proven "
+            "Lagrange remainder can decide it."
+        ),
+    ),
+    Case(
+        id="validated_sign_tangent_at_the_endpoint_false",
+        subsystem="validated",
+        statement="x - sin x - x^3/6 >= 0 is FALSE on [0, 0.5] (it is -x^5/120 + ...)",
+        op=lambda: str(
+            ak.verified_sign(X - ak.sin(X) - X ** _int(3) / _int(6), [(X, 0.0, 0.5)], "nonnegative")
+        ),
+        contract=Returns("false"),
+        verified_by=(
+            "x - sin x = x^3/6 - x^5/120 + x^7/5040 - ..., so the expression is "
+            "-x^5/120 + x^7/5040 - ... which is < 0 throughout (0, 0.5]; at x = 0.5 mpmath "
+            "gives -2.58872e-4. The mirror image of the Cusa-Huygens case -- same shape, same "
+            "tangency at the endpoint, opposite leading sign -- so an endpoint expansion that "
+            "misread the leading coefficient's sign would certify a false inequality here."
+        ),
+    ),
+    Case(
+        id="validated_sign_interior_tangency_stays_undecided",
+        subsystem="validated",
+        statement="(x - 7/10)^2 (x+1) >= 0 on [0, 3/2] touches zero in the interior",
+        op=lambda: str(
+            ak.verified_sign(
+                (X - _rat(7, 10)) ** _int(2) * (X + _int(1)), [(X, 0.0, 1.5)], "nonnegative"
+            )
+        ),
+        contract=Returns("undecided"),
+        verified_by=(
+            "The expression is a square times (x+1) > 0 on [0, 3/2], so it is non-negative "
+            "there, and it vanishes at the interior point x = 7/10. The statement is TRUE and "
+            "'undecided' is the honest answer, because the endpoint expansion does not reach "
+            "an interior tangency. The case pins that down: upgrading it to 'true' on the "
+            "strength of an enclosure that merely touches zero would let every "
+            "grazing-but-negative expression certify too."
+        ),
+        note=(
+            "Contract is Returns('undecided') deliberately. A later improvement that genuinely "
+            "proves it 'true' should trip this case and be reviewed rather than pass silently."
+        ),
+    ),
+    Case(
+        id="validated_sign_strict_fails_where_the_margin_vanishes",
+        subsystem="validated",
+        statement="x - sin x > 0 is FALSE on [0, 1]: the expression is 0 at x = 0",
+        op=lambda: str(ak.verified_sign(X - ak.sin(X), [(X, 0.0, 1.0)], "positive")),
+        contract=Returns("false"),
+        verified_by=(
+            "x - sin x >= 0 on [0, 1] with equality exactly at x = 0, so the non-strict "
+            "inequality holds and the strict one does not. Reporting 'true' for the strict "
+            "form is the classic boundary error, and it is the kind that survives every "
+            "numerical spot-check that happens to avoid the endpoint."
         ),
     ),
 ]


### PR DESCRIPTION
An audit of the rigorous-numerics layer — the one subsystem whose entire claim
is a *guarantee*. `tests/silent_errors/corpus.py` had no cases for it at all.

**~8,000 randomised trials plus ~150 hand-picked cases**, each checked against
an independently computed truth (mpmath at 40–60 dps, `mpmath.quad`, exact
sympy root isolation, or a closed form): `bound_on_box`, `verified_integral`,
`verified_sign`, `verified_no_roots`, `interval_eval`, `ArbBall`, SOS
certificates, and starved-budget behaviour.

## One soundness violation, found and fixed

`ArbBall` could return a NaN-radius ball whose `contains` answers **`false` for
every real number**:

```
interval_eval((x^-3)^2, {x: ArbBall(-2.325, 1.0)})  ->  ArbBall(0.0 ± NaN)
r.contains(0.006331864446927654)                    ->  False
```

Independently: on `|x| ∈ [1.325, 3.325]`, `x^-6` ranges over
`[7.400313e-4, 0.1848012]` (mpmath, 50 digits), and the queried value is the
image of the box midpoint — so it is *in* the true range. The cause is `0 · ∞`
in the radius of a product with an indeterminate operand.

This is a **directed** lie, which is what makes it serious: `contains` is the
documented way to cross-check a symbolic identity, so `False` reads as a
refutation. NaN can no longer escape; "no information" is canonically
`[0 ± ∞]`, which `contains`/`lo`/`hi` read as the whole real line.

## Two more, of lower severity

- **`powi` used repeated ball multiplication.** `[-1,1]²` gave `[-2,4]` instead
  of `[0,1]`, and `[2,3]^-6` had *no finite enclosure at all* for a function
  whose range is `[1/729, 1/64]`. Sound before, but unusable. Now enclosed from
  the endpoints, which is the exact range.
- **Corner-built balls were not rounded outward.** `Div`/`pow_f`/`exp`/`log`
  built `mid=(min+max)/2`, `rad=(max−min)/2` with round-to-nearest and no bump,
  and `add_rounding_error` scaled its bump by `|mid|` alone — which covers
  nothing for a ball centred on zero. Found by inspection while fixing `powi`;
  **no runtime counterexample was constructed**, and the commit says so. All
  such balls now go through one `from_min_max` that rounds outward by 4 ulps of
  `|mid| + rad`.

## Stale documentation corrected

`docs/mdbook/src/validated-bounds.md` listed `gamma`, `digamma`, `lambert_w`,
`bessel_j0`, `bessel_j1` as outside the Taylor-model fragment. All have
rigorous rules (as do `trigamma`, `dilog`, `Si`, `Ci`, `Shi`, `Chi`, `Ei`,
`li`, Fresnel), verified sound against mpmath on 25 boxes; only the elliptic
integrals and the non-differentiable primitives are genuinely outside. The
table also claimed `verified_no_roots((x−1)², [0,2]) == "undecided"`; it is
`"false"` — `[0,3/2]` is the actually-undecided case.

## What held up

Worth recording, because these are the claims the layer sells:

- **`budget_exhausted=True` still guarantees containment** — 955 exhausted
  results, all containing the truth.
- **No `f64` fallback anywhere.** `sign`, `round`, `arg`, `conjugate`, `re`,
  `im`, the elliptic family and `atan2` all refuse rather than laundering a
  non-rigorous value; `bounds_supported` agrees with what `bound_on_box`
  accepts.
- **No false SOS certificate** in 15 cases; the Motzkin certificate is a real
  Reznick multiplier identity that `sympy.expand`s to residual 0.
- `floor`/`ceil` balls straddling an integer cover both values; `tan` up to the
  last `f64` below `π/2` encloses `1.63e16` correctly.
- 500 polynomials checked against **exact** sympy `count_roots`/`real_roots`:
  no false root verdict in 500, no false sign verdict in 2000.

Three "silent errors" flagged by the removable-singularity fuzzer
(`x/(eˣ−1)`, `x/sin x`, `atan x / x`) were harness false positives — all three
re-verified against `mp.quad` on the continuous extension; alkahest's
enclosures are correct and tight.

## Left as refusals

`√x` on `[0,1]`, `asin` on `[-1,1]`, `∫₋₁¹ (1−cos x)/x²` and `x^(1/3)` over
negative boxes are refused where an answer exists — honest coded refusals
matching documented limits (unbounded endpoint derivative; vanishing `D'`;
`x^(1/3)` routed through `exp(⅓ log x)`). Imprecision, not unsoundness.
`verified_sign(x² ≥ 0, [-1,1])` is `"undecided"` by interior tangency and is
now pinned with a `Returns("undecided")` case, so an improvement trips the test
rather than passing silently.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2898 passed, 0
failed, 11 ignored** (main: 2895). `pytest tests/silent_errors/` → 296 passed,
**286 cases, 0 silent errors** (main: 261 cases) — 25 new cases across two new
subsystems, `ball` (7) and `validated` (18), scoring the containment claim
itself via three new helpers. clippy `-D warnings`, `fmt --check`,
`RUSTDOCFLAGS=-D warnings cargo doc`, `ruff check`, `check_error_codes.py`
(231 codes) and `check_api_freeze.py` all clean. No public enum variant or
struct field added, so `cargo semver-checks` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interval arithmetic reliability and outward rounding across division, powers, logarithms, roots, and trigonometric functions.
  - Indeterminate results now safely widen to the whole real line instead of producing unusable intervals.
  - Power calculations provide more accurate endpoint enclosures, including cases spanning zero.
  - Membership and endpoint queries now behave consistently for unbounded or indeterminate results.

- **Documentation**
  - Added guidance for unbounded interval results, finiteness checks, and containment behavior.
  - Clarified root-verification outcomes and Taylor-model function coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->