### PR TITLE
release: 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Changelog
 
-## Unreleased
+## 3.10.0 — 2026-09-10
+
+- **Series with a fractional valuation are expanded rather than refused.** New
+  `alkahest.experimental.puiseux_series` /
+  `alkahest_cas::experimental::puiseux_series`. `series` refused every
+  expansion whose valuation is not an integer, because `Series` has no
+  representation for one — honest, but the answers are standard:
+
+  | input | before | after |
+  |---|---|---|
+  | `√x` | `E-SERIES-004` | `x^{1/2} + O(x⁵)`, ramification 2 |
+  | `√(sin x)` | `E-SERIES-004` | `x^{1/2} − x^{5/2}/12 + x^{9/2}/1440` |
+  | `(sin x)^{1/3}` | refused | `x^{1/3} − x^{7/3}/18 − x^{13/3}/3240` |
+  | `sin(√x)` | refused | `x^{1/2} − x^{3/2}/6 + x^{5/2}/120 − x^{7/2}/5040` |
+  | `√(x²+x³)` | refused | `x + x²/2 − x³/8 + x⁴/16`, ramification **1** |
+  | `√(t⁻²+t⁻¹)` — `series`' own documented "unreachable" case | `E-SERIES-004` | order 8 in 48 ms |
+
+  Ramification is the lcm of the exponents that come *out*, not read off the
+  input, which is why `√(x²+x³)` reduces to 1. Every one of these agrees with
+  `sympy.series` exactly.
+
+  It is a sibling type, not a wider `Series`: `Series` is
+  `pub struct Series(pub ExprId)` — publicly constructible, so a ramification
+  field is a major semver break — and the internal `LocalExpansion` carries an
+  `i32` valuation that `limit`, `gruntz`, `asymptotic` and `fps` all read, so a
+  rational valuation there would have silently changed *limits*. `series.rs`
+  gets no behaviour change at all, and an integer-exponent expansion returns
+  the identical interned `ExprId` it did before, which is asserted rather than
+  assumed.
+
+  Verification is a **prefix ladder**: a single check against `O(h^order)` is
+  vacuous for a good series — the residual falls under the `f64` floor before
+  it can be measured — so every prefix is fitted against the first omitted
+  term's exponent, with sample points derived from the claimed exponent. Where
+  the shape allows, an exact `S^e` vs `f^e` comparison runs as well. Failure
+  discards the expansion and returns `E-SERIES-006`. A test corrupts an
+  expansion — scaling coefficients, shifting the valuation, dropping a term —
+  and asserts each is rejected, so the ladder is known to be able to fail.
+
+  `log x` and `√x·log x` still refuse with `E-SERIES-005`: those are
+  Puiseux–*log* (transseries), and truncating `√x·log x` to `x^{1/2}` is
+  opposite-sign and unboundedly wrong, not merely coarse.
 
 - **An enclosure that could not bound a value reported that it *excluded* it.**
   `ArbBall` could return a NaN-radius ball whose `contains` answers `false` for
@@ -157,9 +198,9 @@
   the wrong candidate `C1·e^{kx}` is certified by the positive rows alone and
   refused by all six.
 
-- **The silent-error corpus grew from 261 to 356 cases**, and gained five
+- **The silent-error corpus grew from 261 to 361 cases**, and gained five
   subsystems that had no coverage at all: `codegen` (10), `ode` (21),
-  `transform` (15), `validated` (18) and `ball` (7). The ODE cases score three
+  `transform` (15), `validated` (18) and `ball` (7); `series` grew 12 → 27. The ODE cases score three
   distinct claims, because substituting an answer back cannot detect all three
   kinds of wrong: that the answer solves the equation, that it *spans* the
   solution space, and that it states the branch condition it depends on. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-cas"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "bitflags 2.12.1",
  "boxcar",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-mlir"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "alkahest-cas",
  "proptest",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-py"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "alkahest-cas",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "3.9.0"
