### PR TITLE
fix(ode): stop binding π to 1.7, and sample symbolic coefficients at both signs

### DIFF
--- a/alkahest-core/src/eval/mod.rs
+++ b/alkahest-core/src/eval/mod.rs
@@ -7,6 +7,7 @@
 
 mod complex_f64;
 mod root_sum;
+pub(crate) mod symbols;
 
 use crate::ball::{ArbBall, IntervalEval};
 use crate::kernel::expr::PredicateKind;

--- a/alkahest-core/src/eval/symbols.rs
+++ b/alkahest-core/src/eval/symbols.rs
@@ -1,0 +1,107 @@
+//! Which symbols carry a value of their own, and which are free parameters a
+//! numeric gate is allowed to bind to a sample.
+//!
+//! Every sampling gate in the crate — [`crate::matrix::spectrum`],
+//! [`crate::ode::dsolve::verify`], [`crate::ode::dsolve::system`] — has to
+//! answer the same question before it can build an environment: *which of the
+//! symbols in this expression am I permitted to invent a value for?*
+//!
+//! Two of them must never be invented, because they already denote a number:
+//!
+//! * **`pi`**, which is an ordinary [`ExprData::Symbol`] in this crate rather
+//!   than a distinguished constant node.  Collected as a free parameter it is
+//!   bound to a sample such as `1.7`, and every expression containing it is
+//!   then evaluated with `π = 1.7` — so a correct answer in the casus
+//!   irreducibilis form `2√(−p/3)·cos((acos c + 2πk)/3)` disagrees at every
+//!   sample and is refused.  That is a false refusal caused entirely by the
+//!   collector.
+//! * **the imaginary unit** `I`, which has no real value at all.  Binding it
+//!   to a real sample turns `e^{iωt}` into a real exponential and reports a
+//!   disagreement that is an artefact of the binding.
+//!
+//! Getting this wrong is silent in the safe direction — it refuses correct
+//! answers rather than accepting wrong ones — which is why it survived in
+//! three places at once.  The predicate lives here so a fourth gate inherits
+//! it instead of rediscovering it.
+
+use crate::kernel::{ExprData, ExprId, ExprPool};
+
+/// The name `π` is interned under.
+pub(crate) const PI_NAME: &str = "pi";
+
+/// Is `expr` the symbol `π`?
+pub(crate) fn is_pi(expr: ExprId, pool: &ExprPool) -> bool {
+    matches!(pool.get(expr), ExprData::Symbol { name, .. } if name == PI_NAME)
+}
+
+/// Is `expr` a symbol that already denotes a number — `π` or the imaginary
+/// unit — and so must never be bound to a sampled value?
+pub(crate) fn is_named_constant(expr: ExprId, pool: &ExprPool) -> bool {
+    is_pi(expr, pool) || pool.is_imaginary_unit(expr)
+}
+
+/// Visit every [`ExprData::Symbol`] node reachable from `expr`.
+pub(crate) fn walk_symbols(expr: ExprId, pool: &ExprPool, f: &mut impl FnMut(ExprId, &ExprPool)) {
+    match pool.get(expr) {
+        ExprData::Symbol { .. } => f(expr, pool),
+        ExprData::Add(args) | ExprData::Mul(args) | ExprData::Func { args, .. } => {
+            for a in args {
+                walk_symbols(a, pool, f);
+            }
+        }
+        ExprData::Pow { base, exp } => {
+            walk_symbols(base, pool, f);
+            walk_symbols(exp, pool, f);
+        }
+        _ => {}
+    }
+}
+
+/// Append the symbols of `expr` that are genuine free parameters — everything
+/// [`is_named_constant`] rejects is left out.  Existing entries of `out` are
+/// preserved and not duplicated, so several expressions can be accumulated.
+pub(crate) fn collect_free_symbols(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
+    walk_symbols(expr, pool, &mut |s, pool| {
+        if !is_named_constant(s, pool) && !out.contains(&s) {
+            out.push(s);
+        }
+    });
+}
+
+/// Append the named constants of `expr` — the symbols a caller has to *bind*
+/// rather than sample.
+pub(crate) fn collect_named_constants(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
+    walk_symbols(expr, pool, &mut |s, pool| {
+        if is_named_constant(s, pool) && !out.contains(&s) {
+            out.push(s);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Domain;
+
+    #[test]
+    fn pi_and_i_are_constants_and_everything_else_is_a_parameter() {
+        let p = ExprPool::new();
+        let pi = p.symbol(PI_NAME, Domain::Real);
+        let i = p.imaginary_unit();
+        let k = p.symbol("k", Domain::Real);
+        assert!(is_named_constant(pi, &p));
+        assert!(is_named_constant(i, &p));
+        assert!(!is_named_constant(k, &p));
+
+        // `cos(k + 2*pi) * I`
+        let two_pi = p.mul(vec![p.integer(2_i32), pi]);
+        let e = p.mul(vec![p.func("cos", vec![p.add(vec![k, two_pi])]), i]);
+        let mut free = Vec::new();
+        collect_free_symbols(e, &p, &mut free);
+        assert_eq!(free, vec![k]);
+        let mut named = Vec::new();
+        collect_named_constants(e, &p, &mut named);
+        assert_eq!(named.len(), 2);
+        assert!(named.contains(&pi) && named.contains(&i));
+    }
+}

--- a/alkahest-core/src/matrix/spectrum.rs
+++ b/alkahest-core/src/matrix/spectrum.rs
@@ -47,8 +47,9 @@
 //! Putzer expansion, which turns a bad spectrum into a page-long candidate —
 //! ask for `SpectrumCheck::Confirmed` explicitly.
 
+use crate::eval::symbols::{collect_free_symbols, collect_named_constants, is_pi};
 use crate::eval::{eval_complex_f64, ComplexF64};
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{ExprId, ExprPool};
 use crate::matrix::Matrix;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -352,12 +353,17 @@ pub(crate) fn confirm_spectrum(
 /// Bind the named constants the eigen formulas emit but that
 /// [`eval_complex_f64`] has no value for.
 ///
-/// `pi` is a plain [`ExprData::Symbol`] in this crate, so the casus
-/// irreducibilis form `2√(−p/3)·cos((acos c + 2πk)/3)` would otherwise be
+/// `pi` is a plain symbol in this crate (see [`crate::eval::symbols`]), so the
+/// casus irreducibilis form `2√(−p/3)·cos((acos c + 2πk)/3)` would otherwise be
 /// unevaluable — and, worse, `pi` would be collected as a free *parameter* and
 /// given a sample value, turning a correct spectrum into a spurious refusal.
 /// Binding it here is what lets the three-real-roots branch be confirmed rather
 /// than merely tolerated.
+///
+/// The imaginary unit is the other symbol
+/// [`collect_named_constants`](crate::eval::symbols::collect_named_constants)
+/// reports, and it is deliberately *not* bound: `eval_complex_f64` knows it
+/// natively, and binding it here would overwrite `i` with `π`.
 fn bind_constants(
     pool: &ExprPool,
     env: &mut HashMap<ExprId, ComplexF64>,
@@ -372,45 +378,9 @@ fn bind_constants(
         collect_named_constants(l, pool, &mut all);
     }
     for s in all {
-        env.insert(s, ComplexF64::new(std::f64::consts::PI, 0.0));
-    }
-}
-
-fn is_pi(expr: ExprId, pool: &ExprPool) -> bool {
-    matches!(pool.get(expr), ExprData::Symbol { name, .. } if name == "pi")
-}
-
-fn collect_named_constants(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
-    walk_symbols(expr, pool, &mut |s, pool| {
-        if is_pi(s, pool) && !out.contains(&s) {
-            out.push(s);
+        if is_pi(s, pool) {
+            env.insert(s, ComplexF64::new(std::f64::consts::PI, 0.0));
         }
-    });
-}
-
-/// Symbols that are genuine free parameters: neither `pi` nor the imaginary
-/// unit, both of which have values and must not be sampled.
-fn collect_free_symbols(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
-    walk_symbols(expr, pool, &mut |s, pool| {
-        if !is_pi(s, pool) && !pool.is_imaginary_unit(s) && !out.contains(&s) {
-            out.push(s);
-        }
-    });
-}
-
-fn walk_symbols(expr: ExprId, pool: &ExprPool, f: &mut impl FnMut(ExprId, &ExprPool)) {
-    match pool.get(expr) {
-        ExprData::Symbol { .. } => f(expr, pool),
-        ExprData::Add(args) | ExprData::Mul(args) | ExprData::Func { args, .. } => {
-            for a in args {
-                walk_symbols(a, pool, f);
-            }
-        }
-        ExprData::Pow { base, exp } => {
-            walk_symbols(base, pool, f);
-            walk_symbols(exp, pool, f);
-        }
-        _ => {}
     }
 }
 

--- a/alkahest-core/src/ode/dsolve/system.rs
+++ b/alkahest-core/src/ode/dsolve/system.rs
@@ -75,9 +75,10 @@
 // allow for the same reason.
 #![allow(clippy::needless_range_loop)]
 
-use super::verify::{eval_complex, C64};
+use super::verify::{eval_complex, C64, CONST_SETS, PARAM_SETS, X_SAMPLES};
 use super::{contains, ddx, integrate_or_decline, simp, simp_plain, sub, AssumedSign, SolveCtx};
 use crate::deriv::SideCondition;
+use crate::eval::symbols::collect_free_symbols;
 use crate::kernel::eval_const::try_expr_f64;
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use crate::matrix::zero_test::{zero_status, ZeroStatus};
@@ -754,20 +755,24 @@ fn verify_system(
     let mut bound: Vec<ExprId> = vec![t];
     bound.extend_from_slice(&ode.state_vars);
     bound.extend_from_slice(constants);
+    // `pi` and the imaginary unit are symbols in this crate but they are not
+    // parameters: `collect_free_symbols` leaves them out and `eval_complex`
+    // gives them their own values.  Sampling `pi` at 1.7 is what refused the
+    // casus-irreducibilis companion matrix, whose eigenvalues are the correct
+    // `2√(−p/3)·cos((acos c + 2πk)/3)`.
     let mut params: Vec<ExprId> = Vec::new();
     for &r in &residuals {
-        collect_symbols(r, pool, &mut params);
+        collect_free_symbols(r, pool, &mut params);
     }
     params.retain(|s| !bound.contains(s));
     params.sort_by_key(|&s| pool.display(s).to_string());
 
-    let param_sets: [&[f64]; 3] = [
-        &[1.7, 0.6, 2.3, 1.1, 0.4],
-        &[0.37, 1.9, 0.83, 2.7, 1.3],
-        &[2.9, 0.45, 1.15, 0.71, 3.3],
-    ];
-    let const_sets: [&[f64]; 2] = [&[5.7, 4.3, 6.4, 5.1, 4.9], &[8.5, 7.8, 6.6, 9.2, 7.1]];
-    let t_samples = [0.11, 0.27, 0.43, 0.61, 0.79];
+    // The scalar gate's tables, not a second copy of them: a parameter must be
+    // sampled the same way whichever gate is asking, and the sign coverage of
+    // `PARAM_SETS` is a soundness property that has to hold in both.
+    let param_sets = PARAM_SETS;
+    let const_sets = CONST_SETS;
+    let t_samples = X_SAMPLES;
 
     let (mut agree, mut disagree, mut skipped) = (0usize, 0usize, 0usize);
     let mut sets_agreeing = 0usize;
@@ -884,26 +889,6 @@ fn verify_system(
 
 fn is_literal_zero(e: ExprId, pool: &ExprPool) -> bool {
     matches!(pool.get(e), ExprData::Integer(n) if n.0 == 0)
-}
-
-fn collect_symbols(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
-    pool.with(expr, |d| match d {
-        ExprData::Symbol { .. } => {
-            if !out.contains(&expr) {
-                out.push(expr);
-            }
-        }
-        ExprData::Add(args) | ExprData::Mul(args) | ExprData::Func { args, .. } => {
-            for &a in args {
-                collect_symbols(a, pool, out);
-            }
-        }
-        ExprData::Pow { base, exp } => {
-            collect_symbols(*base, pool, out);
-            collect_symbols(*exp, pool, out);
-        }
-        _ => {}
-    });
 }
 
 #[cfg(test)]

--- a/alkahest-core/src/ode/dsolve/system/tests.rs
+++ b/alkahest-core/src/ode/dsolve/system/tests.rs
@@ -118,6 +118,27 @@ fn triple_jordan_block_solves() {
     );
 }
 
+/// `pi` is an ordinary symbol in this crate, so a gate that collects free
+/// symbols and binds each to a sample value binds **π to 1.7** — and every
+/// expression whose correctness depends on π being π then disagrees at every
+/// sample.  The casus irreducibilis is where that bites: the three real
+/// eigenvalues of a `λ³ − 3λ + 1` companion matrix are
+/// `2√(−p/3)·cos((acos c + 2πk)/3)`, correct only at the real π, and the system
+/// built on them used to be refused with `VerificationFailed`.
+#[test]
+fn casus_irreducibilis_eigenvalues_are_not_refused_over_a_sampled_pi() {
+    // Companion matrix of λ³ − 3λ + 1 (Δ < 0: three distinct real roots).
+    // x' = -z, y' = x + 3z, z' = y.
+    let (pool, ode, _) = build(&["x", "y", "z"], &["-1*z", "x + 3*z", "y"], &[]);
+    let sol = dsolve_system(&ode, &pool).expect("the trigonometric eigenvalues verify");
+    assert_eq!(sol.constants.len(), 3);
+    let shown = pool.display(sol.y_of_t[0]).to_string();
+    assert!(
+        shown.contains("pi") || shown.contains('π') || shown.contains("acos"),
+        "expected the trigonometric root form, got {shown}"
+    );
+}
+
 #[test]
 fn forced_system_closes_by_variation_of_parameters() {
     // x' = -x + 1, y' = x - 2y.

--- a/alkahest-core/src/ode/dsolve/verify.rs
+++ b/alkahest-core/src/ode/dsolve/verify.rs
@@ -93,12 +93,15 @@
 //! ([`parameter_env`] is the single table both draw from).  It knows a few
 //! heads ℂ does not; where it also cannot conclude, the candidate is refused.
 //!
-//! **Known conservatism, stated plainly.** Every row of [`PARAM_SETS`] is
-//! positive.  A candidate that is right for `Kₘ > 0` and wrong for `Kₘ < 0` is
-//! therefore certified here.  The sign is not represented in the input —
-//! `OdeInput` carries no assumptions — and sampling negative values instead
-//! would reject correct answers to equations whose parameters are physically
-//! positive far more often than it would catch anything.
+//! [`PARAM_SETS`] samples **both signs**.  It did not always: every row used to
+//! be positive, so a candidate right for `Kₘ > 0` and wrong for `Kₘ < 0` was
+//! certified on the half of the parameter space it happened to be right on,
+//! while `OdeInput` carries no assumption that would justify the restriction.
+//! Negative rows are safe here only because the pass they feed evaluates over
+//! ℂ — where `log(−1.3)` and `√(−1.3)` are ordinary numbers and a correct
+//! candidate's analytic continuation is still correct — and because a row that
+//! cannot be resolved is *no information* rather than a refusal.  See
+//! [`PARAM_SETS`] for the measurement.
 //!
 //! # Implicit solutions
 //!
@@ -109,6 +112,7 @@
 //! parameter values from the same [`parameter_env`].
 
 use super::{contains, ddx, simp, subs1, DsolveError, OdeInput};
+use crate::eval::symbols::{collect_free_symbols, is_pi, walk_symbols};
 use crate::kernel::{ExprData, ExprId, ExprPool};
 use std::collections::HashMap;
 use std::fmt;
@@ -190,8 +194,14 @@ fn verify_inner(
     // symbol, nor an integration constant) make the real sampler useless: every
     // sample is `None` and the report says only "unevaluable".  Bind them too,
     // and evaluate over ℂ so the complex branch of the answer is reachable.
+    //
+    // A residual that mentions the imaginary unit takes the same route with no
+    // parameters at all: `eval` has no `f64` for `i` and reports the whole
+    // residual unevaluable, so the real sampler can only ever decline it.  The
+    // complex evaluator knows `i` natively and is the right instrument; the
+    // classification it applies is the same one.
     let params = free_parameters(input, &[residual], constants, pool);
-    if !params.is_empty() {
+    if !params.is_empty() || mentions_imaginary_unit(residual, pool) {
         let report =
             parametric_report(input, residual, &candidate_derivs, constants, &params, pool);
         if report.certifies() {
@@ -242,6 +252,14 @@ fn verify_inner(
 /// the derivative symbols cannot survive [`build_residual`]'s substitution, but
 /// are excluded defensively so a stray one becomes a decline rather than a
 /// parameter that gets a random value bound to it.
+///
+/// `pi` and the imaginary unit are excluded by
+/// [`collect_free_symbols`](crate::eval::symbols::collect_free_symbols): they
+/// are ordinary [`ExprData::Symbol`]s in this crate but they already denote a
+/// number, and sampling them is a false-refusal machine — a candidate written
+/// in the casus irreducibilis form `2√(−p/3)·cos((acos c + 2πk)/3)` evaluated
+/// at `π = 1.7` disagrees at every sample.  [`eval`] and [`eval_complex`] give
+/// them their real values instead.
 fn free_parameters(
     input: &OdeInput,
     exprs: &[ExprId],
@@ -253,7 +271,7 @@ fn free_parameters(
     bound.extend_from_slice(constants);
     let mut out: Vec<ExprId> = Vec::new();
     for &e in exprs {
-        collect_symbols(e, pool, &mut out);
+        collect_free_symbols(e, pool, &mut out);
     }
     out.retain(|s| !bound.contains(s));
     // Deterministic order: the sampled value of a parameter must not depend on
@@ -265,6 +283,12 @@ fn free_parameters(
 
 /// Comma-separated parameter names, for a refusal message.
 fn param_names(params: &[ExprId], pool: &ExprPool) -> String {
+    if params.is_empty() {
+        // The complex path was entered for the residual's own sake, not for a
+        // parameter; saying "the parameters " with nothing after it reads as a
+        // formatting bug.
+        return "(none: a complex-valued residual)".to_string();
+    }
     params
         .iter()
         .map(|&p| pool.display(p).to_string())
@@ -272,24 +296,16 @@ fn param_names(params: &[ExprId], pool: &ExprPool) -> String {
         .join(", ")
 }
 
-fn collect_symbols(expr: ExprId, pool: &ExprPool, out: &mut Vec<ExprId>) {
-    pool.with(expr, |d| match d {
-        ExprData::Symbol { .. } => {
-            if !out.contains(&expr) {
-                out.push(expr);
-            }
-        }
-        ExprData::Add(args) | ExprData::Mul(args) | ExprData::Func { args, .. } => {
-            for &a in args {
-                collect_symbols(a, pool, out);
-            }
-        }
-        ExprData::Pow { base, exp } => {
-            collect_symbols(*base, pool, out);
-            collect_symbols(*exp, pool, out);
-        }
-        _ => {}
+/// Does `expr` mention the imaginary unit anywhere?
+///
+/// The real [`eval`] has no value for it, so such a residual is unevaluable to
+/// the real sampler however its parameters are bound.
+fn mentions_imaginary_unit(expr: ExprId, pool: &ExprPool) -> bool {
+    let mut found = false;
+    walk_symbols(expr, pool, &mut |s, pool| {
+        found |= pool.is_imaginary_unit(s);
     });
+    found
 }
 
 /// Substitute the candidate into the equation.
@@ -386,16 +402,23 @@ impl fmt::Display for NumericReport {
 /// Constants are kept positive and reasonably large so that radicands such as
 /// `sqrt(4·C − 3x²)` arising from quadratic-implicit solutions stay real over
 /// the (small) x-sample range.
-const CONST_SETS: [&[f64]; 3] = [
+pub(crate) const CONST_SETS: [&[f64]; 3] = [
     &[5.7, 4.3, 6.4, 5.1, 4.9],
     &[8.5, 7.8, 6.6, 9.2, 7.1],
     &[12.3, 10.0, 11.7, 10.5, 9.4],
 ];
 
 /// `x` sample points, shared by the explicit, parametric and implicit gates.
-const X_SAMPLES: [f64; 5] = [0.11, 0.27, 0.43, 0.61, 0.79];
+pub(crate) const X_SAMPLES: [f64; 5] = [0.11, 0.27, 0.43, 0.61, 0.79];
 
 /// Numerically check residual ≈ 0 at several `x` over random constants.
+///
+/// When there are parameters the grid is the *product* of [`PARAM_SETS`] and
+/// [`CONST_SETS`], not a pairing of the two: pairing them by index would leave
+/// the negative rows of `PARAM_SETS` unsampled here, so the real second opinion
+/// would be reasoning about a different parameter region than the complex pass
+/// that asked for it.  With no parameters every row gives the same environment,
+/// so one pass is the whole grid.
 fn numeric_report(
     input: &OdeInput,
     residual: ExprId,
@@ -405,7 +428,12 @@ fn numeric_report(
     pool: &ExprPool,
 ) -> NumericReport {
     let mut report = NumericReport::default();
-    for (set, cs) in CONST_SETS.iter().enumerate() {
+    let rows = if params.is_empty() {
+        1
+    } else {
+        PARAM_SETS.len()
+    };
+    for (set, cs) in (0..rows).flat_map(|s| CONST_SETS.iter().map(move |cs| (s, cs))) {
         let param_env = parameter_env(params, set);
         let mut env: HashMap<ExprId, f64> = param_env.clone();
         for (i, &c) in constants.iter().enumerate() {
@@ -534,6 +562,11 @@ fn ode_is_regular_at(
 /// Evaluate `expr` to an `f64` given a symbol→value environment.
 /// Returns `None` for constructs the evaluator does not understand (so the
 /// caller refuses to certify rather than guessing).
+///
+/// `pi` resolves to π without being in `env` — it is a plain symbol in this
+/// crate, and [`free_parameters`] deliberately does not sample it, so nothing
+/// else would bind it.  The imaginary unit stays `None` here: it has no `f64`
+/// value, and "unknown construct" (→ no information) is the honest reading.
 pub(crate) fn eval(expr: ExprId, env: &HashMap<ExprId, f64>, pool: &ExprPool) -> Option<f64> {
     match pool.get(expr) {
         ExprData::Integer(n) => Some(n.0.to_f64()),
@@ -542,7 +575,10 @@ pub(crate) fn eval(expr: ExprId, env: &HashMap<ExprId, f64>, pool: &ExprPool) ->
             Some(num.to_f64() / den.to_f64())
         }
         ExprData::Float(f) => Some(f.inner.to_f64()),
-        ExprData::Symbol { .. } => env.get(&expr).copied(),
+        ExprData::Symbol { .. } => env
+            .get(&expr)
+            .copied()
+            .or_else(|| is_pi(expr, pool).then_some(std::f64::consts::PI)),
         ExprData::Add(args) => {
             let mut s = 0.0;
             for a in args {
@@ -606,10 +642,45 @@ fn eval_func(name: &str, a: &[f64]) -> Option<f64> {
 /// equation such as `y'' + 2ζω y' + ω² y = 0` is sampled on *both* sides of its
 /// discriminant — `ζ < 1` (complex roots) and `ζ > 1` (real roots) — rather
 /// than only on the side the real evaluator happens to reach.
-const PARAM_SETS: [&[f64]; 3] = [
+///
+/// # Both signs, and why that is safe here
+///
+/// The first three rows are positive; the last three carry the sign patterns a
+/// two-parameter equation needs to be sampled in all four quadrants —
+/// `(−, +)`, `(+, −)`, `(−, −)`.  Sampling positive values only certified a
+/// candidate that is right for `Kₘ > 0` and wrong for `Kₘ < 0`, and `OdeInput`
+/// carries no assumption that would justify the restriction.
+///
+/// "Add negative values" is not on its own a safe change: many correct answers
+/// are legitimately domain-limited, and a `log k` or `√k` in a candidate is
+/// genuinely undefined at `k < 0`.  Three things make it safe:
+///
+/// * The parametric gate evaluates over **ℂ**, where `log(−1.3)` and `√(−1.3)`
+///   are ordinary finite numbers on the principal branch, and where a correct
+///   candidate's analytic continuation is still correct.  The negative rows
+///   therefore mostly *resolve* rather than dropping out.
+/// * Where a sample does not resolve, the three-way classification the whole
+///   gate is built on books it as **no information** — never as agreement and
+///   never as disagreement.  A row that is entirely unevaluable raises
+///   `sets_unresolved`, which cannot refuse anything on its own; only
+///   `disagree` and `blowup_at_regular_point` can.
+/// * The bar is `sets_agreeing ≥ 2` out of six rows rather than out of three,
+///   so a candidate that resolves only on the positive side is still certified
+///   on the evidence it does produce.
+///
+/// Measured on the dsolve corpus (`corpus::corpus_report`), the six rows leave
+/// all 121 of 125 solved entries solved, with no entry changing status in
+/// either direction.  Nor are the new rows inert: running the corpus with the
+/// three **negative** rows *alone* also solves 121 of 125, so every
+/// parameterised entry resolves and agrees there rather than dropping out of
+/// the evidence.
+pub(crate) const PARAM_SETS: [&[f64]; 6] = [
     &[1.7, 0.6, 2.3, 1.1, 0.4],
     &[0.37, 1.9, 0.83, 2.7, 1.3],
     &[2.9, 0.45, 1.15, 0.71, 3.3],
+    &[-1.3, 0.9, -2.1, 1.6, -0.55],
+    &[0.62, -1.45, 2.05, -0.78, 1.1],
+    &[-2.4, -0.83, -1.35, -3.1, -0.6],
 ];
 
 /// Bind `params` to the values of `PARAM_SETS[set]`.
@@ -630,7 +701,7 @@ fn parameter_env(params: &[ExprId], set: usize) -> HashMap<ExprId, f64> {
 
 /// Agreeing samples required before a *parametric* numeric certificate issues.
 ///
-/// Higher than [`MIN_AGREEING_SAMPLES`] because the grid is three times larger
+/// Higher than [`MIN_AGREEING_SAMPLES`] because the grid is far larger
 /// and because an identity in the parameters is a stronger claim than an
 /// identity at fixed coefficients: it has to hold on an open set, not at a
 /// point.
@@ -694,8 +765,33 @@ fn parametric_report(
     params: &[ExprId],
     pool: &ExprPool,
 ) -> ParametricReport {
+    parametric_report_over(
+        &PARAM_SETS,
+        input,
+        residual,
+        candidate_derivs,
+        constants,
+        params,
+        pool,
+    )
+}
+
+/// [`parametric_report`] restricted to `rows` of the parameter table.
+///
+/// Split out so a test can ask what a *subset* of [`PARAM_SETS`] would have
+/// concluded — which is the only way to pin that the negative rows are the
+/// thing catching a candidate the positive rows certify.
+fn parametric_report_over(
+    rows: &[&[f64]],
+    input: &OdeInput,
+    residual: ExprId,
+    candidate_derivs: &[ExprId],
+    constants: &[ExprId],
+    params: &[ExprId],
+    pool: &ExprPool,
+) -> ParametricReport {
     let mut report = ParametricReport::default();
-    for ps in PARAM_SETS {
+    for &ps in rows {
         let mut env: HashMap<ExprId, C64> = HashMap::new();
         for (i, &p) in params.iter().enumerate() {
             env.insert(p, C64::real(ps[i % ps.len()]));
@@ -947,6 +1043,10 @@ const I: C64 = C64 { re: 0.0, im: 1.0 };
 
 /// Evaluate `expr` over C.  `None` for constructs this evaluator does not know,
 /// which the gate treats as no information (never as agreement).
+///
+/// `pi` and the imaginary unit resolve to their own values without being in
+/// `env`; see [`crate::eval::symbols`] for why binding them to samples instead
+/// is a false-refusal machine.
 pub(crate) fn eval_complex(
     expr: ExprId,
     env: &HashMap<ExprId, C64>,
@@ -959,7 +1059,15 @@ pub(crate) fn eval_complex(
             Some(C64::real(num.to_f64() / den.to_f64()))
         }
         ExprData::Float(f) => Some(C64::real(f.inner.to_f64())),
-        ExprData::Symbol { .. } => env.get(&expr).copied(),
+        ExprData::Symbol { .. } => env.get(&expr).copied().or_else(|| {
+            if is_pi(expr, pool) {
+                Some(C64::real(std::f64::consts::PI))
+            } else if pool.is_imaginary_unit(expr) {
+                Some(I)
+            } else {
+                None
+            }
+        }),
         ExprData::Add(args) => {
             let mut s = C64::real(0.0);
             for a in args {

--- a/alkahest-core/src/ode/dsolve/verify/tests.rs
+++ b/alkahest-core/src/ode/dsolve/verify/tests.rs
@@ -252,3 +252,166 @@ fn regularity_probe_declines_on_an_unknown_construct() {
     let input = input.with_equation(f.pool.add(vec![yp, f.neg(ei)]));
     assert!(!ode_is_regular_at(&input, 0.43, &HashMap::new(), &f.pool));
 }
+
+// ---------------------------------------------------------------------------
+// Named constants are not free parameters
+// ---------------------------------------------------------------------------
+
+/// `pi` is an ordinary symbol here, so the collector used to hand it to the
+/// sampler and the gate evaluated candidates at `π = 1.7`.  Anything whose
+/// correctness depends on π being π then disagrees at every sample — a correct
+/// answer refused.
+#[test]
+fn pi_is_bound_to_its_value_rather_than_sampled() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let pi = f.pool.symbol("pi", Domain::Real);
+    // y' − cos(π + π)·y·(eˣ·e⁻ˣ) = 0.  `cos(2π) = 1`, so this is `y' = y` and
+    // `y = C1·eˣ` is exactly right — but only at the real π.  At `π = 1.7` the
+    // coefficient is `cos(3.4) = −0.967` and the candidate is wrong.
+    let coeff = f.pool.func("cos", vec![f.pool.add(vec![pi, pi])]);
+    let eq = f.pool.add(vec![
+        yp,
+        f.neg(f.pool.mul(vec![coeff, f.y, f.one_that_does_not_simplify()])),
+    ]);
+    let input = input.with_equation(eq);
+    let cand = simp(
+        f.pool.mul(vec![f.c1, f.pool.func("exp", vec![f.x])]),
+        &f.pool,
+    );
+
+    let (residual, _) = build_residual(&input, cand, &f.pool).expect("residual builds");
+    // Non-vacuity: `simp` must not have folded `cos(2π)` away, or the case
+    // would never reach the sampler at all.
+    assert!(
+        contains(residual, pi, &f.pool),
+        "the residual must still mention pi: {}",
+        f.pool.display(residual)
+    );
+    assert!(
+        free_parameters(&input, &[residual], &[f.c1], &f.pool).is_empty(),
+        "pi must not be collected as a free parameter"
+    );
+    // `pi` resolves without ever being in the environment.
+    let sin_pi = f.pool.func("sin", vec![pi]);
+    assert!(
+        eval(sin_pi, &HashMap::new(), &f.pool)
+            .expect("pi has a value")
+            .abs()
+            < 1e-12,
+        "sin(pi) must evaluate to 0"
+    );
+
+    residual_is_zero(&input, cand, &[f.c1], &f.pool)
+        .expect("a solution that is correct at the real pi must verify");
+}
+
+/// The imaginary unit is the other symbol that already denotes a number.  Bound
+/// to a real sample it turns `e^{iπ}` into an ordinary real exponential and the
+/// gate reports a disagreement that is entirely an artefact of the binding.
+#[test]
+fn the_imaginary_unit_is_not_sampled_either() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let pi = f.pool.symbol("pi", Domain::Real);
+    let i = f.pool.imaginary_unit();
+    // y' + e^{iπ}·y·(eˣ·e⁻ˣ) = 0.  `e^{iπ} = −1`, so this is `y' = y`.
+    let coeff = f.pool.func("exp", vec![f.pool.mul(vec![i, pi])]);
+    let eq = f.pool.add(vec![
+        yp,
+        f.pool.mul(vec![coeff, f.y, f.one_that_does_not_simplify()]),
+    ]);
+    let input = input.with_equation(eq);
+    let cand = simp(
+        f.pool.mul(vec![f.c1, f.pool.func("exp", vec![f.x])]),
+        &f.pool,
+    );
+
+    let (residual, _) = build_residual(&input, cand, &f.pool).expect("residual builds");
+    assert!(
+        contains(residual, i, &f.pool) && contains(residual, pi, &f.pool),
+        "the residual must still mention both constants: {}",
+        f.pool.display(residual)
+    );
+    assert!(
+        free_parameters(&input, &[residual], &[f.c1], &f.pool).is_empty(),
+        "neither pi nor the imaginary unit is a free parameter"
+    );
+    residual_is_zero(&input, cand, &[f.c1], &f.pool)
+        .expect("e^{i*pi} = -1 must be read as -1, not as a sampled product");
+}
+
+// ---------------------------------------------------------------------------
+// Parameters are sampled at both signs
+// ---------------------------------------------------------------------------
+
+/// The soundness hole a positive-only [`PARAM_SETS`] left open.
+///
+/// The equation is `y' = √(k²)·y`, whose general solution is `y = C1·e^{|k|x}`.
+/// The candidate `y = C1·e^{kx}` is **right for every `k > 0` and wrong for
+/// every `k < 0`** — the single commonest way a symbolic-coefficient class goes
+/// wrong, since `√(k²) → k` is the step it is tempted to take.  Sampled only at
+/// positive `k` the two are indistinguishable and the wrong candidate was
+/// certified; the negative rows separate them.
+#[test]
+fn a_candidate_right_only_for_positive_parameters_is_refused() {
+    let f = Fixture::new();
+    let (input, yp) = OdeInput::first_order(f.x, f.y, &f.pool);
+    let k = f.pool.symbol("k", Domain::Real);
+    let abs_k = f
+        .pool
+        .func("sqrt", vec![f.pool.pow(k, f.pool.integer(2_i32))]);
+    let input = input.with_equation(f.pool.add(vec![yp, f.neg(f.pool.mul(vec![abs_k, f.y]))]));
+
+    let wrong = simp(
+        f.pool.mul(vec![
+            f.c1,
+            f.pool.func("exp", vec![f.pool.mul(vec![k, f.x])]),
+        ]),
+        &f.pool,
+    );
+    let (residual, derivs) = build_residual(&input, wrong, &f.pool).expect("residual builds");
+    // Non-vacuity: `simp` must not have rewritten `√(k²)` to `k`, which would
+    // make the candidate correct as written and the case meaningless.
+    assert!(
+        !is_symbolic_zero(residual, &f.pool),
+        "the residual must not already be zero: {}",
+        f.pool.display(residual)
+    );
+    let params = free_parameters(&input, &[residual], &[f.c1], &f.pool);
+    assert_eq!(params, vec![k], "k is the one free parameter");
+
+    // On the positive rows alone the candidate is indistinguishable from the
+    // truth — this is what the old table could see, and why it certified.
+    let positive_only = parametric_report_over(
+        &PARAM_SETS[..3],
+        &input,
+        residual,
+        &derivs,
+        &[f.c1],
+        &params,
+        &f.pool,
+    );
+    assert_eq!(positive_only.inner.disagree, 0, "{positive_only}");
+    assert!(
+        positive_only.certifies(),
+        "the positive rows on their own certify a wrong candidate: {positive_only}"
+    );
+
+    // With both signs the disagreement is visible and the gate refuses.
+    let full = parametric_report(&input, residual, &derivs, &[f.c1], &params, &f.pool);
+    assert!(full.has_counterevidence(), "{full}");
+    residual_is_zero(&input, wrong, &[f.c1], &f.pool)
+        .expect_err("a candidate wrong for every k < 0 must not be certified");
+
+    // …and the correct answer still is.
+    let right = simp(
+        f.pool.mul(vec![
+            f.c1,
+            f.pool.func("exp", vec![f.pool.mul(vec![abs_k, f.x])]),
+        ]),
+        &f.pool,
+    );
+    residual_is_zero(&input, right, &[f.c1], &f.pool)
+        .expect("y = C1*e^{|k|x} is the general solution and must still verify");
+}

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -1165,6 +1165,204 @@ def _ball_upper(expr: ak.Expr, binding: dict[Any, Any]) -> Callable[[], float]:
     return op
 
 
+_ODE_T = POOL.symbol("t")
+_ODE_Y = POOL.symbol("y_ode")
+_ODE_DERIVS = tuple(POOL.symbol("y_ode" + "'" * k) for k in range(1, 5))
+_YP, _YPP, _YPPP = _ODE_DERIVS[0], _ODE_DERIVS[1], _ODE_DERIVS[2]
+_PI = POOL.symbol("pi")
+_ODE_CONSTANTS = (_rat(13, 10), _rat(7, 10), _rat(19, 10), _rat(1, 2))
+_ODE_SAMPLES = (0.31, 0.57, 1.13)
+_ODE_Y_SAMPLES = (0.43, 1.7)
+_ODE_K = POOL.symbol("k")
+_ODE_KM = POOL.symbol("Km")
+_ODE_VM = POOL.symbol("Vm")
+_ODE_KA = POOL.symbol("ka")
+_ODE_KE = POOL.symbol("ke")
+_S1 = POOL.symbol("s1")
+_S2 = POOL.symbol("s2")
+_S3 = POOL.symbol("s3")
+
+
+def _ode_branch(equation: ak.Expr, order: int) -> dict[str, Any]:
+    branches = ex.dsolve(equation, X, _ODE_Y, list(_ODE_DERIVS[:order]))
+    if not branches:
+        raise ValueError("dsolve reported success with no branch")
+    return branches[0]
+
+
+def _ode_env(extra: dict[ak.Expr, float]) -> dict[ak.Expr, float]:
+    env: dict[ak.Expr, float] = {_PI: math.pi}
+    env.update(extra)
+    return env
+
+
+def ode_residual(
+    equation: ak.Expr, order: int, params: dict[ak.Expr, ak.Expr] | None = None
+) -> Callable[[], float]:
+    """Answer = max |equation| after substituting alkahest's *own* answer back.
+
+    Never asserts the shape of a solution — `C1·eˣ` and `e^{x+C1}` are the same
+    family and a corpus that preferred one would measure spelling.  What it
+    asserts is the only thing that means anything: that differentiating the
+    returned `y(x)` and putting it, and its derivatives, back into the equation
+    leaves zero.  A wrong solution cannot survive that; a differently-written
+    right one is unaffected.
+
+    Implicit answers (`G(x, y) = 0`, which separable and exact classes often
+    return) are handled in their own right rather than being scored as a
+    refusal: the implicit function theorem gives the slope `y' = −Gₓ/G_y`, and
+    the equation must vanish on a free `(x, y)` grid — a stronger claim than the
+    explicit one, since it is an identity in two variables.
+
+    *params* binds the equation's own symbolic coefficients.  Sampling one of
+    them at a **negative** value is the point of some of these cases.
+    """
+    params = dict(params or {})
+
+    def op() -> float:
+        sol = _ode_branch(equation, order)
+        binding: dict[ak.Expr, ak.Expr] = {
+            c: _ODE_CONSTANTS[i % len(_ODE_CONSTANTS)] for i, c in enumerate(sol["constants"])
+        }
+        binding.update(params)
+        worst = 0.0
+        if sol["form"] == "explicit":
+            y = ak.subs(sol["y_of_x"], binding)
+            mapping: dict[ak.Expr, ak.Expr] = {_ODE_Y: y}
+            cur = y
+            for dsym in _ODE_DERIVS[:order]:
+                cur = ak.diff(cur, X).value
+                mapping[dsym] = cur
+            resid = ak.subs(ak.subs(equation, mapping), params)
+            for xv in _ODE_SAMPLES:
+                worst = max(worst, abs(float(ak.eval_expr(resid, _ode_env({X: xv})))))
+            return worst
+        g = sol["implicit_relation"]
+        gx = ak.subs(ak.diff(g, X).value, params)
+        gy = ak.subs(ak.diff(g, _ODE_Y).value, params)
+        resid = ak.subs(ak.subs(equation, {_ODE_DERIVS[0]: -gx / gy}), params)
+        for xv in _ODE_SAMPLES:
+            for yv in _ODE_Y_SAMPLES:
+                worst = max(worst, abs(float(ak.eval_expr(resid, _ode_env({X: xv, _ODE_Y: yv})))))
+        return worst
+
+    return op
+
+
+def _numeric_rank(rows: list[list[float]], tol: float = 1e-7) -> int:
+    """Rank of a small float matrix by Gauss–Jordan with a pivot threshold."""
+    rows = [list(r) for r in rows]
+    rank = 0
+    for col in range(len(rows[0])):
+        piv = next((r for r in range(rank, len(rows)) if abs(rows[r][col]) > tol), None)
+        if piv is None:
+            continue
+        rows[rank], rows[piv] = rows[piv], rows[rank]
+        pivot = rows[rank][col]
+        for r in range(len(rows)):
+            if r != rank and rows[r][col] != 0.0:
+                factor = rows[r][col] / pivot
+                rows[r] = [a - factor * b for a, b in zip(rows[r], rows[rank])]
+        rank += 1
+        if rank == len(rows):
+            break
+    return rank
+
+
+def ode_family_rank(
+    equation: ak.Expr, order: int, samples: tuple[float, ...] = (0.31, 0.57, 0.83, 1.19, 1.61)
+) -> Callable[[], int]:
+    """Answer = how many independent directions the returned family spans.
+
+    For an order-`n` linear ODE the general solution is an `n`-dimensional
+    family, so `rank[∂y/∂C_i(x_j)]` must be `n`.  A family that is a *solution*
+    but not the general one — the repeated-root answer written with the
+    distinct-root formula — has full residual agreement and a deficient rank,
+    and this is the only check in the corpus that can tell the difference.
+
+    A caller who integrates such an answer against initial conditions gets an
+    unsolvable linear system, or, worse, a least-squares fit that quietly
+    ignores half of them.
+    """
+
+    def op() -> int:
+        sol = _ode_branch(equation, order)
+        if sol["form"] != "explicit":
+            raise ValueError("a family's dimension is only defined for an explicit answer")
+        binding = {
+            c: _ODE_CONSTANTS[i % len(_ODE_CONSTANTS)] for i, c in enumerate(sol["constants"])
+        }
+        rows = []
+        for c in sol["constants"]:
+            partial = ak.subs(ak.diff(sol["y_of_x"], c).value, binding)
+            rows.append([float(ak.eval_expr(partial, _ode_env({X: s}))) for s in samples])
+        return _numeric_rank(rows)
+
+    return op
+
+
+def ode_states_its_branch_condition(equation: ak.Expr, order: int) -> Callable[[], bool]:
+    """Answer = did the answer come with the condition it is only valid under?
+
+    A symbolic-coefficient answer whose discriminant can vanish is *undefined*
+    at the confluence, not merely non-general.  Returning it bare is a silent
+    error of the narrowing kind: the formula is right where it is defined and
+    the caller has no way to learn where that is.
+    """
+
+    def op() -> bool:
+        sol = _ode_branch(equation, order)
+        return bool(sol["side_conditions"]) and bool(sol["notes"])
+
+    return op
+
+
+def _system_solution(states: list[ak.Expr], rhs: list[ak.Expr]) -> dict[str, Any]:
+    return ex.dsolve_system(ak.ODE(states, rhs, _ODE_T))
+
+
+def system_residual(
+    states: list[ak.Expr], rhs: list[ak.Expr], params: dict[ak.Expr, ak.Expr] | None = None
+) -> Callable[[], float]:
+    """Answer = max |y_i'(t) − rhs_i(y(t))| over every component and sample.
+
+    The system analogue of :func:`ode_residual`: every component of the returned
+    `y(t)` is differentiated and checked against *its own* equation with the
+    whole state substituted, so a solution that is right in one coordinate and
+    wrong in another cannot average out.
+    """
+    params = dict(params or {})
+
+    def op() -> float:
+        sol = _system_solution(states, rhs)
+        binding: dict[ak.Expr, ak.Expr] = {
+            c: _ODE_CONSTANTS[i % len(_ODE_CONSTANTS)] for i, c in enumerate(sol["constants"])
+        }
+        binding.update(params)
+        ys = [ak.subs(e, binding) for e in sol["y_of_t"]]
+        state_map = dict(zip(states, ys))
+        worst = 0.0
+        for i in range(len(states)):
+            resid = ak.subs(ak.diff(ys[i], _ODE_T).value - ak.subs(rhs[i], state_map), params)
+            for tv in _ODE_SAMPLES:
+                worst = max(worst, abs(float(ak.eval_expr(resid, _ode_env({_ODE_T: tv})))))
+        return worst
+
+    return op
+
+
+def system_states_its_branch_condition(
+    states: list[ak.Expr], rhs: list[ak.Expr]
+) -> Callable[[], bool]:
+    """Answer = did the system's answer disclose the confluence it divides by?"""
+
+    def op() -> bool:
+        sol = _system_solution(states, rhs)
+        return bool(sol["side_conditions"]) and bool(sol["notes"])
+
+    return op
+
+
 CASES: list[Case] = [
     # ── real quantifier elimination ──────────────────────────────────────────
     #
@@ -5145,6 +5343,347 @@ CASES: list[Case] = [
             "inequality holds and the strict one does not. Reporting 'true' for the strict "
             "form is the classic boundary error, and it is the kind that survives every "
             "numerical spot-check that happens to avoid the endpoint."
+        ),
+    ),
+    Case(
+        id="ode_repeated_root_family_spans_two_dimensions",
+        subsystem="ode",
+        statement="y'' − 2y' + y = 0 has a 2-dimensional solution space: (C1 + C2·x)·eˣ",
+        op=ode_family_rank(_YPP - _int(2) * _YP + _ODE_Y, 2),
+        contract=Returns(2),
+        verified_by=(
+            "The characteristic polynomial is (r−1)², a double root, so a fundamental system "
+            "is {eˣ, x·eˣ} (reduction of order: y = v·eˣ gives v'' = 0). Existence and "
+            "uniqueness make the solution space of a second-order linear ODE exactly "
+            "2-dimensional, so the rank of [∂y/∂C_i] must be 2."
+        ),
+        note=(
+            "The one ODE silent error that substituting the answer back cannot find. The "
+            "distinct-root formula applied without checking the discriminant yields "
+            "C1·eˣ + C2·eˣ, whose residual is identically zero and whose family is a line, "
+            "not a plane. alkahest's own gate is substitution-based and is blind to it by "
+            "construction, which is exactly why the check belongs here."
+        ),
+    ),
+    Case(
+        id="ode_triple_root_family_spans_three_dimensions",
+        subsystem="ode",
+        statement="y''' − 3y'' + 3y' − y = 0 has the 3-dimensional space (C1+C2x+C3x²)eˣ",
+        op=ode_family_rank(_YPPP - _int(3) * _YPP + _int(3) * _YP - _ODE_Y, 3),
+        contract=Returns(3),
+        verified_by=(
+            "The characteristic polynomial is (r−1)³. A root of multiplicity m contributes "
+            "{eʳˣ, x·eʳˣ, …, x^{m−1}·eʳˣ}, so {eˣ, x·eˣ, x²·eˣ} is a fundamental system and "
+            "the rank must be 3."
+        ),
+        note=(
+            "The second-order case above can be passed by special-casing a double root; a "
+            "triple root cannot, so the two together test the rule rather than one instance."
+        ),
+    ),
+    Case(
+        id="ode_euler_cauchy_repeated_root_needs_its_logarithm",
+        subsystem="ode",
+        statement="x²y'' − xy' + y = 0 has the 2-dimensional space C1·x + C2·x·log x",
+        op=ode_family_rank(X * X * _YPP - X * _YP + _ODE_Y, 2),
+        contract=Returns(2),
+        verified_by=(
+            "x = e^t turns it into the constant-coefficient equation with indicial polynomial "
+            "r² − 2r + 1 = (r−1)², a double root at r = 1, so the second basis element is "
+            "x·log x, not a second copy of x."
+        ),
+        note=(
+            "The Euler–Cauchy spelling of the trap above: a solver that reads two equal "
+            "indicial roots as two basis elements x¹ and x¹ returns a rank-1 family whose "
+            "residual is zero."
+        ),
+    ),
+    Case(
+        id="ode_control_distinct_roots_still_span",
+        subsystem="ode",
+        statement="y'' + y = 0 has the 2-dimensional space C1·cos x + C2·sin x",
+        op=ode_family_rank(_YPP + _ODE_Y, 2),
+        contract=Returns(2),
+        verified_by=(
+            "Characteristic roots ±i, distinct, so {cos x, sin x} is a fundamental system "
+            "(Wronskian cos²+sin² = 1 ≠ 0 everywhere). The control for the three repeated-root "
+            "cases: a solver that answered every equation with a rank-deficient family, or a "
+            "rank routine that always said 2, would be caught by one of the four."
+        ),
+    ),
+    Case(
+        id="ode_resonant_forcing_is_not_the_naive_ansatz",
+        subsystem="ode",
+        statement="y'' + y = cos x needs the secular ½·x·sin x, not A·cos x + B·sin x",
+        op=ode_residual(_YPP + _ODE_Y - POOL.func("cos", [X]), 2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "cos x solves the homogeneous equation, so every A·cos x + B·sin x is annihilated "
+            "by y'' + y and no such ansatz can produce the forcing term. Variation of "
+            "parameters gives y_p = ½·x·sin x, and (½x sin x)'' + ½x sin x = cos x by hand."
+        ),
+        note=(
+            "The classic undetermined-coefficients trap: the linear system for A and B is "
+            "singular, and an implementation that solves it by elimination without checking "
+            "produces a clean wrong particular solution instead of detecting the resonance."
+        ),
+    ),
+    Case(
+        id="ode_sqrt_of_a_square_coefficient_keeps_its_modulus",
+        subsystem="ode",
+        statement="y' = √(k²)·y at k = −13/10 solves as e^{+1.3x}, not e^{−1.3x}",
+        op=ode_residual(
+            _YP - POOL.func("sqrt", [_ODE_K ** _int(2)]) * _ODE_Y, 1, {_ODE_K: _rat(-13, 10)}
+        ),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "√(k²) = |k| for real k, so at k = −13/10 the equation is y' = 1.3·y and its "
+            "solutions are C·e^{1.3x}. The tempting rewrite √(k²) → k is valid only for "
+            "k ≥ 0 and gives C·e^{−1.3x}, which is a solution of a different equation."
+        ),
+        note=(
+            "The sign-of-a-parameter trap, sampled where it bites. A verifier that only ever "
+            "binds symbolic parameters to positive values cannot distinguish the two answers "
+            "at all — both certify — so this case is as much a test of the gate as of the "
+            "solver."
+        ),
+    ),
+    Case(
+        id="ode_michaelis_menten_negative_km",
+        subsystem="ode",
+        statement="(Km + y)·y' + Vm·y = 0 at Km = −11/10: solve it, or say you cannot",
+        op=ode_residual(
+            (_ODE_KM + _ODE_Y) * _YP + _ODE_VM * _ODE_Y,
+            1,
+            {_ODE_KM: _rat(-11, 10), _ODE_VM: _rat(3, 5)},
+        ),
+        contract=RefusesOr(0.0, tol=1e-9),
+        verified_by=(
+            "Separating variables gives Km·log y + y + Vm·x = C for every non-zero Km; the "
+            "sign of Km changes nothing about the derivation. Inverting it through Lambert W "
+            "does depend on the sign — the argument of W₀ is negative for Km < 0 and leaves "
+            "[−1/e, ∞) — so 'no answer here' is defensible and 'here is a formula' is only "
+            "acceptable if the formula solves the equation."
+        ),
+        note=(
+            "Passes today by a *weak* refusal: the Lambert-W inversion is returned and "
+            "eval_expr declines it at these samples. The Km > 0 control below is the half "
+            "that must keep working."
+        ),
+    ),
+    Case(
+        id="ode_control_michaelis_menten_positive_km",
+        subsystem="ode",
+        statement="(Km + y)·y' + Vm·y = 0 at Km = 11/10, Vm = 3/5 solves",
+        op=ode_residual(
+            (_ODE_KM + _ODE_Y) * _YP + _ODE_VM * _ODE_Y,
+            1,
+            {_ODE_KM: _rat(11, 10), _ODE_VM: _rat(3, 5)},
+        ),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "Km·log y + y + Vm·x = C, differentiated: (Km/y + 1)·y' + Vm = 0, i.e. "
+            "(Km + y)·y' + Vm·y = 0. The control for the negative-Km case: without it, a "
+            "solver that refused this equation outright would score a clean pass there."
+        ),
+    ),
+    Case(
+        id="ode_riccati_without_a_particular_solution",
+        subsystem="ode",
+        statement="y' = y² + x has no elementary solution — refuse, or produce one that works",
+        op=ode_residual(_YP - _ODE_Y * _ODE_Y - X, 1),
+        contract=RefusesOr(0.0, tol=1e-9),
+        verified_by=(
+            "y = −u'/u linearises it to u'' + x·u = 0, the Airy equation, whose solutions are "
+            "not elementary (Liouville's theorem; Kovacic's algorithm returns no case). So no "
+            "elementary closed form exists and the honest answer is a refusal."
+        ),
+        note=(
+            "The Riccati trap: guess a polynomial particular solution, substitute it into the "
+            "reduction, and out comes a clean formula for an equation that has none. The "
+            "contract admits an answer only if it solves the equation, so a future "
+            "Airy-function answer passes and a guessed one does not."
+        ),
+    ),
+    Case(
+        id="ode_abel_first_kind_has_no_closed_form",
+        subsystem="ode",
+        statement="y' = y³ + x — refuse, or produce a y(x) that solves it",
+        op=ode_residual(_YP - _ODE_Y ** _int(3) - X, 1),
+        contract=RefusesOr(0.0, tol=1e-9),
+        verified_by=(
+            "An Abel equation of the first kind with no known closed-form solution; it is not "
+            "separable, linear, exact, homogeneous, Bernoulli, Clairaut or Riccati, and no "
+            "integrating factor of the standard forms applies. Kamke lists no solution."
+        ),
+        note=(
+            "The nearest neighbour of the Riccati case one power up: the classes that *do* "
+            "match a y² right-hand side must not match this one by pattern alone."
+        ),
+    ),
+    Case(
+        id="ode_clairaut_family_is_the_general_solution",
+        subsystem="ode",
+        statement="y = x·y' + (y')² solves as the line family y = C·x + C²",
+        op=ode_residual(_ODE_Y - X * _YP - _YP ** _int(2), 1),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "Substituting y = Cx + C² gives y' = C and Cx + C² = x·C + C², an identity. "
+            "(The parabola y = −x²/4 is the *singular* solution, an envelope of the family "
+            "and not a member of it; a solver that returned it as 'the general solution' "
+            "would still have residual zero, which is what the rank case below is for.)"
+        ),
+    ),
+    Case(
+        id="ode_clairaut_family_is_one_dimensional",
+        subsystem="ode",
+        statement="the Clairaut general solution is a one-parameter family, not a single curve",
+        op=ode_family_rank(_ODE_Y - X * _YP - _YP ** _int(2), 1),
+        contract=Returns(1),
+        verified_by=(
+            "y = Cx + C² carries one arbitrary constant, so ∂y/∂C = x + 2C is not identically "
+            "zero and the rank is 1. The envelope y = −x²/4 carries none, so returning it "
+            "instead gives rank 0 — the same equation's other, non-general, solution."
+        ),
+    ),
+    Case(
+        id="ode_symbolic_discriminant_confluence_is_disclosed",
+        subsystem="ode",
+        statement="y'' − k²y = 0's two-exponential answer is not general at k = 0, and says so",
+        op=ode_states_its_branch_condition(_YPP - _ODE_K ** _int(2) * _ODE_Y, 2),
+        contract=Returns(True),
+        verified_by=(
+            "The characteristic roots are ±k. At k = 0 they coincide and the general solution "
+            "is C1 + C2·x, which no C1·e^{kx} + C2·e^{−kx} spans — at k = 0 that family "
+            "degenerates to the constants. So the returned family is the general solution on "
+            "k ≠ 0 only, and the condition is part of the answer rather than an aside."
+        ),
+        note=(
+            "A narrowing silent error: the formula is right everywhere it is defined, and a "
+            "caller who substitutes k = 0 into it gets a one-dimensional family presented as "
+            "a two-dimensional one with nothing to warn them."
+        ),
+    ),
+    Case(
+        id="ode_system_confluent_rates_are_disclosed",
+        subsystem="ode",
+        statement="the two-compartment model x'=−ka·x, y'=ka·x−ke·y divides by (ka−ke)",
+        op=system_states_its_branch_condition(
+            [_S1, _S2], [-_ODE_KA * _S1, _ODE_KA * _S1 - _ODE_KE * _S2]
+        ),
+        contract=Returns(True),
+        verified_by=(
+            "The coefficient matrix has eigenvalues −ka and −ke; the second component of the "
+            "solution carries a factor 1/(ke − ka) (integrate ka·C·e^{−ka t} against the "
+            "e^{−ke t} kernel). At ka = ke that expression is 0/0 — undefined as written, "
+            "though its limit is the confluent t·e^{−ka t} form — so the caller must be told."
+        ),
+        note=(
+            "The commonest real parameterisation of this model in pharmacokinetics is "
+            "ka ≈ ke, so the excluded point is not a corner case: it is where a fitter lands."
+        ),
+    ),
+    Case(
+        id="ode_control_numeric_system_states_no_condition",
+        subsystem="ode",
+        statement="x'=x+2y, y'=3x+2y has integer eigenvalues 4 and −1 and needs no caveat",
+        op=system_states_its_branch_condition(
+            [_S1, _S2], [_S1 + _int(2) * _S2, _int(3) * _S1 + _int(2) * _S2]
+        ),
+        contract=Returns(False),
+        verified_by=(
+            "det(A − λI) = (1−λ)(2−λ) − 6 = λ² − 3λ − 4 = (λ−4)(λ+1): two distinct integer "
+            "eigenvalues, nothing undecided. The control for the two disclosure cases — a "
+            "solver that emitted a side condition unconditionally would pass both of those "
+            "and fail here."
+        ),
+    ),
+    Case(
+        id="ode_system_casus_irreducibilis_eigenvalues",
+        subsystem="ode",
+        statement="x'=−z, y'=x+3z, z'=y — three real eigenvalues written with acos and π",
+        op=system_residual([_S1, _S2, _S3], [-_S3, _S1 + _int(3) * _S3, _S2]),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "The coefficient matrix is the companion matrix of λ³ − 3λ + 1, whose discriminant "
+            "is positive, so it has three distinct real roots and Cardano's cube roots are "
+            "complex — the casus irreducibilis. The roots are 2·cos((acos(−1/2) + 2πk)/3), "
+            "k = 0,1,2, correct only at the true π. Each returned component is differentiated "
+            "and matched against its own equation."
+        ),
+        note=(
+            "Refused with E-ODE-034 before 3.10: the verifier collected `pi` as a free symbol "
+            "and bound it to a sample value like 1.7, so the correct eigenvalues disagreed at "
+            "every sample. π is a plain symbol in this library, which is why the sample "
+            "environment here binds it explicitly too."
+        ),
+    ),
+    Case(
+        id="ode_control_two_compartment_system_solves",
+        subsystem="ode",
+        statement="x'=−0.8x, y'=0.8x−0.3y — both components must solve their own equation",
+        op=system_residual(
+            [_S1, _S2],
+            [-_ODE_KA * _S1, _ODE_KA * _S1 - _ODE_KE * _S2],
+            {_ODE_KA: _rat(4, 5), _ODE_KE: _rat(3, 10)},
+        ),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "x = C·e^{−0.8t} by inspection; y' + 0.3y = 0.8·C·e^{−0.8t} is first-order linear "
+            "with solution y = (0.8C/(0.3−0.8))·e^{−0.8t} + D·e^{−0.3t}. Checked by "
+            "substitution rather than by comparing to that form, so any equivalent spelling "
+            "passes."
+        ),
+    ),
+    Case(
+        id="ode_control_linear_first_order",
+        subsystem="ode",
+        statement="y' − 3y = x solves (integrating factor e^{−3x})",
+        op=ode_residual(_YP - _int(3) * _ODE_Y - X, 1),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "y = C·e^{3x} − x/3 − 1/9: y' = 3C·e^{3x} − 1/3 and 3y + x = 3C·e^{3x} − x − 1/3 "
+            "+ x, equal. Derived by hand from the integrating factor."
+        ),
+    ),
+    Case(
+        id="ode_control_separable_movable_pole",
+        subsystem="ode",
+        statement="y' = 1 + y² solves as tan(x + C), poles and all",
+        op=ode_residual(_YP - _int(1) - _ODE_Y * _ODE_Y, 1),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "d/dx tan(x+C) = sec²(x+C) = 1 + tan²(x+C). The solution has a movable pole at "
+            "x + C = π/2, which is a property of the equation, not an error: a gate that "
+            "declined every candidate with a singularity would refuse this correct answer."
+        ),
+    ),
+    Case(
+        id="ode_control_euler_cauchy_distinct_roots",
+        subsystem="ode",
+        statement="x²y'' + xy' − y = 0 solves as C1·x + C2/x",
+        op=ode_residual(X * X * _YPP + X * _YP - _ODE_Y, 2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "Indicial equation r(r−1) + r − 1 = r² − 1, roots ±1, so x and x⁻¹ are solutions; "
+            "x²·(2x⁻³) + x·(−x⁻²) − x⁻¹ = 2x⁻¹ − x⁻¹ − x⁻¹ = 0 by hand."
+        ),
+    ),
+    Case(
+        id="ode_control_implicit_relation_defines_the_slope_field",
+        subsystem="ode",
+        statement="(2x + y) + (x + 2y)·y' = 0 is exact; its implicit answer must define the ODE",
+        op=ode_residual((_int(2) * X + _ODE_Y) + (X + _int(2) * _ODE_Y) * _YP, 1),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "∂/∂y(2x+y) = 1 = ∂/∂x(x+2y), so the equation is exact with potential "
+            "F = x² + xy + y². The implicit function theorem gives y' = −F_x/F_y = "
+            "−(2x+y)/(x+2y) on the whole grid, which is the equation itself. Scored on the "
+            "two-variable identity, not on the shape of the relation."
+        ),
+        note=(
+            "The control for the implicit half of ode_residual: without it every implicit "
+            "answer in the corpus could be scored as a refusal and nobody would notice."
         ),
     ),
 ]


### PR DESCRIPTION
Fixes the two known defects in the ODE verifier's numeric gate, and gives the
ODE layer its first silent-error coverage.

## Bug 1 — `pi` was sampled as a free parameter and bound to `1.7`

Reproduced and pinned against the unpatched sources before fixing:
`dsolve_system` on the companion matrix of `λ³ − 3λ + 1`
(`x' = −z, y' = x + 3z, z' = y`) failed with
`E-ODE-034 VerificationFailed("samples: 0 agreeing, 90 disagreeing")`. `pi` is
an ordinary `Symbol` in this crate, so `collect_symbols` picked it up and the
gate evaluated a correct answer with `π = 1.7`.

It lived in **two** places, not one — `verify.rs` and `system.rs`, each with
its own `collect_symbols`, and `system.rs` with its own inline copy of
`PARAM_SETS`/`CONST_SETS`. `spectrum.rs`'s `is_pi` / `walk_symbols` /
`collect_free_symbols` / `collect_named_constants` are now
`crate::eval::symbols` and all three gates share them, so the exclusion is
written once rather than three times.

While refactoring, a latent trap was found and avoided: the shared
`collect_named_constants` also reports the imaginary unit, and
`spectrum::bind_constants` would have bound `i` to π. It now filters on
`is_pi`.

**One change beyond the literal bug, flagged for review.** A residual
mentioning the imaginary unit now takes the complex path even with no free
parameters — without it, excluding `I` from sampling would have silently
converted "sampled as a real number" into "always unevaluable → always refuse".
The complex pass applies the *same* classification with *stricter* thresholds
(12 agreeing samples across ≥2 sets, vs 6), so this is a correct evaluator
rather than a loosened criterion. Nothing in the corpus reaches it today; pinned
by `the_imaginary_unit_is_not_sampled_either`.

## Bug 2 — symbolic parameters were sampled at positive values only

All three `PARAM_SETS` rows were positive, so a candidate correct for `Kₘ > 0`
and wrong for `Kₘ < 0` certified. Three rows added covering the `(−,+)`,
`(+,−)`, `(−,−)` sign patterns, and `numeric_report` now takes the **product**
of `PARAM_SETS × CONST_SETS` rather than pairing by index — otherwise the real
second opinion would reason about a different parameter region than the complex
pass that asked for it.

**Measured, not asserted.** `corpus_report` over 125 entries:

| | solved | explicit | implicit | declined |
|---|---|---|---|---|
| before (`main`) | 121 | 113 | 8 | 4 |
| after | 121 | 113 | 8 | 4 |

**The per-entry diff is empty** — no case moves in either direction, so there is
nothing to justify. `decline_split_report` is `no_candidate=4 gate_refused=0`
on both sides.

Two further measurements, because "no change" could mean "did nothing":

1. **The negative rows are not inert.** With the three *negative* rows alone the
   corpus still solves 121/125 — every parameterised entry resolves and agrees
   there rather than dropping out of the evidence.
2. **The soundness gain is real.** For `y' = √(k²)·y`, the wrong candidate
   `C1·e^{kx}` — right for every `k > 0`, wrong for every `k < 0` — is
   **certified by the three positive rows alone** and **refused by all six**,
   while the correct `C1·e^{|k|x}` still verifies.

## First silent-error coverage for ODEs

21 cases (18 correct / 3 honest refusals / 0 silent errors), because
substituting an answer back cannot detect all three kinds of wrong:

- **`ode_residual` / `system_residual`** — the answer must solve the equation,
  in whatever form (explicit, or implicit via `y' = −Gₓ/G_y`). Never asserts
  shape.
- **`ode_family_rank`** — the answer must be the *general* solution. This check
  is not vacuous: for `y'' − 2y' + y = 0` the wrong family `C1eˣ + C2eˣ` has
  residual **8.9e-16**, indistinguishable from correct, and rank **1** instead
  of 2. **alkahest's own gate is substitution-based and structurally blind to
  this.** Covered for a double root, a triple root, Euler–Cauchy, and a
  distinct-root control.
- **`ode_states_its_branch_condition`** — an answer dividing by a discriminant
  that can vanish must say so, with a numeric-eigenvalue control that must not.

Traps: Airy Riccati, Abel first kind, Michaelis–Menten at `Kₘ < 0` (passes
today only by a *weak* refusal — noted in the case), and `y' = √(k²)·y` at
`k = −13/10`, which is Bug 2 restated at the API level. Controls include the
casus-irreducibilis system (Bug 1's regression test at the Python level),
resonant forcing, the two-compartment model, Clairaut, `y' = 1 + y²`, and an
exact equation's implicit relation.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2900 passed, 0
failed, 11 ignored** (main: 2895, +5). `pytest tests/silent_errors/` → 292
passed, **0 silent errors**, total 282 cases.
`pytest tests/ --ignore=tests/silent_errors` → 2957 passed, 0 failed.
clippy `-D warnings`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`,
`ruff check`, `check_error_codes.py` (231 codes), `check_api_freeze.py` all
clean. No public enum variant or struct field added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ODE and system verification involving π and the imaginary unit.
  - Prevented mathematical constants from being incorrectly treated as free parameters.
  - Expanded parameter sampling across positive and negative values to catch solutions that only work under limited conditions.
  - Systems with valid trigonometric eigenvalue expressions involving π are now accepted more reliably.

- **Tests**
  - Added coverage for constant handling, complex-valued verification, parameter-sign edge cases, and broader ODE solution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->