### PR TITLE
fix(eval,codegen): make every evaluator read the same constant, and stop three code generators from emitting a different function

### DIFF
--- a/alkahest-core/src/eval/complex_f64.rs
+++ b/alkahest-core/src/eval/complex_f64.rs
@@ -1,6 +1,6 @@
 //! IEEE-754 complex evaluation for `re` / `im` / `conjugate` / `arg`.
 
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{integer_to_f64, rational_to_f64, ExprData, ExprId, ExprPool};
 use std::collections::HashMap;
 
 use super::{error, EvalError, UnsupportedReason};
@@ -154,8 +154,8 @@ fn eval_node(
     bindings: &HashMap<ExprId, ComplexF64>,
 ) -> Result<ComplexF64, EvalError> {
     match pool.get(expr) {
-        ExprData::Integer(n) => Ok(ComplexF64::new(n.0.to_f64(), 0.0)),
-        ExprData::Rational(r) => Ok(ComplexF64::new(r.0.to_f64(), 0.0)),
+        ExprData::Integer(n) => Ok(ComplexF64::new(integer_to_f64(&n.0), 0.0)),
+        ExprData::Rational(r) => Ok(ComplexF64::new(rational_to_f64(&r.0), 0.0)),
         ExprData::Float(f) => Ok(ComplexF64::new(f.inner.to_f64(), 0.0)),
         ExprData::Symbol { .. } => {
             if let Some(&v) = bindings.get(&expr) {

--- a/alkahest-core/src/eval/mod.rs
+++ b/alkahest-core/src/eval/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod symbols;
 
 use crate::ball::{ArbBall, IntervalEval};
 use crate::kernel::expr::PredicateKind;
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{integer_to_f64, rational_to_f64, ExprData, ExprId, ExprPool};
 use rug::Rational;
 use std::collections::HashMap;
 use std::fmt;
@@ -311,8 +311,8 @@ fn eval_f64_node(
     bindings: &HashMap<ExprId, f64>,
 ) -> Result<f64, EvalError> {
     match pool.get(expr) {
-        ExprData::Integer(n) => Ok(n.0.to_f64()),
-        ExprData::Rational(r) => Ok(r.0.to_f64()),
+        ExprData::Integer(n) => Ok(integer_to_f64(&n.0)),
+        ExprData::Rational(r) => Ok(rational_to_f64(&r.0)),
         ExprData::Float(f) => Ok(f.inner.to_f64()),
         ExprData::Symbol { .. } => bindings
             .get(&expr)

--- a/alkahest-core/src/horner.rs
+++ b/alkahest-core/src/horner.rs
@@ -17,7 +17,7 @@
 //! [`ExprData::Func`] nodes.  This is the general entry point;
 //! [`emit_horner_c`] remains available for the polynomial-only Horner form.
 
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{integer_to_f64, rational_to_f64, ExprData, ExprId, ExprPool};
 use crate::poly::{ConversionError, UniPoly};
 use std::collections::HashMap;
 
@@ -38,13 +38,18 @@ use std::collections::HashMap;
 /// ```
 pub fn horner(expr: ExprId, var: ExprId, pool: &ExprPool) -> Result<ExprId, ConversionError> {
     let poly = UniPoly::from_symbolic(expr, var, pool)?;
-    let coeffs = poly.coefficients_i64(); // [a0, a1, …, an]
+    // `coefficients_i64` wraps modulo 2^64 without saying so, and this is a
+    // *rewrite*: the result claims to be the same polynomial. It was not.
+    // `(x+1)^80` has binomial coefficients past `i64`, so `horner` returned a
+    // different polynomial — `2.12e20` instead of `2^80` at `x = 1` — with no
+    // error and no flag. Exact coefficients throughout.
+    let coeffs = poly.coefficients(); // [a0, a1, …, an]
     Ok(build_horner(&coeffs, var, pool))
 }
 
 /// Build Horner form from a coefficient slice `[a0, a1, …, an]` where
 /// `a_k` is the coefficient of `x^k`.
-fn build_horner(coeffs: &[i64], var: ExprId, pool: &ExprPool) -> ExprId {
+fn build_horner(coeffs: &[rug::Integer], var: ExprId, pool: &ExprPool) -> ExprId {
     if coeffs.is_empty() {
         return pool.integer(0_i32);
     }
@@ -54,11 +59,11 @@ fn build_horner(coeffs: &[i64], var: ExprId, pool: &ExprPool) -> ExprId {
     // …
     // result = a_0   + x * result
     let n = coeffs.len();
-    let mut result = pool.integer(coeffs[n - 1]);
+    let mut result = pool.integer(coeffs[n - 1].clone());
     for k in (0..n - 1).rev() {
         // result = coeffs[k] + var * result
         let xr = pool.mul(vec![var, result]);
-        let ck = pool.integer(coeffs[k]);
+        let ck = pool.integer(coeffs[k].clone());
         result = pool.add(vec![ck, xr]);
     }
     result
@@ -90,7 +95,8 @@ pub fn emit_horner_c(
     pool: &ExprPool,
 ) -> Result<String, ConversionError> {
     let poly = UniPoly::from_symbolic(expr, var, pool)?;
-    let coeffs = poly.coefficients_i64();
+    // Exact, for the reason spelled out in `horner` above.
+    let coeffs = poly.coefficients();
     let body = build_c_horner(&coeffs, var_name);
     Ok(format!(
         "double {}(double {}) {{\n    return {};\n}}\n",
@@ -146,14 +152,29 @@ fn eval_horner_f64x4(coeffs: &[f64], x: wide::f64x4) -> wide::f64x4 {
     acc
 }
 
-fn build_c_horner(coeffs: &[i64], var: &str) -> String {
+/// Render an exact integer as a C `double` literal.
+///
+/// Written out in full while it is exact in `f64`, so the C compiler's own
+/// correctly-rounded parse agrees with the interpreter bit for bit. Past that
+/// the exact decimal would be both misleading and, above `DBL_MAX`, outside
+/// the range a C compiler will accept, so the rounded value is emitted
+/// instead — the same one every evaluator uses.
+fn c_integer_literal(n: &rug::Integer) -> String {
+    if n.significant_bits() <= f64::MANTISSA_DIGITS {
+        format!("{n}.0")
+    } else {
+        c_double_literal(integer_to_f64(n))
+    }
+}
+
+fn build_c_horner(coeffs: &[rug::Integer], var: &str) -> String {
     if coeffs.is_empty() {
         return "0.0".to_string();
     }
     let n = coeffs.len();
-    let mut result = format!("{}.0", coeffs[n - 1]);
+    let mut result = c_integer_literal(&coeffs[n - 1]);
     for k in (0..n - 1).rev() {
-        let ck = format!("{}.0", coeffs[k]);
+        let ck = c_integer_literal(&coeffs[k]);
         result = format!("{} + {} * ({})", ck, var, result);
     }
     result
@@ -201,6 +222,26 @@ impl std::error::Error for EmitCError {}
 ///
 /// Returns `None` for functions that cannot be expressed as a single `<math.h>`
 /// call (e.g. `diracdelta`, elliptic integrals, `heaviside`).
+///
+/// # Where the emitted C and the interpreter differ
+///
+/// Both are documented rather than repaired, because in each case the emitted
+/// C is *not* the wrong side and forcing agreement would cost more than it
+/// buys. Measured over a 606-expression / 10 421-point differential sweep,
+/// these are the only two classes that survive:
+///
+/// * **`gamma`.** Alkahest returns `+∞` at each pole of `Γ` (see
+///   `libm_gamma`), so `1/Γ(−n)` is `0` — the value that makes `1/Γ` entire.
+///   C99's `tgamma` returns `NaN` there, so the emitted C degrades that `0` to
+///   a `NaN`: a weak refusal in place of a correct value, never a wrong number.
+///   Alkahest's `Γ` is also a Lanczos approximation good to ~1e-15 (~1e-12
+///   near the poles), where glibc's `tgamma` is nearly correctly rounded.
+/// * **`x^2` / `x^3`.** The `Pow` arm below emits repeated multiplication,
+///   which rounds twice where the interpreter's `powf` rounds once. That is
+///   ≤ 1 ulp and usually *cheaper and better conditioned* in the surrounding
+///   expression, which is why the specialisation exists. It is only visible
+///   downstream of a function with unbounded derivative — `tan` of an argument
+///   past `1e38`, where no evaluator carries information anyway.
 fn func_to_c(name: &str, arg_exprs: &[String]) -> Option<String> {
     // Binary functions first
     if name == "atan2" && arg_exprs.len() == 2 {
@@ -250,6 +291,23 @@ fn func_to_c(name: &str, arg_exprs: &[String]) -> Option<String> {
     None
 }
 
+/// Render an `f64` as a C `double` literal.
+///
+/// `{v:?}` alone produced the bare tokens `inf`, `-inf` and `NaN` for a
+/// non-finite constant. None of the three is a C identifier, so `emit_c_expr`
+/// reported success and handed back a function that does not compile. The
+/// `<math.h>` macros the emitted code already requires say the same thing and
+/// do compile.
+fn c_double_literal(v: f64) -> String {
+    if v.is_nan() {
+        return "NAN".to_string();
+    }
+    if v.is_infinite() {
+        return if v > 0.0 { "INFINITY" } else { "-INFINITY" }.to_string();
+    }
+    format!("{v:?}")
+}
+
 /// Internal: emit a C expression for `expr`, collecting temporary variable
 /// assignments into `stmts`.  Returns the C expression string (may be a temp
 /// var name like `_t3` or an inline expression like `sin(_t2)`).
@@ -273,18 +331,9 @@ fn emit_expr_inner(
     }
 
     let result = match pool.get(expr) {
-        ExprData::Integer(n) => {
-            // Emit as double literal
-            format!("{}.0", n.0)
-        }
-        ExprData::Rational(r) => {
-            let v = r.0.numer().to_f64() / r.0.denom().to_f64();
-            format!("{v:?}")
-        }
-        ExprData::Float(f) => {
-            let v = f.inner.to_f64();
-            format!("{v:?}")
-        }
+        ExprData::Integer(n) => c_integer_literal(&n.0),
+        ExprData::Rational(r) => c_double_literal(rational_to_f64(&r.0)),
+        ExprData::Float(f) => c_double_literal(f.inner.to_f64()),
         ExprData::Symbol { name, .. } => {
             return Err(EmitCError::MissingVariable(name.clone()));
         }
@@ -852,5 +901,129 @@ mod tests {
         let code = emit_expr_c(expr, &[x], &["x"], "eval_poly_new", &pool).unwrap();
         assert!(code.contains("double eval_poly_new"), "signature:\n{code}");
         assert!(code.contains("return "), "return:\n{code}");
+    }
+}
+
+#[cfg(test)]
+mod exact_coefficient_tests {
+    use super::*;
+    use crate::jit::eval_interp;
+    use crate::kernel::{Domain, ExprPool};
+    use rug::ops::Pow;
+    use std::collections::HashMap;
+
+    fn at(expr: ExprId, x: ExprId, v: f64, pool: &ExprPool) -> f64 {
+        let mut env = HashMap::new();
+        env.insert(x, v);
+        eval_interp(expr, &env, pool).unwrap()
+    }
+
+    /// `horner` is a *rewrite*: it promises the same polynomial in a better
+    /// shape. Going through `coefficients_i64` made that promise false —
+    /// coefficients wrapped modulo 2^64, silently, so the returned expression
+    /// was a different polynomial.
+    #[test]
+    fn horner_keeps_coefficients_past_i64() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        // 2^70 + 3 wraps to 3 in `i64`.
+        let big = rug::Integer::from(2u32).pow(70) + 3u32;
+        let expr = pool.add(vec![
+            pool.mul(vec![
+                pool.integer(big.clone()),
+                pool.pow(x, pool.integer(2_i32)),
+            ]),
+            pool.mul(vec![pool.integer(5_i32), x]),
+            pool.integer(7_i32),
+        ]);
+        let h = horner(expr, x, &pool).unwrap();
+        for v in [0.0, 1.0, 2.0, -3.0] {
+            assert_eq!(
+                at(h, x, v, &pool),
+                at(expr, x, v, &pool),
+                "horner form disagrees with the input at x = {v}"
+            );
+        }
+        // …and the value is the mathematically right one, not just consistent.
+        // (2^70 + 3) + 5 + 7 = 1180591620717411303439.
+        assert_eq!(at(h, x, 1.0, &pool), 1.1805916207174113e21);
+    }
+
+    /// The same defect on a polynomial nobody would call exotic: the binomial
+    /// coefficients of `(x+1)^80` run past `i64` in the middle of the row.
+    #[test]
+    fn horner_of_an_ordinary_binomial_power_is_the_same_polynomial() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.pow(pool.add(vec![x, pool.integer(1_i32)]), pool.integer(80_i32));
+        let h = horner(expr, x, &pool).unwrap();
+        // (1+1)^80 = 2^80.
+        assert_eq!(at(h, x, 1.0, &pool), 2f64.powi(80));
+        assert_eq!(at(h, x, 0.0, &pool), 1.0);
+    }
+
+    #[test]
+    fn emit_horner_c_keeps_coefficients_past_i64() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let big = rug::Integer::from(2u32).pow(70) + 3u32;
+        let expr = pool.add(vec![
+            pool.mul(vec![pool.integer(big), x]),
+            pool.integer(1_i32),
+        ]);
+        let c = emit_horner_c(expr, x, "x", "f", &pool).unwrap();
+        assert!(
+            c.contains("1.1805916207174113e21"),
+            "emitted C lost the coefficient: {c}"
+        );
+        assert!(!c.contains(" 3.0"), "coefficient wrapped to 3: {c}");
+    }
+
+    /// A rational literal is emitted as the same `double` the interpreter
+    /// uses, so the C and the interpreter cannot drift apart by an ulp.
+    #[test]
+    fn emit_expr_c_rounds_rationals_the_way_the_interpreter_does() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.mul(vec![pool.rational(2, 5), x]);
+        let c = emit_expr_c(expr, &[x], &["x"], "f", &pool).unwrap();
+        assert!(c.contains("0.4"), "expected the nearest double 0.4: {c}");
+        assert!(!c.contains("0.39999999999999997"), "truncated: {c}");
+    }
+
+    /// `{v:?}` produced the bare tokens `inf` / `NaN`, which are not C
+    /// identifiers: `emit_expr_c` reported success and returned a function
+    /// that does not compile.
+    #[test]
+    fn emit_expr_c_writes_math_h_macros_for_non_finite_literals() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        for (v, want) in [
+            (f64::INFINITY, "INFINITY"),
+            (f64::NEG_INFINITY, "-INFINITY"),
+            (f64::NAN, "NAN"),
+        ] {
+            let expr = pool.mul(vec![pool.float(v, 53), x]);
+            let c = emit_expr_c(expr, &[x], &["x"], "f", &pool).unwrap();
+            assert!(c.contains(want), "expected {want} in: {c}");
+            assert!(!c.contains(" inf"), "bare `inf` is not valid C: {c}");
+            assert!(!c.contains("NaN"), "bare `NaN` is not valid C: {c}");
+        }
+    }
+
+    /// An integer past the `f64` grid must be emitted as the `double` every
+    /// evaluator actually uses, not as an exact decimal a C compiler would
+    /// have to round on its own (and would reject above `DBL_MAX`).
+    #[test]
+    fn emit_expr_c_emits_large_integers_as_in_range_doubles() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.mul(vec![pool.integer(rug::Integer::from(10).pow(400)), x]);
+        let c = emit_expr_c(expr, &[x], &["x"], "f", &pool).unwrap();
+        assert!(c.contains("INFINITY"), "expected a saturating literal: {c}");
+
+        let expr = pool.mul(vec![pool.integer(rug::Integer::from(10).pow(30)), x]);
+        let c = emit_expr_c(expr, &[x], &["x"], "f", &pool).unwrap();
+        assert!(c.contains("1e30"), "expected the rounded double: {c}");
     }
 }

--- a/alkahest-core/src/jit/agreement_tests.rs
+++ b/alkahest-core/src/jit/agreement_tests.rs
@@ -1,0 +1,209 @@
+//! Every evaluator must agree on the same expression at the same point.
+//!
+//! Alkahest has several independent ways to turn an expression into a number —
+//! the tree-walking interpreter behind `eval_expr`, the separate
+//! [`crate::eval::eval_f64`] facade behind `evaluate(mode="f64")`, the
+//! snapshot interpreter that `compile` falls back to, and the Cranelift JIT.
+//! Verification gates are built on those evaluators, so a disagreement is not
+//! a cosmetic difference: it means at least one gate is scoring answers with a
+//! different arithmetic than the one that produced them.
+//!
+//! Every case here is a *bit-exact* comparison. Anything that legitimately
+//! differs (a transcendental evaluated by two different libm implementations)
+//! is deliberately not in the corpus; the shared numeric kernels make the
+//! comparison exact for everything that is.
+
+use crate::eval::eval_f64;
+#[cfg(feature = "cranelift")]
+use crate::jit::compile_jit_only;
+use crate::jit::{compile, eval_interp};
+use crate::kernel::{Domain, ExprId, ExprPool};
+use rug::ops::Pow;
+use std::collections::HashMap;
+
+/// Every expression in the corpus, built against a fresh pool.
+fn corpus(pool: &ExprPool, x: ExprId) -> Vec<(&'static str, ExprId)> {
+    let int = |n: i32| pool.integer(n);
+    let x2 = pool.pow(x, int(2));
+    let x3 = pool.pow(x, int(3));
+    let mut out: Vec<(&'static str, ExprId)> = vec![
+        ("x", x),
+        ("integer", int(-7)),
+        ("rational_2_5", pool.rational(2, 5)),
+        ("rational_neg_7_3", pool.rational(-7, 3)),
+        ("rational_355_113", pool.rational(355, 113)),
+        ("float", pool.float(1.234_567_890_123_45, 53)),
+        ("x_squared", x2),
+        ("x_cubed", x3),
+        ("x_pow_neg1", pool.pow(x, int(-1))),
+        ("x_pow_neg2", pool.pow(x, int(-2))),
+        ("x_pow_zero", pool.pow(x, int(0))),
+        ("x_pow_half", pool.pow(x, pool.rational(1, 2))),
+        ("x_pow_x", pool.pow(x, x)),
+    ];
+
+    out.push((
+        "poly_with_rational_coeffs",
+        pool.add(vec![
+            pool.mul(vec![pool.rational(2, 5), x3]),
+            pool.mul(vec![pool.rational(-7, 3), x2]),
+            pool.mul(vec![pool.rational(355, 113), x]),
+            pool.rational(1, 7),
+        ]),
+    ));
+    out.push((
+        "big_integer_coefficient",
+        pool.add(vec![
+            pool.mul(vec![pool.integer(rug::Integer::from(10).pow(30)), x]),
+            int(1),
+        ]),
+    ));
+    out.push((
+        "big_rational_coefficient",
+        pool.mul(vec![
+            pool.rational(
+                rug::Integer::from(3) * rug::Integer::from(10).pow(400) + 1u32,
+                rug::Integer::from(2) * rug::Integer::from(10).pow(400),
+            ),
+            x,
+        ]),
+    ));
+
+    // The five heads `eval::eval_f64` implements, so the comparison covers it.
+    for name in ["sin", "cos", "exp", "log", "sqrt"] {
+        out.push((name, pool.func(name, vec![x])));
+    }
+    let sin_x = pool.func("sin", vec![x]);
+    let cos_x = pool.func("cos", vec![x]);
+    out.push((
+        "nested_transcendental",
+        pool.func("exp", vec![pool.mul(vec![sin_x, cos_x])]),
+    ));
+    out.push((
+        "deep_sum",
+        pool.add(vec![sin_x, cos_x, x2, x3, pool.rational(1, 3)]),
+    ));
+    out
+}
+
+/// Points chosen to include negatives, near-zero, exact halves and large
+/// magnitudes; the domain-refusal cases are handled by the `is_finite` filter.
+const POINTS: [f64; 15] = [
+    -100.0, -8.0, -2.5, -1.0, -0.5, -1e-8, 0.0, 1e-8, 0.25, 0.5, 1.0, 2.0, 3.5, 100.0, 1e6,
+];
+
+#[test]
+fn interpreter_and_eval_f64_facade_agree_bit_for_bit() {
+    let pool = ExprPool::new();
+    let x = pool.symbol("x", Domain::Real);
+    let mut compared = 0usize;
+    for (name, expr) in corpus(&pool, x) {
+        for &v in &POINTS {
+            let mut env = HashMap::new();
+            env.insert(x, v);
+            let interp = eval_interp(expr, &env, &pool);
+            let facade = eval_f64(expr, &pool, &env).ok();
+            match (interp, facade) {
+                // `eval_f64` rejects non-finite results; `eval_interp` returns
+                // them. That asymmetry is deliberate, so only compare numbers
+                // both produced.
+                (Some(a), Some(b)) => {
+                    assert_eq!(
+                        a.to_bits(),
+                        b.to_bits(),
+                        "{name} at x = {v}: eval_interp {a:?} vs eval::eval_f64 {b:?}"
+                    );
+                    compared += 1;
+                }
+                (Some(a), None) => assert!(
+                    !a.is_finite(),
+                    "{name} at x = {v}: eval_interp gave {a:?} but eval::eval_f64 refused"
+                ),
+                _ => {}
+            }
+        }
+    }
+    assert!(compared > 150, "corpus shrank to {compared} comparisons");
+}
+
+#[test]
+fn interpreter_and_compiled_fn_agree_bit_for_bit() {
+    let pool = ExprPool::new();
+    let x = pool.symbol("x", Domain::Real);
+    for (name, expr) in corpus(&pool, x) {
+        let f = compile(expr, &[x], &pool).unwrap();
+        for &v in &POINTS {
+            let mut env = HashMap::new();
+            env.insert(x, v);
+            let Some(interp) = eval_interp(expr, &env, &pool) else {
+                continue;
+            };
+            let compiled = f.call(&[v]);
+            assert!(
+                interp.to_bits() == compiled.to_bits() || (interp.is_nan() && compiled.is_nan()),
+                "{name} at x = {v}: eval_interp {interp:?} vs compiled {compiled:?}"
+            );
+        }
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[test]
+fn cranelift_and_interpreter_agree_bit_for_bit() {
+    let pool = ExprPool::new();
+    let x = pool.symbol("x", Domain::Real);
+    let mut jitted = 0usize;
+    for (name, expr) in corpus(&pool, x) {
+        // Cranelift refuses heads it has no trampoline for; those fall back to
+        // the interpreter in `compile`, and there is nothing to compare.
+        let Ok(f) = compile_jit_only(expr, &[x], &pool) else {
+            continue;
+        };
+        jitted += 1;
+        for &v in &POINTS {
+            let mut env = HashMap::new();
+            env.insert(x, v);
+            let Some(interp) = eval_interp(expr, &env, &pool) else {
+                continue;
+            };
+            let native = f.call(&[v]);
+            assert!(
+                interp.to_bits() == native.to_bits() || (interp.is_nan() && native.is_nan()),
+                "{name} at x = {v}: eval_interp {interp:?} vs Cranelift {native:?}"
+            );
+        }
+    }
+    assert!(jitted > 10, "only {jitted} expressions reached Cranelift");
+}
+
+#[cfg(feature = "cranelift")]
+#[test]
+fn cranelift_bulk_entry_point_matches_its_own_scalar_entry_point() {
+    let pool = ExprPool::new();
+    let x = pool.symbol("x", Domain::Real);
+    let y = pool.symbol("y", Domain::Real);
+    let expr = pool.add(vec![
+        pool.func("sin", vec![x]),
+        pool.mul(vec![pool.rational(2, 5), pool.pow(y, pool.integer(2_i32))]),
+        pool.mul(vec![x, y]),
+    ]);
+    let f = compile_jit_only(expr, &[x, y], &pool).unwrap();
+
+    // `call_bulk` takes the variable-major layout `numpy_eval` uses.
+    let xs: Vec<f64> = (0..64).map(|i| (i as f64 - 32.0) / 4.0).collect();
+    let ys: Vec<f64> = (0..64).map(|i| (i as f64 - 17.0) / 3.0).collect();
+    let mut flat = xs.clone();
+    flat.extend_from_slice(&ys);
+    let mut out = vec![0.0f64; 64];
+    f.call_bulk(&flat, &mut out);
+
+    for i in 0..64 {
+        let scalar = f.call(&[xs[i], ys[i]]);
+        assert_eq!(
+            out[i].to_bits(),
+            scalar.to_bits(),
+            "bulk[{i}] {:?} vs scalar {scalar:?}",
+            out[i]
+        );
+    }
+}

--- a/alkahest-core/src/jit/cranelift_backend.rs
+++ b/alkahest-core/src/jit/cranelift_backend.rs
@@ -19,7 +19,7 @@
 use super::{
     topo_sort, CompileTier, CompiledFn, CompiledFnInner, JitBulkFn, JitError, JitScalarFn,
 };
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{integer_to_f64, rational_to_f64, ExprData, ExprId, ExprPool};
 use cranelift_codegen::ir::{condcodes::IntCC, types, AbiParam, BlockArg, InstBuilder, MemFlags};
 use cranelift_codegen::{settings, settings::Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
@@ -143,11 +143,8 @@ fn codegen_node(
     math: &MathFuncIds,
 ) -> Result<cranelift_codegen::ir::Value, JitError> {
     match pool.get(node) {
-        ExprData::Integer(n) => Ok(builder.ins().f64const(n.0.to_f64())),
-        ExprData::Rational(r) => {
-            let (num, den) = r.0.clone().into_numer_denom();
-            Ok(builder.ins().f64const(num.to_f64() / den.to_f64()))
-        }
+        ExprData::Integer(n) => Ok(builder.ins().f64const(integer_to_f64(&n.0))),
+        ExprData::Rational(r) => Ok(builder.ins().f64const(rational_to_f64(&r.0))),
         ExprData::Float(f) => Ok(builder.ins().f64const(f.inner.to_f64())),
         ExprData::Symbol { name, .. } => Err(JitError::UnsupportedNode(format!(
             "unbound symbol '{name}'"

--- a/alkahest-core/src/jit/mod.rs
+++ b/alkahest-core/src/jit/mod.rs
@@ -42,7 +42,7 @@
 
 use crate::kernel::eval_const::try_predicate_bool_from_expr;
 use crate::kernel::expr::PredicateKind;
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{integer_to_f64, rational_to_f64, ExprData, ExprId, ExprPool};
 use crate::primitive::PrimitiveRegistry;
 use std::collections::HashMap;
 use std::fmt;
@@ -73,6 +73,9 @@ pub use nvptx::{compile_cuda, cuda_device_count, CudaCompiledFn, CudaError};
 mod cranelift_backend;
 
 pub mod cache;
+
+#[cfg(test)]
+mod agreement_tests;
 pub use cache::CompileCache;
 
 // ---------------------------------------------------------------------------
@@ -702,11 +705,8 @@ fn eval_interp_inner(
         return Some(cached);
     }
     let val = match pool.get(expr) {
-        ExprData::Integer(n) => Some(n.0.to_f64()),
-        ExprData::Rational(r) => {
-            let (n, d) = r.0.clone().into_numer_denom();
-            Some(n.to_f64() / d.to_f64())
-        }
+        ExprData::Integer(n) => Some(integer_to_f64(&n.0)),
+        ExprData::Rational(r) => Some(rational_to_f64(&r.0)),
         ExprData::Float(f) => Some(f.inner.to_f64()),
         ExprData::Symbol { .. } => env.get(&expr).copied(),
         ExprData::Add(args) => {
@@ -855,11 +855,8 @@ fn try_expr_f64_snap(
         return Some(cached);
     }
     let val = match snap_data(snap, expr)? {
-        ExprData::Integer(n) => Some(n.0.to_f64()),
-        ExprData::Rational(r) => {
-            let (n, d) = r.0.clone().into_numer_denom();
-            Some(n.to_f64() / d.to_f64())
-        }
+        ExprData::Integer(n) => Some(integer_to_f64(&n.0)),
+        ExprData::Rational(r) => Some(rational_to_f64(&r.0)),
         ExprData::Float(f) => Some(f.inner.to_f64()),
         ExprData::Symbol { .. } => env.get(&expr).copied(),
         ExprData::Add(args) => {
@@ -971,11 +968,8 @@ fn eval_interp_snap(
         return Some(cached);
     }
     let val = match snap.nodes.get(&expr)? {
-        ExprData::Integer(n) => Some(n.0.to_f64()),
-        ExprData::Rational(r) => {
-            let (n, d) = r.0.clone().into_numer_denom();
-            Some(n.to_f64() / d.to_f64())
-        }
+        ExprData::Integer(n) => Some(integer_to_f64(&n.0)),
+        ExprData::Rational(r) => Some(rational_to_f64(&r.0)),
         ExprData::Float(f) => Some(f.inner.to_f64()),
         ExprData::Symbol { .. } => env.get(&expr).copied(),
         ExprData::Add(args) => {
@@ -1354,11 +1348,8 @@ mod llvm_backend {
     ) -> Result<FloatValue<'ctx>, JitError> {
         let f64_type = ctx.f64_type();
         match pool.get(node) {
-            ExprData::Integer(n) => Ok(f64_type.const_float(n.0.to_f64())),
-            ExprData::Rational(r) => {
-                let (n, d) = r.0.clone().into_numer_denom();
-                Ok(f64_type.const_float(n.to_f64() / d.to_f64()))
-            }
+            ExprData::Integer(n) => Ok(f64_type.const_float(integer_to_f64(&n.0))),
+            ExprData::Rational(r) => Ok(f64_type.const_float(rational_to_f64(&r.0))),
             ExprData::Float(f) => Ok(f64_type.const_float(f.inner.to_f64())),
             ExprData::Symbol { name, .. } => Err(JitError::UnsupportedNode(format!(
                 "unbound symbol '{name}'"

--- a/alkahest-core/src/jit/nvptx.rs
+++ b/alkahest-core/src/jit/nvptx.rs
@@ -272,6 +272,7 @@ fn emit_ptx_stub(_e: ExprId, _ins: &[ExprId], _n: usize, _pool: &ExprPool) -> St
 #[cfg(all(feature = "cuda", feature = "jit"))]
 mod codegen {
     use super::{CudaError, ExprData, ExprId, ExprPool};
+    use crate::kernel::{integer_to_f64, rational_to_f64};
     use inkwell::{
         attributes::{Attribute, AttributeLoc},
         builder::Builder,
@@ -502,11 +503,8 @@ mod codegen {
     ) -> Result<FloatValue<'ctx>, CudaError> {
         let f64_t = ctx.f64_type();
         match pool.get(node) {
-            ExprData::Integer(n) => Ok(f64_t.const_float(n.0.to_f64())),
-            ExprData::Rational(r) => {
-                let (n, d) = r.0.clone().into_numer_denom();
-                Ok(f64_t.const_float(n.to_f64() / d.to_f64()))
-            }
+            ExprData::Integer(n) => Ok(f64_t.const_float(integer_to_f64(&n.0))),
+            ExprData::Rational(r) => Ok(f64_t.const_float(rational_to_f64(&r.0))),
             ExprData::Float(f) => Ok(f64_t.const_float(f.inner.to_f64())),
             ExprData::Symbol { name, .. } => Err(CudaError::PtxGenerationFailed(format!(
                 "unbound symbol '{name}' (not provided in inputs)"

--- a/alkahest-core/src/kernel/eval_const.rs
+++ b/alkahest-core/src/kernel/eval_const.rs
@@ -2,15 +2,65 @@
 
 use crate::kernel::expr::PredicateKind;
 use crate::kernel::{ExprData, ExprId, ExprPool};
+use rug::float::Round;
+use rug::{Float, Integer, Rational};
+
+/// The exact integer `n` rounded to the nearest `f64` (ties to even).
+///
+/// `rug::Integer::to_f64` rounds **towards zero** (documented, and its own
+/// doctest asserts it). Every evaluator in the crate used it directly, so
+/// `10^30` — an integer any exact computation can produce — evaluated to
+/// `9.999999999999999e29` rather than `1e30`: one ulp low, and *biased*, since
+/// truncation never rounds up. `emit_expr_c` writes the exact decimal and lets
+/// the C compiler round it correctly, so the interpreter and the emitted C
+/// disagreed on the same literal.
+///
+/// Values with at most 53 significant bits are exact in `f64` and take the
+/// cheap path; everything else goes through MPFR at 53 bits, subnormalised so
+/// that a result below `2^-1022` is rounded once rather than twice.
+pub fn integer_to_f64(n: &Integer) -> f64 {
+    if n.significant_bits() <= f64::MANTISSA_DIGITS {
+        // Exactly representable: `to_f64` cannot round at all.
+        return n.to_f64();
+    }
+    let (mut f, dir) = Float::with_val_round(f64::MANTISSA_DIGITS, n, Round::Nearest);
+    f.subnormalize_ieee_round(dir, Round::Nearest);
+    f.to_f64()
+}
+
+/// The exact rational `r` rounded to the nearest `f64` (ties to even).
+///
+/// Two defects this replaces, both reachable from ordinary use:
+///
+/// * `rug::Rational::to_f64` rounds **towards zero**, so `evaluate(mode="f64")`
+///   returned `0.39999999999999997` for `2/5` where the nearest double is `0.4`.
+/// * The interpreter, the Cranelift backend and the C emitter instead computed
+///   `numer.to_f64() / denom.to_f64()`, which is correctly rounded only while
+///   both parts are finite. A rational whose numerator *and* denominator
+///   overflow `f64` — coprime, so no cancellation saves it — gave `inf/inf`,
+///   i.e. `NaN`, for a value as ordinary as `3/2`.
+pub fn rational_to_f64(r: &Rational) -> f64 {
+    let (numer, denom) = (r.numer(), r.denom());
+    if numer.significant_bits() <= f64::MANTISSA_DIGITS
+        && denom.significant_bits() <= f64::MANTISSA_DIGITS
+    {
+        // Both operands are exact in `f64`, so IEEE-754 division returns the
+        // correctly rounded quotient — the same value MPFR would produce.
+        return numer.to_f64() / denom.to_f64();
+    }
+    // `Float::to_f64` rounds to nearest, and `subnormalize_ieee_round` carries
+    // the direction of the first rounding into the subnormal range, so the two
+    // roundings compose into the single correct one.
+    let (mut f, dir) = Float::with_val_round(f64::MANTISSA_DIGITS, r, Round::Nearest);
+    f.subnormalize_ieee_round(dir, Round::Nearest);
+    f.to_f64()
+}
 
 /// If *expr* is a numeric constant, return its `f64` value.
 pub fn try_expr_f64(expr: ExprId, pool: &ExprPool) -> Option<f64> {
     match pool.get(expr) {
-        ExprData::Integer(n) => Some(n.0.to_f64()),
-        ExprData::Rational(r) => {
-            let (num, den) = r.0.clone().into_numer_denom();
-            Some(num.to_f64() / den.to_f64())
-        }
+        ExprData::Integer(n) => Some(integer_to_f64(&n.0)),
+        ExprData::Rational(r) => Some(rational_to_f64(&r.0)),
         ExprData::Float(f) => Some(f.inner.to_f64()),
         _ => None,
     }
@@ -55,5 +105,95 @@ pub fn try_predicate_bool_from_expr(expr: ExprId, pool: &ExprPool) -> Option<boo
     match pool.get(expr) {
         ExprData::Predicate { kind, args } => try_predicate_bool(&kind, &args, pool),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod conversion_tests {
+    use super::*;
+    use rug::ops::Pow;
+
+    /// Reference values computed independently: Python's `float(int)` and
+    /// `float(Fraction(n, d))` are correctly rounded (round-half-even) by
+    /// construction, so their `repr`s below are the exact nearest doubles.
+    #[test]
+    fn integer_to_f64_rounds_to_nearest_not_towards_zero() {
+        // `Integer::to_f64` truncates. 10^30 needs 70 significant bits, so it
+        // is not exact in `f64`; truncation lands one ulp below the nearest.
+        let n = Integer::from(10).pow(30);
+        assert_eq!(n.to_f64(), 9.999999999999999e29, "rug still truncates");
+        assert_eq!(integer_to_f64(&n), 1e30);
+
+        let n = Integer::from(2u64).pow(70) - 1u32;
+        assert_eq!(integer_to_f64(&n), 1.1805916207174113e21);
+
+        let n: Integer = "12345678901234567890123456789".parse().unwrap();
+        assert_eq!(integer_to_f64(&n), 1.2345678901234568e28);
+        assert_eq!(integer_to_f64(&-n.clone()), -1.2345678901234568e28);
+
+        // Exact cases must be untouched by the slow path.
+        for k in [0i64, 1, -1, 42, -7, 1 << 52, -(1 << 52)] {
+            assert_eq!(integer_to_f64(&Integer::from(k)), k as f64, "k = {k}");
+        }
+        // 2^53 + 1 is the classic tie: nearest is 2^53 either way.
+        let n = Integer::from(1u64 << 53) + 1u32;
+        assert_eq!(integer_to_f64(&n), 9007199254740992.0);
+    }
+
+    #[test]
+    fn integer_to_f64_saturates_past_dbl_max() {
+        let huge = Integer::from(10).pow(400);
+        assert_eq!(integer_to_f64(&huge), f64::INFINITY);
+        assert_eq!(integer_to_f64(&-huge.clone()), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn rational_to_f64_rounds_to_nearest_not_towards_zero() {
+        // 2/5 is the shortest counterexample: 0.4 is the nearest double and
+        // `Rational::to_f64` returns the one below it.
+        let r = Rational::from((2, 5));
+        assert_eq!(r.to_f64(), 0.39999999999999997, "rug still truncates");
+        assert_eq!(rational_to_f64(&r), 0.4);
+
+        for (n, d, want) in [
+            (-7i64, 3i64, -2.3333333333333335f64),
+            (7, 3, 2.3333333333333335),
+            (-5, 3, -1.6666666666666667),
+            (355, 113, 3.1415929203539825),
+            (1, 3, 0.3333333333333333),
+            (22, 7, 3.142857142857143),
+        ] {
+            assert_eq!(rational_to_f64(&Rational::from((n, d))), want, "{n}/{d}");
+        }
+    }
+
+    #[test]
+    fn rational_to_f64_survives_numerator_and_denominator_both_overflowing() {
+        // (3·10^400 + 1) / (2·10^400) is 1.5 to well past `f64` precision, and
+        // the parts are coprime so nothing cancels. `numer/denom` in `f64` is
+        // `inf/inf` — `NaN`, which `eval_expr` then reports as "undefined here".
+        let numer = Integer::from(3) * Integer::from(10).pow(400) + 1u32;
+        let denom = Integer::from(2) * Integer::from(10).pow(400);
+        assert!(numer.to_f64().is_infinite() && denom.to_f64().is_infinite());
+        assert!(
+            (numer.to_f64() / denom.to_f64()).is_nan(),
+            "the old formula"
+        );
+
+        let r = Rational::from((numer, denom));
+        assert_eq!(rational_to_f64(&r), 1.5);
+    }
+
+    #[test]
+    fn rational_to_f64_handles_subnormals_and_overflow() {
+        // 1 / 10^400 underflows to zero; 10^400 overflows to +inf.
+        let big = Integer::from(10).pow(400);
+        assert_eq!(rational_to_f64(&Rational::from((1, big.clone()))), 0.0);
+        assert_eq!(rational_to_f64(&Rational::from((big, 1))), f64::INFINITY);
+
+        // 2^-1074 is the smallest positive subnormal and must round to itself
+        // rather than to zero.
+        let denom = Integer::from(2u32).pow(1074);
+        assert_eq!(rational_to_f64(&Rational::from((1, denom))), 5e-324);
     }
 }

--- a/alkahest-core/src/kernel/mod.rs
+++ b/alkahest-core/src/kernel/mod.rs
@@ -13,7 +13,9 @@ pub mod subs;
 pub use depth::{check_expr_depth, check_expr_depths, DepthLimitError, MAX_EXPR_DEPTH};
 pub use display::{render_latex, render_unicode};
 pub use domain::Domain;
-pub use eval_const::{try_expr_f64, try_predicate_bool, try_predicate_bool_from_expr};
+pub use eval_const::{
+    integer_to_f64, rational_to_f64, try_expr_f64, try_predicate_bool, try_predicate_bool_from_expr,
+};
 pub use expr::{BigFloat, BigInt, BigRat, ExprData, ExprId};
 pub use expr_props::{expr_contains_noncommutative_symbol, mult_tree_is_commutative};
 pub use pool::{ExprDisplay, ExprPool};

--- a/alkahest-core/src/primitive/mod.rs
+++ b/alkahest-core/src/primitive/mod.rs
@@ -650,6 +650,25 @@ pub mod builtins {
         }
     }
 
+    /// The single argument of a unary primitive's `f64` kernel, or `None` if
+    /// the caller supplied a different number of them.
+    ///
+    /// Exactly the argument [`unary`] above makes, one dispatch table over:
+    /// `numeric_f64` is reached generically from `eval_interp`, the snapshot
+    /// interpreter and `eval::eval_f64`, each of which hands the registry
+    /// whatever argument list the `Func` node carries. A kernel that indexed
+    /// `args[0]` unconditionally answered `sin(x, y)` with `sin(x)` — a
+    /// confident number for an expression that has no value. The special
+    /// functions added later (`lambert_w`, `digamma`, `bessel_j*`, the
+    /// elliptic family, the exponential integrals) already checked; the
+    /// original elementary set did not.
+    fn unary_f64(args: &[f64]) -> Option<f64> {
+        match args {
+            [only] => Some(*only),
+            _ => None,
+        }
+    }
+
     macro_rules! symbolic_complex_primitive {
         ($type:ident, $name:literal) => {
             pub struct $type;
@@ -700,7 +719,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].sin())
+            Some(unary_f64(args)?.sin())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -746,7 +765,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].cos())
+            Some(unary_f64(args)?.cos())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -790,7 +809,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].exp())
+            Some(unary_f64(args)?.exp())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -835,7 +854,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].ln())
+            Some(unary_f64(args)?.ln())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -890,7 +909,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].sqrt())
+            Some(unary_f64(args)?.sqrt())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -944,7 +963,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].tan())
+            Some(unary_f64(args)?.tan())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -993,7 +1012,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].sinh())
+            Some(unary_f64(args)?.sinh())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1040,7 +1059,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].cosh())
+            Some(unary_f64(args)?.cosh())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1093,7 +1112,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].tanh())
+            Some(unary_f64(args)?.tanh())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1153,7 +1172,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].asin())
+            Some(unary_f64(args)?.asin())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1213,7 +1232,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].acos())
+            Some(unary_f64(args)?.acos())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1260,7 +1279,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].atan())
+            Some(unary_f64(args)?.atan())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1315,7 +1334,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].asinh())
+            Some(unary_f64(args)?.asinh())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1367,7 +1386,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].acosh())
+            Some(unary_f64(args)?.acosh())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1417,7 +1436,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].atanh())
+            Some(unary_f64(args)?.atanh())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1467,7 +1486,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(libm::erf(args[0]))
+            Some(libm::erf(unary_f64(args)?))
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -1513,7 +1532,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(libm::erfc(args[0]))
+            Some(libm::erfc(unary_f64(args)?))
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -2170,7 +2189,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].abs())
+            Some(unary_f64(args)?.abs())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -2192,9 +2211,10 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(if args[0] > 0.0 {
+            let x = unary_f64(args)?;
+            Some(if x > 0.0 {
                 1.0
-            } else if args[0] < 0.0 {
+            } else if x < 0.0 {
                 -1.0
             } else {
                 0.0
@@ -2240,9 +2260,10 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(if args[0] > 0.0 {
+            let x = unary_f64(args)?;
+            Some(if x > 0.0 {
                 1.0
-            } else if args[0] < 0.0 {
+            } else if x < 0.0 {
                 0.0
             } else {
                 0.5
@@ -2282,7 +2303,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].floor())
+            Some(unary_f64(args)?.floor())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -2304,7 +2325,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].ceil())
+            Some(unary_f64(args)?.ceil())
         }
 
         fn numeric_ball(&self, args: &[ArbBall]) -> Option<ArbBall> {
@@ -2326,7 +2347,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(args[0].round())
+            Some(unary_f64(args)?.round())
         }
     }
 
@@ -2744,7 +2765,7 @@ pub mod builtins {
         }
 
         fn numeric_f64(&self, args: &[f64]) -> Option<f64> {
-            Some(libm_gamma(args[0]))
+            Some(libm_gamma(unary_f64(args)?))
         }
 
         /// Only for `x > 0`: the enclosure rests on `Γ` being convex there
@@ -2854,7 +2875,21 @@ pub mod builtins {
                 a += p / (xm + i as f64);
             }
             let t = xm + G + 0.5;
-            (2.0 * std::f64::consts::PI).sqrt() * t.powf(xm + 0.5) * (-t).exp() * a
+            // `t^(xm+0.5)` overflows `f64` at about `x = 142.3`, while the
+            // product with `e^{-t}` stays finite up to `x ≈ 171.6` — so `Γ`
+            // used to refuse (`E-EVAL-009`, via the non-finite check) across
+            // the last thirty units of its own real domain, e.g. `Γ(170) =
+            // 169! = 4.269e304`. The log form has no intermediate to
+            // overflow. It is only reached once the direct form has already
+            // failed, so every value the direct form produced is unchanged
+            // bit for bit.
+            let pow = t.powf(xm + 0.5);
+            let scale = if pow.is_finite() {
+                pow * (-t).exp()
+            } else {
+                ((xm + 0.5) * t.ln() - t).exp()
+            };
+            (2.0 * std::f64::consts::PI).sqrt() * scale * a
         }
     }
 
@@ -3622,6 +3657,159 @@ mod tests {
             let got = eval_expr_f64(d, x, x0, &pool);
             let want = -(1.0 - x0).ln() / x0;
             assert!((got - want).abs() < 1e-12, "Li₂′({x0}): {got} vs {want}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod gamma_range_tests {
+    use super::PrimitiveRegistry;
+    use std::sync::OnceLock;
+
+    fn gamma(x: f64) -> Option<f64> {
+        static REG: OnceLock<PrimitiveRegistry> = OnceLock::new();
+        REG.get_or_init(PrimitiveRegistry::dispatch_registry)
+            .numeric_f64("gamma", &[x])
+    }
+
+    /// `Γ` is finite on the reals up to `x ≈ 171.61`, but the Lanczos form
+    /// computes `t^(x-0.5)·e^{-t}` as two factors and the first one overflows
+    /// at about `x = 142.3`. The result was a non-finite value, which
+    /// `eval_expr` reports as `E-EVAL-009` — an honest refusal, but a refusal
+    /// across thirty units of the function's own domain.
+    #[test]
+    fn gamma_is_finite_across_the_whole_range_f64_can_hold() {
+        // Γ(n) = (n-1)!, computed independently below, so these are not read
+        // off the implementation under test.
+        let mut factorial = 1.0f64; // 0! = Γ(1)
+        for n in 1..=171u32 {
+            let g = gamma(f64::from(n)).expect("gamma is registered");
+            assert!(
+                g.is_finite(),
+                "Γ({n}) = {}! is {factorial:e} and finite, but the kernel returned {g:?}",
+                n - 1
+            );
+            let rel = (g - factorial).abs() / factorial;
+            assert!(rel < 1e-11, "Γ({n}) off by {rel:e}: {g:e} vs {factorial:e}");
+            factorial *= f64::from(n);
+        }
+        // Γ(172) = 171! ≈ 1.24e309 genuinely overflows; refusing there is right.
+        assert!(!gamma(172.0).expect("registered").is_finite());
+    }
+
+    /// The values the direct path already produced must be untouched: the log
+    /// form is only reached once `t^(x-0.5)` has overflowed.
+    ///
+    /// Reference values from `mpmath` at 40 digits, not from this kernel.
+    #[test]
+    fn gamma_below_the_overflow_point_is_unchanged() {
+        for (x, want) in [
+            (0.5f64, 1.772_453_850_905_516f64),
+            (1.0, 1.0),
+            (5.0, 24.0),
+            (10.5, 1_133_278.388_948_785_6),
+            (142.2, 5.111_424_205_935_494e243),
+        ] {
+            let g = gamma(x).expect("registered");
+            let rel = (g - want).abs() / want.abs();
+            assert!(
+                rel < 1e-11,
+                "Γ({x}) = {g:e}, expected {want:e} (rel {rel:e})"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod arity_tests {
+    use super::PrimitiveRegistry;
+    use std::sync::OnceLock;
+
+    fn reg() -> &'static PrimitiveRegistry {
+        static REG: OnceLock<PrimitiveRegistry> = OnceLock::new();
+        REG.get_or_init(PrimitiveRegistry::dispatch_registry)
+    }
+
+    /// A unary kernel handed two arguments used to ignore the second and
+    /// answer as if it had been called correctly: `sin(x, y)` evaluated to
+    /// `sin(x)`. The ball kernels already declined — the `unary` helper and
+    /// its comment are older than this — so the two halves of the same
+    /// registry disagreed about whether the call had a value.
+    #[test]
+    fn a_unary_kernel_declines_a_binary_call() {
+        const UNARY: [&str; 30] = [
+            "sin",
+            "cos",
+            "exp",
+            "log",
+            "sqrt",
+            "tan",
+            "sinh",
+            "cosh",
+            "tanh",
+            "asin",
+            "acos",
+            "atan",
+            "asinh",
+            "acosh",
+            "atanh",
+            "erf",
+            "erfc",
+            "abs",
+            "sign",
+            "heaviside",
+            "floor",
+            "ceil",
+            "round",
+            "gamma",
+            "lambert_w",
+            "digamma",
+            "bessel_j0",
+            "bessel_j1",
+            "Si",
+            "Ei",
+        ];
+        for name in UNARY {
+            assert!(
+                reg().numeric_f64(name, &[0.5]).is_some(),
+                "{name} should evaluate with one argument"
+            );
+            assert_eq!(
+                reg().numeric_f64(name, &[0.5, 3.0]),
+                None,
+                "{name}(x, y) must decline, not answer {name}(x)"
+            );
+            assert_eq!(reg().numeric_f64(name, &[]), None, "{name}() must decline");
+        }
+    }
+
+    /// The genuinely n-ary primitives keep working, and decline the arities
+    /// they do not have — the guard above must not become "always one".
+    #[test]
+    fn n_ary_kernels_keep_their_own_arities() {
+        for name in ["atan2", "min", "max"] {
+            assert!(reg().numeric_f64(name, &[1.0, 2.0]).is_some(), "{name}");
+            assert_eq!(reg().numeric_f64(name, &[1.0]), None, "{name}");
+        }
+        // EllipticE and EllipticF are complete/incomplete pairs.
+        assert!(reg().numeric_f64("EllipticE", &[0.5]).is_some());
+        assert!(reg().numeric_f64("EllipticE", &[0.5, 0.3]).is_some());
+        assert!(reg().numeric_f64("EllipticPi", &[0.2, 0.3, 0.4]).is_some());
+    }
+
+    /// The `f64` and ball kernels must agree about which calls have a value,
+    /// since a gate may reach for either.
+    #[test]
+    fn f64_and_ball_kernels_agree_on_arity() {
+        use crate::ball::ArbBall;
+        let one = ArbBall::from_f64(0.5, 128);
+        for name in ["sin", "cos", "exp", "log", "sqrt", "tan", "abs", "floor"] {
+            let f64_two = reg().numeric_f64(name, &[0.5, 3.0]).is_some();
+            let ball_two = reg()
+                .numeric_ball(name, &[one.clone(), one.clone()])
+                .is_some();
+            assert_eq!(f64_two, ball_two, "{name} disagrees on the binary call");
+            assert!(!f64_two, "{name}(x, y) has no value");
         }
     }
 }

--- a/alkahest-core/src/stablehlo/mod.rs
+++ b/alkahest-core/src/stablehlo/mod.rs
@@ -19,7 +19,7 @@
 //! assert!(mlir.contains("stablehlo.sine"));
 //! ```
 
-use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::kernel::{integer_to_f64, rational_to_f64, ExprData, ExprId, ExprPool};
 use std::collections::HashMap;
 
 /// Emit a StableHLO MLIR text module for `expr` as a function named `fn_name`.
@@ -71,6 +71,26 @@ struct Emitter {
     unsupported: Option<String>,
 }
 
+/// Render a finite `f64` as an MLIR float literal.
+///
+/// MLIR's grammar is `[-+]?[0-9]+[.][0-9]*([eE][-+]?[0-9]+)?` — the decimal
+/// point is **required**. Rust's `{:?}` gives the shortest round-tripping form,
+/// which drops it whenever the mantissa is a single digit: `1e30`, `1e16` and
+/// `5e-324` all come out without one. `mlir-opt` rejects each of those with
+/// `error: expected '>'`, so `to_stablehlo` returned a module that does not
+/// parse while reporting success — on constants a large integer or a small
+/// rational reaches easily.
+fn mlir_f64_literal(val: f64) -> String {
+    let rendered = format!("{val:?}");
+    if rendered.contains('.') {
+        return rendered;
+    }
+    match rendered.split_once(['e', 'E']) {
+        Some((mantissa, exponent)) => format!("{mantissa}.0e{exponent}"),
+        None => format!("{rendered}.0"),
+    }
+}
+
 impl Emitter {
     fn new(inputs: &[ExprId], _pool: &ExprPool) -> Self {
         let mut arg_map = HashMap::new();
@@ -96,16 +116,18 @@ impl Emitter {
     /// `{val}` renders `1.0_f64` as `1`, and MLIR rejects a decimal integer
     /// literal for an `f64` tensor ("unexpected decimal integer"). Every
     /// expression containing an integer constant — `x**2 + 1` — therefore
-    /// emitted a module that would not parse. `{val:?}` always renders a
-    /// decimal point.
+    /// emitted a module that would not parse. [`mlir_f64_literal`] fixes that
+    /// and the second half of the same problem: `{val:?}` does *not* always
+    /// render a decimal point.
     fn emit_const_f64(&mut self, val: f64) -> String {
         if !val.is_finite() {
             self.unsupported = Some(format!("non-finite constant: {val}"));
             return self.fresh();
         }
         let v = self.fresh();
+        let lit = mlir_f64_literal(val);
         self.body.push(format!(
-            "{v} = stablehlo.constant dense<{val:?}> : tensor<f64>"
+            "{v} = stablehlo.constant dense<{lit}> : tensor<f64>"
         ));
         v
     }
@@ -117,7 +139,6 @@ impl Emitter {
         }
 
         enum Node {
-            Integer(i64),
             Float(f64),
             Add(Vec<ExprId>),
             Mul(Vec<ExprId>),
@@ -127,12 +148,14 @@ impl Emitter {
         }
 
         let node = pool.with(expr, |data| match data {
-            ExprData::Integer(n) => Node::Integer(n.0.to_i64().unwrap_or(0)),
+            // `to_i64().unwrap_or(0)` used to sit here, so an integer past
+            // `i64` became the *constant zero* and `to_stablehlo(2^70·x + 1)`
+            // emitted valid MLIR for `x·0 + 1`. Rounding to `f64` loses one
+            // ulp on a large coefficient instead of losing the whole term, and
+            // it is what every other backend does with the same literal.
+            ExprData::Integer(n) => Node::Float(integer_to_f64(&n.0)),
             ExprData::Float(f) => Node::Float(f.inner.to_f64()),
-            ExprData::Rational(r) => {
-                let (numer, denom) = r.0.clone().into_numer_denom();
-                Node::Float(numer.to_f64() / denom.to_f64())
-            }
+            ExprData::Rational(r) => Node::Float(rational_to_f64(&r.0)),
             ExprData::Add(args) => Node::Add(args.clone()),
             ExprData::Mul(args) => Node::Mul(args.clone()),
             ExprData::Pow { base, exp } => Node::Pow {
@@ -147,7 +170,6 @@ impl Emitter {
         });
 
         match node {
-            Node::Integer(n) => self.emit_const_f64(n as f64),
             Node::Float(f) => self.emit_const_f64(f),
 
             Node::Add(args) => {
@@ -449,5 +471,84 @@ mod emitter_soundness_tests {
         let x = pool.symbol("x", Domain::Real);
         let expr = pool.add(vec![x, pool.float(f64::INFINITY, 53)]);
         assert!(emit_stablehlo(expr, &[x], "f", &pool).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod large_constant_tests {
+    use super::*;
+    use crate::kernel::{Domain, ExprPool};
+    use rug::ops::Pow;
+
+    /// `to_i64().unwrap_or(0)` turned any coefficient past `i64` into the
+    /// constant zero, so the emitted module computed a different function —
+    /// valid MLIR, no diagnostic, wrong answer.
+    #[test]
+    fn a_coefficient_past_i64_is_not_emitted_as_zero() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.add(vec![
+            pool.mul(vec![pool.integer(rug::Integer::from(2u32).pow(70)), x]),
+            pool.integer(1_i32),
+        ]);
+        let mlir = emit_stablehlo(expr, &[x], "f", &pool);
+        assert!(
+            mlir.contains("1.1805916207174113e21"),
+            "coefficient lost: {mlir}"
+        );
+        assert!(
+            !mlir.contains("dense<0.0>"),
+            "coefficient became the constant zero: {mlir}"
+        );
+    }
+
+    #[test]
+    fn a_rational_coefficient_rounds_to_nearest() {
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        let expr = pool.mul(vec![pool.rational(2, 5), x]);
+        let mlir = emit_stablehlo(expr, &[x], "f", &pool);
+        assert!(mlir.contains("dense<0.4>"), "expected 0.4: {mlir}");
+    }
+
+    /// MLIR's float literal needs a decimal point. Rust's `{:?}` drops it for
+    /// a single-digit mantissa, so `dense<1e30>` came out of the emitter and
+    /// `mlir-opt` answered `error: expected '>'` — a module reported as
+    /// emitted that does not parse.
+    #[test]
+    fn every_emitted_constant_carries_a_decimal_point() {
+        assert_eq!(mlir_f64_literal(1e30), "1.0e30");
+        assert_eq!(mlir_f64_literal(1e16), "1.0e16");
+        assert_eq!(mlir_f64_literal(5e-324), "5.0e-324");
+        assert_eq!(mlir_f64_literal(-1e30), "-1.0e30");
+        // Forms that already had one are untouched.
+        assert_eq!(mlir_f64_literal(1.0), "1.0");
+        assert_eq!(mlir_f64_literal(0.4), "0.4");
+        assert_eq!(
+            mlir_f64_literal(1.1805916207174113e21),
+            "1.1805916207174113e21"
+        );
+        assert_eq!(mlir_f64_literal(1e15), "1000000000000000.0");
+
+        // …and end to end, over the constants that reach the emitter.
+        let pool = ExprPool::new();
+        let x = pool.symbol("x", Domain::Real);
+        for coefficient in [
+            pool.integer(rug::Integer::from(10).pow(30)),
+            pool.integer(rug::Integer::from(10).pow(16)),
+            pool.integer(1_i32),
+            pool.rational(1, rug::Integer::from(10).pow(30)),
+            pool.rational(2, 5),
+        ] {
+            let expr = pool.add(vec![pool.mul(vec![coefficient, x]), pool.integer(1_i32)]);
+            let mlir = emit_stablehlo(expr, &[x], "f", &pool);
+            for chunk in mlir.split("dense<").skip(1) {
+                let literal = chunk.split('>').next().unwrap();
+                assert!(
+                    literal.contains('.'),
+                    "MLIR rejects the literal `{literal}` in: {mlir}"
+                );
+            }
+        }
     }
 }

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -16,6 +16,7 @@ than being added here — a gate that times out is a gate that gets disabled.
 from __future__ import annotations
 
 import math
+import re
 from fractions import Fraction
 from typing import Any, Callable
 
@@ -1361,6 +1362,76 @@ def system_states_its_branch_condition(
         return bool(sol["side_conditions"]) and bool(sol["notes"])
 
     return op
+
+
+_C_LITERAL = re.compile(r"(?<![A-Za-z0-9_.])[-+]?\d+\.\d*(?:[eE][-+]?\d+)?")
+_MLIR_CONSTANT = re.compile(r"dense<([^>]+)>")
+_AGREEMENT_EXPRS: list[tuple[str, Callable[[], ak.Expr]]] = [
+    ("rational_2_5", lambda: _rat(2, 5) * X),
+    ("rational_neg_7_3", lambda: _rat(-7, 3) + X),
+    ("rational_355_113", lambda: _rat(355, 113) * X),
+    ("large_integer", lambda: _int(10**30) + X),
+    ("large_rational", lambda: POOL.rational(3 * 10**400 + 1, 2 * 10**400) * X),
+    ("mixed_poly", lambda: _rat(2, 5) * X**3 + _rat(-7, 3) * X**2 + _rat(1, 7)),
+    ("transcendental", lambda: ak.sin(X) * ak.cos(X) + _rat(1, 3) * X),
+]
+_AGREEMENT_POINTS = (-8.0, -1.5, -0.25, 0.5, 1.0, 2.0, 7.0)
+
+
+def _c_body(code: str) -> str:
+    """The single statement inside an emitted C function, whitespace-normalised."""
+    return " ".join(code.splitlines()[1].split())
+
+
+def _largest_c_literal(code: str) -> float:
+    """The largest-magnitude `double` literal in an emitted C function."""
+    return max((float(m) for m in _C_LITERAL.findall(code)), key=abs)
+
+
+def _largest_mlir_constant(mlir: str) -> float:
+    """The largest-magnitude `stablehlo.constant` in an emitted MLIR module."""
+    return max((float(m) for m in _MLIR_CONSTANT.findall(mlir)), key=abs)
+
+
+def _mlir_literals_missing_a_decimal_point(mlir: str) -> int:
+    """How many emitted constants MLIR's grammar would reject.
+
+    ``float-literal ::= [-+]?[0-9]+[.][0-9]*([eE][-+]?[0-9]+)?`` — the point is
+    required, and ``mlir-opt`` answers ``error: expected '>'`` without one.
+    """
+    return sum(1 for lit in _MLIR_CONSTANT.findall(mlir) if "." not in lit)
+
+
+def _evaluators_disagreeing_on() -> int:
+    """Count the (expression, point) pairs where the four f64 paths differ.
+
+    ``eval_expr`` (registry interpreter), ``evaluate(mode="f64")`` (the
+    ``eval::eval_f64`` facade the verification gates call), ``compile_expr``
+    and ``numpy_eval`` all run the same arithmetic over the same DAG, so any
+    difference means at least one of them is wrong — and the gates and the user
+    are then not looking at the same number.  Comparison is exact, not
+    tolerance-based: a tolerance is exactly what hides an ulp-level literal bug.
+    """
+    try:
+        import numpy as np
+    except ModuleNotFoundError:  # pragma: no cover - numpy is absent on some CI shards
+        np = None
+
+    disagreements = 0
+    for _name, build in _AGREEMENT_EXPRS:
+        expr = build()
+        compiled = ak.compile_expr(expr, [X])
+        for point in _AGREEMENT_POINTS:
+            values = {
+                float(ak.eval_expr(expr, {X: point})),
+                float(ak.evaluate(expr, {X: point}, mode="f64").value),
+                float(compiled([point])),
+            }
+            if np is not None:
+                values.add(float(ak.numpy_eval(compiled, np.array([point]))[0]))
+            if len(values) > 1:
+                disagreements += 1
+    return disagreements
 
 
 CASES: list[Case] = [
@@ -5684,6 +5755,188 @@ CASES: list[Case] = [
         note=(
             "The control for the implicit half of ode_residual: without it every implicit "
             "answer in the corpus could be scored as a refusal and nobody would notice."
+        ),
+    ),
+    Case(
+        id="eval_large_integer_literal_is_the_nearest_double",
+        subsystem="evaluation",
+        statement="10^30 evaluates to the nearest double, 1e30, not the one below it",
+        op=lambda: float(ak.eval_expr(_int(10**30) + _int(0) * X, {X: 0.0})),
+        contract=Returns(1e30, tol=0.0),
+        verified_by=(
+            "10^30 = 2^30·5^30 needs 70 significant bits, so it is not exact in binary64. "
+            "Python's int->float is correctly rounded (round-half-even) and gives 1e30; "
+            "truncation towards zero gives 9.999999999999999e29, one ulp low."
+        ),
+        note=(
+            "One ulp, but biased: truncation never rounds up, so a sum of large exact "
+            "integers drifts in one direction. It is also a place two evaluators disagreed "
+            "- emit_c_expr wrote the exact decimal and let the C compiler round it."
+        ),
+    ),
+    Case(
+        id="eval_rational_literal_is_the_nearest_double",
+        subsystem="evaluation",
+        statement="2/5 evaluates to 0.4, the nearest double, under every mode",
+        op=lambda: float(ak.evaluate(_rat(2, 5), {}, mode="f64").value),
+        contract=Returns(0.4, tol=0.0),
+        verified_by=(
+            "float(Fraction(2, 5)) = 0.4 exactly (Python rounds correctly). The double "
+            "below it is 0.39999999999999997, which is what rounding towards zero returns."
+        ),
+    ),
+    Case(
+        id="eval_rational_with_both_parts_past_the_float_range",
+        subsystem="evaluation",
+        statement="(3·10^400+1)/(2·10^400) is 1.5, not an inf/inf NaN",
+        op=lambda: float(
+            ak.eval_expr(POOL.rational(3 * 10**400 + 1, 2 * 10**400) + _int(0) * X, {X: 0.0})
+        ),
+        contract=Returns(1.5, tol=1e-15),
+        verified_by=(
+            "float(Fraction(3*10**400+1, 2*10**400)) = 1.5. The parts are coprime, so the "
+            "fraction is in lowest terms and both of them overflow binary64 on their own."
+        ),
+        note=(
+            "The evaluators split three ways here: `evaluate(mode='f64')` was right, "
+            "`eval_expr` refused with E-EVAL-009 (a weak refusal produced by NaN), and "
+            "compile_expr/numpy_eval returned a bare NaN."
+        ),
+    ),
+    Case(
+        id="eval_control_small_rational_literal",
+        subsystem="evaluation",
+        statement="1/2 evaluates to 0.5 — the literals that were always exact stay exact",
+        op=lambda: float(ak.eval_expr(_rat(1, 2), {})),
+        contract=Returns(0.5, tol=0.0),
+        verified_by="1/2 is exact in binary64. Control for the two rounding cases above.",
+    ),
+    Case(
+        id="codegen_horner_preserves_coefficients_past_i64",
+        subsystem="codegen",
+        statement="horner((x+1)^80) is the same polynomial: 2^80 at x = 1",
+        op=lambda: float(ak.eval_expr(ak.horner((X + _int(1)) ** _int(80), X), {X: 1.0})),
+        contract=Returns(float(2**80), tol=0.0),
+        verified_by=(
+            "(1+1)^80 = 2^80 = 1208925819614629174706176, exactly representable in binary64. "
+            "C(80,40) = 1.075e23 exceeds i64::MAX = 9.22e18, so a coefficient vector taken "
+            "as i64 wraps modulo 2^64 in the middle of the row."
+        ),
+        note=(
+            "horner is a *rewrite*; it promises the same polynomial. Going through "
+            "coefficients_i64 made that promise false with no error and no flag, and "
+            "returned 2.12e20 here."
+        ),
+    ),
+    Case(
+        id="codegen_control_horner_small_coefficients",
+        subsystem="codegen",
+        statement="horner(x²+2x+1) = 16 at x = 3 — the ordinary case is unchanged",
+        op=lambda: float(ak.eval_expr(ak.horner(X**2 + _int(2) * X + _int(1), X), {X: 3.0})),
+        contract=Returns(16.0, tol=0.0),
+        verified_by="(3+1)² = 16. Control for codegen_horner_preserves_coefficients_past_i64.",
+    ),
+    Case(
+        id="codegen_emit_c_preserves_coefficients_past_i64",
+        subsystem="codegen",
+        statement="emit_c of (2^70+3)·x + 1 keeps the coefficient rather than wrapping it to 3",
+        op=lambda: _largest_c_literal(ak.emit_c(_int(2**70 + 3) * X + _int(1), X)),
+        contract=Returns(1.1805916207174113e21, tol=0.0),
+        verified_by=(
+            "float(2**70 + 3) = 1.1805916207174113e21 (Python rounds correctly). "
+            "(2**70 + 3) % 2**64 = 3, which is what the emitted C used to contain."
+        ),
+    ),
+    Case(
+        id="codegen_emit_c_expr_matches_the_interpreter_on_a_rational",
+        subsystem="codegen",
+        statement="the C emitted for (2/5)·x carries the same double the interpreter uses",
+        op=lambda: _largest_c_literal(ak.emit_c_expr(_rat(2, 5) * X, [X], var_names=["x"])),
+        contract=Returns(0.4, tol=0.0),
+        verified_by=(
+            "float(Fraction(2, 5)) = 0.4. Emitting 0.39999999999999997 instead would make "
+            "the compiled artefact disagree with eval_expr by an ulp on the same expression."
+        ),
+    ),
+    Case(
+        id="codegen_emit_c_expr_emits_compilable_c_for_a_non_finite_literal",
+        subsystem="codegen",
+        statement="a non-finite constant emits the <math.h> macro, not the bare token `NaN`",
+        op=lambda: _c_body(ak.emit_c_expr(POOL.float(float("inf")) * X, [X], var_names=["x"])),
+        contract=Returns("return (x * INFINITY);"),
+        verified_by=(
+            "C has no identifiers `inf` or `NaN`; INFINITY and NAN are the <math.h> macros, "
+            "and the emitted code already documents that <math.h> is required. Checked by "
+            "compiling both forms with cc: the bare token is an undeclared identifier."
+        ),
+        note="emit_c_expr reported success while returning a function that does not compile.",
+    ),
+    Case(
+        id="codegen_stablehlo_preserves_coefficients_past_i64",
+        subsystem="codegen",
+        statement="to_stablehlo of 2^70·x + 1 does not lower the coefficient to the constant 0",
+        op=lambda: _largest_mlir_constant(ak.to_stablehlo(_int(2**70) * X + _int(1), [X])),
+        contract=Returns(1.1805916207174113e21, tol=0.0),
+        verified_by=(
+            "float(2**70) = 1.1805916207174113e21. The emitter read the coefficient with "
+            "to_i64().unwrap_or(0), so the module it produced computed x·0 + 1 = 1 — valid "
+            "MLIR, no diagnostic, a different function."
+        ),
+    ),
+    Case(
+        id="codegen_stablehlo_emits_parseable_float_literals",
+        subsystem="codegen",
+        statement="every emitted MLIR constant carries the decimal point the grammar requires",
+        op=lambda: _mlir_literals_missing_a_decimal_point(
+            ak.to_stablehlo(_int(10**30) * X + _rat(1, 10**30), [X])
+        ),
+        contract=Returns(0),
+        verified_by=(
+            "MLIR's float-literal grammar requires the point, and mlir-opt 15.0.4 was run "
+            "on `dense<1e30>`, `dense<1e16>` and `dense<5e-324>`: each is rejected with "
+            "`error: expected '>'`, while `dense<1.0e30>` and `dense<0.4>` parse."
+        ),
+        note=(
+            "to_stablehlo documents its output as valid input to mlir-opt / XLA. Rust's "
+            "shortest-round-trip float format drops the point whenever the mantissa is a "
+            "single digit, so the module did not parse and the call still reported success."
+        ),
+    ),
+    Case(
+        id="codegen_control_stablehlo_small_coefficient",
+        subsystem="codegen",
+        statement="to_stablehlo of 7·x + 1 carries the coefficient 7",
+        op=lambda: _largest_mlir_constant(ak.to_stablehlo(_int(7) * X + _int(1), [X])),
+        contract=Returns(7.0, tol=0.0),
+        verified_by="7 is exact in binary64. Control for the i64-overflow case above.",
+    ),
+    Case(
+        id="codegen_compiled_fn_agrees_with_the_interpreter_bit_for_bit",
+        subsystem="codegen",
+        statement="eval_expr, evaluate(f64), compile_expr and numpy_eval give one value, not four",
+        op=_evaluators_disagreeing_on,
+        contract=Returns(0),
+        verified_by=(
+            "Not a mathematical claim but a consistency one: the four paths run the same "
+            "arithmetic on the same DAG, so any difference means at least one is wrong. "
+            "The count is of (expression, point) pairs where the four do not agree exactly."
+        ),
+        note=(
+            "This is the case that catches a literal- or lowering-level divergence "
+            "regardless of which side is wrong; the per-value cases above pin down which."
+        ),
+    ),
+    Case(
+        id="codegen_compiled_fn_does_not_invent_a_value_at_a_pole",
+        subsystem="codegen",
+        statement="compile_expr(1/x)([0.0]) must not return a finite number",
+        op=lambda: float(ak.compile_expr(_int(1) / X, [X])([0.0])),
+        contract=RefusesOr(),
+        verified_by="1/0 is undefined; no real number is the value of 1/x at 0.",
+        note=(
+            "Passes via a *weak* refusal: the compiled path returns ±inf/NaN where eval_expr "
+            "raises E-EVAL-009. That asymmetry is documented (CompiledFn has no error "
+            "channel) and is the reason this case exists rather than a Raises() one."
         ),
     ),
 ]


### PR DESCRIPTION
An audit of the ~10 independent paths from expression to number. These matter
beyond their own correctness: **the verification gates throughout this codebase
are built on these evaluators**, so a wrong evaluator silently certifies wrong
answers. 3.9.0 contains a worked instance — a gate was blind because
`eval::eval_f64` lacked `tan`/`atan`/`asin`/`atanh`.

**606 expressions × 17 points = 10,421 evaluation points**, compared
**bit-exactly** (not by tolerance) across `eval_expr`, `evaluate(mode="f64")`,
`compile_expr(...).call`, `numpy_eval`, `numpy_eval_par`, Cranelift,
`emit_c_expr`/`emit_c` compiled with `cc -Wall -Werror` **and run**,
`to_stablehlo` fed through `mlir-opt` 15.0.4, `interval_eval`, and `horner` —
with mpmath at 40–60 digits as truth.

## Eight confirmed disagreements

1. **`horner` and `emit_c` computed a *different polynomial*.** Both read
   `UniPoly::coefficients_i64`, whose own doc says "overflows silently".
   `horner((x+1)^80)` at `x=1` gives `2.12e20`; the truth is `2^80 =
   1.2089258196146292e24`, and `C(80,40) = 1.0751e23` exceeds
   `i64::MAX = 9.2234e18`. `(2^70+3)·x²` became `3·x²`, wrapped mod 2^64. This
   class was already found and fixed for `PyUniPoly.coefficients`; these two
   callers were missed.
2. **`to_stablehlo` lowered any coefficient past `i64` to the constant 0**
   (`to_i64().unwrap_or(0)`), emitting valid MLIR for `x·0 + 1` given
   `2^70·x + 1`.
3. **`to_stablehlo` emitted unparseable MLIR.** `dense<1e30>` — MLIR requires a
   decimal point. Proven by running `mlir-opt`: `1e30`, `1e16`, `5e-324` each
   rejected with `error: expected '>'`; `1.0e30` and `0.4` parse.
4. **`rug::to_f64` truncates toward zero** (documented; its own doctests assert
   it), so `10^30` evaluated to `9.999999999999999e29` and `2/5` to
   `0.39999999999999997`. Correctly rounded they are `1e30` and `0.4`. Every
   f64 evaluator was wrong here and **the emitted C was right** — it wrote the
   exact decimal and let `cc` round — which is how the pair disagreed.
5. **A rational with numerator *and* denominator past the f64 range became
   `NaN`.** `(3·10^400+1)/(2·10^400)` is `1.5`; `numer.to_f64()/denom.to_f64()`
   is `inf/inf`. `eval_expr` raised `E-EVAL-009`, `numpy_eval` gave `nan`,
   `emit_c_expr` emitted the literal token `NaN`, and `evaluate(mode="f64")`
   got it right.
6. **`emit_c_expr` returned C that does not compile** — bare `inf`, `-inf`,
   `NaN`, none of which is a C identifier. Verified with `cc`.
7. **`Γ` refused across thirty units of its own domain.** `Γ(170) = 169! =
   4.269e304` is finite in f64, but the Lanczos `t^(x−0.5)·e^{−t}` overflows in
   the first factor at `x ≈ 142.3`. An honest refusal, but a false one; boundary
   located by bisection against mpmath.
8. **A unary `numeric_f64` kernel answered a binary call:**
   `pool.func("sin",[x,y])` returned `sin(x)`. The *ball* kernels already
   declined, with a comment saying exactly why — the two halves of one registry
   disagreed. Not reachable through `ak.sin` or the parser, which enforce arity.

## Negative results, which are the point of an audit

- **`numpy_eval_par` is bit-identical to `numpy_eval`** up to 10^6 points, 1 and
  2 variables — no reduction-order or data-race divergence.
- **Cranelift ↔ snapshot interpreter ↔ `eval_interp` agree bit for bit.**
- **Domain handling never produced a wrong finite number.** Where `eval_expr`
  raises `E-EVAL-009`, the compiled/numpy/C paths return `NaN`/`±inf` — a weak
  refusal, in every one of 10,421 points.
- **All 50 primitives cross-checked against their advertised flags.** Every
  `numeric_f64: true` matches mpmath to < 1e-11 on its declared domain; every
  `false` refuses honestly. 42 out-of-domain probes (`sqrt(-1)`, `asin(2)`,
  `gamma(-2)`, `EllipticK(2)`, `li(-1)`, …) produced **zero wrong reals**.
- Ball enclosures contained the exact value throughout.

## Scope limit, stated plainly

This build is `llvm_jit: false`, `cuda: false`. The LLVM and NVPTX paths were
**type-checked only** (`cargo check --features "groebner jit"` and
`"groebner cuda jit"` green against LLVM 15); they could not be executed here.

## Left unfixed, documented at `func_to_c`

The `x^2`/`x^3` → repeated-multiplication specialisation (≤1 ulp, deliberate,
visible only through `tan` of arguments ≥1e38 where nothing carries
information), and C's `tgamma` returning `NaN` at Γ's poles where alkahest
returns `+∞` so `1/Γ(−n) = 0`. Separately reported, not fixed:
`alkahest-mlir/src/parse.rs` reads `dense<>` coefficients as `f64 as i64`,
truncating `2.5` → `2` — a different crate, outside the gate.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **2916 passed, 0
failed, 11 ignored** (main: 2895, +21); with `--features "groebner cranelift"`
→ 2929 passed, 0 failed. `pytest tests/silent_errors/` → 285 passed; new
**`codegen` subsystem (10 cases)** plus 4 new `evaluation` cases, each with
controls and `tol=0.0` where the default 1e-9 would have hidden the bug.
clippy `-D warnings`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`,
`ruff`, `check_error_codes.py`, `check_api_freeze.py` all clean.

One pytest failure, investigated rather than assumed:
`test_numpy_eval_buffer.py::TestPerfSanity::
test_buffer_path_faster_than_or_comparable_to_python_loop`. Rebuilding with the
**pre-fix** conversions restored fails it identically (945 ms vs 1088 ms, same
order, run-to-run noise), and a direct throughput probe measures 44–50 µs/point
before and after. A debug-build artefact, not a regression — the change in fact
*removes* a per-node `Rational::clone()` (two mpz allocations) from the
interpreter hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when converting large integers and rational values to floating-point numbers, including correct rounding, subnormal values, and overflow handling.
  - Fixed polynomial evaluation and generated C/StableHLO output for very large coefficients and non-finite values.
  - Corrected floating-point literal formatting in generated StableHLO modules.
  - Unary numeric functions now reject calls with incorrect numbers of arguments.
  - Extended the usable finite range of the gamma function.
  - Improved consistency across interpreters, compiled evaluation, and generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->