+version = "3.10.0"
 edition = "2021"
 authors = ["Alkahest Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Probe your environment after install: `alkahest.capabilities()["features"]` and 
 
 ### Opt-in Linux wheels: `+jit` and `+full` (PyTorch-style)
 
-**Why a separate index or direct wheel URL:** feature-heavy wheels use a PEP 440 **local version** (for example `3.9.0+jit` or `3.9.0+full`). Those builds **must not** be mixed into the main PyPI project’s simple API for the same reason PyTorch publishes CUDA wheels on `download.pytorch.org`: otherwise `pip install alkahest` could resolve a `+jit` / `+full` build as “newer” than `3.9.0` and pull LLVM (or a much larger binary) when you wanted the default wheel.
+**Why a separate index or direct wheel URL:** feature-heavy wheels use a PEP 440 **local version** (for example `3.10.0+jit` or `3.10.0+full`). Those builds **must not** be mixed into the main PyPI project’s simple API for the same reason PyTorch publishes CUDA wheels on `download.pytorch.org`: otherwise `pip install alkahest` could resolve a `+jit` / `+full` build as “newer” than `3.10.0` and pull LLVM (or a much larger binary) when you wanted the default wheel.
 
 There is **no** `pip install alkahest[jit]` / `alkahest[full]` that swaps the native extension: **pip extras only add Python dependencies**, not alternate binaries for the same wheel slot.
 
@@ -76,13 +76,13 @@ There is **no** `pip install alkahest[jit]` / `alkahest[full]` that swaps the na
 Direct-install examples (adjust tag and filename after checking the release assets):
 
 ```bash
-pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.9.0/alkahest-3.9.0+full-cp311-cp311-linux_x86_64.whl"
-pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.9.0/alkahest-3.9.0+jit-cp311-cp311-linux_x86_64.whl"
+pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.10.0/alkahest-3.10.0+full-cp311-cp311-linux_x86_64.whl"
+pip install "https://github.com/alkahest-cas/alkahest/releases/download/v3.10.0/alkahest-3.10.0+jit-cp311-cp311-linux_x86_64.whl"
 ```
 
 These wheels vendor LLVM (for JIT) and related `.so` files under `site-packages/alkahest.libs/`. If `import alkahest` fails with a missing `libffi-*.so` or `libLLVM-*.so`, prepend that directory to `LD_LIBRARY_PATH` (or install matching system packages). Release CI uses the same `LD_LIBRARY_PATH` step when smoke-testing wheels.
 
-If your client chokes on `+` in the URL, use percent-encoding (`3.9.0%2Bfull` in the filename segment).
+If your client chokes on `+` in the URL, use percent-encoding (`3.10.0%2Bfull` in the filename segment).
 
 After installing the **default** wheel, `alkahest.jit_is_available()` is `True` (Cranelift). After **`+jit`** it is also `True` (LLVM, in place of Cranelift); **`+full`** carries both backends. Gröbner-backed APIs such as `alkahest.solve` are available in **all** wheels since `groebner` became a default feature.
 
@@ -91,7 +91,7 @@ After installing the **default** wheel, `alkahest.jit_is_available()` is `True` 
 **Target layout (roadmap):** a small **extra index** URL (PEP 503) hosting only `+jit` / `+full` wheels, mirroring PyTorch’s `--extra-index-url` workflow:
 
 ```bash
-pip install 'alkahest==3.9.0+full' --extra-index-url https://EXAMPLE/alkahest-extras/simple
+pip install 'alkahest==3.10.0+full' --extra-index-url https://EXAMPLE/alkahest-extras/simple
 ```
 
 ### From source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "alkahest"
-version = "3.9.0"
+version = "3.10.0"
 description = "A high-performance computer algebra system for Python"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Cuts **3.10.0**. Version in the workspace manifest, `pyproject.toml` and the
lock file; the `## Unreleased` changelog section dated; and the README install
examples repointed at the new tag — the same file set the 3.9.0 release
touched.

Note this branch is `release/3.10.0`, which the CI workflows treat specially:
`ci-cross`, `codspeed` and `semver-check` all include `release/**` in their
`push` triggers precisely so a release branch cannot reach a tag with no CI,
a gap that bit `release/3.8.0`.

## What 3.10.0 contains

Thirteen merged PRs. The release is dominated by correctness work — of the
fifteen defects fixed, **nine were silent wrong answers**, two were soundness
failures and one was a false proof:

- **An enclosure that reported it *excluded* a value it could not bound**
  (`ArbBall.contains` answering `false` for every real number), plus `tan`
  accepting a box across a pole and `pow_f` hulling across a sign change —
  both returning finite bounds for unbounded functions.
- **A certificate that proved a recurrence for sums that do not exist** —
  `zeilberger` returning `boundary="vanishes"` where the licensed recurrence
  gives `S(2) = −10/3` against a true `−7/3`.
- **A Fourier transform taking the wrong square root on literal input**
  (`+1.3499` against a true `−0.7408182206817178660668738`), finite answers
  for divergent integrals, and forward Laplace applying the unilateral shift
  rule to negative shifts.
- **Three code generators emitting a different function than the one given** —
  `horner((x+1)^80)` returning `2.12e20` for `2^80`, because `coefficients_i64`
  overflows silently and `C(80,40)` exceeds `i64::MAX`.
- **Two limits outright wrong for a free parameter** (`lim k·x` and `lim −k·x`
  both `+∞`), and a DPLL that would have called a satisfiable formula
  unsatisfiable.
- **Symbolic eigenvalues that were not roots** of their own characteristic
  polynomial under any branch convention the crate implements.
- **`series` returning `0⁻¹` coefficients as success.**

And the capability work: the five load-bearing refusals closed (definite
Gaussians, inverse Laplace with symbolic parameters, the first-order ODE
classes, symbolic-coefficient and system `dsolve`, symbolic-rate improper
integrals), `solve` accepting rational equations, propositional satisfiability,
and **Puiseux series**.

## Verification

- `cargo test -p alkahest-cas --features groebner --lib` on the tip:
  **3050 passed, 0 failed, 11 ignored** (2738 at the start of this cycle).
- Silent-error corpus **261 → 361 cases** across 16 subsystems, five of them
  (`codegen`, `ode`, `transform`, `validated`, `ball`) created from nothing —
  0 silent errors.
- `cargo semver-checks` against `main`: 223 pass, no semver update required.

One known, quantified performance cost, carried deliberately: sound enclosures
are wider, so root isolation does more work. CodSpeed measures −12.9% on
`test_real_roots_deg8` and −11.6% on `test_solve_circle_line_size5` in
instruction counts; measured as wall time on the same benchmark shape the cost
is **+1.8%**. That buys two Critical soundness fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for expanding series with fractional valuations through the experimental Puiseux-series APIs.
  - Fractional exponents are handled with automatic ramification and verification.

- **Behavior**
  - Expressions involving `log x` or `√x·log x` continue to be rejected.

- **Documentation**
  - Updated the changelog, README, and release references for version 3.10.0.
  - Expanded documented silent-error corpus coverage, including increased series coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->