### PR TITLE
fix(holonomic,sum): withhold a boundary verdict when the sum does not exist

### DIFF
--- a/alkahest-core/src/holonomic/boundary.rs
+++ b/alkahest-core/src/holonomic/boundary.rs
@@ -235,6 +235,23 @@ fn collect_terms(
         ));
     }
 
+    // A pole of the *summand* at an integer strictly between the bounds is
+    // invisible to everything below — the telescoped part reads `G` only at the
+    // two endpoints, and the certificate identity is one in `Q(n)(k)`, which a
+    // pole in `k` does not disturb. But `S(n)` has no value at any `n` whose
+    // range contains one, so no verdict on `b(n)` may be issued. This is the
+    // same lesson as `sum::interior_undefined_index` and the definite-integral
+    // interior-pole guards: the guard has to look at the summand, not at
+    // `G(k_hi+1) − G(k_lo)`, which is precisely the object that has forgotten
+    // the interior.
+    if let Some(pt) = summand_pole_inside(&f, lo_pt, hi_pt) {
+        return Err(format!(
+            "the summand is undefined at k = {pt}, which lies inside the summation range \
+             k = {lo_pt}..{hi_pt}: that term of S(n) is a division by zero, so the sum has \
+             no value and no recurrence for it follows from the certificate"
+        ));
+    }
+
     let mut terms: Vec<HypTerm> = Vec::new();
 
     // The telescoped part: + G(n, k_hi+1) − G(n, k_lo).
@@ -363,6 +380,102 @@ fn endpoint_point(e: ExprId, n: ExprId, k: ExprId, pool: &ExprPool) -> Result<Po
     Ok(Point { alpha: a, beta })
 }
 
+impl std::fmt::Display for Point {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.alpha, self.beta) {
+            (0, b) => write!(f, "{b}"),
+            (1, 0) => write!(f, "n"),
+            (a, 0) => write!(f, "{a}*n"),
+            (1, b) if b > 0 => write!(f, "n + {b}"),
+            (1, b) => write!(f, "n - {}", -b),
+            (a, b) if b > 0 => write!(f, "{a}*n + {b}"),
+            (a, b) => write!(f, "{a}*n - {}", -b),
+        }
+    }
+}
+
+/// `a(n) ≥ b(n)` for every sufficiently large `n`, for integer-affine points.
+fn ge_eventually(a: Point, b: Point) -> bool {
+    a.alpha > b.alpha || (a.alpha == b.alpha && a.beta >= b.beta)
+}
+
+/// Largest `|β|` offset scanned when looking for a pole of the summand strictly
+/// inside the summation range.
+///
+/// The scan is structural — a pole sits at `k = α·n + β` — and a real summand
+/// never places one far from an endpoint, so the window is generous rather than
+/// tuned. Finding nothing past it is *no opinion*, never *no pole*: the verdict
+/// then falls through to the endpoint analysis exactly as it did before.
+const MAX_INTERIOR_POLE_OFFSET: i64 = 64;
+
+/// A point `k = α·n + β` in `[lo, hi]` at which the summand is **undefined**,
+/// when one can be exhibited.
+///
+/// `S(n) = Σ_{k=κ₀(n)}^{κ₁(n)} F(n,k)` does not exist at any `n` for which some
+/// integer `k` in the range is a pole of `F`, and a verdict on `b(n)` is a claim
+/// about `S`. The certificate identity is one in `Q(n)(k)`, so it survives the
+/// pole happily and the boundary analysis — which only ever looks at the two
+/// endpoints and the finitely many range-shift corrections — never meets it.
+///
+/// `Σ_{k=0}^{n} C(n,k)/(k−3)` is the shape this exists for: the certificate
+/// verifies, every endpoint is finite, and `"vanishes"` came back for a sum that
+/// is undefined for every `n ≥ 3`. Reading the homogeneous recurrence off it at
+/// `n = 1` gives `S(2) = −10/3` against a true `−7/3`.
+///
+/// `None` is *no pole was found*, never *there is no pole*: a refusal rests on
+/// [`Value::Pole`], which is positive evidence obtained by the same exact order
+/// counting the endpoint values use.
+fn summand_pole_inside(f: &ProperTerm, lo: Point, hi: Point) -> Option<Point> {
+    // A backwards range `Σ_{k=lo}^{hi} = −Σ_{k=hi+1}^{lo−1}` runs over the
+    // reversed window, and a pole in *that* window is just as fatal.
+    let (first, last) = if ge_eventually(hi, lo) {
+        (lo, hi)
+    } else {
+        (hi.offset(1), lo.offset(-1))
+    };
+    if first.alpha > last.alpha {
+        return None;
+    }
+
+    // `F(n,k) = R(n,k)·z^k·w^n·∏ Γ(aⱼn + bⱼk + cⱼ)^{eⱼ}` can only blow up *in k*
+    // through `R`'s denominator or through a `Γ` with a positive exponent whose
+    // argument stops moving with `n` — everything else is either `k`-free (an
+    // isolated-`n` question, which the residual hypothesis already covers) or a
+    // `Γ` with a negative exponent, i.e. a zero. So the great majority of
+    // summands, `C(n,k)^j` and Apéry's among them, are answered without
+    // substituting anything at all.
+    let den_can_vanish = f.rat.den.degree() >= 1;
+    let gamma_can_pole = |alpha: i64| {
+        f.gammas
+            .iter()
+            .any(|g| g.e > 0 && g.b != 0 && g.a.checked_add(g.b.wrapping_mul(alpha)) == Some(0))
+    };
+
+    let w = MAX_INTERIOR_POLE_OFFSET;
+    let one = RatK::one();
+    for alpha in first.alpha..=last.alpha {
+        if !den_can_vanish && !gamma_can_pole(alpha) {
+            continue;
+        }
+        // `α·n + β` lies in `[first, last]` for all large `n` exactly when it
+        // clears the endpoint it shares a slope with; a strictly interior slope
+        // clears both for free.
+        let (blo, bhi) = match (alpha == first.alpha, alpha == last.alpha) {
+            (true, true) => (first.beta, last.beta.min(first.beta.saturating_add(w))),
+            (true, false) => (first.beta, first.beta.saturating_add(w)),
+            (false, true) => (last.beta.saturating_sub(w), last.beta),
+            (false, false) => (-w, w),
+        };
+        for beta in blo..=bhi {
+            let pt = Point { alpha, beta };
+            if let Value::Pole { .. } = value_at(&one, f, 0, pt) {
+                return Some(pt);
+            }
+        }
+    }
+    None
+}
+
 /// The integer offsets in `Σ_{t=from}^{to}`, with `Σ_{t=from}^{to} = −Σ_{t=to+1}^{from−1}`
 /// when the range runs backwards — so a limit that *decreases* with `n` is
 /// handled with the right sign rather than silently dropped.
