### PR TITLE
fix(transform): a hypothesis whose negation is a fact is a refutation, not a side condition

### DIFF
--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -429,9 +429,10 @@ pub mod experimental {
     pub use crate::transform::fourier::fourier_derivative_rule;
     pub use crate::transform::laplace::laplace_derivative_rule;
     pub use crate::transform::{
-        fourier_transform, inverse_fourier_transform, inverse_laplace_transform,
+        fourier_transform, fourier_transform_with_conditions, inverse_fourier_transform,
+        inverse_fourier_transform_with_conditions, inverse_laplace_transform,
         inverse_laplace_transform_with_assumptions, inverse_laplace_transform_with_conditions,
-        laplace_transform, FourierError, LaplaceError,
+        laplace_transform, laplace_transform_with_conditions, FourierError, LaplaceError,
     };
     pub use crate::transform::{
         inverse_z_transform, inverse_z_transform_with_assumptions,

--- a/alkahest-core/src/transform/fourier.rs
+++ b/alkahest-core/src/transform/fourier.rs
@@ -46,14 +46,38 @@
 //! | `f(b·x)` (`b>0`)       | `(1/b)·F(ξ/b)`                         | scaling         |
 //! | `f'(x)`                | `2πi ξ·F(ξ)`                          | derivative rule |
 //!
+//! # Positivity is part of the table, not a footnote
+//!
+//! Every row above marked `a > 0` is *false* on the other side of `a = 0`, not
+//! merely unproven: `e^{+a x²}`, `e^{+a|x|}` and `θ(x)e^{+a x}` have no Fourier
+//! transform at all, and the Lorentzian's is
+//!
+//! ```text
+//!   F{2a/(a² + 4π²x²)}(ξ) = sgn(a)·e^{−|a||ξ|},
+//! ```
+//!
+//! so at `a < 0` the tabulated `e^{−a|ξ|}` has the wrong sign *and* grows where
+//! the truth decays.  So the rate is checked rather than assumed:
+//!
+//! * a **literal** `a ≤ 0` refutes the row and returns [`FourierError::NoRule`];
+//! * a **symbolic** `a` is a hypothesis, recorded as a
+//!   [`crate::deriv::SideCondition::Positive`] and returned by
+//!   [`fourier_transform_with_conditions`] (or, for the historical signature, on
+//!   [`super::take_transform_side_conditions`]).  A symbol whose static
+//!   [`Domain`] is `Positive` discharges it silently.
+//!
 //! # Caveats
 //!
-//! The transform is **formal** — no convergence region or distribution-theoretic
-//! side condition is attached.  Unrecognised forms return
-//! [`FourierError::NoRule`] rather than guessing.  The convolution theorem is
-//! declined (the kernel has no convolution primitive to represent the input).
+//! The transform is otherwise **formal** — no convergence *region* is computed
+//! and no distribution-theoretic side condition is attached.  Unrecognised forms
+//! return [`FourierError::NoRule`] rather than guessing.  The convolution
+//! theorem is declined (the kernel has no convolution primitive to represent the
+//! input).
 
+use crate::deriv::SideCondition;
 use crate::kernel::{Domain, ExprData, ExprId, ExprPool};
+
+use super::{stash_transform_side_conditions, Genericity};
 
 /// Errors from the Fourier transform routines.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -291,6 +315,39 @@ fn phase_minus(a: ExprId, xi: ExprId, pool: &ExprPool) -> ExprId {
     pool.func("exp", vec![simp(arg, pool)])
 }
 
+/// Require the decay rate / amplitude `a` of a table entry to be positive.
+///
+/// Every entry in this module's table is stated for `a > 0`, and the two ways
+/// that can fail are different failures:
+///
+/// * A **literal** `a ≤ 0` refutes the hypothesis.  `e^{+3|x|}` and
+///   `θ(x)·e^{+3x}` have no Fourier transform at all — their defining integrals
+///   diverge — and a Lorentzian with a negative amplitude has the transform
+///   `−e^{−|a||ξ|}`, whose sign and whose direction of growth are both opposite
+///   to the `e^{−a|ξ|}` the table would emit.  Neither is a conditional answer;
+///   both are refused.
+/// * A **symbolic** `a` settles nothing, so it is recorded as a hypothesis on
+///   [`super::take_transform_side_conditions`] — unless the symbol's static
+///   [`Domain`] or the ambient facts already prove it.
+fn require_positive_rate(
+    a: ExprId,
+    what: &str,
+    pool: &ExprPool,
+    gen: &mut Genericity<'_>,
+) -> Result<(), FourierError> {
+    if let Some(r) = literal_rational(a, pool) {
+        if r <= 0 {
+            return Err(FourierError::NoRule(format!(
+                "{what}: {} is not positive, so this table entry does not apply",
+                pool.display(a)
+            )));
+        }
+        return Ok(());
+    }
+    gen.need_positive(a, pool);
+    Ok(())
+}
+
 // ===========================================================================
 // Forward transform
 // ===========================================================================
@@ -332,11 +389,34 @@ pub fn fourier_transform(
     xi: ExprId,
     pool: &ExprPool,
 ) -> Result<ExprId, FourierError> {
+    stash_transform_side_conditions(Vec::new());
+    let (out, conds) = fourier_transform_with_conditions(f, x, xi, pool)?;
+    stash_transform_side_conditions(conds);
+    Ok(out)
+}
+
+/// [`fourier_transform`] with its genericity hypotheses returned in band rather
+/// than through [`super::take_transform_side_conditions`].
+///
+/// The list is empty for every input whose rates are literal numbers.  It is
+/// non-empty exactly when a table entry was selected on a positivity fact about
+/// a symbolic parameter that the input does not settle: `a > 0` for the
+/// Gaussian `e^{−a x²}`, the two-sided exponential `e^{−a|x|}`, the one-sided
+/// `θ(x)e^{−a x}`, and the Lorentzian `2a/(a² + 4π²x²)`.  Each of those pairs is
+/// *false* on the other side of `a = 0` rather than merely unproven — the first
+/// three integrals diverge, and the Lorentzian's transform changes sign.
+pub fn fourier_transform_with_conditions(
+    f: ExprId,
+    x: ExprId,
+    xi: ExprId,
+    pool: &ExprPool,
+) -> Result<(ExprId, Vec<SideCondition>), FourierError> {
     if x == xi {
         return Err(FourierError::SameVariable);
     }
-    let out = fourier_inner(f, x, xi, pool, 0)?;
-    Ok(normalize(simp(out, pool), pool))
+    let mut gen = Genericity::new(None);
+    let out = fourier_inner(f, x, xi, pool, 0, &mut gen)?;
+    Ok((normalize(simp(out, pool), pool), gen.into_conditions()))
 }
 
 /// Compute the inverse Fourier transform `F⁻¹{g(ξ)}(x) = ∫ g(ξ) e^{+2πiξx} dξ`.
@@ -355,15 +435,30 @@ pub fn inverse_fourier_transform(
     x: ExprId,
     pool: &ExprPool,
 ) -> Result<ExprId, FourierError> {
+    stash_transform_side_conditions(Vec::new());
+    let (out, conds) = inverse_fourier_transform_with_conditions(g, xi, x, pool)?;
+    stash_transform_side_conditions(conds);
+    Ok(out)
+}
+
+/// [`inverse_fourier_transform`] with its genericity hypotheses returned in
+/// band.  See [`fourier_transform_with_conditions`] — the inverse is the
+/// forward transform at `−x`, so it rests on exactly the same hypotheses.
+pub fn inverse_fourier_transform_with_conditions(
+    g: ExprId,
+    xi: ExprId,
+    x: ExprId,
+    pool: &ExprPool,
+) -> Result<(ExprId, Vec<SideCondition>), FourierError> {
     if xi == x {
         return Err(FourierError::SameVariable);
     }
     // F⁻¹{g}(x) = F{g}(−x): transform in ξ to a fresh frequency, then negate it.
-    let forward = fourier_transform(g, xi, x, pool)?;
+    let (forward, conds) = fourier_transform_with_conditions(g, xi, x, pool)?;
     let neg_x = neg(x, pool);
-    Ok(normalize(
-        simp(subs_one(forward, x, neg_x, pool), pool),
-        pool,
+    Ok((
+        normalize(simp(subs_one(forward, x, neg_x, pool), pool), pool),
+        conds,
     ))
 }
 
@@ -373,6 +468,7 @@ fn fourier_inner(
     xi: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, FourierError> {
     if depth > MAX_DEPTH {
         return Err(FourierError::NoRule("recursion depth exceeded".into()));
@@ -386,7 +482,7 @@ fn fourier_inner(
 
     // Lorentzian `2a/(a² + 4π² x²)` → e^{−a|ξ|}  (the dual of the two-sided
     // exponential; makes that pair invertible by the duality `F⁻¹{g} = F{g}(−·)`).
-    if let Some(res) = try_lorentzian(f, x, xi, pool) {
+    if let Some(res) = try_lorentzian(f, x, xi, pool, gen)? {
         return Ok(res);
     }
 
@@ -395,16 +491,16 @@ fn fourier_inner(
         ExprData::Add(args) => {
             let mut terms = Vec::with_capacity(args.len());
             for a in args {
-                terms.push(fourier_inner(a, x, xi, pool, depth + 1)?);
+                terms.push(fourier_inner(a, x, xi, pool, depth + 1, gen)?);
             }
             Ok(pool.add(terms))
         }
 
         // Products: peel the constant scalar, then dispatch the x-dependent body.
-        ExprData::Mul(args) => fourier_mul(&args, x, xi, pool, depth),
+        ExprData::Mul(args) => fourier_mul(&args, x, xi, pool, depth, gen),
 
         ExprData::Func { name, args } if args.len() == 1 => {
-            fourier_func(&name, args[0], f, x, xi, pool, depth)
+            fourier_func(&name, args[0], f, x, xi, pool, depth, gen)
         }
 
         _ => Err(FourierError::NoRule(pool.display(f).to_string())),
@@ -418,6 +514,7 @@ fn fourier_mul(
     xi: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, FourierError> {
     // Pull out the constant (x-free) scalar prefactor (linearity).
     let (consts, rest): (Vec<ExprId>, Vec<ExprId>) =
@@ -431,13 +528,13 @@ fn fourier_mul(
         0 => {
             // Wholly constant — handled by caller, but be safe.
             let c = scalar.unwrap_or_else(|| pool.integer(1_i32));
-            return fourier_inner(c, x, xi, pool, depth + 1);
+            return fourier_inner(c, x, xi, pool, depth + 1, gen);
         }
         1 => rest[0],
         _ => pool.mul(rest.clone()),
     };
 
-    let transformed = fourier_product_body(body, &rest, x, xi, pool, depth)?;
+    let transformed = fourier_product_body(body, &rest, x, xi, pool, depth, gen)?;
     Ok(match scalar {
         Some(c) => pool.mul(vec![c, transformed]),
         None => transformed,
@@ -447,6 +544,7 @@ fn fourier_mul(
 /// Transform an x-dependent product (constant scalar already peeled), applying
 /// the structural product theorems: modulation `e^{2πi a x}·f`, two-sided
 /// exponential `e^{−a|x|}`, one-sided `θ(x)·e^{−a x}`.
+#[allow(clippy::too_many_arguments)]
 fn fourier_product_body(
     body: ExprId,
     factors: &[ExprId],
@@ -454,9 +552,10 @@ fn fourier_product_body(
     xi: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, FourierError> {
     // (1) θ(x)·e^{−a x}  →  1/(a + 2πi ξ)   [causal / one-sided exponential]
-    if let Some(res) = try_one_sided_exponential(factors, x, xi, pool)? {
+    if let Some(res) = try_one_sided_exponential(factors, x, xi, pool, gen)? {
         return Ok(res);
     }
 
@@ -464,7 +563,7 @@ fn fourier_product_body(
     for (i, &fac) in factors.iter().enumerate() {
         if let Some(a) = match_modulation(fac, x, pool) {
             let rest = remove_index(factors, i, pool);
-            let g_transform = fourier_inner(rest, x, xi, pool, depth + 1)?;
+            let g_transform = fourier_inner(rest, x, xi, pool, depth + 1, gen)?;
             let xi_minus_a = simp(pool.add(vec![xi, neg(a, pool)]), pool);
             return Ok(subs_one(g_transform, xi, xi_minus_a, pool));
         }
@@ -473,7 +572,7 @@ fn fourier_product_body(
     // No product theorem applied; if `body` is a lone factor, fall through to the
     // structural table (cannot recurse forever — a non-`Mul` re-enters the table).
     if !matches!(pool.get(body), ExprData::Mul(_)) {
-        return fourier_inner(body, x, xi, pool, depth + 1);
+        return fourier_inner(body, x, xi, pool, depth + 1, gen);
     }
 
     Err(FourierError::NoRule(pool.display(body).to_string()))
@@ -530,6 +629,7 @@ fn try_one_sided_exponential(
     x: ExprId,
     xi: ExprId,
     pool: &ExprPool,
+    gen: &mut Genericity<'_>,
 ) -> Result<Option<ExprId>, FourierError> {
     // Locate a Heaviside θ(x).
     let heaviside_idx = factors.iter().position(|&fac| {
@@ -558,6 +658,7 @@ fn try_one_sided_exponential(
             if off == pool.integer(0_i32) && coeff != pool.integer(0_i32) {
                 // exponent = coeff·x; want coeff = −a, so a = −coeff.
                 let a = simp(neg(coeff, pool), pool);
+                require_positive_rate(a, "one-sided exponential θ(x)·e^{−a x}", pool, gen)?;
                 let denom = pool.add(vec![a, pool.mul(vec![two_pi_i(pool), xi])]);
                 return Ok(Some(recip(denom, pool)));
             }
@@ -575,7 +676,13 @@ fn try_one_sided_exponential(
 /// Strategy: split `f = numer · denom^{−1}` with `denom = C₀ + C₂·x²` quadratic
 /// in `x` (no linear term).  Solve `a = numer/2`, then verify `C₀ = a²` and
 /// `C₂ = 4π²` by simplifying the differences to `0`.
-fn try_lorentzian(f: ExprId, x: ExprId, xi: ExprId, pool: &ExprPool) -> Option<ExprId> {
+fn try_lorentzian(
+    f: ExprId,
+    x: ExprId,
+    xi: ExprId,
+    pool: &ExprPool,
+    gen: &mut Genericity<'_>,
+) -> Result<Option<ExprId>, FourierError> {
     let factors: Vec<ExprId> = match pool.get(f) {
         ExprData::Mul(a) => a,
         _ => vec![f],
@@ -587,7 +694,7 @@ fn try_lorentzian(f: ExprId, x: ExprId, xi: ExprId, pool: &ExprPool) -> Option<E
         if let ExprData::Pow { base, exp } = pool.get(fac) {
             if exp == pool.integer(-1_i32) && !is_free_of(base, x, pool) {
                 if denom.is_some() {
-                    return None; // more than one x-dependent denominator factor
+                    return Ok(None); // more than one x-dependent denominator factor
                 }
                 denom = Some(base);
                 continue;
@@ -595,25 +702,29 @@ fn try_lorentzian(f: ExprId, x: ExprId, xi: ExprId, pool: &ExprPool) -> Option<E
         }
         numer_parts.push(fac);
     }
-    let denom = denom?;
+    let Some(denom) = denom else {
+        return Ok(None);
+    };
     let numer = match numer_parts.len() {
         0 => pool.integer(1_i32),
         1 => numer_parts[0],
         _ => pool.mul(numer_parts),
     };
     if !is_free_of(numer, x, pool) {
-        return None;
+        return Ok(None);
     }
 
     // denom = C₀ + C₂·x²  (reject any linear or higher term).
-    let (c0, c2) = quadratic_in_x(denom, x, pool)?;
+    let Some((c0, c2)) = quadratic_in_x(denom, x, pool) else {
+        return Ok(None);
+    };
 
     // a = numer / 2.
     let a = simp(pool.mul(vec![numer, pool.rational(1_i32, 2_i32)]), pool);
     let a2 = pool.pow(a, pool.integer(2_i32));
     // Verify C₀ − a² = 0.
     if simp(pool.add(vec![c0, neg(a2, pool)]), pool) != pool.integer(0_i32) {
-        return None;
+        return Ok(None);
     }
     // Verify C₂ − 4π² = 0.
     let four_pi2 = pool.mul(vec![
@@ -621,13 +732,22 @@ fn try_lorentzian(f: ExprId, x: ExprId, xi: ExprId, pool: &ExprPool) -> Option<E
         pool.pow(pi(pool), pool.integer(2_i32)),
     ]);
     if simp(pool.add(vec![c2, neg(four_pi2, pool)]), pool) != pool.integer(0_i32) {
-        return None;
+        return Ok(None);
     }
+
+    // `C₀ = a²` is satisfied by `a` and by `−a` alike, and the two give
+    // *different* transforms: the pair is `2a/(a² + 4π²x²) ↦ sgn(a)·e^{−|a||ξ|}`.
+    // Reading the root off the numerator picks `a` and emits `e^{−a|ξ|}`, which
+    // for `a < 0` is both the wrong sign and unbounded — `F{−2/(1 + 4π²x²)}`
+    // came back as `e^{+|ξ|}` (`1.3499` at `ξ = 0.3`) against a true
+    // `−e^{−|ξ|} = −0.7408`.  So positivity is not decoration here; it is what
+    // selects the branch.
+    require_positive_rate(a, "Lorentzian 2a/(a² + 4π²x²)", pool, gen)?;
 
     // F = e^{−a|ξ|}.
     let abs_xi = pool.func("abs", vec![xi]);
     let arg = neg(pool.mul(vec![a, abs_xi]), pool);
-    Some(pool.func("exp", vec![simp(arg, pool)]))
+    Ok(Some(pool.func("exp", vec![simp(arg, pool)])))
 }
 
 /// Decompose `expr = C₀ + C₂·x²` (both `Cᵢ` free of `x`, no linear or higher
@@ -695,6 +815,7 @@ fn fourier_func(
     xi: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, FourierError> {
     // δ(x − a) → e^{−2πi a ξ}   (δ(x) ↦ 1).
     if name == "diracdelta" {
@@ -714,7 +835,7 @@ fn fourier_func(
     }
 
     if name == "exp" {
-        return fourier_exp(arg, x, xi, pool);
+        return fourier_exp(arg, x, xi, pool, gen);
     }
 
     let _ = (f, depth);
@@ -730,6 +851,7 @@ fn fourier_exp(
     x: ExprId,
     xi: ExprId,
     pool: &ExprPool,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, FourierError> {
     // ── Gaussian (centred or shifted): arg = −a·(x − b)² + d. ───────────────
     // Completing the square handles the centred case (b = 0, d = 0) as well as
@@ -737,6 +859,9 @@ fn fourier_exp(
     // (its derivation collapses an I² cross-term via the kernel's i² = −1 rule);
     // the constant offset d rides along as the scalar e^{d}.
     if let Some((a, b, d)) = match_gaussian_quadratic(arg, x, pool) {
+        // A literal `a ≤ 0` was already rejected by the matcher; a symbolic one
+        // is a hypothesis (`e^{+a x²}` has no transform), so record it.
+        require_positive_rate(a, "Gaussian e^{−a x²}", pool, gen)?;
         // F{e^{−a x²}}(ξ) = √(π/a)·e^{−π² ξ²/a}; shift by b multiplies by the
         // phase e^{−2πi b ξ} (shift theorem); the offset d scales by e^{d}.
         let pi_e = pi(pool);
@@ -760,6 +885,7 @@ fn fourier_exp(
 
     // ── Two-sided exponential: arg = −a·|x| (a free of x, a > 0 assumed). ────
     if let Some(a) = match_abs_neg(arg, x, pool) {
+        require_positive_rate(a, "two-sided exponential e^{−a|x|}", pool, gen)?;
         // F{e^{−a|x|}}(ξ) = 2a/(a² + 4π² ξ²).
         let two_a = pool.mul(vec![pool.integer(2_i32), a]);
         let a2 = pool.pow(a, pool.integer(2_i32));

--- a/alkahest-core/src/transform/fourier.rs
+++ b/alkahest-core/src/transform/fourier.rs
@@ -344,6 +344,12 @@ fn require_positive_rate(
         }
         return Ok(());
     }
+    if gen.refuted(&SideCondition::Positive(a), pool) {
+        return Err(FourierError::NoRule(format!(
+            "{what}: {} is known to be negative, so this table entry does not apply",
+            pool.display(a)
+        )));
+    }
     gen.need_positive(a, pool);
     Ok(())
 }

--- a/alkahest-core/src/transform/fourier/tests.rs
+++ b/alkahest-core/src/transform/fourier/tests.rs
@@ -600,3 +600,195 @@ fn divergent_product_form_still_declines() {
     let err = fourier_transform(pool.func("exp", vec![arg]), x, xi, &pool).unwrap_err();
     assert!(matches!(err, FourierError::NoRule(_)), "{err}");
 }
+
+// ===========================================================================
+// Positivity of a rate is a branch selector, not decoration
+// ===========================================================================
+//
+// Every entry in the table is stated for `a > 0`.  A literal `a ≤ 0` refutes
+// the entry — `e^{+3|x|}` and `θ(x)e^{+3x}` have no transform at all, and the
+// Lorentzian's transform changes sign — and is refused.  A symbolic `a` leaves
+// it open and is reported.
+//
+// The Lorentzian is the sharp one: `C₀ = a²` is satisfied by `a` and `−a`
+// alike, so reading the root off the numerator silently picked the wrong branch
+// for a negative amplitude.  `F{−2/(1 + 4π²x²)}` returned `e^{+|ξ|}` — 1.3499
+// at ξ = 0.3, and *growing* — against a true `−e^{−|ξ|} = −0.7408` (mpmath
+// `quadosc` agrees with the closed form to 10 digits).
+
+mod rate_positivity {
+    use super::*;
+    use crate::deriv::SideCondition;
+
+    /// `c/(c0 + 4π²x²)`.
+    fn lorentzian(pool: &ExprPool, x: ExprId, numer: ExprId, c0: ExprId) -> ExprId {
+        let pi = pool.symbol("pi", Domain::Real);
+        let four_pi2_x2 = pool.mul(vec![
+            int(pool, 4),
+            pool.pow(pi, int(pool, 2)),
+            pool.pow(x, int(pool, 2)),
+        ]);
+        let denom = pool.add(vec![c0, four_pi2_x2]);
+        pool.mul(vec![numer, pool.pow(denom, int(pool, -1))])
+    }
+
+    fn positives(conds: &[SideCondition]) -> Vec<ExprId> {
+        conds
+            .iter()
+            .filter_map(|c| match c {
+                SideCondition::Positive(e) => Some(*e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn negative_amplitude_lorentzian_is_declined() {
+        let (pool, x, xi) = setup();
+        let f = lorentzian(&pool, x, int(&pool, -2), int(&pool, 1));
+        let err = fourier_transform(f, x, xi, &pool).unwrap_err();
+        assert!(matches!(err, FourierError::NoRule(_)), "{err}");
+    }
+
+    #[test]
+    fn negative_amplitude_lorentzian_is_declined_at_a_second_scale() {
+        let (pool, x, xi) = setup();
+        let f = lorentzian(&pool, x, int(&pool, -6), int(&pool, 9));
+        let err = fourier_transform(f, x, xi, &pool).unwrap_err();
+        assert!(matches!(err, FourierError::NoRule(_)), "{err}");
+    }
+
+    #[test]
+    fn positive_amplitude_lorentzian_still_transforms() {
+        // The control: the neighbouring case that must keep working.
+        let (pool, x, xi) = setup();
+        let f = lorentzian(&pool, x, int(&pool, 6), int(&pool, 9));
+        let (g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert!(conds.is_empty(), "conds = {conds:?}");
+        let abs_xi = pool.func("abs", vec![xi]);
+        let want = pool.func(
+            "exp",
+            vec![simp(
+                pool.mul(vec![int(&pool, -1), int(&pool, 3), abs_xi]),
+                &pool,
+            )],
+        );
+        assert_eq_simplified(&pool, g, want);
+    }
+
+    #[test]
+    fn symbolic_amplitude_lorentzian_reports_its_positivity() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let numer = pool.mul(vec![int(&pool, 2), a]);
+        let c0 = pool.pow(a, int(&pool, 2));
+        let f = lorentzian(&pool, x, numer, c0);
+        let (_g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert_eq!(positives(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn a_positive_domain_amplitude_discharges_it() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Positive);
+        let numer = pool.mul(vec![int(&pool, 2), a]);
+        let c0 = pool.pow(a, int(&pool, 2));
+        let f = lorentzian(&pool, x, numer, c0);
+        let (_g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert!(conds.is_empty(), "conds = {conds:?}");
+    }
+
+    #[test]
+    fn a_growing_two_sided_exponential_is_declined() {
+        // ∫ e^{+3|x|}·e^{−2πiξx} dx does not converge; the table would have
+        // reported the finite `−6/(9 + 4π²ξ²)`.
+        let (pool, x, xi) = setup();
+        let absx = pool.func("abs", vec![x]);
+        let f = pool.func("exp", vec![pool.mul(vec![int(&pool, 3), absx])]);
+        let err = fourier_transform(f, x, xi, &pool).unwrap_err();
+        assert!(matches!(err, FourierError::NoRule(_)), "{err}");
+    }
+
+    #[test]
+    fn a_growing_one_sided_exponential_is_declined() {
+        let (pool, x, xi) = setup();
+        let f = pool.mul(vec![
+            pool.func("heaviside", vec![x]),
+            pool.func("exp", vec![pool.mul(vec![int(&pool, 3), x])]),
+        ]);
+        let err = fourier_transform(f, x, xi, &pool).unwrap_err();
+        assert!(matches!(err, FourierError::NoRule(_)), "{err}");
+    }
+
+    #[test]
+    fn a_symbolic_two_sided_exponential_reports_its_rate() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let absx = pool.func("abs", vec![x]);
+        let f = pool.func("exp", vec![pool.mul(vec![int(&pool, -1), a, absx])]);
+        let (_g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert_eq!(positives(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn a_symbolic_gaussian_reports_its_curvature() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let f = pool.func(
+            "exp",
+            vec![pool.mul(vec![int(&pool, -1), a, pool.pow(x, int(&pool, 2))])],
+        );
+        let (_g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert_eq!(positives(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn a_symbolic_one_sided_exponential_reports_its_rate() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let f = pool.mul(vec![
+            pool.func("heaviside", vec![x]),
+            pool.func(
+                "exp",
+                vec![simp(pool.mul(vec![int(&pool, -1), a, x]), &pool)],
+            ),
+        ]);
+        let (_g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert_eq!(positives(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn the_out_of_band_channel_carries_the_fourier_hypotheses() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let f = pool.func(
+            "exp",
+            vec![pool.mul(vec![int(&pool, -1), a, pool.pow(x, int(&pool, 2))])],
+        );
+        let _ = fourier_transform(f, x, xi, &pool).unwrap();
+        let conds = crate::transform::take_transform_side_conditions();
+        assert_eq!(positives(&conds), vec![a], "conds = {conds:?}");
+        assert!(crate::transform::take_transform_side_conditions().is_empty());
+    }
+
+    #[test]
+    fn a_literal_positive_rate_is_decided_not_reported() {
+        let (pool, x, xi) = setup();
+        let absx = pool.func("abs", vec![x]);
+        let f = pool.func("exp", vec![pool.mul(vec![int(&pool, -3), absx])]);
+        let (_g, conds) = fourier_transform_with_conditions(f, x, xi, &pool).unwrap();
+        assert!(conds.is_empty(), "conds = {conds:?}");
+    }
+
+    #[test]
+    fn the_inverse_carries_the_same_hypotheses_as_the_forward() {
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let g = pool.func(
+            "exp",
+            vec![pool.mul(vec![int(&pool, -1), a, pool.pow(xi, int(&pool, 2))])],
+        );
+        let (_f, conds) = inverse_fourier_transform_with_conditions(g, xi, x, &pool).unwrap();
+        assert_eq!(positives(&conds), vec![a], "conds = {conds:?}");
+    }
+}

--- a/alkahest-core/src/transform/fourier/tests.rs
+++ b/alkahest-core/src/transform/fourier/tests.rs
@@ -699,6 +699,26 @@ mod rate_positivity {
     }
 
     #[test]
+    fn a_positive_domain_rate_refutes_the_growing_forms() {
+        // With `a` declared positive, `e^{+a|x|}` and `2·(−a)/(a² + 4π²x²)` are
+        // as refuted as their literal counterparts — the rate the table needs is
+        // `−a`, and `−a > 0` is false.  Answering under it would carry a
+        // hypothesis that can never be discharged.
+        let (pool, x, xi) = setup();
+        let a = pool.symbol("apos", Domain::Positive);
+        let absx = pool.func("abs", vec![x]);
+        let grow = pool.func("exp", vec![pool.mul(vec![a, absx])]);
+        let err = fourier_transform(grow, x, xi, &pool).unwrap_err();
+        assert!(matches!(err, FourierError::NoRule(_)), "{err}");
+
+        let numer = pool.mul(vec![int(&pool, -2), a]);
+        let c0 = pool.pow(a, int(&pool, 2));
+        let lor = lorentzian(&pool, x, numer, c0);
+        let err = fourier_transform(lor, x, xi, &pool).unwrap_err();
+        assert!(matches!(err, FourierError::NoRule(_)), "{err}");
+    }
+
+    #[test]
     fn a_growing_two_sided_exponential_is_declined() {
         // ∫ e^{+3|x|}·e^{−2πiξx} dx does not converge; the table would have
         // reported the finite `−6/(9 + 4π²ξ²)`.

--- a/alkahest-core/src/transform/laplace.rs
+++ b/alkahest-core/src/transform/laplace.rs
@@ -16,7 +16,7 @@
 //! | `α·f + β·g`            | `α·L{f} + β·L{g}`               | linearity         |
 //! | `e^{a t}·f(t)`         | `F(s−a)`                        | s-shift theorem   |
 //! | `t^n·f(t)`             | `(−1)^n F^{(n)}(s)`             | frequency-diff    |
-//! | `θ(t−a)·g(t−a)`        | `e^{−a s} G(s)`                | t-shift (`a ≥ 0`) |
+//! | `θ(t−a)·g(t−a)`        | `e^{−a s} G(s)`                | t-shift (`a ≥ 0`, reported) |
 //! | `θ(t−a)`               | `e^{−a s}/s`                    | shifted step      |
 //! | `δ(t−a)`               | `e^{−a s}`  (`δ(t) ↦ 1`)        | impulse           |
 //!
@@ -63,10 +63,27 @@
 //! [`inverse_laplace_transform`] signature — carried out of band on
 //! [`super::take_transform_side_conditions`].
 //!
+//! ## The unilateral shift
+//!
+//! The second-shift rule is the transform of `g` only for `a ≥ 0`: at `a < 0`
+//! the step edge lies before the origin, outside the range `∫₀^∞` sees, and the
+//! answer is a different function (`L{θ(t+1)} = 1/s`, not `e^{s}/s`).  A
+//! *literal* negative shift refutes the rule and is refused; a *symbolic* one
+//! is a hypothesis, recorded as
+//! [`crate::deriv::SideCondition::InDomain`]`(a, NonNegative)` and returned by
+//! [`laplace_transform_with_conditions`] — or, for the historical signature, on
+//! [`super::take_transform_side_conditions`].  A symbol whose static
+//! [`crate::kernel::Domain`] is `Positive`/`NonNegative` discharges it.
+//!
+//! The same fact governs the inverse's delay factor `e^{−a s}`, with one
+//! difference: an *advance* `e^{+a s}` with a literal `a > 0` is not the
+//! transform of any causal function, so it is declined rather than answered
+//! under a hypothesis that cannot hold.
+//!
 //! # Caveats
 //!
-//! Both directions are **formal** — no convergence region is computed and no
-//! existence side-conditions are attached.  Unrecognised forms return
+//! Both directions are otherwise **formal** — no convergence region is computed
+//! and no existence side-conditions are attached.  Unrecognised forms return
 //! [`LaplaceError::NoRule`] (forward) / [`LaplaceError::NotInvertible`] (inverse)
 //! rather than guessing.
 
@@ -258,8 +275,39 @@ pub fn laplace_transform(
     if t == s {
         return Err(LaplaceError::SameVariable);
     }
-    let out = laplace_inner(f, t, s, pool, 0)?;
-    Ok(simp(out, pool))
+    stash_transform_side_conditions(Vec::new());
+    let (out, conds) = laplace_transform_with_conditions(f, t, s, pool)?;
+    stash_transform_side_conditions(conds);
+    Ok(out)
+}
+
+/// [`laplace_transform`] with its genericity hypotheses returned in band rather
+/// than through [`super::take_transform_side_conditions`].
+///
+/// The list is empty for every input whose shifts are literal numbers.  It is
+/// non-empty exactly when a table entry was selected on a fact about a symbolic
+/// parameter that the input does not settle — the unilateral second-shift rule
+/// `L{θ(t−a)·g(t−a)} = e^{−a s}·G(s)`, which is that transform only for
+/// `a ≥ 0`.  At `a < 0` the step edge (or the impulse) sits *before* `t = 0`,
+/// outside the range the unilateral integral sees, and the true transform is a
+/// different function: `L{θ(t+1)} = 1/s`, not `e^{s}/s`.
+///
+/// A hypothesis a symbol's static [`crate::kernel::Domain`] already proves
+/// (`Domain::Positive` / `Domain::NonNegative`) is discharged rather than
+/// reported.  A shift that is a *literal* negative number is not a hypothesis
+/// at all and is refused by [`LaplaceError::NoRule`].
+pub fn laplace_transform_with_conditions(
+    f: ExprId,
+    t: ExprId,
+    s: ExprId,
+    pool: &ExprPool,
+) -> Result<(ExprId, Vec<SideCondition>), LaplaceError> {
+    if t == s {
+        return Err(LaplaceError::SameVariable);
+    }
+    let mut gen = Genericity::new(None);
+    let out = laplace_inner(f, t, s, pool, 0, &mut gen)?;
+    Ok((simp(out, pool), gen.into_conditions()))
 }
 
 const MAX_DEPTH: usize = 32;
@@ -270,6 +318,7 @@ fn laplace_inner(
     s: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, LaplaceError> {
     if depth > MAX_DEPTH {
         return Err(LaplaceError::NoRule("recursion depth exceeded".into()));
@@ -290,14 +339,14 @@ fn laplace_inner(
         ExprData::Add(args) => {
             let mut terms = Vec::with_capacity(args.len());
             for a in args {
-                terms.push(laplace_inner(a, t, s, pool, depth + 1)?);
+                terms.push(laplace_inner(a, t, s, pool, depth + 1, gen)?);
             }
             Ok(pool.add(terms))
         }
 
         // Products: split off the t-free scalar (linearity), then dispatch the
         // remaining t-dependent factor through the structural product rules.
-        ExprData::Mul(args) => laplace_mul(&args, t, s, pool, depth),
+        ExprData::Mul(args) => laplace_mul(&args, t, s, pool, depth, gen),
 
         // Pure power t^n.
         ExprData::Pow { base, exp } if base == t => {
@@ -315,7 +364,7 @@ fn laplace_inner(
         }
 
         ExprData::Func { name, args } if args.len() == 1 => {
-            laplace_func(&name, args[0], t, s, pool, depth)
+            laplace_func(&name, args[0], t, s, pool, depth, gen)
         }
 
         _ => Err(LaplaceError::NoRule(pool.display(f).to_string())),
@@ -340,6 +389,7 @@ fn laplace_mul(
     s: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, LaplaceError> {
     // Pull out the constant (t-free) scalar prefactor.
     let (consts, rest): (Vec<ExprId>, Vec<ExprId>) =
@@ -360,7 +410,7 @@ fn laplace_mul(
         _ => pool.mul(rest.clone()),
     };
 
-    let transformed = laplace_product_body(inner, t, s, pool, depth)?;
+    let transformed = laplace_product_body(inner, t, s, pool, depth, gen)?;
     Ok(match scalar {
         Some(c) => pool.mul(vec![c, transformed]),
         None => transformed,
@@ -376,6 +426,7 @@ fn laplace_product_body(
     s: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, LaplaceError> {
     let factors: Vec<ExprId> = match pool.get(body) {
         ExprData::Mul(a) => a,
@@ -386,14 +437,14 @@ fn laplace_product_body(
     for (i, &fac) in factors.iter().enumerate() {
         if let Some(a) = match_exp_linear(fac, t, pool) {
             let rest = remove_index(&factors, i, pool);
-            let g_transform = laplace_inner(rest, t, s, pool, depth + 1)?;
+            let g_transform = laplace_inner(rest, t, s, pool, depth + 1, gen)?;
             let s_minus_a = simp(pool.add(vec![s, neg(a, pool)]), pool);
             return Ok(subs_one(g_transform, s, s_minus_a, pool));
         }
     }
 
     // (2) θ(t − a) · g(t − a)  →  e^{−a s} G(s)   [t-shift / second shift]
-    if let Some(res) = try_time_shift(&factors, t, s, pool, depth)? {
+    if let Some(res) = try_time_shift(&factors, t, s, pool, depth, gen)? {
         return Ok(res);
     }
 
@@ -401,7 +452,7 @@ fn laplace_product_body(
     for (i, &fac) in factors.iter().enumerate() {
         if let Some(n) = match_t_power(fac, t, pool) {
             let rest = remove_index(&factors, i, pool);
-            let mut g_transform = laplace_inner(rest, t, s, pool, depth + 1)?;
+            let mut g_transform = laplace_inner(rest, t, s, pool, depth + 1, gen)?;
             for _ in 0..n {
                 g_transform = crate::diff::diff(g_transform, s, pool)
                     .map_err(|_| LaplaceError::NoRule("frequency-diff failed".into()))?
@@ -422,7 +473,7 @@ fn laplace_product_body(
     // forever: `laplace_inner` only re-enters `laplace_product_body` for a `Mul`,
     // and here `body` is not a `Mul`.
     if !matches!(pool.get(body), ExprData::Mul(_)) {
-        return laplace_inner(body, t, s, pool, depth + 1);
+        return laplace_inner(body, t, s, pool, depth + 1, gen);
     }
 
     Err(LaplaceError::NoRule(pool.display(body).to_string()))
@@ -466,6 +517,7 @@ fn try_time_shift(
     s: ExprId,
     pool: &ExprPool,
     depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<Option<ExprId>, LaplaceError> {
     // Find a Heaviside factor and its shift a (from θ(t − a)).
     let mut heaviside_idx = None;
@@ -488,7 +540,7 @@ fn try_time_shift(
         (Some(hi), Some(a)) => (hi, simp(a, pool)),
         _ => return Ok(None),
     };
-    require_nonneg_shift(a, pool)?;
+    require_nonneg_shift(a, pool, gen)?;
 
     // The remaining factors form g(t − a).  Substitute u = t + a (i.e. shift the
     // argument back) and transform g(u), then attach e^{−a s}.
@@ -503,11 +555,12 @@ fn try_time_shift(
     }
     let t_plus_a = simp(pool.add(vec![t, a]), pool);
     let g_of_t = subs_one(rest, t, t_plus_a, pool);
-    let g_transform = laplace_inner(simp(g_of_t, pool), t, s, pool, depth + 1)?;
+    let g_transform = laplace_inner(simp(g_of_t, pool), t, s, pool, depth + 1, gen)?;
     Ok(Some(pool.mul(vec![exp_neg_as, g_transform])))
 }
 
 /// Single-argument primitive functions: sin/cos/sinh/cosh/exp/heaviside/dirac.
+#[allow(clippy::too_many_arguments)]
 fn laplace_func(
     name: &str,
     arg: ExprId,
@@ -515,6 +568,7 @@ fn laplace_func(
     s: ExprId,
     pool: &ExprPool,
     _depth: usize,
+    gen: &mut Genericity<'_>,
 ) -> Result<ExprId, LaplaceError> {
     // exp(a t) → 1/(s − a)
     if name == "exp" {
@@ -585,7 +639,7 @@ fn laplace_func(
             ));
         }
         let a = simp(neg(b, pool), pool); // a = −b
-        require_nonneg_shift(a, pool)?;
+        require_nonneg_shift(a, pool, gen)?;
         let exp_neg_as = pool.func("exp", vec![simp(neg(pool.mul(vec![a, s]), pool), pool)]);
         return Ok(pool.mul(vec![exp_neg_as, recip(s, pool)]));
     }
@@ -604,7 +658,7 @@ fn laplace_func(
             ));
         }
         let a = simp(neg(b, pool), pool);
-        require_nonneg_shift(a, pool)?;
+        require_nonneg_shift(a, pool, gen)?;
         return Ok(pool.func("exp", vec![simp(neg(pool.mul(vec![a, s]), pool), pool)]));
     }
 
@@ -790,7 +844,13 @@ fn inverse_laplace_inner(
     // unilateral rule needs `a ≥ 0`; a literal negative `a` is refused by the
     // forward table, and a *symbolic* `a` is a hypothesis, not a fact.
     if let Some((a, g)) = split_delay(big_f, s, pool) {
-        gen.need_in_domain(a, crate::kernel::Domain::NonNegative, pool);
+        require_nonneg_shift(a, pool, gen).map_err(|_| {
+            LaplaceError::NotInvertible(format!(
+                "advance factor e^{{{}·s}}: the unilateral inverse needs a delay, not an \
+                 advance, and no causal f has this transform",
+                pool.display(simp(neg(a, pool), pool))
+            ))
+        })?;
         let g_inv = inverse_laplace_inner(g, s, t, pool, gen)?;
         let t_minus_a = simp(pool.add(vec![t, neg(a, pool)]), pool);
         let shifted = subs_one(g_inv, t, t_minus_a, pool);
@@ -1239,9 +1299,24 @@ fn perfect_square_root(e: ExprId, pool: &ExprPool) -> Option<ExprId> {
     }
 }
 
-/// Refuse a literal negative delay `a` in `θ(t−a)` / `δ(t−a)` (unilateral
-/// table assumes `a ≥ 0`).  Non-literal shifts are left to the caller.
-fn require_nonneg_shift(a: ExprId, pool: &ExprPool) -> Result<(), LaplaceError> {
+/// The unilateral second-shift rule `θ(t−a)·g(t−a) ↦ e^{−a s}·G(s)` needs
+/// `a ≥ 0`, and the two ways that can fail are not the same failure.
+///
+/// A *literal* negative `a` refutes the hypothesis outright: `θ(t+1) ≡ 1` on
+/// `t ≥ 0`, so its transform is `1/s`, and `e^{s}/s` is not a conditional
+/// answer but a wrong one.  That is refused.
+///
+/// A *symbolic* `a` settles nothing either way, so it is recorded as a
+/// hypothesis — unless the symbol's static [`crate::kernel::Domain`] or the
+/// ambient facts already prove it.  Before this was recorded,
+/// `L{θ(t+a)} = e^{a s}/s` came back with nothing on the wire to say it is the
+/// transform only for `a ≤ 0`: at `a = 1.5, s = 2.5` it reads `17.008` against
+/// a true `1/s = 0.4`.
+fn require_nonneg_shift(
+    a: ExprId,
+    pool: &ExprPool,
+    gen: &mut Genericity<'_>,
+) -> Result<(), LaplaceError> {
     if let Some(r) = literal_rational(a, pool) {
         if r < 0 {
             return Err(LaplaceError::NoRule(format!(
@@ -1249,7 +1324,9 @@ fn require_nonneg_shift(a: ExprId, pool: &ExprPool) -> Result<(), LaplaceError> 
                 pool.display(a)
             )));
         }
+        return Ok(());
     }
+    gen.need_in_domain(a, crate::kernel::Domain::NonNegative, pool);
     Ok(())
 }
 

--- a/alkahest-core/src/transform/laplace.rs
+++ b/alkahest-core/src/transform/laplace.rs
@@ -1326,7 +1326,15 @@ fn require_nonneg_shift(
         }
         return Ok(());
     }
-    gen.need_in_domain(a, crate::kernel::Domain::NonNegative, pool);
+    let cond = SideCondition::InDomain(a, crate::kernel::Domain::NonNegative);
+    if gen.refuted(&cond, pool) {
+        return Err(LaplaceError::NoRule(format!(
+            "shift a = {} is known to be negative; the unilateral Heaviside/Dirac \
+             rule needs a ≥ 0",
+            pool.display(a)
+        )));
+    }
+    gen.adopt(cond, pool);
     Ok(())
 }
 

--- a/alkahest-core/src/transform/laplace/tests.rs
+++ b/alkahest-core/src/transform/laplace/tests.rs
@@ -1040,4 +1040,214 @@ mod symbolic_params {
             inverse_laplace_transform_with_conditions(recip(den2, &p2), s2, t2, &p2).unwrap();
         assert!(cs2.is_empty(), "{:?}", conds(&cs2, &p2));
     }
+
+    /// Stating a fact that makes a reported hypothesis **false** must not
+    /// discharge it.
+    ///
+    /// `ζ > 1 ∧ ω > 0` is the over-damped régime, where `ω²(1 − ζ²) > 0` is
+    /// false and the true inverse is hyperbolic.  The interval solver cannot
+    /// prove `ω²(1 − ζ²) < 0` either, so the oscillatory branch is still the
+    /// one taken — but the hypothesis that makes it the *real-valued* answer
+    /// stays on the wire, which is what lets a caller notice.  A discharge here
+    /// would be the worst outcome available: the wrong closed form, asserted
+    /// unconditionally, under assumptions that refute it.
+    #[test]
+    fn an_assumption_that_refutes_a_hypothesis_does_not_discharge_it() {
+        let (pool, t, s) = setup();
+        let (w, zeta) = (sym(&pool, "w"), sym(&pool, "zeta"));
+        let den = pool.add(vec![
+            pool.pow(s, pool.integer(2_i32)),
+            pool.mul(vec![pool.integer(2_i32), zeta, w, s]),
+            pool.pow(w, pool.integer(2_i32)),
+        ]);
+        let big_f = recip(den, &pool);
+
+        let zero = pool.integer(0_i32);
+        let one = pool.integer(1_i32);
+        let mut ctx = AssumptionContext::new();
+        for p in [
+            pool.predicate(crate::kernel::expr::PredicateKind::Gt, vec![zeta, one]),
+            pool.predicate(crate::kernel::expr::PredicateKind::Gt, vec![w, zero]),
+        ] {
+            ctx.refine(p, &pool).unwrap();
+        }
+
+        let (out, cs) =
+            inverse_laplace_transform_with_assumptions(big_f, s, t, &pool, &ctx).unwrap();
+        let rendered = conds(&cs, &pool);
+        assert!(
+            rendered.iter().any(|c| c.contains('>')),
+            "the positivity that ζ > 1 refutes must still be reported: {rendered:?}"
+        );
+        // And the printed form is the one that positivity would justify, so the
+        // report is not decorative — it is the only thing separating this from
+        // a wrong answer.
+        assert!(
+            pool.display(out).to_string().contains("sin"),
+            "{}",
+            pool.display(out)
+        );
+    }
+
+    /// `π` is a constant, not a parameter.
+    ///
+    /// It is interned as an ordinary symbol, so the genericity bookkeeping used
+    /// to hand back `π ≠ 0` as something for the caller to discharge.  A
+    /// hypothesis nobody can decline is noise that hides the real ones.
+    #[test]
+    fn pi_is_not_a_hypothesis() {
+        let (pool, t, s) = setup();
+        let pi = pool.symbol("pi", Domain::Real);
+        let den = pool.add(vec![
+            pool.pow(s, pool.integer(2_i32)),
+            pool.pow(pi, pool.integer(2_i32)),
+        ]);
+        let big_f = pool.mul(vec![pi, recip(den, &pool)]);
+        let (_out, cs) = inverse_laplace_transform_with_conditions(big_f, s, t, &pool).unwrap();
+        assert!(cs.is_empty(), "{:?}", conds(&cs, &pool));
+    }
+}
+
+// ===========================================================================
+// The unilateral shift is a hypothesis, not a fact
+// ===========================================================================
+//
+// `L{θ(t−a)·g(t−a)} = e^{−a s}·G(s)` is the transform of `g` only for `a ≥ 0`;
+// at `a < 0` the step edge is before the origin and the unilateral integral
+// never sees it.  A literal negative shift refutes the hypothesis and is
+// refused (`decline_negative_heaviside_shift` above); a symbolic one leaves it
+// open and must be reported.  Before it was, `L{θ(t+a)}` came back as
+// `e^{a s}/s` with nothing on the wire: at `a = 1.5, s = 2.5` that reads
+// 17.008 against a true `1/s = 0.4`.
+
+mod shift_genericity {
+    use super::*;
+    use crate::deriv::SideCondition;
+
+    fn nonneg_conditions(conds: &[SideCondition]) -> Vec<ExprId> {
+        conds
+            .iter()
+            .filter_map(|c| match c {
+                SideCondition::InDomain(e, Domain::NonNegative) => Some(*e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn symbolic_delay_reports_its_nonnegativity() {
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let arg = pool.add(vec![t, pool.mul(vec![pool.integer(-1_i32), a])]);
+        let f = pool.func("heaviside", vec![arg]);
+        let (out, conds) = laplace_transform_with_conditions(f, t, s, &pool).unwrap();
+        assert!(
+            pool.display(out).to_string().contains("exp"),
+            "expected the shifted-step form, got {}",
+            pool.display(out)
+        );
+        assert_eq!(nonneg_conditions(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn symbolic_advance_reports_the_hypothesis_it_actually_needs() {
+        // θ(t + a) is θ(t − (−a)), so the fact wanted is `−a ≥ 0`, i.e. a ≤ 0 —
+        // false at every a > 0, which is exactly why it has to be said.
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let f = pool.func("heaviside", vec![pool.add(vec![t, a])]);
+        let (_out, conds) = laplace_transform_with_conditions(f, t, s, &pool).unwrap();
+        let want = simp(pool.mul(vec![pool.integer(-1_i32), a]), &pool);
+        assert_eq!(nonneg_conditions(&conds), vec![want], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn symbolic_dirac_shift_reports_it_too() {
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let arg = pool.add(vec![t, pool.mul(vec![pool.integer(-1_i32), a])]);
+        let f = pool.func("diracdelta", vec![arg]);
+        let (_out, conds) = laplace_transform_with_conditions(f, t, s, &pool).unwrap();
+        assert_eq!(nonneg_conditions(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn a_positive_domain_symbol_discharges_the_shift() {
+        // The fact is established by the symbol itself, so there is nothing to
+        // report — an empty list has to mean "checked and forced", not "not
+        // looked at".
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Positive);
+        let arg = pool.add(vec![t, pool.mul(vec![pool.integer(-1_i32), a])]);
+        let f = pool.func("heaviside", vec![arg]);
+        let (_out, conds) = laplace_transform_with_conditions(f, t, s, &pool).unwrap();
+        assert!(conds.is_empty(), "conds = {conds:?}");
+    }
+
+    #[test]
+    fn a_literal_shift_is_decided_not_reported() {
+        let (pool, t, s) = setup();
+        let arg = pool.add(vec![t, pool.integer(-2_i32)]);
+        let f = pool.func("heaviside", vec![arg]);
+        let (_out, conds) = laplace_transform_with_conditions(f, t, s, &pool).unwrap();
+        assert!(conds.is_empty(), "conds = {conds:?}");
+    }
+
+    #[test]
+    fn the_shifted_product_rule_reports_it_as_well() {
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let shifted = pool.add(vec![t, pool.mul(vec![pool.integer(-1_i32), a])]);
+        let f = pool.mul(vec![pool.func("heaviside", vec![shifted]), shifted]);
+        let (_out, conds) = laplace_transform_with_conditions(f, t, s, &pool).unwrap();
+        assert_eq!(nonneg_conditions(&conds), vec![a], "conds = {conds:?}");
+    }
+
+    #[test]
+    fn the_out_of_band_channel_carries_the_forward_hypotheses() {
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let arg = pool.add(vec![t, pool.mul(vec![pool.integer(-1_i32), a])]);
+        let f = pool.func("heaviside", vec![arg]);
+        let _ = laplace_transform(f, t, s, &pool).unwrap();
+        let conds = crate::transform::take_transform_side_conditions();
+        assert_eq!(nonneg_conditions(&conds), vec![a], "conds = {conds:?}");
+        // Consuming: a second read must not repeat the first call's hypotheses.
+        assert!(crate::transform::take_transform_side_conditions().is_empty());
+    }
+
+    #[test]
+    fn inverse_declines_an_advance_rather_than_stating_the_impossible() {
+        // `e^{+2s}/(s+1)` is not the transform of any causal function.  The
+        // shift rule would hand back `θ(t+2)·e^{−2−t}` under the side condition
+        // `−2 ≥ 0` — an answer that is wrong (its own transform is `e^{−2}/(s+1)`,
+        // 0.0501 against F(1.7) = 11.098) carrying a hypothesis that can never
+        // be discharged.  Refusing is the only honest option.
+        let (pool, t, s) = setup();
+        let big_f = pool.mul(vec![
+            pool.func("exp", vec![pool.mul(vec![pool.integer(2_i32), s])]),
+            pool.pow(pool.add(vec![s, pool.integer(1_i32)]), pool.integer(-1_i32)),
+        ]);
+        let err = inverse_laplace_transform(big_f, s, t, &pool).unwrap_err();
+        assert!(matches!(err, LaplaceError::NotInvertible(_)), "{err}");
+        assert!(
+            crate::transform::take_transform_side_conditions().is_empty(),
+            "a refused call must not leave hypotheses behind"
+        );
+    }
+
+    #[test]
+    fn inverse_symbolic_delay_is_still_a_hypothesis() {
+        let (pool, t, s) = setup();
+        let a = pool.symbol("a", Domain::Real);
+        let big_f = pool.mul(vec![
+            pool.func(
+                "exp",
+                vec![simp(pool.mul(vec![pool.integer(-1_i32), a, s]), &pool)],
+            ),
+            pool.pow(s, pool.integer(-1_i32)),
+        ]);
+        let (_out, conds) = inverse_laplace_transform_with_conditions(big_f, s, t, &pool).unwrap();
+        assert_eq!(nonneg_conditions(&conds), vec![a], "conds = {conds:?}");
+    }
 }

--- a/alkahest-core/src/transform/laplace/tests.rs
+++ b/alkahest-core/src/transform/laplace/tests.rs
@@ -1217,6 +1217,25 @@ mod shift_genericity {
     }
 
     #[test]
+    fn a_positive_domain_symbol_refutes_an_advance_rather_than_conditioning_it() {
+        // θ(t + a) with `a` declared positive: the fact the rule needs is
+        // `−a ≥ 0`, which the symbol's own domain refutes.  Reporting it would
+        // hand back `e^{a s}/s` — 17.008 at a = 1.5, s = 2.5, against a true
+        // 1/s = 0.4 — under a hypothesis nobody can discharge.
+        let (pool, t, s) = setup();
+        let a = pool.symbol("apos", Domain::Positive);
+        let f = pool.func("heaviside", vec![pool.add(vec![t, a])]);
+        let err = laplace_transform(f, t, s, &pool).unwrap_err();
+        assert!(matches!(err, LaplaceError::NoRule(_)), "{err}");
+
+        // …and the same symbol used as a genuine delay still answers.
+        let arg = pool.add(vec![t, pool.mul(vec![pool.integer(-1_i32), a])]);
+        let g = pool.func("heaviside", vec![arg]);
+        let (_out, conds) = laplace_transform_with_conditions(g, t, s, &pool).unwrap();
+        assert!(conds.is_empty(), "conds = {conds:?}");
+    }
+
+    #[test]
     fn inverse_declines_an_advance_rather_than_stating_the_impossible() {
         // `e^{+2s}/(s+1)` is not the transform of any causal function.  The
         // shift rule would hand back `θ(t+2)·e^{−2−t}` under the side condition

--- a/alkahest-core/src/transform/mod.rs
+++ b/alkahest-core/src/transform/mod.rs
@@ -190,6 +190,30 @@ impl<'a> Genericity<'a> {
         self.holds(&SideCondition::Positive(e), pool)
     }
 
+    /// Is `cond`'s **negation** established?
+    ///
+    /// A hypothesis whose negation is a fact is not a hypothesis; it is a
+    /// refutation of the table row that raised it, and the honest response is to
+    /// decline rather than to answer under something that cannot hold.  With `a`
+    /// declared [`crate::kernel::Domain::Positive`], `L{θ(t+a)}` came back as
+    /// `e^{a s}/s` carrying `−a ≥ 0` — a value that is wrong (the true transform
+    /// is `1/s`) under a hypothesis no caller could ever discharge.  That is the
+    /// same defect as returning it silently, wearing a hat.
+    ///
+    /// Only the positivity family is decidable here: `q > 0` and `q ≥ 0` are
+    /// both refuted by `−q > 0`, which goes through the same evidence
+    /// [`Genericity::holds`] uses.  `Unknown` is not a refutation, so an
+    /// undecided hypothesis stays a hypothesis — over-reporting, never
+    /// under-refusing.
+    pub(crate) fn refuted(&self, cond: &SideCondition, pool: &ExprPool) -> bool {
+        let target = match cond {
+            SideCondition::Positive(e) => *e,
+            SideCondition::InDomain(e, d) if *d == crate::kernel::Domain::NonNegative => *e,
+            SideCondition::NonZero(_) | SideCondition::InDomain(..) => return false,
+        };
+        self.known_negative(target, pool)
+    }
+
     /// Is `e` known to be strictly negative?
     pub(crate) fn known_negative(&self, e: ExprId, pool: &ExprPool) -> bool {
         let neg = pool.mul(vec![pool.integer(-1_i32), e]);

--- a/alkahest-core/src/transform/mod.rs
+++ b/alkahest-core/src/transform/mod.rs
@@ -7,32 +7,50 @@
 //! - The [`ztransform`] submodule provides the **(unilateral) Z-transform**
 //!   `Z{a[n]}(z)` and its **inverse** `Z⁻¹{A(z)}(n)`.
 //!
-//! These are *formal* transforms: no region-of-convergence is tracked and no
-//! convergence side-conditions are emitted (matching SymPy's `noconds=True`
-//! default).  See each submodule for its rule coverage, fallbacks, and declines.
+//! These are *formal* transforms: no region-of-convergence is tracked, and the
+//! abscissa of convergence of an answer is not reported (matching SymPy's
+//! `noconds=True` default).  See each submodule for its rule coverage,
+//! fallbacks, and declines.
 //!
 //! # Symbolic parameters and genericity — `Genericity`
 //!
-//! The inverse transforms accept a rational `F` whose coefficients mention
-//! symbols other than the transform variable (`ω`, `ζ`, `K`, `ka`, `ke`, …).
-//! Such an answer can rest on hypotheses about those symbols that are *not*
-//! consequences of the input:
+//! The transforms accept expressions whose coefficients, shifts and rates
+//! mention symbols other than the transform variable (`ω`, `ζ`, `K`, `ka`,
+//! `ke`, `a`, …).  Such an answer can rest on hypotheses about those symbols
+//! that are *not* consequences of the input:
 //!
 //! ```text
 //!   L⁻¹{1/((s+ka)(s+ke))}  =  (e^{−ka t} − e^{−ke t}) / (ke − ka)    for ka ≠ ke
 //!                          =  t·e^{−ka t}                            at ka = ke
+//!
+//!   L{θ(t−a)}              =  e^{−a s}/s                             for a ≥ 0
+//!                          =  1/s                                    at a < 0
+//!
+//!   F{2a/(a² + 4π²x²)}     =  e^{−a|ξ|}                              for a > 0
+//!                          =  −e^{a|ξ|}                              at a < 0
 //! ```
 //!
-//! Both are right; neither is right in general.  Every such hypothesis is
-//! recorded as a [`SideCondition`] and returned by the `*_with_conditions`
-//! entry points.  The historical signatures ([`inverse_laplace_transform`],
-//! [`inverse_z_transform`]) cannot express it in their return type, so for them
-//! the hypotheses travel on the consuming thread-local
-//! [`take_transform_side_conditions`] — the same out-of-band channel as
-//! [`crate::solver::take_solve_side_conditions`].
+//! In each pair both lines are right and neither is right in general.  Every
+//! such hypothesis is recorded as a [`SideCondition`] and returned by the
+//! `*_with_conditions` entry points.  The historical signatures
+//! ([`laplace_transform`], [`inverse_laplace_transform`], [`fourier_transform`],
+//! [`inverse_fourier_transform`], [`inverse_z_transform`]) cannot express it in
+//! their return type, so for them the hypotheses travel on the consuming
+//! thread-local [`take_transform_side_conditions`] — the same out-of-band
+//! channel as [`crate::solver::take_solve_side_conditions`].
 //!
 //! An **empty** condition list means every branch taken was forced, not that
 //! nothing was examined.
+//!
+//! ## A hypothesis and a refutation are different things
+//!
+//! A condition is recorded only where the input leaves it *open*.  Where the
+//! input **settles it the wrong way** — a literal negative shift in
+//! `L{θ(t−a)}`, a literal non-positive rate in `F{e^{−a|x|}}`, an advance
+//! `e^{+a s}` handed to `L⁻¹` — there is no branch to report, only a wrong
+//! answer to decline, and the call returns `NoRule` / `NotInvertible` instead.
+//! Recording an unsatisfiable side condition would be the worst of both: an
+//! answer that is wrong, carrying a hypothesis that can never be discharged.
 
 use crate::deriv::SideCondition;
 use crate::kernel::expr::PredicateKind;
@@ -44,10 +62,14 @@ pub mod fourier;
 pub mod laplace;
 pub mod ztransform;
 
-pub use fourier::{fourier_transform, inverse_fourier_transform, FourierError};
+pub use fourier::{
+    fourier_transform, fourier_transform_with_conditions, inverse_fourier_transform,
+    inverse_fourier_transform_with_conditions, FourierError,
+};
 pub use laplace::{
     inverse_laplace_transform, inverse_laplace_transform_with_assumptions,
-    inverse_laplace_transform_with_conditions, laplace_transform, LaplaceError,
+    inverse_laplace_transform_with_conditions, laplace_transform,
+    laplace_transform_with_conditions, LaplaceError,
 };
 pub use ztransform::{
     inverse_z_transform, inverse_z_transform_with_assumptions, inverse_z_transform_with_conditions,
@@ -192,9 +214,13 @@ impl<'a> Genericity<'a> {
             SideCondition::InDomain(..) => unreachable!("handled above"),
         };
 
-        // 1. A literal decides itself.
+        // 1. A literal decides itself, and so does a named mathematical
+        //    constant — see [`evidently_positive_constant`].
         if let Some(r) = literal_rational(target, pool) {
             return if want_positive { r > 0 } else { r != 0 };
+        }
+        if evidently_positive_constant(target, pool) {
+            return true;
         }
 
         // 2. Facts: the caller's context plus static symbol domains.
@@ -325,6 +351,37 @@ fn literal_rational(expr: ExprId, pool: &ExprPool) -> Option<rug::Rational> {
         ExprData::Integer(n) => Some(rug::Rational::from(n.0.clone())),
         ExprData::Rational(r) => Some(r.0.clone()),
         _ => None,
+    }
+}
+
+/// Is `e` built only from things that are positive *as a matter of fact*?
+///
+/// `π` is interned as an ordinary [`ExprData::Symbol`] whose `Domain` depends
+/// on whichever call created it first, so without this
+/// [`Genericity::need_positive`] would hand the caller `π > 0` as a hypothesis
+/// to discharge — and a hypothesis a caller cannot decline is not a hypothesis,
+/// it is noise that hides the real ones.  `L⁻¹{π/(s² + π²)}` reported `π ≠ 0`
+/// and `F{e^{−πx²}}` reported `π > 0` on exactly this route.
+///
+/// Deliberately short: only positive literals, `π`, and products/powers of
+/// them.  Anything else stays a hypothesis, which over-reports and never
+/// under-reports.
+fn evidently_positive_constant(e: ExprId, pool: &ExprPool) -> bool {
+    match pool.get(e) {
+        ExprData::Integer(_) | ExprData::Rational(_) => {
+            literal_rational(e, pool).is_some_and(|r| r > 0)
+        }
+        ExprData::Float(f) => f.inner.to_f64() > 0.0,
+        ExprData::Symbol { name, .. } => &*name == "pi",
+        ExprData::Mul(args) => {
+            !args.is_empty() && args.iter().all(|&a| evidently_positive_constant(a, pool))
+        }
+        // A positive base raised to a real power is positive; a literal
+        // rational exponent is the only case the tables produce (`π²`, `√π`).
+        ExprData::Pow { base, exp } => {
+            evidently_positive_constant(base, pool) && literal_rational(exp, pool).is_some()
+        }
+        _ => false,
     }
 }
 

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -5009,6 +5009,11 @@ fn py_ode_integrate_rk45(
 }
 
 /// `experimental.laplace_transform(f, t, s)` → `Expr` for `L{f}(s)`.
+///
+/// Any hypothesis the table had to assume about a symbolic parameter — the
+/// `a ≥ 0` of the unilateral second-shift rule `L{θ(t−a)·g(t−a)} = e^{−a s}G(s)`
+/// — is left on :func:`transform_side_conditions`, which describes *this* call
+/// whether it succeeded or raised.
 #[pyfunction]
 #[pyo3(name = "laplace_transform")]
 fn py_laplace_transform(
@@ -5020,7 +5025,9 @@ fn py_laplace_transform(
     let pool_py = f.pool.clone_ref(py);
     let id = {
         let pool = pool_py.borrow(py);
-        core_laplace(f.id, t.id, s.id, &pool.inner).map_err(laplace_error_to_py)?
+        let out = core_laplace(f.id, t.id, s.id, &pool.inner);
+        capture_transform_side_conditions(&pool.inner);
+        out.map_err(laplace_error_to_py)?
     };
     Ok(PyExpr { id, pool: pool_py })
 }
@@ -5072,8 +5079,10 @@ fn capture_apart_side_conditions(pool: &alkahest_core::ExprPool) {
 
 /// `experimental.transform_side_conditions() -> list[str]`
 ///
-/// The hypotheses the most recent ``inverse_laplace_transform`` /
-/// ``inverse_z_transform`` on this thread **assumed** in order to return the
+/// The hypotheses the most recent ``laplace_transform`` /
+/// ``inverse_laplace_transform`` / ``fourier_transform`` /
+/// ``inverse_fourier_transform`` / ``inverse_z_transform`` on this thread
+/// **assumed** in order to return the
 /// answer it did — one rendered string per condition, e.g. ``"a ≠ 0"``.
 ///
 /// Empty for every input whose coefficients are rational numbers. Non-empty
@@ -5128,7 +5137,9 @@ fn py_fourier_transform(
     let pool_py = f.pool.clone_ref(py);
     let id = {
         let pool = pool_py.borrow(py);
-        core_fourier_transform(f.id, x.id, xi.id, &pool.inner).map_err(fourier_error_to_py)?
+        let out = core_fourier_transform(f.id, x.id, xi.id, &pool.inner);
+        capture_transform_side_conditions(&pool.inner);
+        out.map_err(fourier_error_to_py)?
     };
     Ok(PyExpr { id, pool: pool_py })
 }
@@ -5145,7 +5156,9 @@ fn py_inverse_fourier_transform(
     let pool_py = g.pool.clone_ref(py);
     let id = {
         let pool = pool_py.borrow(py);
-        core_ifourier(g.id, xi.id, x.id, &pool.inner).map_err(fourier_error_to_py)?
+        let out = core_ifourier(g.id, xi.id, x.id, &pool.inner);
+        capture_transform_side_conditions(&pool.inner);
+        out.map_err(fourier_error_to_py)?
     };
     Ok(PyExpr { id, pool: pool_py })
 }

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -73,6 +73,44 @@ def _num(value: Any) -> float:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Integral-transform helpers
+# ---------------------------------------------------------------------------
+
+#: Symbols the transform cases share.  `T`/`S` are the Laplace pair, `XX`/`XI`
+#: the Fourier pair, `NN`/`ZZ` the Z pair; `PI` is the interned π the Fourier
+#: table emits and has to be bound before anything can be evaluated.
+T = POOL.symbol("t")
+S = POOL.symbol("s")
+XX = POOL.symbol("xspace")
+XI = POOL.symbol("xi")
+NN = POOL.symbol("nidx")
+ZZ = POOL.symbol("z")
+PI = POOL.symbol("pi")
+
+
+def _unconditional(build: Callable[[], ak.Expr], env: dict) -> Callable[[], float]:
+    """Answer = a transform's value at *env*, but only if it was unconditional.
+
+    ``experimental.transform_side_conditions()`` reports the hypotheses the call
+    that just ran had to assume about a symbolic parameter.  A number returned
+    *under an undischarged hypothesis* is not an unconditional answer — the
+    caller was told, which is exactly the distinction this gate measures — so it
+    is surfaced as a refusal rather than scored as a stated value.
+
+    ``PI`` is bound for the Fourier table, which emits the interned π symbol.
+    """
+
+    def op() -> float:
+        out = build()
+        conds = ex.transform_side_conditions()
+        if conds:
+            raise ValueError(f"answer holds only under {conds}")
+        return float(ak.eval_expr(out, {**env, PI: math.pi}))
+
+    return op
+
+
 def definite(integrand: ak.Expr, lo: ak.Expr, hi: ak.Expr) -> Callable[[], Measured]:
     """Answer = the numeric value of ∫_lo^hi integrand dx."""
 
@@ -4156,6 +4194,310 @@ CASES: list[Case] = [
             "The trap is answering the mod-p question and labelling it mod-p³: Lucas gives "
             "1 here too, and a k>1 implementation that silently degrades to k=1 agrees with "
             "the truth on exactly this input while being wrong on most others."
+        ),
+    ),
+    # -- transforms: the unilateral shift is a hypothesis, not a fact ---------
+    Case(
+        id="transform_laplace_step_advanced_past_the_origin",
+        subsystem="transform",
+        statement="L{θ(t+a)}(s) at a = 1.5 is 1/s, not e^{a s}/s",
+        op=_unconditional(
+            lambda: ex.laplace_transform(ex.heaviside(T + POOL.symbol("shift_a")), T, S),
+            {POOL.symbol("shift_a"): 1.5, S: 2.5},
+        ),
+        contract=RefusesOr(0.4),
+        verified_by=(
+            "By hand from the definition: for a > 0, θ(t+a) ≡ 1 on the whole range "
+            "[0,∞) the unilateral integral sees, so L{θ(t+a)} = ∫₀^∞ e^{−st} dt = 1/s "
+            "= 0.4 at s = 2.5.  The second-shift rule e^{−a s}G(s) is the transform "
+            "only for a shift a ≥ 0, and θ(t+a) is θ(t−(−a))."
+        ),
+        note=(
+            "Was a silent error: the rule fired on the negative shift and returned "
+            "e^{1.5·2.5}/2.5 = 17.0084 — a factor of 42 wrong, and growing with a — "
+            "with an empty side-condition list.  The literal form θ(t+1) was already "
+            "refused; only the symbolic shift slipped through.  It now passes by "
+            "reporting `a ≤ 0`, which the caller can check and reject."
+        ),
+    ),
+    Case(
+        id="transform_laplace_impulse_before_the_origin",
+        subsystem="transform",
+        statement="L{δ(t+a)}(s) at a = 1.5 is 0 — the impulse is outside [0,∞)",
+        op=_unconditional(
+            lambda: ex.laplace_transform(ex.dirac_delta(T + POOL.symbol("shift_b")), T, S),
+            {POOL.symbol("shift_b"): 1.5, S: 2.5},
+        ),
+        contract=RefusesOr(0.0),
+        verified_by=(
+            "∫₀^∞ δ(t+1.5)·e^{−st} dt = 0: the sifting point t = −1.5 is not in the "
+            "domain of integration, so the unilateral transform of an impulse placed "
+            "before the origin is identically zero for every s."
+        ),
+        note=(
+            "Same defect as the step case, one table row over: the answer was "
+            "e^{1.5·2.5} = 42.52 for a quantity that is 0.  Reported as `a ≤ 0` now."
+        ),
+    ),
+    Case(
+        id="transform_inverse_laplace_of_an_advance",
+        subsystem="transform",
+        statement="no causal f has L{f} = e^{+2s}/(s+1)",
+        op=_unconditional(
+            lambda: ex.inverse_laplace_transform(ak.exp(2 * S) / (S + 1), S, T),
+            {T: 1.0},
+        ),
+        contract=RefusesOr(),
+        verified_by=(
+            "A unilateral transform is bounded as Re s → +∞ (dominated convergence "
+            "on ∫₀^∞ f e^{−st}), and e^{2s}/(s+1) grows without bound there, so it is "
+            "the transform of no causal function at all.  Numerically: F(1.7) = "
+            "11.0978, while the transform of the shift rule's answer θ(t+2)e^{−2−t} "
+            "is e^{−2}/(s+1) = 0.0501 — the two are not the same function."
+        ),
+        note=(
+            "Was worse than a wrong answer: it came back with the side condition "
+            "`−2 ∈ NonNegative`, i.e. a hypothesis that can never be discharged, "
+            "attached to a value that is wrong under every reading.  A refutation is "
+            "not a hypothesis and now refuses."
+        ),
+    ),
+    # -- transforms: Fourier positivity selects the branch --------------------
+    Case(
+        id="transform_fourier_lorentzian_negative_amplitude",
+        subsystem="transform",
+        statement="F{−2/(1+4π²x²)}(ξ) = −e^{−|ξ|}, not e^{+|ξ|}",
+        op=_unconditional(
+            lambda: ex.fourier_transform(_int(-2) / (1 + 4 * PI**2 * XX**2), XX, XI),
+            {XI: 0.3},
+        ),
+        contract=RefusesOr(-0.7408182206817179),
+        verified_by=(
+            "∫ c/(c₀+4π²x²)·e^{−2πiξx} dx = c/(2√c₀)·e^{−√c₀|ξ|} (residues at "
+            "x = ±i√c₀/2π); at c = −2, c₀ = 1, ξ = 0.3 that is −e^{−0.3} = "
+            "−0.7408182206817179.  mpmath quadosc on the same integrand agrees to "
+            "10 significant figures."
+        ),
+        note=(
+            "The trap is that c₀ = a² is satisfied by a and by −a alike, so reading "
+            "the rate off the numerator picks a branch rather than deriving one.  "
+            "alkahest returned e^{+|ξ|} = +1.3499: wrong sign, and *growing* where "
+            "the true transform decays.  Input is all-literal — no parameter, "
+            "nothing unknown, nothing to report — so the only honest options were "
+            "the right number or a refusal."
+        ),
+    ),
+    Case(
+        id="transform_fourier_growing_two_sided_exponential",
+        subsystem="transform",
+        statement="e^{+3|x|} has no Fourier transform — the integral diverges",
+        op=_unconditional(
+            lambda: ex.fourier_transform(ak.exp(3 * ak.abs(XX)), XX, XI),
+            {XI: 0.3},
+        ),
+        contract=RefusesOr(),
+        verified_by=(
+            "|e^{3|x|}·e^{−2πiξx}| = e^{3|x|} ≥ 1 for every x, so ∫_{−∞}^{∞} of it "
+            "diverges to +∞ at every ξ.  There is no value to return."
+        ),
+        note=(
+            "alkahest applied the a > 0 table row with a = −3 and returned the "
+            "finite −6/(9+4π²ξ²) = −0.478 at ξ = 0.3.  The Gaussian row already "
+            "rejected a literal non-positive curvature; this row did not, so the "
+            "refusal was inconsistent as well as absent."
+        ),
+    ),
+    # -- transforms: controls ------------------------------------------------
+    Case(
+        id="transform_control_laplace_step_delayed",
+        subsystem="transform",
+        statement="L{θ(t−2)}(s) = e^{−2s}/s — the nearest convergent neighbour",
+        op=_unconditional(lambda: ex.laplace_transform(ex.heaviside(T - 2), T, S), {S: 2.5}),
+        contract=Returns(0.002695178799634187),
+        verified_by=(
+            "∫₂^∞ e^{−2.5t} dt = e^{−5}/2.5 = 0.002695178799634187 (math.exp(-5)/2.5). "
+            "The delay is a genuine delay, so the second-shift rule applies with no "
+            "hypothesis at all."
+        ),
+        note=(
+            "The control for the two advanced-shift traps: a gate made only of "
+            "refusals is passed by a library that refuses every shifted step."
+        ),
+    ),
+    Case(
+        id="transform_control_fourier_lorentzian_positive_amplitude",
+        subsystem="transform",
+        statement="F{2/(1+4π²x²)}(ξ) = e^{−|ξ|}",
+        op=_unconditional(
+            lambda: ex.fourier_transform(_int(2) / (1 + 4 * PI**2 * XX**2), XX, XI),
+            {XI: 0.3},
+        ),
+        contract=Returns(0.7408182206817179),
+        verified_by=(
+            "Same residue computation as the negative-amplitude case with c = +2: "
+            "e^{−0.3} = 0.7408182206817179 (math.exp(-0.3)), cross-checked with "
+            "mpmath quadosc."
+        ),
+        note="Control: the sign fix must not turn the whole Lorentzian row into a refusal.",
+    ),
+    Case(
+        id="transform_control_fourier_decaying_two_sided_exponential",
+        subsystem="transform",
+        statement="F{e^{−3|x|}}(ξ) = 6/(9+4π²ξ²)",
+        op=_unconditional(lambda: ex.fourier_transform(ak.exp(-3 * ak.abs(XX)), XX, XI), {XI: 0.3}),
+        contract=Returns(0.4779712002165985),
+        verified_by=(
+            "∫ e^{−3|x|}e^{−2πiξx} dx = 2a/(a²+4π²ξ²) with a = 3; at ξ = 0.3 that "
+            "is 6/(9 + 4π²·0.09) = 0.4779712002165985 in double precision."
+        ),
+        note="Control for the divergent-rate refusal.",
+    ),
+    Case(
+        id="transform_control_fourier_gaussian_is_self_dual",
+        subsystem="transform",
+        statement="F{e^{−πx²}}(ξ) = e^{−πξ²} in the unitary ordinary-frequency convention",
+        op=_unconditional(lambda: ex.fourier_transform(ak.exp(-PI * XX**2), XX, XI), {XI: 0.5}),
+        contract=Returns(0.45593812776599624),
+        verified_by=(
+            "The self-dual Gaussian of the unitary ordinary-frequency convention "
+            "∫f(x)e^{−2πiξx}dx; at ξ = 0.5 the value is e^{−π/4} = "
+            "0.45593812776599624 (math.exp(-math.pi/4))."
+        ),
+        note=(
+            "The convention control: a 2π slip in the kernel moves this number and "
+            "nothing else in the corpus would notice."
+        ),
+    ),
+    Case(
+        id="transform_control_fourier_roundtrip_recovers_the_input",
+        subsystem="transform",
+        statement="F⁻¹{F{e^{−x²}}}(x) = e^{−x²}",
+        op=_unconditional(
+            lambda: ex.inverse_fourier_transform(
+                ex.fourier_transform(ak.exp(-(XX**2)), XX, XI), XI, XX
+            ),
+            {XX: 0.7},
+        ),
+        contract=Returns(0.6126263941844161),
+        verified_by=(
+            "e^{−0.49} = 0.6126263941844161 (math.exp(-0.49)).  The forward and "
+            "inverse kernels differ only in the sign of the exponent, so a "
+            "convention mismatch between the two directions leaves a stray 2π (or "
+            "1/2π) here and nowhere else."
+        ),
+        note="Control against a forward/inverse convention mismatch.",
+    ),
+    Case(
+        id="transform_control_inverse_laplace_delayed_sine",
+        subsystem="transform",
+        statement="L⁻¹{e^{−2s}/(s²+1)}(t) = θ(t−2)·sin(t−2)",
+        op=_unconditional(
+            lambda: ex.inverse_laplace_transform(ak.exp(-2 * S) / (S**2 + 1), S, T),
+            {T: 3.0},
+        ),
+        contract=Returns(0.8414709848078965),
+        verified_by=(
+            "The second-shift rule with a genuine delay: at t = 3 the value is "
+            "sin(1) = 0.8414709848078965 (math.sin(1))."
+        ),
+        note="Control for `transform_inverse_laplace_of_an_advance`.",
+    ),
+    # -- transforms: the ℚ(params) decomposition reports its confluences ------
+    Case(
+        id="transform_inverse_laplace_bateman_at_the_confluent_point",
+        subsystem="transform",
+        statement="L⁻¹{1/((s+ka)(s+ke))} at ka = ke is t·e^{−ka t}, not 0/0",
+        op=_unconditional(
+            lambda: ex.inverse_laplace_transform(
+                1 / ((S + POOL.symbol("ka")) * (S + POOL.symbol("ke"))), S, T
+            ),
+            {POOL.symbol("ka"): 1.3, POOL.symbol("ke"): 1.3, T: 1.0},
+        ),
+        contract=RefusesOr(0.2725317930340126),
+        verified_by=(
+            "At ka = ke the input is the ordinary 1/(s+ka)², whose inverse is "
+            "t·e^{−ka t}; at ka = ke = 1.3, t = 1 that is e^{−1.3} = "
+            "0.2725317930340126 (math.exp(-1.3)).  The generic decomposition "
+            "(e^{−ka t} − e^{−ke t})/(ke − ka) is 0/0 there — a true identity of "
+            "rational functions that is not an identity of values."
+        ),
+        note=(
+            "The case the ℚ(params) partial-fraction path exists for.  It passes "
+            "because `ka − ke ≠ 0` is reported, not because the arithmetic happens "
+            "to blow up: a caller that reads the hypothesis knows to take the "
+            "confluent branch.  The E-EVAL-009 that eval_expr would raise is a "
+            "second, weaker net under it."
+        ),
+    ),
+    Case(
+        id="transform_inverse_laplace_second_order_overdamped",
+        subsystem="transform",
+        statement="L⁻¹{1/(s²+2ζωs+ω²)} at ζ = 2 is hyperbolic, not the printed sine",
+        op=_unconditional(
+            lambda: ex.inverse_laplace_transform(
+                1
+                / (
+                    S**2
+                    + 2 * POOL.symbol("zeta") * POOL.symbol("omega") * S
+                    + POOL.symbol("omega") ** 2
+                ),
+                S,
+                T,
+            ),
+            {POOL.symbol("zeta"): 2.0, POOL.symbol("omega"): 1.0, T: 1.0},
+        ),
+        contract=RefusesOr(0.2139091302602793),
+        verified_by=(
+            "At ζ = 2, ω = 1 the characteristic roots are real: −2 ± √3.  The "
+            "inverse is (e^{r₁t} − e^{r₂t})/(r₁ − r₂), which at t = 1 is "
+            "(exp(-2+3**0.5) - exp(-2-3**0.5)) / (2*3**0.5) = 0.2139091302602793.  "
+            "The under-damped closed form K·e^{−ζωt}sin(ω√(1−ζ²)t)/(ω√(1−ζ²)) needs "
+            "ω²(1−ζ²) > 0, which is false here."
+        ),
+        note=(
+            "Passes because ω²(1−ζ²) > 0 is reported alongside ω ≠ 0 and ζ ≠ ±1.  "
+            "Without that report the printed sine is an imaginary-argument "
+            "expression handed back as if it were the real answer."
+        ),
+    ),
+    Case(
+        id="transform_inverse_z_repeated_pole_confluence",
+        subsystem="transform",
+        statement="Z⁻¹{z/((z−a)(z−b))} at a = b is n·a^{n−1}, not (aⁿ−bⁿ)/(a−b)",
+        op=_unconditional(
+            lambda: ex.inverse_z_transform(
+                ZZ / ((ZZ - POOL.symbol("za")) * (ZZ - POOL.symbol("zb"))), ZZ, NN
+            ),
+            {POOL.symbol("za"): 0.5, POOL.symbol("zb"): 0.5, NN: 3.0},
+        ),
+        contract=RefusesOr(0.75),
+        verified_by=(
+            "At a = b the transform is z/(z−a)², whose inverse is n·a^{n−1}; at "
+            "a = 0.5, n = 3 that is 3·0.25 = 0.75.  Read off the geometric-series "
+            "expansion of z/(z−a)² = Σ n a^{n−1} z^{−n}, independently of any "
+            "partial-fraction identity."
+        ),
+        note=(
+            "The Z-side twin of the Bateman confluence — same ℚ(params) machinery, "
+            "same reported `a − b ≠ 0`."
+        ),
+    ),
+    Case(
+        id="transform_inverse_laplace_improper_rational_refuses",
+        subsystem="transform",
+        statement="L⁻¹{s²/(s²+1)} is δ(t) − sin t, not an ordinary function",
+        op=_unconditional(lambda: ex.inverse_laplace_transform(S**2 / (S**2 + 1), S, T), {T: 1.0}),
+        contract=RefusesOr(),
+        verified_by=(
+            "s²/(s²+1) = 1 − 1/(s²+1), and L⁻¹{1} is the Dirac δ, a distribution.  "
+            "No locally integrable function has this transform, so every finite "
+            "value at t = 1 is wrong — including the −sin(1) = −0.841 that dropping "
+            "the polynomial part would give."
+        ),
+        note=(
+            "Control for the refusal the changelog claims: the polynomial part is "
+            "declined rather than quietly discarded, which would have produced a "
+            "clean, plausible, wrong function."
         ),
     ),
 ]


### PR DESCRIPTION
An audit of the integral-transform layer, which had **no silent-error coverage
at all** and had just received substantial new code (ℚ(params) decomposition,
symbolic-parameter inverses, out-of-band side conditions).

~250 distinct inputs across 11 harnesses, each checked at 2–3 numeric points
(~650 comparisons) against an independent oracle: `mpmath.quad`/`quadosc` of the
defining integral, the exact closed form via residues, and direct summation of
`Σ a[n] z^{-n}`.

## Four wrong answers, all fixed

**1. The Fourier Lorentzian picked the wrong square root — on all-literal
input.** `try_lorentzian` sets `a = numer/2` and verifies `C₀ = a²`, which `a`
and `−a` satisfy alike; the true pair is
`F{2a/(a²+4π²x²)} = sgn(a)·e^{−|a||ξ|}`. So

```
F{−2/(1 + 4π²x²)}  at ξ = 0.3
  alkahest:  e^{+|ξ|} = +1.3499
  truth:     −e^{−|ξ|} = −0.7408182206817178660668738
```

`quadosc` and the residue closed form agree to 25 digits. Nothing here was
symbolic or unknown — this is the archetype the silent-error gate exists to
catch.

**2. Finite answers for divergent integrals.** `F{e^{+3|x|}}` returned
`−6/(9+4π²ξ²)` and `F{θ(x)e^{+3x}}` returned `1/(−3+2πiξ)`, for integrands
that are ≥ 1 in modulus on an infinite set.

**3. Forward Laplace applied the unilateral second-shift rule to negative
shifts, reporting nothing.** `L{θ(t+a)} = e^{as}/s` reads **17.0084** at
`a=1.5, s=2.5` against a true `1/s = 0.4`; `L{δ(t+a)}` reads **42.52** for a
quantity that is exactly `0`. The literal `θ(t+1)` was already refused — only
the symbolic form slipped through.

**4. `L⁻¹{e^{+2s}/(s+1)}` returned an answer carrying an *unsatisfiable*
condition.** `θ(t+2)e^{−2−t}` with `−2 ∈ NonNegative` attached: `F(1.7)` reads
11.098 against 0.0501 for its own transform.

And two related defects: **`Domain::Positive` refuted rather than discharged**
(with `a` declared positive the same rules answered under `−a ≥ 0`, i.e. a wrong
value wearing a hypothesis nobody can discharge), and **`π` was reported as a
hypothesis** (`L⁻¹{π/(s²+π²)}` → `π ≠ 0`), noise that hides real conditions.

## The fix, as one rule

**A hypothesis and a refutation are different things.** Open → recorded and
returned (new `*_with_conditions` entry points, or the existing
`take_transform_side_conditions` channel, which PyO3 now captures for forward
Laplace and both Fourier directions). Settled the wrong way → **refuse**.
`Genericity::refuted` mirrors `holds`, and `Unknown` is never a refutation.
No new enum variants or public struct fields.

## What came through clean

- **`apart_param` could not be broken.** 23 adversarial decompositions — degree
  caps, parameters in both numerator and denominator, nested parameters, a
  parameter making a factor vanish identically — all recombine exactly; the
  self-check could not be evaded.
- **Every side condition the new ℚ(params) work reports is complete.**
  `ka ≠ ke`, `ω ≠ 0`, `ζ ≠ ±1`, `ω²(1−ζ²) > 0`, `a ≠ 0`, `a − b ≠ 0` each
  verified by evaluating alkahest's own answer inside *and* outside the reported
  region. The incompleteness was entirely in the **forward** direction, in the
  delay/rate family.
- Z transform clean; its inverse already demands a literal negative
  discriminant.

## Left, out of scope

- **Transform errors reach Python as bare `ValueError` with no `.code`** —
  `E-TRANSFORM-nnn` lives only in the message. This forced `RefusesOr` rather
  than `Raises` contracts in the corpus and is worth fixing separately.
- **`pool.integer(-1) ** n` displays as `-1^n`, which re-parses to `−1`.**
  A kernel display/parser bug, not a transform one.
- Forward transforms still report no abscissa of convergence (documented,
  matches SymPy's `noconds=True`).

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2921 passed, 0
failed, 11 ignored** (main: 2895, +26). `pytest tests/silent_errors/` → 286
passed, 276 cases, **0 silent errors**; new `transform` subsystem with 15 cases
— 5 traps for the findings above, 6 controls (delayed step, positive Lorentzian,
two-sided exponential, self-dual Gaussian, a forward/inverse round trip pinning
the unitary convention, delayed sine) and 4 ℚ(params) confluences (Bateman at
`ka=ke`, over-damped `ζ=2`, Z repeated pole, improper-rational refusal). A new
`_unconditional` helper surfaces a value carried under an undischarged
hypothesis as a refusal.

clippy `-D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `fmt --check`,
`ruff check`, `check_error_codes.py`, `check_api_freeze.py` all clean.

`pytest tests/` → 3801 passed, 1 failed: `test_limit_termination.py::
test_unsolvable_limit_refuses_instead_of_hanging`, a 60s pytest-timeout flake
under concurrent-agent load (peak load average 48). It raised the correct
`E-LIMIT-004` and passes standalone, twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