@@ -416,6 +529,12 @@ enum Value {
     Zero,
     /// Finite, with this closed form.
     Finite(HypTerm),
+    /// Proved *unbounded*: the value has a pole of this order at the point.
+    ///
+    /// Distinguished from [`Value::Undecidable`] because it is positive
+    /// evidence — "there is a pole here", not "this analysis cannot say" — and
+    /// [`summand_pole_inside`] may only refuse on the former.
+    Pole { order: u64 },
     /// Not decidable by this analysis.
     Undecidable(String),
 }
@@ -423,6 +542,10 @@ enum Value {
 fn push_value(out: &mut Vec<HypTerm>, v: Value, weight: &Rn) -> Result<(), String> {
     match v {
         Value::Zero => Ok(()),
+        Value::Pole { order } => Err(format!(
+            "the value is unbounded there (pole of order {order}), so the telescoped sum has \
+             no finite boundary value"
+        )),
         Value::Undecidable(why) => Err(why),
         Value::Finite(mut t) => {
             t.coeff = rn_mul(&t.coeff, weight);
@@ -503,11 +626,9 @@ fn value_at(extra: &RatK, f: &ProperTerm, n_shift: i64, at: Point) -> Value {
         return Value::Zero;
     }
     if order < 0 {
-        return Value::Undecidable(format!(
-            "the value is unbounded there (pole of order {}), so the telescoped sum has no \
-             finite boundary value",
-            -order
-        ));
+        return Value::Pole {
+            order: order.unsigned_abs(),
+        };
     }
     if rn_is_zero(&coeff) {
         return Value::Zero;
@@ -1064,6 +1185,61 @@ mod tests {
         assert_eq!(signed_window(1, -1), vec![(0, -1)]);
         assert_eq!(signed_window(0, -1), Vec::<(i64, i32)>::new());
         assert_eq!(signed_window(-1, -1), vec![(-1, 1)]);
+    }
+
+    /// A pole of the *summand* inside the range makes `S(n)` not exist, so no
+    /// verdict may be issued — and the one that used to be issued was false.
+    ///
+    /// `F(n,k) = C(n,k)/(k−3)`: the certificate verifies exactly in `Q(n)(k)`,
+    /// both endpoints of `G` are finite, and `"vanishes"` came back. The
+    /// recurrence it licenses is
+    /// `(2n+2)·S(n) + (2−3n)·S(n+1) + (n−1)·S(n+2) = 0`, and at `n = 1` the
+    /// last coefficient is `0`, so it reads `4·S(1) − S(2) = 0` with
+    /// `S(1) = −5/6` and `S(2) = −7/3` — that is `−1`, not `0`, and solving it
+    /// for `S(2)` gives `−10/3` against a true `−7/3`. Every quantity in that
+    /// instance is defined; the sum is only undefined from `n = 3` on, where
+    /// the `k = 3` term divides by zero.
+    #[test]
+    fn a_pole_inside_the_range_is_unknown_not_vanishes() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        for m in 2..=6_i32 {
+            let den = pool.add(vec![k, pool.integer(-m)]);
+            let f = pool.mul(vec![
+                binom(&pool, n, k),
+                pool.pow(den, pool.integer(-1_i32)),
+            ]);
+            let status = verdict(f, n, k, &pool, Some(natural_limits(n, &pool)));
+            let BoundaryStatus::Unknown { reason } = &status else {
+                panic!("C(n,k)/(k-{m}) must not get a verdict: got {status:?}");
+            };
+            assert!(
+                reason.contains(&format!("k = {m}")),
+                "the reason must name the offending index: {reason}"
+            );
+            assert!(!status.implies_sum_recurrence());
+        }
+    }
+
+    /// The control the guard must not swallow: a pole *outside* the range.
+    ///
+    /// `C(n,k)/(k+1)` has its pole at `k = −1`, below `k_lo = 0`, and is the
+    /// A279013-shaped case whose `"nonzero"` verdict is the module's headline
+    /// result. Refusing it would trade one false verdict for a dead engine.
+    #[test]
+    fn a_pole_below_the_range_still_gets_a_verdict() {
+        let pool = ExprPool::new();
+        let (n, k) = nk(&pool);
+        let den = pool.add(vec![k, pool.integer(1_i32)]);
+        let f = pool.mul(vec![
+            binom(&pool, n, k),
+            pool.pow(den, pool.integer(-1_i32)),
+        ]);
+        let status = verdict(f, n, k, &pool, Some(natural_limits(n, &pool)));
+        assert!(
+            matches!(status, BoundaryStatus::Nonzero { .. }),
+            "got {status:?}"
+        );
     }
 
     /// `⌊·⌋`, not truncation — the `Γ` ladder is wrong by one for negative

--- a/alkahest-core/src/sum/expr_ratio.rs
+++ b/alkahest-core/src/sum/expr_ratio.rs
@@ -166,7 +166,7 @@ fn ratio_factor(f: ExprId, k: ExprId, pool: &ExprPool) -> Result<RatFunc, SumErr
     }
 }
 
-fn is_free_of_k(expr: ExprId, k: ExprId, pool: &ExprPool) -> bool {
+pub(super) fn is_free_of_k(expr: ExprId, k: ExprId, pool: &ExprPool) -> bool {
     if expr == k {
         return false;
     }
@@ -254,7 +254,7 @@ fn geometric_base_ratio(
 }
 
 /// Extract integer slope `a` from an affine exponent `a·k + b` (`b` free of `k`).
-fn affine_slope_in_k(exp: ExprId, k: ExprId, pool: &ExprPool) -> Result<i64, SumError> {
+pub(super) fn affine_slope_in_k(exp: ExprId, k: ExprId, pool: &ExprPool) -> Result<i64, SumError> {
     if exp == k {
         return Ok(1);
     }

--- a/alkahest-core/src/sum/mod.rs
+++ b/alkahest-core/src/sum/mod.rs
@@ -23,7 +23,7 @@ pub use recurrence::{
 };
 pub use rsolve::{rsolve, RsolveError};
 
-use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep};
+use crate::deriv::log::{DerivationLog, DerivedExpr, RewriteStep, SideCondition};
 use crate::kernel::subs::subs;
 use crate::kernel::{ExprId, ExprPool};
 use crate::matrix::normal_form::RatUniPoly;
@@ -142,6 +142,13 @@ pub fn sum_indefinite(
 /// else with an infinite bound honestly returns
 /// [`SumError::NotGosperSummable`] rather than a wrong or unresolved-`∞`
 /// answer.
+///
+/// One family is summed *off* the Gosper path, on its failure branch only:
+/// `Σ c·r^{a·k+b}` with a **symbolic** ratio, which the `Q(k)` machinery cannot
+/// represent — Gosper's certificate lives in `Q(k)` and a symbolic ratio is not
+/// in `Q`. Its `q = 1` branch is recorded as a [`SideCondition::NonZero`] on the
+/// derivation step rather than assumed away, and an infinite upper bound still
+/// refuses, because convergence needs `|q| < 1` and nothing here knows it.
 pub fn sum_definite(
     term: ExprId,
     k: ExprId,
@@ -156,7 +163,25 @@ pub fn sum_definite(
         log.push(RewriteStep::simple("basel_zeta_even", term, value));
         return Ok(DerivedExpr::with_log(value, log));
     }
-    let ind = sum_indefinite(term, k, pool)?;
+    let ind = match sum_indefinite(term, k, pool) {
+        Ok(ind) => ind,
+        Err(e) => {
+            // The one elementary family the `Q(k)` machinery structurally
+            // cannot see: a geometric series whose ratio is a symbol.
+            if let Some((value, q)) = symbolic_geometric_closed_form(term, k, lo, hi, pool) {
+                let cond = simp(pool, pool.add(vec![q, pool.integer(-1_i32)]));
+                let mut log = DerivationLog::new();
+                log.push(RewriteStep::with_conditions(
+                    "geometric_symbolic_ratio",
+                    term,
+                    value,
+                    vec![SideCondition::NonZero(cond)],
+                ));
+                return Ok(DerivedExpr::with_log(value, log));
+            }
+            return Err(e);
+        }
+    };
     let g = ind.value;
     let one = pool.integer(1_i32);
     let hi_p1 = simp(pool, pool.add(vec![hi, one]));
@@ -204,6 +229,109 @@ pub fn sum_definite(
     let mut log = DerivationLog::new();
     log.push(RewriteStep::simple("gosper_definite_telescope", term, diff));
     Ok(DerivedExpr::with_log(diff, log))
+}
+
+/// `Σ_{k=lo}^{hi} c·q^k = c·(q^{hi+1} − q^{lo})/(q − 1)` when the ratio `q` is a
+/// **symbolic** constant, with the `q = 1` branch returned as a side condition
+/// rather than assumed away.
+///
+/// Gosper cannot reach this. Its certificate lives in `Q(k)` and its shift
+/// ratio must be a rational *number*, so [`expr_ratio::hypergeom_ratio`]
+/// refuses `r^k` for a symbol `r` with `E-SUM-001` — not because the sum is
+/// hard but because the whole layer underneath is over `Q`. The series is
+/// elementary, so it is summed here instead, on the failure path only: nothing
+/// that summed before goes through this function.
+///
+/// The returned pair is `(value, q)`. `q = 1` is a genuine second branch —
+/// `Σ_{k=lo}^{hi} 1 = hi − lo + 1`, and the formula is `0/0` there — so the
+/// caller records `q − 1 ≠ 0` on the derivation step. It is not proved, only
+/// stated: a caller that does not read it still gets an expression that is
+/// `0/0` at `q = 1` rather than a wrong number.
+fn symbolic_geometric_closed_form(
+    term: ExprId,
+    k: ExprId,
+    lo: ExprId,
+    hi: ExprId,
+    pool: &ExprPool,
+) -> Option<(ExprId, ExprId)> {
+    use crate::kernel::ExprData;
+    use expr_ratio::{affine_slope_in_k, is_free_of_k};
+
+    if hi == pool.pos_infinity() || lo == pool.pos_infinity() {
+        // A geometric series to infinity converges only for |q| < 1, which is a
+        // fact about a symbol nothing here has established. Refusing is the
+        // honest answer; `E-SUM-002` already says so.
+        return None;
+    }
+
+    let factors: Vec<ExprId> = match pool.get(term) {
+        ExprData::Mul(args) => args.to_vec(),
+        _ => vec![term],
+    };
+
+    // Exactly one factor may mention `k`, and it has to be `base^{a·k + b}`
+    // with `base` free of `k`. Two `k`-dependent factors would make the term
+    // `k·q^k` or `q^k·s^k` — the first is not geometric, the second is, but
+    // folding it would duplicate work Gosper already does for numeric bases.
+    let mut geom: Option<(ExprId, ExprId)> = None;
+    let mut rest: Vec<ExprId> = Vec::new();
+    for f in factors {
+        if is_free_of_k(f, k, pool) {
+            rest.push(f);
+            continue;
+        }
+        if geom.is_some() {
+            return None;
+        }
+        let ExprData::Pow { base, exp } = pool.get(f) else {
+            return None;
+        };
+        if !is_free_of_k(base, k, pool) || is_free_of_k(exp, k, pool) {
+            return None;
+        }
+        geom = Some((base, exp));
+    }
+    let (base, exp) = geom?;
+
+    // A rational base is Gosper's business, and it got here only because
+    // something else about the term was unsupported; claiming it now would
+    // answer a call whose real defect is elsewhere.
+    if matches!(pool.get(base), ExprData::Integer(_) | ExprData::Rational(_)) {
+        return None;
+    }
+
+    let a = affine_slope_in_k(exp, k, pool).ok()?;
+    if a == 0 {
+        return None;
+    }
+    // `b = exp − a·k`, the part of the exponent that does not move with `k`.
+    let b = simp(
+        pool,
+        pool.add(vec![exp, pool.mul(vec![pool.integer(-a), k])]),
+    );
+    if !is_free_of_k(b, k, pool) {
+        return None;
+    }
+
+    let q = simp(pool, pool.pow(base, pool.integer(a)));
+    let one = pool.integer(1_i32);
+    let coeff = {
+        let mut fs = rest;
+        fs.push(pool.pow(base, b));
+        simp(pool, pool.mul(fs))
+    };
+
+    let hi_p1 = simp(pool, pool.add(vec![hi, one]));
+    let numer = pool.add(vec![
+        pool.pow(q, hi_p1),
+        pool.mul(vec![pool.integer(-1_i32), pool.pow(q, lo)]),
+    ]);
+    let denom = pool.add(vec![q, pool.integer(-1_i32)]);
+    let value = simp(
+        pool,
+        pool.mul(vec![coeff, numer, pool.pow(denom, pool.integer(-1_i32))]),
+    );
+    Some((value, q))
 }
 
 /// Largest number of individual indices [`interior_undefined_index`] will
@@ -366,16 +494,35 @@ fn contains_zero_to_negative_power(expr: ExprId, pool: &ExprPool) -> bool {
 }
 
 /// Witness `(F, G)` for Zeilberger/WZ-style telescoping in `k`:
-/// checks `F(n+1,k)-F(n,k) = G(n,k+1)-G(n,k)` after clearing denominators by cross-multiplication.
+/// [`verify_wz_pair`] checks `F(n+1,k)-F(n,k) = G(n,k+1)-G(n,k)`.
 ///
-/// Requires `n`, `k` distinct symbols. Uses [`simplify`] and structural equality; dense normalization
-/// for general `binom`/`gamma` identities is not guaranteed without extra rewrite rules.
+/// Requires `n`, `k` distinct symbols.
 #[derive(Clone, Debug)]
 pub struct WzPair {
     pub f: ExprId,
     pub g: ExprId,
 }
 
+/// `true` only when `F(n+1,k) − F(n,k) = G(n,k+1) − G(n,k)` was *established*.
+///
+/// Two decision procedures, tried in that order, and a `true` from either is a
+/// proof rather than a match:
+///
+/// 1. **Exact, in `Q(n)(k)`.** When both sides read as rational functions of
+///    `n` and `k`, their difference is put in the canonical form the Zeilberger
+///    engine uses and compared with zero. This decides the rational class in
+///    both directions.
+/// 2. **Structural, after [`simplify`].** The fallback for everything else —
+///    a pair built from `gamma` / `binom`, say, where no canonical form is
+///    available here.
+///
+/// The second is *one-sided*: `simplify` does not expand products, so it says
+/// `false` for pairs it cannot put in a common shape. `F = n·k`,
+/// `G = k(k−1)/2` is a true WZ pair — both sides are `k` — and used to fail
+/// exactly there, because `k·(n+1) − n·k` and `k(k+1)/2 − k(k−1)/2` are both
+/// left unexpanded and are not structurally equal. Step 1 now decides it.
+/// A `false` from step 2 alone therefore still means *not verified* rather than
+/// *refuted*; a `false` from step 1 means refuted.
 pub fn verify_wz_pair(pair: &WzPair, n: ExprId, k: ExprId, pool: &ExprPool) -> bool {
     let k1 = simp(pool, pool.add(vec![k, pool.integer(1_i32)]));
     let n1 = simp(pool, pool.add(vec![n, pool.integer(1_i32)]));
@@ -398,7 +545,19 @@ pub fn verify_wz_pair(pair: &WzPair, n: ExprId, k: ExprId, pool: &ExprPool) -> b
         pool.add(vec![g_n_k1, pool.mul(vec![pair.g, pool.integer(-1_i32)])]),
     );
 
-    lhs == rhs
+    if lhs == rhs {
+        return true;
+    }
+    // `Q(n)(k)` decides the rational class outright — and decides it *against*
+    // a non-pair too, so this can only turn a spurious `false` into `true`,
+    // never the other way round.
+    if let (Some(l), Some(r)) = (
+        crate::holonomic::hyperterm::as_ratk(lhs, n, k, pool, 0),
+        crate::holonomic::hyperterm::as_ratk(rhs, n, k, pool, 0),
+    ) {
+        return l.sub(&r).is_zero();
+    }
+    false
 }
 
 #[cfg(test)]
@@ -586,5 +745,102 @@ mod tests {
         let z = pool.integer(0_i32);
         let pair = WzPair { f: z, g: z };
         assert!(verify_wz_pair(&pair, n, k, &pool));
+    }
+
+    /// A *true* polynomial WZ pair the structural check cannot see.
+    ///
+    /// `F = n·k`, `G = k(k−1)/2`: both `F(n+1,k) − F(n,k)` and
+    /// `G(n,k+1) − G(n,k)` are `k`. `simplify` does not expand a product, so it
+    /// leaves `k·(n+1) − n·k` and `k(k+1)/2 − k(k−1)/2` as they stand and the
+    /// two are not structurally equal — a verifier answering `false` about a
+    /// pair that verifies.
+    #[test]
+    fn a_polynomial_wz_pair_verifies() {
+        let pool = ExprPool::new();
+        let n = pool.symbol("n", Domain::Real);
+        let k = pool.symbol("k", Domain::Real);
+        let i = |v: i32| pool.integer(v);
+
+        let f = pool.mul(vec![n, k]);
+        let g = pool.mul(vec![k, pool.add(vec![k, i(-1)]), pool.pow(i(2), i(-1))]);
+        assert!(verify_wz_pair(&WzPair { f, g }, n, k, &pool));
+
+        // …and the same escalation still refutes a non-pair, in both the
+        // "wrong G" and the "no G" directions.
+        let g_bad = pool.mul(vec![i(2), g]);
+        assert!(!verify_wz_pair(&WzPair { f, g: g_bad }, n, k, &pool));
+        assert!(!verify_wz_pair(&WzPair { f, g: i(0) }, n, k, &pool));
+    }
+
+    /// A geometric series with a *symbolic* ratio is elementary, and the
+    /// `r = 1` branch is reported rather than assumed away.
+    #[test]
+    fn symbolic_geometric_ratio_sums_with_its_side_condition() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let n = pool.symbol("n", Domain::Real);
+        let r = pool.symbol("r", Domain::Real);
+        let i = |v: i32| pool.integer(v);
+
+        let term = pool.pow(r, k);
+        let s = sum_definite(term, k, i(0), n, &pool).expect("geometric series");
+
+        // The condition is on the record, and it is `r − 1 ≠ 0`.
+        let conds: Vec<_> = s
+            .log
+            .0
+            .iter()
+            .flat_map(|st| st.side_conditions.iter())
+            .collect();
+        assert_eq!(conds.len(), 1, "expected exactly one side condition");
+        let SideCondition::NonZero(c) = conds[0] else {
+            panic!("expected a NonZero condition, got {:?}", conds[0]);
+        };
+        let want = simp(&pool, pool.add(vec![r, i(-1)]));
+        assert_eq!(*c, want, "got {}", pool.display(*c));
+
+        // The value is the closed form, checked against direct summation.
+        for rv in [2.0_f64, 0.5, -3.0, 7.0] {
+            for nv in 0..6 {
+                let mut env = HashMap::new();
+                env.insert(r, rv);
+                env.insert(n, nv as f64);
+                let got = eval_interp(s.value, &env, &pool).expect("eval");
+                let want: f64 = (0..=nv).map(|j| rv.powi(j)).sum();
+                assert!(
+                    (got - want).abs() < 1e-9 * want.abs().max(1.0),
+                    "r={rv} n={nv}: got {got} want {want}"
+                );
+            }
+        }
+    }
+
+    /// The refusals the geometric path must not swallow.
+    #[test]
+    fn symbolic_geometric_declines_what_it_cannot_sum() {
+        let pool = ExprPool::new();
+        let k = pool.symbol("k", Domain::Real);
+        let n = pool.symbol("n", Domain::Real);
+        let r = pool.symbol("r", Domain::Real);
+        let i = |v: i32| pool.integer(v);
+
+        // To infinity: convergence needs |r| < 1, which nothing here knows.
+        let term = pool.pow(r, k);
+        assert!(sum_definite(term, k, i(0), pool.pos_infinity(), &pool).is_err());
+
+        // `k·r^k` is geometric times a polynomial — outside this path, and
+        // Gosper cannot reach it either with a symbolic ratio.
+        let term = pool.mul(vec![k, pool.pow(r, k)]);
+        assert!(sum_definite(term, k, i(0), n, &pool).is_err());
+
+        // A numeric base is Gosper's, and still is: `Σ_{k=0}^{n} 2^k`
+        // telescopes as before, with no side condition attached.
+        let term = pool.pow(i(2), k);
+        let s = sum_definite(term, k, i(0), n, &pool).expect("2^k");
+        assert!(s.log.0.iter().all(|st| st.side_conditions.is_empty()));
+        let mut env = HashMap::new();
+        env.insert(n, 5.0);
+        let got = eval_interp(s.value, &env, &pool).expect("eval");
+        assert!((got - 63.0).abs() < 1e-9, "got {got}");
     }
 }

--- a/docs/mdbook/src/telescoping.md
+++ b/docs/mdbook/src/telescoping.md
@@ -137,6 +137,27 @@ b(n) = G(n, k_hi+1) − G(n, k_lo) + Σ_i a_i(n)·D_i(n)
 with `D_i` the finitely many values of `F` between the range at `n` and the range
 at `n+i`, and it is `b(n)` that the verdict is about.
 
+### The sum has to exist before a verdict is worth anything
+
+Everything above assumes `S(n)` is a finite sum of finite terms. That is a
+statement about the **summand**, and it is checked rather than assumed: a pole of
+`F(n,k)` at an integer `k` inside `[k_lo, k_hi]` is `"unknown"`, naming the
+index.
+
+The check is not decorative. `F(n,k) = C(n,k)/(k−3)` has a certificate that
+verifies exactly in `Q(n)(k)`, finite `G` at both endpoints, and used to come
+back `"vanishes"` with coefficients `(2n+2)`, `(2−3n)`, `(n−1)` — for a sum whose
+`k = 3` term divides by zero, so that `S(n)` does not exist for any `n ≥ 3`. At
+`n = 1` the last coefficient is `0`, so the "proved" recurrence reads
+`4·S(1) − S(2) = 0` with both quantities defined: `S(1) = −5/6` and
+`S(2) = −7/3`, which is `−1`, and solving it for `S(2)` gives `−10/3`. This is
+the same lesson as `sum_definite`'s interior-pole guard and the definite-integral
+one — the guard has to look at the summand, because `G(k_hi+1) − G(k_lo)` is
+precisely the object that has forgotten the interior.
+
+A pole *outside* the range is not this defect and is left alone:
+`Σ_{k=0}^{n} C(n,k)/(k+1)` still gets its `"nonzero"` verdict.
+
 Symmetrically, `"nonzero"` needs a *witness*: an integer `n₀` at which `b(n₀)`
 is nonzero in exact rational arithmetic. Sampling that finds only zeros proves
 nothing and yields `"unknown"`.

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -1343,6 +1343,21 @@ def sum_definite(expr, k, lo, hi):
     difference is not the sum, and ``SumError`` (``E-SUM-003``) is raised
     instead of returning the division by zero embedded in an otherwise
     plausible expression.
+
+    **A geometric ratio that is a symbol.** ``Σ_{k=0}^{n} rᵏ`` is summed to
+    ``(r^{n+1} − 1)/(r − 1)``, which Gosper cannot reach: its certificate lives
+    in ``ℚ(k)`` and a symbolic ratio is not in ``ℚ``.  ``r = 1`` is a genuine
+    second branch — the sum is ``n + 1`` there and the formula is ``0/0`` — so
+    it is **not** assumed away: the derivation step carries the side condition
+    ``r − 1 ≠ 0``, readable as::
+
+        s = ak.sum_definite(r**k, k, pool.integer(0), n)
+        s.steps[0]["side_conditions"]        # ['(r + -1) ≠ 0']
+
+    and the returned expression declines to evaluate at ``r = 1`` rather than
+    producing a number there.  An infinite upper bound still refuses: the
+    series converges only for ``|r| < 1``, which is a fact about ``r`` that
+    nothing here establishes.
     """
     return _maybe_context_simplify(
         _native_sum_definite(

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -40,6 +40,8 @@ X = POOL.symbol("x")
 Y = POOL.symbol("y")
 N = POOL.symbol("n")
 K = POOL.symbol("k")
+#: Symbolic geometric ratio, for the `Σ rᵏ` cases.
+R = POOL.symbol("r")
 
 
 def _int(v: int) -> ak.Expr:
@@ -687,6 +689,22 @@ def _zeilberger_sum_recurrence_defect(
                 total += coeff * exact_sum(ni + i)
             worst = max(worst, abs(float(total)))
         return worst
+
+    return op
+
+
+def _zeilberger_boundary_tag(term: ak.Expr) -> Callable[[], str]:
+    """Answer = ``cert.boundary``, the three-valued verdict on the *sum*.
+
+    The certificate is an identity about the summand and always holds; the
+    verdict is the separate claim that a recurrence for ``S(n)`` follows from
+    it.  Scoring the verdict rather than the coefficients is what makes a
+    ``"vanishes"`` about a sum that does not exist a silent error rather than a
+    detail buried in a side-condition string.
+    """
+
+    def op() -> str:
+        return str(ak.zeilberger(term, N, K).boundary)
 
     return op
 
@@ -3714,6 +3732,175 @@ CASES: list[Case] = [
             "1·2·3·4·5 = 120. The Γ-quotient here is Γ(6)/Γ(1) with no pole in it, so the pole "
             "guard must stay silent; together with product_control_contains_zero (which needs "
             "1/Γ(0) = 0) it pins both sides of the guard."
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    # A pole of the *summand* inside the summation range, seen from the
+    # holonomic side.  `sum_definite` has had an interior-pole guard since
+    # 3.8.0; `zeilberger`'s boundary verdict did not, and a verdict is a much
+    # more dangerous thing to get wrong than a number, because it is labelled
+    # "proved".
+    # -----------------------------------------------------------------------
+    Case(
+        id="zeilberger_boundary_pole_inside_range",
+        subsystem="sums_products",
+        statement=(
+            "Σ_{k=0}^{n} C(n,k)/(k-3) has no value for n ≥ 3, so its certificate implies no "
+            "recurrence for the sum"
+        ),
+        op=_zeilberger_boundary_tag(_binom(N, K) / (K - _int(3))),
+        contract=Returns("unknown"),
+        verified_by=(
+            "The k=3 term of the sum is C(n,3)/0. alkahest returned boundary='vanishes' — "
+            "'proved: Σ_i a_i(n)·S(n+i) = 0' — with coefficients (2n+2), (2-3n), (n-1). At n=1 "
+            "the last one is 0, so the claim reads 4·S(1) - S(2) = 0 with every quantity in it "
+            "defined: S(1) = 1/(-3) + 1/(-2) = -5/6 and S(2) = 1/(-3) + 2/(-2) + 1/(-1) = -7/3, "
+            "computed term by term from the definition. That is -1, not 0, and solving the "
+            "claimed recurrence for S(2) gives -10/3 against the true -7/3."
+        ),
+    ),
+    Case(
+        id="zeilberger_control_pole_below_the_range",
+        subsystem="sums_products",
+        statement="Σ_{k=0}^{n} C(n,k)/(k+1): the pole is at k = -1, outside the range",
+        op=_zeilberger_boundary_tag(_binom(N, K) / (K + _int(1))),
+        contract=Returns("nonzero"),
+        verified_by=(
+            "Every term C(n,k)/(k+1) with 0 ≤ k ≤ n is finite, so the sum exists and the "
+            "boundary analysis must still answer. It is the A279013-shaped case whose true "
+            "recurrence is inhomogeneous: (n+2)·S(n+1) - (2n+2)·S(n) = 1, checked against "
+            "S(0) = 1, S(1) = 3/2, S(2) = 7/3 from Σ_{k=0}^{m} C(m,k)/(k+1) = (2^{m+1}-1)/(m+1). "
+            "The control for the interior-pole guard: refusing this would trade a false verdict "
+            "for a dead engine."
+        ),
+    ),
+    Case(
+        id="zeilberger_control_natural_boundary_still_vanishes",
+        subsystem="sums_products",
+        statement="Σ_{k=0}^{n} C(n,k) = 2ⁿ — the textbook natural boundary",
+        op=_zeilberger_boundary_tag(_binom(N, K)),
+        contract=Returns("vanishes"),
+        verified_by=(
+            "C(n,k) is finite at every integer k, and vanishes outside 0 ≤ k ≤ n, so the "
+            "homogeneous S(n+1) = 2·S(n) holds — as 1, 2, 4, 8 confirms. The second control: a "
+            "guard that fired on the shape rather than on a pole would break this."
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    # `verify_wz_pair` — a verifier's false *negative* is not a lie, but it is
+    # a verifier that cannot verify.
+    # -----------------------------------------------------------------------
+    Case(
+        id="wz_pair_polynomial_is_verified",
+        subsystem="sums_products",
+        statement="(F, G) = (n·k, k(k-1)/2) is a WZ pair: both differences are k",
+        op=lambda: bool(ak.verify_wz_pair(N * K, K * (K - _int(1)) * _rat(1, 2), N, K)),
+        contract=Returns(True),
+        verified_by=(
+            "F(n+1,k) - F(n,k) = (n+1)k - nk = k, and G(n,k+1) - G(n,k) = (k+1)k/2 - k(k-1)/2 = "
+            "k. Expanded by hand; both sides are the polynomial k. alkahest returned False — "
+            "simplify does not expand a product, so k·(n+1) - n·k and k(k+1)/2 - k(k-1)/2 were "
+            "compared structurally and found different."
+        ),
+    ),
+    Case(
+        id="wz_pair_control_non_pair_is_refuted",
+        subsystem="sums_products",
+        statement="(F, G) = (n·k, 0) is not a WZ pair: k ≠ 0",
+        op=lambda: bool(ak.verify_wz_pair(N * K, _int(0), N, K)),
+        contract=Returns(False),
+        verified_by=(
+            "F(n+1,k) - F(n,k) = k while G(n,k+1) - G(n,k) = 0, and k is not identically zero. "
+            "The control for the case above: a verifier that answered True by giving up would "
+            "pass that one and fail this."
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    # A geometric series whose ratio is a symbol: elementary, and the r = 1
+    # branch is a second case rather than a detail.
+    # -----------------------------------------------------------------------
+    Case(
+        id="sum_geometric_symbolic_ratio",
+        subsystem="sums_products",
+        statement="Σ_{k=0}^{n} rᵏ = (r^{n+1} - 1)/(r - 1); at r = 3, n = 4 that is 121",
+        op=lambda: float(
+            ak.eval_expr(ak.sum_definite(R**K, K, _int(0), N).value, {R: 3.0, N: 4.0})
+        ),
+        contract=Returns(121.0, tol=1e-9),
+        verified_by=(
+            "1 + 3 + 9 + 27 + 81 = 121, summed term by term. alkahest refused with E-SUM-001 "
+            "('geometric base must be a rational constant') — Gosper's certificate lives in "
+            "Q(k) and a symbolic ratio is not in Q, so the whole layer underneath could not "
+            "see an elementary series."
+        ),
+    ),
+    Case(
+        id="sum_geometric_symbolic_ratio_at_one",
+        subsystem="sums_products",
+        statement="the closed form for Σ_{k=0}^{n} rᵏ is 0/0 at r = 1 and must not answer there",
+        op=lambda: float(
+            ak.eval_expr(ak.sum_definite(R**K, K, _int(0), N).value, {R: 1.0, N: 4.0})
+        ),
+        contract=RefusesOr(),
+        verified_by=(
+            "Σ_{k=0}^{4} 1ᵏ = 5, but (1^5 - 1)/(1 - 1) is 0/0 — the r = 1 branch is a separate "
+            "case, which is why SymPy answers this with a Piecewise. Any finite value out of "
+            "the r ≠ 1 formula at r = 1 would be an arithmetic accident. alkahest records "
+            "r - 1 ≠ 0 as a side condition on the derivation step and the expression itself "
+            "declines to evaluate."
+        ),
+        note=(
+            "Weak refusal: the guard is that 0/0 has no float, not a coded error. The stronger "
+            "signal is the recorded side condition, which the contract vocabulary here cannot "
+            "express."
+        ),
+    ),
+    Case(
+        id="sum_geometric_symbolic_ratio_to_infinity",
+        subsystem="sums_products",
+        statement="Σ_{k=0}^{∞} rᵏ converges only for |r| < 1, which nothing states here",
+        op=lambda: _num(ak.sum_definite(R**K, K, _int(0), POOL.pos_infinity()).value),
+        contract=RefusesOr(),
+        verified_by=(
+            "The series diverges for every |r| ≥ 1, and r is an unconstrained symbol. Returning "
+            "1/(1-r) would be the geometric-series answer stated outside its disc of "
+            "convergence — the same error as summing Σ2ᵏ to -1."
+        ),
+    ),
+    Case(
+        id="zeilberger_even_row_sum_holds_where_the_certificate_is_defined",
+        subsystem="sums_products",
+        statement=(
+            "for F = C(2n,2k) the verdict is 'vanishes', and S(n+1) = 4·S(n) does hold at "
+            "every n where the certificate is defined"
+        ),
+        op=_zeilberger_sum_recurrence_defect(
+            _binom(_int(2) * N, _int(2) * K),
+            lambda m: Fraction(sum(math.comb(2 * m, 2 * j) for j in range(m + 1))),
+            disclosure_counts=False,
+        ),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by=(
+            "Σ_{k=0}^{n} C(2n,2k) is the even half of row 2n, i.e. 2^{2n-1} for n ≥ 1: "
+            "1, 2, 8, 32, 128, 512 summed term by term. S(n+1) - 4·S(n) = 0 for every n ≥ 1, "
+            "checked in exact Fraction arithmetic against alkahest's own coefficients (-4, 1). "
+            "It fails by -2 at n = 0 only, and n = 0 is exactly where the certificate — which "
+            "carries a 1/n — is undefined, the residual hypothesis the side condition names. "
+            "Pinned here so that a future verdict that ignored that hypothesis, or a guard that "
+            "over-refused this shape, would show up as a change."
+        ),
+    ),
+    Case(
+        id="sum_control_empty_range",
+        subsystem="sums_products",
+        statement="Σ_{k=5}^{4} k = 0 — an empty range takes no terms",
+        op=lambda: _num(ak.sum_definite(K, K, _int(5), _int(4)).value),
+        contract=Returns(0.0),
+        verified_by=(
+            "hi = lo - 1 is the empty range under every convention: no term is ever taken, so "
+            "the sum is 0. The telescoped G(hi+1) - G(lo) = G(5) - G(5) gives it for free, "
+            "which is exactly what makes it a good check that the bounds are wired the right "
+            "way round."
         ),
     ),
     # -----------------------------------------------------------------------


### PR DESCRIPTION
An audit of the summation, product and holonomic layer — the one that emits
**certificates**, where a wrong answer arrives wearing a proof.

Every probe checked against an exact oracle (`Fraction`, exact sympy rationals,
or 60-dps `mpmath`), never against alkahest's own output:

| Sweep | Cases | Wrong |
|---|---|---|
| `sum_definite`, concrete bounds (20 summands × 18 ranges incl. empty/reversed/negative) | 338 | 0 |
| `sum_definite`, symbolic `hi`, evaluated at n = −4…8 | 622 | 0 in-domain |
| `product_definite` (15 terms × 12 ranges) | 180 | 0 |
| `sum_indefinite`/`product_indefinite` as antidifferences | 28 | 0 |
| `rsolve` closed forms vs exact iteration | 220 answered, 104 refused | 0 |
| Zeilberger certificate identities, 30 random 60-dps points each | 11 | 0 (worst residual 5.4e-53) |
| Zeilberger **boundary verdicts** vs direct summation, n = 0…8 | 31 | **1** |
| `guess_holonomic` (6 holonomic + 3 not) | 9 | 0 |
| `asymptotics_from_recurrence` | 5 | 0 |

## The headline: a false proof

`zeilberger` issued `boundary="vanishes"` — which means *"proved: the
homogeneous recurrence holds for the sum"* — **for sums that do not exist.**

For `F(n,k) = C(n,k)/(k−3)` summed over `k = 0..n`, the certificate verifies in
`Q(n)(k)`, the endpoints are finite, `implies_sum_recurrence=True`, and the
coefficients come back as `(2n+2), (2−3n), (n−1)`. Computed term by term from
the definition in exact rationals:

```
S(1) = 1/(−3) + 1/(−2)          = −5/6
S(2) = 1/(−3) + 2/(−2) + 1/(−1) = −7/3
S(3)                              does not exist   (k=3 term divides by zero)

claimed recurrence at n=1:  4·S(1) − S(2) + 0·S(3)  =  −10/3 + 7/3  =  −1  ≠ 0
```

Both quantities are defined and the identity is simply false; solving it for
`S(2)` yields `−10/3` against the true `−7/3`. Reproduced for `k−m` with
m = 0..7, for `C(n,k)/(n−k)`, and for `C(n,k)/(k(k−2))`.

**Cause:** the boundary analysis only ever inspects `G` at the two endpoints and
the range-shift corrections. A pole of `F` strictly *inside* the range is
invisible there, and it does not disturb the `Q(n)(k)` identity either — the
certificate is genuinely valid as a rational-function identity; it is the
*second* step, the claim about the sum, that does not follow.

Fixed by `boundary::summand_pole_inside` (exact order counting, with
`Value::Pole` split out of `Value::Undecidable` so the refusal rests on positive
evidence). The verdict is now `Unknown`, naming the offending index. **All 23
classical verdicts are unchanged.**

## Two more

- **`verify_wz_pair` returned `False` for a true WZ pair.** `F = n·k`,
  `G = k(k−1)/2` — both differences are `k`. `simplify` does not expand
  products, so `k(n+1) − nk` and `k(k+1)/2 − k(k−1)/2` were compared
  structurally. Now escalates to the exact `Q(n)(k)` normal form, which decides
  the rational class in both directions and cannot turn a refutation into a
  spurious `true`.
- **`sum_definite(r**k, k, 0, n)` refused** with `E-SUM-001`. Added on the
  Gosper *failure* branch only, so `sum_indefinite` is untouched and
  `emit_gosper_cert` can never emit a Lean certificate for it. The `r = 1` case
  is **recorded**, not assumed: `SideCondition::NonZero(r−1)` appears on the
  derivation step and the expression raises `E-EVAL-009` at `r = 1` rather than
  producing a number. Infinite bounds still refuse, since `|r| < 1` is
  unestablished.

## Certificates specifically

Every emitted `ZeilbergerCertificate` satisfies its own defining identity
`Σᵢ aᵢ(n)·F(n+i,k) = R(n,k+1)F(n,k+1) − R(n,k)F(n,k)` — 11 summands (binomial
row, Franel, Dixon-type, Apéry, `C(2n,k)`, …), 30 random non-integer points
each at 60 dps, worst relative residual `5.4e-53`. **No certificate fails its
own identity.** `verify_wz_pair` could not be fooled into a false *positive* by
any of 13 adversarial pairs; its only failure mode was the false negative above.

## Reported, not fixed

- **`zeilberger`'s side-condition string is invariant and does not name the
  excluded `n`.** For `F = C(2n,2k)` the certificate carries `1/n`, the verdict
  is `"vanishes"`, and `S(n+1) − 4S(n) = 0` holds for every `n ≥ 1` but fails by
  `−2` at `n = 0` — exactly where the certificate is undefined. Correct under
  the stated hypothesis, but a loop cannot act on it. Pinned by a corpus case.
- **`product_definite` returns unevaluable Γ-ratios** (`Γ(0)/Γ(−3)`) for ranges
  spanning a Γ pole — 34 of 180 sweep cases. `eval_expr` refuses, so it is a
  weak refusal, never a wrong number.
- **`telescope2d`'s boundary module is separate and does not inherit the fix.**
  It already answers `"unknown"` for `n`-dependent ranges, so the classical
  shape is honestly declined; the constant-rectangle-with-a-pole window is
  unaudited.
- **Not defects:** "`sum_definite` cannot compute `Σk` from 1 to 10" is stale —
  it returns `55`. The sum/product backwards-range asymmetry is deliberate and
  documented. The unsimplified `((n+1)*(-1/2 + 1/2*(n+1)))` shapes are cosmetic,
  correct at every `n` tested.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2900 passed, 0
failed, 11 ignored** (main: 2895, +5). `pytest tests/silent_errors/` → 281
passed, 271 cases, 0 silent errors (`sums_products` 28 → 38, each trap paired
with its control; new `_zeilberger_boundary_tag` helper scores the verdict
itself rather than the coefficients).
`pytest tests/ --ignore=tests/silent_errors` → 3516 passed, 0 failed.
clippy `-D warnings`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`,
`ruff check`, `check_error_codes.py`, `check_api_freeze.py` all clean. The new
`Value::Pole` variant is on a module-private enum and the geometric side
condition rides the existing `DerivationLog`, so `cargo semver-checks` is
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
