### PR TITLE
feat(vector,quaternion): vector calculus over orthogonal charts, and Hamilton quaternions

### DIFF
--- a/alkahest-core/src/algebra/mod.rs
+++ b/alkahest-core/src/algebra/mod.rs
@@ -1,6 +1,11 @@
 //! Domain-specific algebras built on the expression kernel (V3-2+).
 
 pub mod noncommutative;
+pub mod quaternion;
+#[cfg(test)]
+mod quaternion_tests;
+
+pub use quaternion::{Quaternion, QuaternionError};
 
 pub use noncommutative::{
     clifford_orthogonal_rules, imag_unit_atom, pauli_product_rules, PauliSpinAlgebraRule,

--- a/alkahest-core/src/algebra/quaternion.rs
+++ b/alkahest-core/src/algebra/quaternion.rs
@@ -1,0 +1,686 @@
+//! Hamilton quaternions, and the rotation operator built on them.
+//!
+//! # Why this is a type and not a rewrite rule
+//!
+//! [`super::noncommutative`] handles Pauli and Clifford generators by matching
+//! products of *non-commutative symbols* and firing a product table. That is
+//! the right shape when the generators are opaque and a user writes
+//! `σx·σy` by hand. It is the wrong shape here.
+//!
+//! A quaternion is used numerically as often as symbolically — an attitude
+//! state is four floats — and every operation a GNC engineer wants
+//! (`q₁q₂`, `q⁻¹`, `q v q⁻¹`, the rotation matrix) is a closed-form function of
+//! the four components, not a normal form to be searched for. Expressing
+//! `q v q⁻¹` as a rewrite problem over `1, i, j, k` means interning a product
+//! of three general quaternions as an unexpanded tree and hoping the rules
+//! reach a canonical form; expressing it as arithmetic on four `ExprId`s makes
+//! it one deterministic evaluation that cannot half-finish. The
+//! non-commutativity lives in [`Quaternion::mul`]'s formula, where it is
+//! visible and testable, rather than in the order the simplifier happens to
+//! visit a `Mul`.
+//!
+//! # Conventions
+//!
+//! * `q = w + xi + yj + zk` with `i² = j² = k² = ijk = −1`, hence
+//!   `ij = k`, `ji = −k` ([`Quaternion::mul`] is asserted against both).
+//! * [`Quaternion::rotate`] is the **active** rotation `v ↦ q v q⁻¹` in a
+//!   right-handed frame: it moves the vector, it does not re-express it in a
+//!   rotated frame. The inverse convention differs by a transpose, which is
+//!   the single most common silent sign error in attitude code.
+//! * Composition follows from that and is **not** symmetric:
+//!   `(q₁q₂) v (q₁q₂)⁻¹ = q₁ (q₂ v q₂⁻¹) q₁⁻¹`, so `q₂` acts first and
+//!   `R(q₁q₂) = R(q₁)·R(q₂)`. A test asserts exactly this, at random axes and
+//!   angles, and asserts that the reversed product does *not* agree.
+//! * `q` and `−q` are the same rotation. Nothing here canonicalises the sign.
+
+use crate::jit::eval_interp_checked;
+use crate::kernel::{ExprId, ExprPool};
+use crate::matrix::zero_test::{zero_status, ZeroStatus};
+use crate::matrix::{Matrix, MatrixError};
+use crate::simplify::engine::simplify;
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Why a quaternion operation refused.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QuaternionError {
+    /// `|q|²` is zero, or could not be shown to be non-zero, and the operation
+    /// divides by it.
+    ///
+    /// `q⁻¹ = q̄/|q|²`, so a zero norm has no inverse and no rotation operator.
+    /// Over the reals only `q = 0` has `|q|² = 0`, but the components are
+    /// arbitrary expressions here, so the question is a zero test and its
+    /// undecided answer is a refusal.
+    ZeroNorm {
+        /// Rendered form of `|q|²`.
+        norm_squared: String,
+        /// `true` when `|q|²` was *proven* zero, `false` when undecided.
+        proven_zero: bool,
+    },
+    /// The rotation has no axis: the vector part of `q` is zero, so `q` is a
+    /// real scalar and `q v q⁻¹ = v` for every `v`.
+    ///
+    /// Every unit vector is then a valid axis, so there is no axis to return.
+    /// Returning `(0,0,1)` — the conventional stand-in — is a stated answer to
+    /// a question with no answer, which is the failure mode this crate refuses
+    /// by policy.
+    UndefinedAxis {
+        /// Rendered form of the quaternion.
+        quaternion: String,
+    },
+    /// A matrix handed to [`Quaternion::from_rotation_matrix`] is not a proper
+    /// rotation, or its entries are not numbers.
+    NotARotation {
+        /// What failed: not 3×3, symbolic entries, `RᵀR ≠ I`, `det R = −1`, or
+        /// the reconstruction check.
+        reason: String,
+    },
+}
+
+impl fmt::Display for QuaternionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QuaternionError::ZeroNorm {
+                norm_squared,
+                proven_zero,
+            } => {
+                if *proven_zero {
+                    write!(
+                        f,
+                        "quaternion has zero norm (|q|² = `{norm_squared}`); it has no inverse"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "|q|² = `{norm_squared}` could not be shown to be non-zero, and this operation divides by it"
+                    )
+                }
+            }
+            QuaternionError::UndefinedAxis { quaternion } => write!(
+                f,
+                "`{quaternion}` has zero vector part: it is the identity rotation, and every unit vector is an axis for it"
+            ),
+            QuaternionError::NotARotation { reason } => {
+                write!(f, "not a proper rotation matrix: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for QuaternionError {}
+
+impl crate::errors::AlkahestError for QuaternionError {
+    fn code(&self) -> &'static str {
+        match self {
+            QuaternionError::ZeroNorm { .. } => "E-QUAT-001",
+            QuaternionError::UndefinedAxis { .. } => "E-QUAT-002",
+            QuaternionError::NotARotation { .. } => "E-QUAT-003",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        match self {
+            QuaternionError::ZeroNorm { .. } => Some(
+                "use a non-zero quaternion; if the components are symbolic, substitute concrete values or declare the parameters so the norm can be decided",
+            ),
+            QuaternionError::UndefinedAxis { .. } => Some(
+                "the rotation is the identity — report the angle as 0 and pick whatever axis your convention prefers, explicitly, at the call site",
+            ),
+            QuaternionError::NotARotation { .. } => Some(
+                "pass a 3×3 matrix of numbers with RᵀR = I and det R = +1; a reflection (det = −1) is not a rotation and has no quaternion",
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The type
+// ---------------------------------------------------------------------------
+
+/// A quaternion `w + xi + yj + zk` over symbolic expressions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Quaternion {
+    w: ExprId,
+    x: ExprId,
+    y: ExprId,
+    z: ExprId,
+}
+
+/// Numeric tolerance for the `RᵀR = I`, `det R = 1` and reconstruction checks
+/// in [`Quaternion::from_rotation_matrix`].
+///
+/// Loose enough to accept a matrix assembled from `f64` trigonometry, tight
+/// enough that a matrix that is not a rotation cannot slip through: the
+/// nearest non-rotation to a rotation in these norms is a scaling or a shear,
+/// both of which move the residual by many orders of magnitude more than this.
+const ROTATION_TOL: f64 = 1e-9;
+
+impl Quaternion {
+    /// `w + xi + yj + zk` from its four components.
+    pub fn new(w: ExprId, x: ExprId, y: ExprId, z: ExprId) -> Self {
+        Quaternion { w, x, y, z }
+    }
+
+    /// The real quaternion `w`.
+    pub fn scalar(w: ExprId, pool: &ExprPool) -> Self {
+        let zero = pool.integer(0_i32);
+        Quaternion {
+            w,
+            x: zero,
+            y: zero,
+            z: zero,
+        }
+    }
+
+    /// The pure (vector) quaternion `0 + v₁i + v₂j + v₃k`.
+    pub fn pure(v: &[ExprId; 3], pool: &ExprPool) -> Self {
+        Quaternion {
+            w: pool.integer(0_i32),
+            x: v[0],
+            y: v[1],
+            z: v[2],
+        }
+    }
+
+    /// The multiplicative identity `1`.
+    pub fn identity(pool: &ExprPool) -> Self {
+        Quaternion::scalar(pool.integer(1_i32), pool)
+    }
+
+    /// The real part `w`.
+    pub fn w(&self) -> ExprId {
+        self.w
+    }
+
+    /// The `i` component.
+    pub fn x(&self) -> ExprId {
+        self.x
+    }
+
+    /// The `j` component.
+    pub fn y(&self) -> ExprId {
+        self.y
+    }
+
+    /// The `k` component.
+    pub fn z(&self) -> ExprId {
+        self.z
+    }
+
+    /// `[w, x, y, z]`, scalar first.
+    pub fn components(&self) -> [ExprId; 4] {
+        [self.w, self.x, self.y, self.z]
+    }
+
+    /// The vector part `[x, y, z]`.
+    pub fn vector_part(&self) -> [ExprId; 3] {
+        [self.x, self.y, self.z]
+    }
+
+    /// Simplify all four components.
+    pub fn simplified(&self, pool: &ExprPool) -> Self {
+        Quaternion {
+            w: simplify(self.w, pool).value,
+            x: simplify(self.x, pool).value,
+            y: simplify(self.y, pool).value,
+            z: simplify(self.z, pool).value,
+        }
+    }
+
+    /// Componentwise sum.
+    pub fn add(&self, other: &Quaternion, pool: &ExprPool) -> Self {
+        Quaternion {
+            w: simplify(pool.add(vec![self.w, other.w]), pool).value,
+            x: simplify(pool.add(vec![self.x, other.x]), pool).value,
+            y: simplify(pool.add(vec![self.y, other.y]), pool).value,
+            z: simplify(pool.add(vec![self.z, other.z]), pool).value,
+        }
+    }
+
+    /// Componentwise difference.
+    pub fn sub(&self, other: &Quaternion, pool: &ExprPool) -> Self {
+        let neg = pool.integer(-1_i32);
+        let negated = other.scale(neg, pool);
+        self.add(&negated, pool)
+    }
+
+    /// Multiply every component by the scalar `s`.
+    pub fn scale(&self, s: ExprId, pool: &ExprPool) -> Self {
+        Quaternion {
+            w: simplify(pool.mul(vec![s, self.w]), pool).value,
+            x: simplify(pool.mul(vec![s, self.x]), pool).value,
+            y: simplify(pool.mul(vec![s, self.y]), pool).value,
+            z: simplify(pool.mul(vec![s, self.z]), pool).value,
+        }
+    }
+
+    /// The **Hamilton product** `self · other`. Non-commutative.
+    ///
+    /// ```text
+    /// w = w₁w₂ − x₁x₂ − y₁y₂ − z₁z₂
+    /// x = w₁x₂ + x₁w₂ + y₁z₂ − z₁y₂
+    /// y = w₁y₂ − x₁z₂ + y₁w₂ + z₁x₂
+    /// z = w₁z₂ + x₁y₂ − y₁x₂ + z₁w₂
+    /// ```
+    ///
+    /// Equivalently `(s₁, v₁)(s₂, v₂) = (s₁s₂ − v₁·v₂, s₁v₂ + s₂v₁ + v₁×v₂)`;
+    /// the cross product is what makes `ij = k` and `ji = −k`.
+    pub fn mul(&self, other: &Quaternion, pool: &ExprPool) -> Self {
+        let (a, b) = (self, other);
+        let neg = pool.integer(-1_i32);
+        let m = |p: ExprId, q: ExprId| pool.mul(vec![p, q]);
+        let nm = |p: ExprId, q: ExprId| pool.mul(vec![neg, p, q]);
+
+        let w = pool.add(vec![m(a.w, b.w), nm(a.x, b.x), nm(a.y, b.y), nm(a.z, b.z)]);
+        let x = pool.add(vec![m(a.w, b.x), m(a.x, b.w), m(a.y, b.z), nm(a.z, b.y)]);
+        let y = pool.add(vec![m(a.w, b.y), nm(a.x, b.z), m(a.y, b.w), m(a.z, b.x)]);
+        let z = pool.add(vec![m(a.w, b.z), m(a.x, b.y), nm(a.y, b.x), m(a.z, b.w)]);
+
+        Quaternion {
+            w: simplify(w, pool).value,
+            x: simplify(x, pool).value,
+            y: simplify(y, pool).value,
+            z: simplify(z, pool).value,
+        }
+    }
+
+    /// `q̄ = w − xi − yj − zk`.
+    pub fn conjugate(&self, pool: &ExprPool) -> Self {
+        let neg = pool.integer(-1_i32);
+        Quaternion {
+            w: self.w,
+            x: simplify(pool.mul(vec![neg, self.x]), pool).value,
+            y: simplify(pool.mul(vec![neg, self.y]), pool).value,
+            z: simplify(pool.mul(vec![neg, self.z]), pool).value,
+        }
+    }
+
+    /// `|q|² = w² + x² + y² + z²`, simplified.
+    pub fn norm_squared(&self, pool: &ExprPool) -> ExprId {
+        let two = pool.integer(2_i32);
+        let terms: Vec<ExprId> = self
+            .components()
+            .iter()
+            .map(|&c| pool.pow(c, two))
+            .collect();
+        simplify(pool.add(terms), pool).value
+    }
+
+    /// `|q| = √(w² + x² + y² + z²)`, simplified.
+    pub fn norm(&self, pool: &ExprPool) -> ExprId {
+        let n2 = self.norm_squared(pool);
+        simplify(pool.func("sqrt", vec![n2]), pool).value
+    }
+
+    /// `|q|²`, but only once it is known not to vanish.
+    fn nonzero_norm_squared(&self, pool: &ExprPool) -> Result<ExprId, QuaternionError> {
+        let n2 = self.norm_squared(pool);
+        match zero_status(pool, n2) {
+            ZeroStatus::NonZero => Ok(n2),
+            status => Err(QuaternionError::ZeroNorm {
+                norm_squared: pool.display(n2).to_string(),
+                proven_zero: status == ZeroStatus::Zero,
+            }),
+        }
+    }
+
+    /// `q⁻¹ = q̄ / |q|²`.
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-001` when `|q|²` is zero or its vanishing is undecided.
+    pub fn inverse(&self, pool: &ExprPool) -> Result<Self, QuaternionError> {
+        let n2 = self.nonzero_norm_squared(pool)?;
+        let inv = pool.pow(n2, pool.integer(-1_i32));
+        Ok(self.conjugate(pool).scale(inv, pool))
+    }
+
+    /// `q / |q|` — the unit quaternion with the same rotation.
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-001` when `|q|²` is zero or its vanishing is undecided.
+    pub fn normalize(&self, pool: &ExprPool) -> Result<Self, QuaternionError> {
+        let n2 = self.nonzero_norm_squared(pool)?;
+        let n = simplify(pool.func("sqrt", vec![n2]), pool).value;
+        let inv = pool.pow(n, pool.integer(-1_i32));
+        Ok(self.scale(inv, pool))
+    }
+
+    /// The **active** rotation `v ↦ q v q⁻¹`, returned as a 3-vector.
+    ///
+    /// `q` need not be a unit quaternion: the operator is invariant under
+    /// `q ↦ λq`, because `λ` cancels against `λ⁻¹` in `q⁻¹`. The scalar part of
+    /// `q v q⁻¹` is identically zero, so only the vector part is returned.
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-001` when `|q|²` is zero or its vanishing is undecided.
+    pub fn rotate(&self, v: &[ExprId; 3], pool: &ExprPool) -> Result<[ExprId; 3], QuaternionError> {
+        let inv = self.inverse(pool)?;
+        let p = Quaternion::pure(v, pool);
+        let out = self.mul(&p, pool).mul(&inv, pool);
+        Ok(out.vector_part())
+    }
+
+    /// The 3×3 rotation matrix `R` with `R v = q v q⁻¹`.
+    ///
+    /// ```text
+    ///       1   ⎡ w²+x²−y²−z²   2(xy−wz)      2(xz+wy)    ⎤
+    /// R = ───── ⎢ 2(xy+wz)      w²−x²+y²−z²   2(yz−wx)    ⎥
+    ///     |q|²  ⎣ 2(xz−wy)      2(yz+wx)      w²−x²−y²+z² ⎦
+    /// ```
+    ///
+    /// For a unit quaternion the `1/|q|²` is `1` and the diagonal reads
+    /// `1 − 2(y²+z²)`, etc. The agreement `R v = q v q⁻¹` is asserted in the
+    /// tests at random axes and angles, not assumed.
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-001` when `|q|²` is zero or its vanishing is undecided.
+    pub fn to_rotation_matrix(&self, pool: &ExprPool) -> Result<Matrix, QuaternionError> {
+        let n2 = self.nonzero_norm_squared(pool)?;
+        let inv = pool.pow(n2, pool.integer(-1_i32));
+        let two = pool.integer(2_i32);
+        let neg = pool.integer(-1_i32);
+        let sq = |c: ExprId| pool.pow(c, two);
+        let nsq = |c: ExprId| pool.mul(vec![neg, pool.pow(c, two)]);
+        let p2 = |a: ExprId, b: ExprId| pool.mul(vec![two, a, b]);
+        let m2 = |a: ExprId, b: ExprId| pool.mul(vec![neg, two, a, b]);
+        let (w, x, y, z) = (self.w, self.x, self.y, self.z);
+
+        let raw = [
+            [
+                pool.add(vec![sq(w), sq(x), nsq(y), nsq(z)]),
+                pool.add(vec![p2(x, y), m2(w, z)]),
+                pool.add(vec![p2(x, z), p2(w, y)]),
+            ],
+            [
+                pool.add(vec![p2(x, y), p2(w, z)]),
+                pool.add(vec![sq(w), nsq(x), sq(y), nsq(z)]),
+                pool.add(vec![p2(y, z), m2(w, x)]),
+            ],
+            [
+                pool.add(vec![p2(x, z), m2(w, y)]),
+                pool.add(vec![p2(y, z), p2(w, x)]),
+                pool.add(vec![sq(w), nsq(x), nsq(y), sq(z)]),
+            ],
+        ];
+
+        let rows: Vec<Vec<ExprId>> = raw
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|&e| simplify(pool.mul(vec![inv, e]), pool).value)
+                    .collect()
+            })
+            .collect();
+        Matrix::new(rows).map_err(|e: MatrixError| QuaternionError::NotARotation {
+            reason: e.to_string(),
+        })
+    }
+
+    /// `q = cos(θ/2) + sin(θ/2)·û` for the rotation of `angle` about `axis`.
+    ///
+    /// `axis` is normalised internally, so it need not be a unit vector; the
+    /// literal-`1` case (`(0,0,1)` and friends) skips the normalisation so the
+    /// result stays readable. The returned quaternion is a unit quaternion and
+    /// rotates by `angle` **about `axis`, right-handed**, in the sense of
+    /// [`Quaternion::rotate`].
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-001` when `|axis|²` is zero or its vanishing is undecided — the
+    /// zero vector picks out no axis.
+    pub fn from_axis_angle(
+        axis: &[ExprId; 3],
+        angle: ExprId,
+        pool: &ExprPool,
+    ) -> Result<Self, QuaternionError> {
+        let n2 = crate::vector::norm_squared(axis, pool);
+        let unit = match zero_status(pool, n2) {
+            ZeroStatus::NonZero => {
+                let one = pool.integer(1_i32);
+                if n2 == one {
+                    *axis
+                } else {
+                    let n = simplify(pool.func("sqrt", vec![n2]), pool).value;
+                    let inv = pool.pow(n, pool.integer(-1_i32));
+                    crate::vector::scale(inv, axis, pool)
+                }
+            }
+            status => {
+                return Err(QuaternionError::ZeroNorm {
+                    norm_squared: pool.display(n2).to_string(),
+                    proven_zero: status == ZeroStatus::Zero,
+                })
+            }
+        };
+        let half = pool.mul(vec![pool.rational(1, 2), angle]);
+        let c = simplify(pool.func("cos", vec![half]), pool).value;
+        let s = simplify(pool.func("sin", vec![half]), pool).value;
+        Ok(Quaternion {
+            w: c,
+            x: simplify(pool.mul(vec![s, unit[0]]), pool).value,
+            y: simplify(pool.mul(vec![s, unit[1]]), pool).value,
+            z: simplify(pool.mul(vec![s, unit[2]]), pool).value,
+        })
+    }
+
+    /// The axis–angle form: `(û, θ)` with `θ = 2·atan2(|v|, w)` and
+    /// `û = v/|v|`, where `v` is the vector part.
+    ///
+    /// `atan2` rather than `acos(w/|q|)` because `acos` loses all precision as
+    /// `θ → 0`, which is where attitude code spends most of its time, and
+    /// because it does not need `q` normalised first.
+    ///
+    /// Since `|v| ≥ 0` the returned `θ` lies in `[0, 2π]`: a quaternion with
+    /// `w < 0` reports an angle past `π` about the returned axis rather than
+    /// the equivalent angle `2π − θ` about `−û`. Both describe the same
+    /// rotation; nothing here canonicalises, because `q` and `−q` are the same
+    /// rotation and choosing between them is the caller's convention.
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-002` when the vector part is zero or its vanishing is
+    /// undecided: `q` is then a real scalar, the rotation is the identity, and
+    /// *every* unit vector is an axis for it. There is no axis to return.
+    pub fn to_axis_angle(&self, pool: &ExprPool) -> Result<([ExprId; 3], ExprId), QuaternionError> {
+        let v = self.vector_part();
+        let n2 = crate::vector::norm_squared(&v, pool);
+        if zero_status(pool, n2) != ZeroStatus::NonZero {
+            return Err(QuaternionError::UndefinedAxis {
+                quaternion: format!(
+                    "{} + {}i + {}j + {}k",
+                    pool.display(self.w),
+                    pool.display(self.x),
+                    pool.display(self.y),
+                    pool.display(self.z)
+                ),
+            });
+        }
+        let n = simplify(pool.func("sqrt", vec![n2]), pool).value;
+        let inv = pool.pow(n, pool.integer(-1_i32));
+        let axis = crate::vector::scale(inv, &v, pool);
+        let angle = simplify(
+            pool.mul(vec![
+                pool.integer(2_i32),
+                pool.func("atan2", vec![n, self.w]),
+            ]),
+            pool,
+        )
+        .value;
+        Ok((axis, angle))
+    }
+
+    /// Recover a quaternion from a **numeric** proper rotation matrix.
+    ///
+    /// Shepperd's method: the branch with the largest pivot is taken, so no
+    /// square root of a near-zero quantity is ever divided by. The result is
+    /// the unit quaternion `q` with `R(q) = R`, up to the unavoidable sign
+    /// ambiguity (`q` and `−q` give the same `R`); the branch is chosen to
+    /// make the pivot component positive.
+    ///
+    /// Three things are checked before anything is returned, and each is a
+    /// refusal:
+    ///
+    /// 1. every entry is a number — the branch selection is a comparison, and
+    ///    there is no comparison to make on symbols;
+    /// 2. `RᵀR = I` and `det R = +1` — a reflection has no quaternion, and a
+    ///    scaled or skewed matrix would otherwise yield a plausible unit
+    ///    quaternion for a transform that is not a rotation;
+    /// 3. `R(q)` is rebuilt and compared against the input entry by entry.
+    ///
+    /// # Errors
+    ///
+    /// `E-QUAT-003` for any of the three.
+    pub fn from_rotation_matrix(m: &Matrix, pool: &ExprPool) -> Result<Self, QuaternionError> {
+        if m.rows != 3 || m.cols != 3 {
+            return Err(QuaternionError::NotARotation {
+                reason: format!("expected a 3×3 matrix, got {}×{}", m.rows, m.cols),
+            });
+        }
+        let mut r = [[0.0_f64; 3]; 3];
+        for (i, row) in r.iter_mut().enumerate() {
+            for (j, cell) in row.iter_mut().enumerate() {
+                let entry = m.get(i, j);
+                match eval_interp_checked(entry, &std::collections::HashMap::new(), pool) {
+                    Ok(v) if v.is_finite() => *cell = v,
+                    _ => {
+                        return Err(QuaternionError::NotARotation {
+                            reason: format!(
+                                "entry ({i},{j}) = `{}` is not a finite number; the branch \
+                                 selection is a comparison between entries and there is none \
+                                 to make on a symbol",
+                                pool.display(entry)
+                            ),
+                        })
+                    }
+                }
+            }
+        }
+        check_proper_rotation(&r)?;
+
+        let q = shepperd(&r);
+        // Rebuild and compare: the branch algebra is where this goes wrong.
+        let rebuilt = rotation_matrix_f64(&q);
+        let worst = (0..3)
+            .flat_map(|i| (0..3).map(move |j| (i, j)))
+            .map(|(i, j)| (rebuilt[i][j] - r[i][j]).abs())
+            .fold(0.0_f64, f64::max);
+        if worst > ROTATION_TOL {
+            return Err(QuaternionError::NotARotation {
+                reason: format!(
+                    "the recovered quaternion does not reproduce the matrix \
+                     (worst entry discrepancy {worst:.3e} > {ROTATION_TOL:.0e})"
+                ),
+            });
+        }
+
+        Ok(Quaternion {
+            w: pool.float(q[0], 53),
+            x: pool.float(q[1], 53),
+            y: pool.float(q[2], 53),
+            z: pool.float(q[3], 53),
+        })
+    }
+}
+
+fn check_proper_rotation(r: &[[f64; 3]; 3]) -> Result<(), QuaternionError> {
+    let mut worst = 0.0_f64;
+    for i in 0..3 {
+        for j in 0..3 {
+            let dot: f64 = (0..3).map(|k| r[k][i] * r[k][j]).sum();
+            let target = if i == j { 1.0 } else { 0.0 };
+            worst = worst.max((dot - target).abs());
+        }
+    }
+    if worst > ROTATION_TOL {
+        return Err(QuaternionError::NotARotation {
+            reason: format!(
+                "columns are not orthonormal: worst |RᵀR − I| entry is {worst:.3e} \
+                 (tolerance {ROTATION_TOL:.0e})"
+            ),
+        });
+    }
+    let det = r[0][0] * (r[1][1] * r[2][2] - r[1][2] * r[2][1])
+        - r[0][1] * (r[1][0] * r[2][2] - r[1][2] * r[2][0])
+        + r[0][2] * (r[1][0] * r[2][1] - r[1][1] * r[2][0]);
+    if (det - 1.0).abs() > ROTATION_TOL {
+        return Err(QuaternionError::NotARotation {
+            reason: format!(
+                "det R = {det:.6}, not +1; an orthogonal matrix with det = −1 is a \
+                 reflection and is not in the image of the quaternion rotation map"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Shepperd's branch-selecting matrix-to-quaternion conversion. Returns
+/// `[w, x, y, z]`.
+fn shepperd(r: &[[f64; 3]; 3]) -> [f64; 4] {
+    let trace = r[0][0] + r[1][1] + r[2][2];
+    if trace > 0.0 {
+        let s = (trace + 1.0).sqrt() * 2.0;
+        [
+            0.25 * s,
+            (r[2][1] - r[1][2]) / s,
+            (r[0][2] - r[2][0]) / s,
+            (r[1][0] - r[0][1]) / s,
+        ]
+    } else if r[0][0] > r[1][1] && r[0][0] > r[2][2] {
+        let s = (1.0 + r[0][0] - r[1][1] - r[2][2]).sqrt() * 2.0;
+        [
+            (r[2][1] - r[1][2]) / s,
+            0.25 * s,
+            (r[0][1] + r[1][0]) / s,
+            (r[0][2] + r[2][0]) / s,
+        ]
+    } else if r[1][1] > r[2][2] {
+        let s = (1.0 + r[1][1] - r[0][0] - r[2][2]).sqrt() * 2.0;
+        [
+            (r[0][2] - r[2][0]) / s,
+            (r[0][1] + r[1][0]) / s,
+            0.25 * s,
+            (r[1][2] + r[2][1]) / s,
+        ]
+    } else {
+        let s = (1.0 + r[2][2] - r[0][0] - r[1][1]).sqrt() * 2.0;
+        [
+            (r[1][0] - r[0][1]) / s,
+            (r[0][2] + r[2][0]) / s,
+            (r[1][2] + r[2][1]) / s,
+            0.25 * s,
+        ]
+    }
+}
+
+/// `R(q)` for a **unit** `q = [w, x, y, z]`, in `f64`. The `f64` mirror of
+/// [`Quaternion::to_rotation_matrix`], used to re-check
+/// [`Quaternion::from_rotation_matrix`]'s answer against its input.
+fn rotation_matrix_f64(q: &[f64; 4]) -> [[f64; 3]; 3] {
+    let [w, x, y, z] = *q;
+    let n2 = w * w + x * x + y * y + z * z;
+    let inv = 1.0 / n2;
+    [
+        [
+            (w * w + x * x - y * y - z * z) * inv,
+            2.0 * (x * y - w * z) * inv,
+            2.0 * (x * z + w * y) * inv,
+        ],
+        [
+            2.0 * (x * y + w * z) * inv,
+            (w * w - x * x + y * y - z * z) * inv,
+            2.0 * (y * z - w * x) * inv,
+        ],
+        [
+            2.0 * (x * z - w * y) * inv,
+            2.0 * (y * z + w * x) * inv,
+            (w * w - x * x - y * y + z * z) * inv,
+        ],
+    ]
+}

--- a/alkahest-core/src/algebra/quaternion_tests.rs
+++ b/alkahest-core/src/algebra/quaternion_tests.rs
@@ -1,0 +1,762 @@
+//! Quaternion tests: the algebra, the rotation operator, and the order.
+//!
+//! The rotation tests do not check `q v q⁻¹` against another quaternion
+//! routine — that would only prove this module is self-consistent. They check
+//! it against **Rodrigues' rotation formula**
+//! `v cos θ + (n̂ × v) sin θ + n̂ (n̂·v)(1 − cos θ)`, which is derived
+//! independently of quaternions, and against the rotation matrix this module
+//! builds by a separate formula.
+//!
+//! Composition order gets its own test that asserts both halves: that
+//! `R(q₁q₂) = R(q₁)R(q₂)` and that `R(q₁q₂) ≠ R(q₂)R(q₁)` for the sample
+//! rotations used. A convention error that reversed the order would satisfy
+//! the first only if both sides were reversed together, which the Rodrigues
+//! anchor rules out.
+
+use super::quaternion::{Quaternion, QuaternionError};
+use crate::errors::AlkahestError;
+use crate::jit::eval_interp_checked;
+use crate::kernel::{Domain, ExprId, ExprPool};
+use crate::matrix::Matrix;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed | 1)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn range(&mut self, lo: f64, hi: f64) -> f64 {
+        let u = (self.next_u64() >> 11) as f64 / (1_u64 << 53) as f64;
+        lo + (hi - lo) * u
+    }
+}
+
+fn num(e: ExprId, pool: &ExprPool) -> f64 {
+    eval_interp_checked(e, &HashMap::new(), pool)
+        .unwrap_or_else(|err| panic!("could not evaluate `{}`: {err:?}", pool.display(e)))
+}
+
+fn lit(v: f64, pool: &ExprPool) -> ExprId {
+    pool.float(v, 53)
+}
+
+fn qnum(c: [f64; 4], pool: &ExprPool) -> Quaternion {
+    Quaternion::new(
+        lit(c[0], pool),
+        lit(c[1], pool),
+        lit(c[2], pool),
+        lit(c[3], pool),
+    )
+}
+
+fn vnum(v: [f64; 3], pool: &ExprPool) -> [ExprId; 3] {
+    [lit(v[0], pool), lit(v[1], pool), lit(v[2], pool)]
+}
+
+fn qvals(q: &Quaternion, pool: &ExprPool) -> [f64; 4] {
+    let c = q.components();
+    [
+        num(c[0], pool),
+        num(c[1], pool),
+        num(c[2], pool),
+        num(c[3], pool),
+    ]
+}
+
+fn vvals(v: &[ExprId; 3], pool: &ExprPool) -> [f64; 3] {
+    [num(v[0], pool), num(v[1], pool), num(v[2], pool)]
+}
+
+fn mvals(m: &Matrix, pool: &ExprPool) -> [[f64; 3]; 3] {
+    let mut out = [[0.0; 3]; 3];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            *cell = num(m.get(i, j), pool);
+        }
+    }
+    out
+}
+
+#[track_caller]
+fn close(a: f64, b: f64, what: &str) {
+    let scale = 1.0_f64.max(a.abs()).max(b.abs());
+    assert!(
+        (a - b).abs() <= 1e-9 * scale,
+        "{what}: {a} vs {b} (gap {:.3e})",
+        (a - b).abs()
+    );
+}
+
+#[track_caller]
+fn close_v(a: [f64; 3], b: [f64; 3], what: &str) {
+    for i in 0..3 {
+        close(a[i], b[i], &format!("{what}[{i}]"));
+    }
+}
+
+/// Rodrigues' rotation formula — the independent oracle for `q v q⁻¹`.
+fn rodrigues(axis: [f64; 3], angle: f64, v: [f64; 3]) -> [f64; 3] {
+    let len = (axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]).sqrt();
+    let n = [axis[0] / len, axis[1] / len, axis[2] / len];
+    let (c, s) = (angle.cos(), angle.sin());
+    let cross = [
+        n[1] * v[2] - n[2] * v[1],
+        n[2] * v[0] - n[0] * v[2],
+        n[0] * v[1] - n[1] * v[0],
+    ];
+    let dot = n[0] * v[0] + n[1] * v[1] + n[2] * v[2];
+    [
+        v[0] * c + cross[0] * s + n[0] * dot * (1.0 - c),
+        v[1] * c + cross[1] * s + n[1] * dot * (1.0 - c),
+        v[2] * c + cross[2] * s + n[2] * dot * (1.0 - c),
+    ]
+}
+
+fn matvec(m: [[f64; 3]; 3], v: [f64; 3]) -> [f64; 3] {
+    [
+        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+    ]
+}
+
+/// A symbolic quaternion with four free real symbols.
+fn symbolic(prefix: &str, pool: &ExprPool) -> Quaternion {
+    Quaternion::new(
+        pool.symbol(format!("{prefix}w"), Domain::Real),
+        pool.symbol(format!("{prefix}x"), Domain::Real),
+        pool.symbol(format!("{prefix}y"), Domain::Real),
+        pool.symbol(format!("{prefix}z"), Domain::Real),
+    )
+}
+
+fn bind(q: &Quaternion, vals: [f64; 4], env: &mut HashMap<ExprId, f64>) {
+    for (id, v) in q.components().into_iter().zip(vals) {
+        env.insert(id, v);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The algebra
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_hamilton_product_table() {
+    let p = ExprPool::new();
+    let (o, l) = (p.integer(0_i32), p.integer(1_i32));
+    let neg = p.integer(-1_i32);
+    let one = Quaternion::new(l, o, o, o);
+    let i = Quaternion::new(o, l, o, o);
+    let j = Quaternion::new(o, o, l, o);
+    let k = Quaternion::new(o, o, o, l);
+    let minus_one = Quaternion::new(neg, o, o, o);
+    let minus = |q: &Quaternion| q.scale(neg, &p);
+
+    assert_eq!(i.mul(&j, &p), k, "ij = k");
+    assert_eq!(j.mul(&i, &p), minus(&k), "ji = -k");
+    assert_eq!(j.mul(&k, &p), i, "jk = i");
+    assert_eq!(k.mul(&j, &p), minus(&i), "kj = -i");
+    assert_eq!(k.mul(&i, &p), j, "ki = j");
+    assert_eq!(i.mul(&k, &p), minus(&j), "ik = -j");
+    assert_eq!(i.mul(&i, &p), minus_one, "i² = -1");
+    assert_eq!(j.mul(&j, &p), minus_one, "j² = -1");
+    assert_eq!(k.mul(&k, &p), minus_one, "k² = -1");
+    assert_eq!(
+        i.mul(&j, &p).mul(&k, &p),
+        minus_one,
+        "ijk = -1 (Hamilton's bridge relation)"
+    );
+    assert_eq!(one.mul(&i, &p), i, "1 is the identity");
+    assert_eq!(i.mul(&one, &p), i, "1 is the identity on the right too");
+}
+
+#[test]
+fn the_hamilton_product_does_not_commute() {
+    let p = ExprPool::new();
+    let a = symbolic("a", &p);
+    let b = symbolic("b", &p);
+    let ab = a.mul(&b, &p);
+    let ba = b.mul(&a, &p);
+    assert_ne!(
+        ab, ba,
+        "a general quaternion product must depend on the order of its factors"
+    );
+    // …and the difference is a real one, not a formatting artefact.
+    let mut rng = Rng::new(0x1D1D_1D1D);
+    let mut env = HashMap::new();
+    bind(
+        &a,
+        [
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+        ],
+        &mut env,
+    );
+    bind(
+        &b,
+        [
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+        ],
+        &mut env,
+    );
+    let differs = (0..4).any(|i| {
+        let l = eval_interp_checked(ab.components()[i], &env, &p).unwrap();
+        let r = eval_interp_checked(ba.components()[i], &env, &p).unwrap();
+        (l - r).abs() > 1e-9
+    });
+    assert!(differs, "ab and ba must differ numerically as well");
+}
+
+#[test]
+fn the_product_is_associative() {
+    let p = ExprPool::new();
+    let mut rng = Rng::new(0x0A55_0C1A);
+    for _ in 0..24 {
+        let mk = |rng: &mut Rng| {
+            qnum(
+                [
+                    rng.range(-2.0, 2.0),
+                    rng.range(-2.0, 2.0),
+                    rng.range(-2.0, 2.0),
+                    rng.range(-2.0, 2.0),
+                ],
+                &p,
+            )
+        };
+        let (a, b, c) = (mk(&mut rng), mk(&mut rng), mk(&mut rng));
+        let left = a.mul(&b, &p).mul(&c, &p);
+        let right = a.mul(&b.mul(&c, &p), &p);
+        let (lv, rv) = (qvals(&left, &p), qvals(&right, &p));
+        for i in 0..4 {
+            close(lv[i], rv[i], &format!("(ab)c vs a(bc), component {i}"));
+        }
+    }
+}
+
+#[test]
+fn the_norm_is_multiplicative() {
+    // |q₁q₂| = |q₁||q₂| — Euler's four-square identity. Checked symbolically
+    // first (the identity is polynomial, so the zero test can settle it) and
+    // then numerically at random points.
+    let p = ExprPool::new();
+    let a = symbolic("a", &p);
+    let b = symbolic("b", &p);
+    let lhs = a.mul(&b, &p).norm_squared(&p);
+    let rhs = p.mul(vec![a.norm_squared(&p), b.norm_squared(&p)]);
+    let residual = p.add(vec![lhs, p.mul(vec![p.integer(-1_i32), rhs])]);
+    assert_eq!(
+        crate::matrix::zero_test::zero_status(&p, residual),
+        crate::matrix::zero_test::ZeroStatus::Zero,
+        "|q₁q₂|² − |q₁|²|q₂|² must be provably zero"
+    );
+
+    let mut rng = Rng::new(0x4A4A_4A4A);
+    for _ in 0..24 {
+        let mk = |rng: &mut Rng| {
+            qnum(
+                [
+                    rng.range(-2.0, 2.0),
+                    rng.range(-2.0, 2.0),
+                    rng.range(-2.0, 2.0),
+                    rng.range(-2.0, 2.0),
+                ],
+                &p,
+            )
+        };
+        let (q1, q2) = (mk(&mut rng), mk(&mut rng));
+        let prod = num(q1.mul(&q2, &p).norm(&p), &p);
+        let separate = num(q1.norm(&p), &p) * num(q2.norm(&p), &p);
+        close(prod, separate, "|q₁q₂| = |q₁||q₂|");
+    }
+}
+
+#[test]
+fn a_quaternion_times_its_inverse_is_one() {
+    // For a *symbolic* `q` this is a rational-function identity: every
+    // component of `q q⁻¹` carries a `(w²+x²+y²+z²)⁻¹` factor that the
+    // simplifier does not cancel against the numerator, so the zero test
+    // returns `Unknown` rather than `Zero`. It is checked numerically at random
+    // points instead, on both sides, and exactly for a concrete quaternion.
+    let p = ExprPool::new();
+    let q = symbolic("q", &p);
+    let inv = q
+        .inverse(&p)
+        .expect("a symbolic quaternion has a generic inverse");
+    let one = [1.0, 0.0, 0.0, 0.0];
+    let mut rng = Rng::new(0x1111_0001);
+    for _ in 0..20 {
+        let mut env = HashMap::new();
+        bind(
+            &q,
+            [
+                rng.range(-2.0, 2.0),
+                rng.range(-2.0, 2.0),
+                rng.range(-2.0, 2.0),
+                rng.range(-2.0, 2.0),
+            ],
+            &mut env,
+        );
+        for (label, product) in [("q q⁻¹", q.mul(&inv, &p)), ("q⁻¹ q", inv.mul(&q, &p))] {
+            for (i, &c) in product.components().iter().enumerate() {
+                close(
+                    eval_interp_checked(c, &env, &p).unwrap(),
+                    one[i],
+                    &format!("{label} component {i}"),
+                );
+            }
+        }
+    }
+
+    // The concrete case closes exactly: 1 + i + j + k has |q|² = 4.
+    let l = p.integer(1_i32);
+    let qc = Quaternion::new(l, l, l, l);
+    let invc = qc.inverse(&p).unwrap();
+    assert_eq!(
+        qc.mul(&invc, &p),
+        Quaternion::identity(&p),
+        "(1+i+j+k)(1+i+j+k)⁻¹ must be exactly 1"
+    );
+    assert_eq!(
+        invc.mul(&qc, &p),
+        Quaternion::identity(&p),
+        "…from the left too"
+    );
+}
+
+#[test]
+fn conjugation_reverses_a_product() {
+    // conj(q₁q₂) = conj(q₂)·conj(q₁) — the order matters here too.
+    let p = ExprPool::new();
+    let a = symbolic("a", &p);
+    let b = symbolic("b", &p);
+    let lhs = a.mul(&b, &p).conjugate(&p);
+    let rhs = b.conjugate(&p).mul(&a.conjugate(&p), &p);
+    assert_eq!(lhs, rhs, "conj(ab) must equal conj(b)conj(a)");
+    let wrong = a.conjugate(&p).mul(&b.conjugate(&p), &p);
+    assert_ne!(
+        lhs, wrong,
+        "conj(a)conj(b) is the *other* order and must not coincide with it"
+    );
+}
+
+#[test]
+fn the_zero_quaternion_has_no_inverse() {
+    let p = ExprPool::new();
+    let zero = Quaternion::scalar(p.integer(0_i32), &p);
+    let err = zero.inverse(&p).expect_err("0 has no inverse");
+    assert_eq!(err.code(), "E-QUAT-001");
+    assert!(matches!(
+        err,
+        QuaternionError::ZeroNorm {
+            proven_zero: true,
+            ..
+        }
+    ));
+    assert!(zero.normalize(&p).is_err());
+    assert!(zero.to_rotation_matrix(&p).is_err());
+    let v = [p.integer(1_i32), p.integer(0_i32), p.integer(0_i32)];
+    assert!(zero.rotate(&v, &p).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Rotation
+// ---------------------------------------------------------------------------
+
+/// Random `(axis, angle, vector)` triples for the rotation tests.
+fn rotation_samples(n: usize, seed: u64) -> Vec<([f64; 3], f64, [f64; 3])> {
+    let mut rng = Rng::new(seed);
+    (0..n)
+        .map(|_| {
+            let axis = [
+                rng.range(-1.0, 1.0),
+                rng.range(-1.0, 1.0),
+                rng.range(-1.0, 1.0),
+            ];
+            // Keep the axis away from the origin so `axis/|axis|` is stable.
+            let axis = if axis.iter().map(|a| a * a).sum::<f64>() < 0.04 {
+                [0.31, -0.77, 0.55]
+            } else {
+                axis
+            };
+            let angle = rng.range(-3.0, 3.0);
+            let v = [
+                rng.range(-2.0, 2.0),
+                rng.range(-2.0, 2.0),
+                rng.range(-2.0, 2.0),
+            ];
+            (axis, angle, v)
+        })
+        .collect()
+}
+
+#[test]
+fn the_rotation_operator_agrees_with_rodrigues() {
+    let p = ExprPool::new();
+    for (axis, angle, v) in rotation_samples(40, 0x0D01_0D01) {
+        let q = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let got = vvals(&q.rotate(&vnum(v, &p), &p).unwrap(), &p);
+        close_v(got, rodrigues(axis, angle, v), "q v q⁻¹ vs Rodrigues");
+    }
+}
+
+#[test]
+fn the_rotation_matrix_agrees_with_the_rotation_operator() {
+    let p = ExprPool::new();
+    for (axis, angle, v) in rotation_samples(40, 0x51D2) {
+        let q = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let operator = vvals(&q.rotate(&vnum(v, &p), &p).unwrap(), &p);
+        let matrix = matvec(mvals(&q.to_rotation_matrix(&p).unwrap(), &p), v);
+        close_v(matrix, operator, "R(q)·v vs q v q⁻¹");
+        close_v(matrix, rodrigues(axis, angle, v), "R(q)·v vs Rodrigues");
+    }
+}
+
+#[test]
+fn the_rotation_matrix_of_a_non_unit_quaternion_is_still_a_rotation() {
+    // `q v q⁻¹` is invariant under `q ↦ λq`; so must `to_rotation_matrix` be,
+    // which is what the `1/|q|²` factor is for.
+    let p = ExprPool::new();
+    let mut rng = Rng::new(0x5CA1_AB1E);
+    for (axis, angle, v) in rotation_samples(20, 0x5CA2) {
+        let lambda = rng.range(0.3, 4.0);
+        let unit = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let scaled = unit.scale(lit(lambda, &p), &p);
+        close_v(
+            matvec(mvals(&scaled.to_rotation_matrix(&p).unwrap(), &p), v),
+            rodrigues(axis, angle, v),
+            "R(λq)·v",
+        );
+        close_v(
+            vvals(&scaled.rotate(&vnum(v, &p), &p).unwrap(), &p),
+            rodrigues(axis, angle, v),
+            "(λq) v (λq)⁻¹",
+        );
+    }
+}
+
+#[test]
+fn rotation_by_a_unit_quaternion_preserves_length() {
+    let p = ExprPool::new();
+    for (axis, angle, v) in rotation_samples(30, 0x1E47) {
+        let q = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let out = vvals(&q.rotate(&vnum(v, &p), &p).unwrap(), &p);
+        let before = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+        let after = (out[0] * out[0] + out[1] * out[1] + out[2] * out[2]).sqrt();
+        close(after, before, "|q v q⁻¹| = |v|");
+    }
+}
+
+#[test]
+fn a_rotation_about_z_is_right_handed() {
+    // The concrete orientation check: rotating x̂ by θ about ẑ must land on
+    // (cos θ, sin θ, 0), not (cos θ, −sin θ, 0). One sign, and every attitude
+    // derived from it, hangs on this.
+    let p = ExprPool::new();
+    let z = [p.integer(0_i32), p.integer(0_i32), p.integer(1_i32)];
+    let xhat = [p.integer(1_i32), p.integer(0_i32), p.integer(0_i32)];
+    for theta in [0.3_f64, 1.1, 2.4, -0.9] {
+        let q = Quaternion::from_axis_angle(&z, lit(theta, &p), &p).unwrap();
+        let out = vvals(&q.rotate(&xhat, &p).unwrap(), &p);
+        close_v(out, [theta.cos(), theta.sin(), 0.0], "R_z(θ)·x̂");
+    }
+}
+
+#[test]
+fn composition_multiplies_the_matrices_in_the_same_order() {
+    // The classic place to be silently wrong.
+    //
+    // `(q₁q₂) v (q₁q₂)⁻¹ = q₁ (q₂ v q₂⁻¹) q₁⁻¹`, so `q₂` acts first and
+    // `R(q₁q₂) = R(q₁)·R(q₂)`. Both halves are asserted: that the forward
+    // order agrees *and* that the reversed order does not, so a test that
+    // reversed both conventions at once could not pass.
+    let p = ExprPool::new();
+    let mut rng = Rng::new(0x0DE4_0DE4);
+    let mut reversed_disagreed = 0;
+    let samples = 25;
+    for _ in 0..samples {
+        let mk = |rng: &mut Rng| {
+            let axis = [
+                rng.range(-1.0, 1.0),
+                rng.range(-1.0, 1.0),
+                rng.range(-1.0, 1.0),
+            ];
+            let axis = if axis.iter().map(|a| a * a).sum::<f64>() < 0.04 {
+                [0.2, 0.9, -0.4]
+            } else {
+                axis
+            };
+            (axis, rng.range(-3.0, 3.0))
+        };
+        let (axis1, ang1) = mk(&mut rng);
+        let (axis2, ang2) = mk(&mut rng);
+        let v = [
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+            rng.range(-2.0, 2.0),
+        ];
+        let q1 = Quaternion::from_axis_angle(&vnum(axis1, &p), lit(ang1, &p), &p).unwrap();
+        let q2 = Quaternion::from_axis_angle(&vnum(axis2, &p), lit(ang2, &p), &p).unwrap();
+
+        let r1 = mvals(&q1.to_rotation_matrix(&p).unwrap(), &p);
+        let r2 = mvals(&q2.to_rotation_matrix(&p).unwrap(), &p);
+        let composed = mvals(&q1.mul(&q2, &p).to_rotation_matrix(&p).unwrap(), &p);
+
+        // R(q₁q₂)·v = R(q₁)·(R(q₂)·v): q₂ acts first.
+        close_v(
+            matvec(composed, v),
+            matvec(r1, matvec(r2, v)),
+            "R(q₁q₂)·v vs R(q₁)(R(q₂)v)",
+        );
+        // …and the same statement through the operator, with no matrix in it.
+        close_v(
+            vvals(&q1.mul(&q2, &p).rotate(&vnum(v, &p), &p).unwrap(), &p),
+            vvals(
+                &q1.rotate(&q2.rotate(&vnum(v, &p), &p).unwrap(), &p)
+                    .unwrap(),
+                &p,
+            ),
+            "(q₁q₂) v (q₁q₂)⁻¹ vs q₁(q₂ v q₂⁻¹)q₁⁻¹",
+        );
+
+        // The reversed order is a genuinely different rotation for
+        // non-parallel axes. Counted rather than asserted per sample, because
+        // two rotations about (nearly) the same axis do commute.
+        let other = matvec(r2, matvec(r1, v));
+        if (0..3).any(|i| (other[i] - matvec(composed, v)[i]).abs() > 1e-6) {
+            reversed_disagreed += 1;
+        }
+    }
+    assert!(
+        reversed_disagreed >= samples * 3 / 4,
+        "R(q₂)R(q₁) agreed with R(q₁q₂) in {} of {samples} samples — composition is \
+         being applied symmetrically, which means the order convention is not being \
+         tested at all",
+        samples - reversed_disagreed
+    );
+}
+
+#[test]
+fn q_and_minus_q_are_the_same_rotation() {
+    let p = ExprPool::new();
+    let neg = p.integer(-1_i32);
+    for (axis, angle, v) in rotation_samples(15, 0x5164) {
+        let q = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let minus_q = q.scale(neg, &p);
+        close_v(
+            vvals(&minus_q.rotate(&vnum(v, &p), &p).unwrap(), &p),
+            vvals(&q.rotate(&vnum(v, &p), &p).unwrap(), &p),
+            "(-q) v (-q)⁻¹ vs q v q⁻¹",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axis–angle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn axis_angle_round_trips() {
+    let p = ExprPool::new();
+    let mut rng = Rng::new(0xA713_A713);
+    for _ in 0..30 {
+        let axis = [
+            rng.range(-1.0, 1.0),
+            rng.range(-1.0, 1.0),
+            rng.range(-1.0, 1.0),
+        ];
+        let len = axis.iter().map(|a| a * a).sum::<f64>().sqrt();
+        if len < 0.2 {
+            continue;
+        }
+        let unit = [axis[0] / len, axis[1] / len, axis[2] / len];
+        // θ ∈ (0, π) is where (axis, angle) is unique.
+        let angle = rng.range(0.05, std::f64::consts::PI - 0.05);
+        let q = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let (got_axis, got_angle) = q.to_axis_angle(&p).unwrap();
+        close(num(got_angle, &p), angle, "recovered angle");
+        close_v(vvals(&got_axis, &p), unit, "recovered axis");
+    }
+}
+
+#[test]
+fn the_identity_rotation_has_no_axis() {
+    // The refusal. `q = 1` rotates nothing, so *every* unit vector is an axis
+    // for it and there is no axis to return. Returning the conventional
+    // (0, 0, 1) would be a stated answer to a question with no answer.
+    let p = ExprPool::new();
+    let err = Quaternion::identity(&p)
+        .to_axis_angle(&p)
+        .expect_err("the identity quaternion has no axis");
+    assert_eq!(err.code(), "E-QUAT-002");
+    assert!(matches!(err, QuaternionError::UndefinedAxis { .. }));
+
+    // …and so does −1, the other representative of the identity rotation
+    // (a rotation by 2π).
+    let minus_one = Quaternion::scalar(p.integer(-1_i32), &p);
+    assert_eq!(
+        minus_one.to_axis_angle(&p).unwrap_err().code(),
+        "E-QUAT-002"
+    );
+
+    // A real scalar multiple of 1 is the same story.
+    let three = Quaternion::scalar(p.integer(3_i32), &p);
+    assert_eq!(three.to_axis_angle(&p).unwrap_err().code(), "E-QUAT-002");
+}
+
+#[test]
+fn a_zero_axis_picks_out_no_rotation() {
+    let p = ExprPool::new();
+    let zero = [p.integer(0_i32); 3];
+    let err = Quaternion::from_axis_angle(&zero, p.rational(1, 2), &p)
+        .expect_err("the zero vector is not an axis");
+    assert_eq!(err.code(), "E-QUAT-001");
+}
+
+// ---------------------------------------------------------------------------
+// Matrix → quaternion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_rotation_matrix_round_trips_through_every_shepperd_branch() {
+    // The four branches are selected by which of `tr`, `R₀₀`, `R₁₁`, `R₂₂` is
+    // largest; a rotation by an angle near π about each axis in turn exercises
+    // all four. Random samples on top of that.
+    let p = ExprPool::new();
+    let mut cases: Vec<([f64; 3], f64)> = vec![
+        ([0.0, 0.0, 1.0], 0.2),                         // trace branch
+        ([1.0, 0.0, 0.0], std::f64::consts::PI - 0.02), // R₀₀ branch
+        ([0.0, 1.0, 0.0], std::f64::consts::PI - 0.02), // R₁₁ branch
+        ([0.0, 0.0, 1.0], std::f64::consts::PI - 0.02), // R₂₂ branch
+    ];
+    cases.extend(
+        rotation_samples(25, 0x5E79_5E79)
+            .into_iter()
+            .map(|(a, t, _)| (a, t)),
+    );
+
+    for (axis, angle) in cases {
+        let q = Quaternion::from_axis_angle(&vnum(axis, &p), lit(angle, &p), &p).unwrap();
+        let r = q.to_rotation_matrix(&p).unwrap();
+        let recovered = Quaternion::from_rotation_matrix(&r, &p).unwrap();
+
+        // The quaternion is recovered up to sign …
+        let (a, b) = (qvals(&q, &p), qvals(&recovered, &p));
+        let same = (0..4).all(|i| (a[i] - b[i]).abs() < 1e-8);
+        let negated = (0..4).all(|i| (a[i] + b[i]).abs() < 1e-8);
+        assert!(
+            same || negated,
+            "recovered quaternion {b:?} is neither q {a:?} nor −q"
+        );
+        // … and the matrix is reproduced exactly.
+        let r2 = mvals(&recovered.to_rotation_matrix(&p).unwrap(), &p);
+        let r1 = mvals(&r, &p);
+        for i in 0..3 {
+            close_v(r2[i], r1[i], &format!("R(q(R)) row {i}"));
+        }
+    }
+}
+
+#[test]
+fn from_rotation_matrix_refuses_what_is_not_a_rotation() {
+    let p = ExprPool::new();
+    let f = |v: f64| lit(v, &p);
+
+    // Not 3×3.
+    let small = Matrix::new(vec![vec![f(1.0), f(0.0)], vec![f(0.0), f(1.0)]]).unwrap();
+    assert_eq!(
+        Quaternion::from_rotation_matrix(&small, &p)
+            .unwrap_err()
+            .code(),
+        "E-QUAT-003"
+    );
+
+    // Symbolic entries: the branch selection is a comparison and there is none
+    // to make. Note the matrix *is* a rotation for every real θ — refusing is
+    // a capability limit stated honestly, not a claim that it is not one.
+    let th = p.symbol("theta", Domain::Real);
+    let (c, s) = (p.func("cos", vec![th]), p.func("sin", vec![th]));
+    let neg_s = p.mul(vec![p.integer(-1_i32), s]);
+    let (z, o) = (p.integer(0_i32), p.integer(1_i32));
+    let sym = Matrix::new(vec![vec![c, neg_s, z], vec![s, c, z], vec![z, z, o]]).unwrap();
+    let err = Quaternion::from_rotation_matrix(&sym, &p).unwrap_err();
+    assert_eq!(err.code(), "E-QUAT-003");
+    assert!(
+        err.to_string().contains("not a finite number"),
+        "the message must say *why* it refused: {err}"
+    );
+
+    // A reflection: orthogonal, det = −1. No quaternion represents it.
+    let reflection = Matrix::new(vec![
+        vec![f(1.0), f(0.0), f(0.0)],
+        vec![f(0.0), f(1.0), f(0.0)],
+        vec![f(0.0), f(0.0), f(-1.0)],
+    ])
+    .unwrap();
+    let err = Quaternion::from_rotation_matrix(&reflection, &p).unwrap_err();
+    assert_eq!(err.code(), "E-QUAT-003");
+    assert!(
+        err.to_string().contains("det"),
+        "must name the determinant: {err}"
+    );
+
+    // A scaled rotation: `2·I` is not orthogonal. Shepperd would happily return
+    // a unit quaternion for it.
+    let scaled = Matrix::new(vec![
+        vec![f(2.0), f(0.0), f(0.0)],
+        vec![f(0.0), f(2.0), f(0.0)],
+        vec![f(0.0), f(0.0), f(2.0)],
+    ])
+    .unwrap();
+    assert_eq!(
+        Quaternion::from_rotation_matrix(&scaled, &p)
+            .unwrap_err()
+            .code(),
+        "E-QUAT-003"
+    );
+
+    // A shear that is close to a rotation but is not one.
+    let shear = Matrix::new(vec![
+        vec![f(1.0), f(1e-3), f(0.0)],
+        vec![f(0.0), f(1.0), f(0.0)],
+        vec![f(0.0), f(0.0), f(1.0)],
+    ])
+    .unwrap();
+    assert_eq!(
+        Quaternion::from_rotation_matrix(&shear, &p)
+            .unwrap_err()
+            .code(),
+        "E-QUAT-003"
+    );
+}
+
+#[test]
+fn the_identity_matrix_maps_to_the_identity_quaternion() {
+    let p = ExprPool::new();
+    let identity = Matrix::identity(3, &p);
+    let q = Quaternion::from_rotation_matrix(&identity, &p).unwrap();
+    let v = qvals(&q, &p);
+    close(v[0].abs(), 1.0, "|w| of the identity rotation");
+    for c in &v[1..] {
+        close(*c, 0.0, "vector part of the identity rotation");
+    }
+}

--- a/alkahest-core/src/errors/codes.rs
+++ b/alkahest-core/src/errors/codes.rs
@@ -408,6 +408,22 @@ pub const REGISTRY: &[ErrorSpec] = &[
     ErrorSpec { code: "E-VALIDATED-003", class: "ValidatedError", cause: Cause::Domain, remediation: None },
     ErrorSpec { code: "E-VALIDATED-004", class: "ValidatedError", cause: Cause::Domain, remediation: None },
     ErrorSpec { code: "E-VALIDATED-005", class: "ValidatedError", cause: Cause::UserInput, remediation: None },
+    // E-VEC — VectorError (vector calculus over orthogonal curvilinear charts)
+    ErrorSpec { code: "E-VEC-001", class: "VectorError", cause: Cause::Unsupported, remediation: Some("the field contains a function with no differentiation rule; register it in PrimitiveRegistry or rewrite the component") },
+    ErrorSpec { code: "E-VEC-002", class: "VectorError", cause: Cause::UserInput,   remediation: Some("pass three distinct coordinate symbols, e.g. Coordinates::cylindrical(rho, phi, z)") },
+    ErrorSpec { code: "E-VEC-003", class: "VectorError", cause: Cause::UserInput,   remediation: Some("build each coordinate with `pool.symbol(..)` before constructing Coordinates") },
+    // Every grad/div/curl/laplacian formula in `vector` assumes the chart is
+    // orthogonal.  On a skew chart they still evaluate — to a number that looks
+    // like a divergence and is not one — so an *undecided* inner product is a
+    // refusal rather than an assumption.
+    ErrorSpec { code: "E-VEC-004", class: "VectorError", cause: Cause::Domain,      remediation: Some("these formulas hold only for orthogonal charts; supply an orthogonal embedding, or work in Cartesian coordinates and transform the result by hand") },
+    ErrorSpec { code: "E-VEC-005", class: "VectorError", cause: Cause::Domain,      remediation: Some("restrict the chart to a region where the scale factor is non-zero, or re-parametrise; a chart that collapses a direction has no unique orthonormal frame there") },
+    // E-QUAT — QuaternionError (Hamilton quaternions and the rotation operator)
+    ErrorSpec { code: "E-QUAT-001", class: "QuaternionError", cause: Cause::Domain,    remediation: Some("use a non-zero quaternion; if the components are symbolic, substitute concrete values or declare the parameters so the norm can be decided") },
+    // The identity rotation has no axis — *every* unit vector is one.  Returning
+    // the conventional (0,0,1) is a stated answer to a question with no answer.
+    ErrorSpec { code: "E-QUAT-002", class: "QuaternionError", cause: Cause::Domain,    remediation: Some("the rotation is the identity — report the angle as 0 and pick whatever axis your convention prefers, explicitly, at the call site") },
+    ErrorSpec { code: "E-QUAT-003", class: "QuaternionError", cause: Cause::UserInput, remediation: Some("pass a 3×3 matrix of numbers with RᵀR = I and det R = +1; a reflection (det = −1) is not a rotation and has no quaternion") },
 ];
 
 #[cfg(test)]

--- a/alkahest-core/src/lib.rs
+++ b/alkahest-core/src/lib.rs
@@ -57,6 +57,8 @@ pub mod sum;
 pub mod transform;
 // P1 item 9 — rigorous global bounds (Taylor models / validated numerics)
 pub mod validated;
+// Vector calculus over orthogonal curvilinear coordinates (grad/div/curl/laplacian)
+pub mod vector;
 // Plot — dependency-free SVG / DOT renderers
 pub mod plot;
 
@@ -361,6 +363,9 @@ pub mod stable {
 /// on it.
 pub mod experimental {
     pub use crate::acausal::{capacitor, resistor, voltage_source, Component, Port, System};
+    /// Hamilton quaternions and the active rotation operator `q v q⁻¹`, with
+    /// conversions to and from a rotation matrix and axis–angle form.
+    pub use crate::algebra::quaternion::{Quaternion, QuaternionError};
     pub use crate::ball::{AcbBall, ArbBall, IntervalEval};
     pub use crate::calculus::asymptotic::{
         asymptotic_expand, AsymptoticError, AsymptoticExpansion, AsymptoticTerm,
@@ -447,6 +452,15 @@ pub mod experimental {
         inverse_z_transform, inverse_z_transform_with_assumptions,
         inverse_z_transform_with_conditions, take_transform_side_conditions, z_shift_advance,
         z_shift_delay, z_transform, ZTransformError,
+    };
+    /// Vector calculus over orthogonal curvilinear coordinates: `grad`, `div`,
+    /// `curl`, the scalar and vector Laplacian, and the vector algebra they
+    /// are used with. Cartesian, cylindrical and spherical charts are built
+    /// in; `Coordinates::from_embedding` derives one from its Cartesian
+    /// parametrisation and checks orthogonality before returning it.
+    pub use crate::vector::{
+        cross, curl, divergence, dot, gradient, laplacian, norm, norm_squared, vector_laplacian,
+        Coordinates, VectorError,
     };
     // ℚ(params) partial fractions: the in-band and out-of-band forms of the
     // hypotheses a parametric decomposition rests on.

--- a/alkahest-core/src/vector/coords.rs
+++ b/alkahest-core/src/vector/coords.rs
@@ -1,0 +1,240 @@
+//! Orthogonal coordinate systems, described by their scale factors.
+//!
+//! An orthogonal chart `u ↦ r(u)` is fully characterised, for the purposes of
+//! `grad`/`div`/`curl`/`∇²`, by the three **scale factors** (Lamé
+//! coefficients)
+//!
+//! ```text
+//! hᵢ = |∂r/∂uᵢ|
+//! ```
+//!
+//! together with the fact that the tangent vectors `∂r/∂uᵢ` are mutually
+//! orthogonal. Nothing else about the embedding enters the formulas. So this
+//! type stores exactly that: three coordinate symbols and three scale factors.
+
+use super::VectorError;
+use crate::diff::diff;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::matrix::zero_test::{zero_status, ZeroStatus};
+use crate::simplify::engine::simplify;
+
+/// An orthogonal coordinate system: three coordinate symbols and their scale
+/// factors.
+///
+/// Build one with [`Coordinates::cartesian`], [`Coordinates::cylindrical`],
+/// [`Coordinates::spherical`] or [`Coordinates::from_embedding`]. There is no
+/// public field and no public constructor that takes scale factors directly:
+/// the three built-in charts carry textbook values, and anything else has to
+/// come from an embedding whose orthogonality was checked.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Coordinates {
+    vars: [ExprId; 3],
+    scale: [ExprId; 3],
+    label: String,
+}
+
+fn validate_vars(vars: &[ExprId; 3], pool: &ExprPool) -> Result<(), VectorError> {
+    for (i, &v) in vars.iter().enumerate() {
+        let is_symbol = pool.with(v, |d| matches!(d, ExprData::Symbol { .. }));
+        if !is_symbol {
+            return Err(VectorError::NotACoordinateSymbol {
+                got: pool.display(v).to_string(),
+            });
+        }
+        for &w in &vars[..i] {
+            if v == w {
+                return Err(VectorError::RepeatedCoordinate {
+                    coordinate: pool.display(v).to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+impl Coordinates {
+    /// Cartesian `(x, y, z)` — scale factors `(1, 1, 1)`.
+    ///
+    /// # Errors
+    ///
+    /// `E-VEC-002` / `E-VEC-003` if the three arguments are not distinct
+    /// symbols.
+    pub fn cartesian(
+        x: ExprId,
+        y: ExprId,
+        z: ExprId,
+        pool: &ExprPool,
+    ) -> Result<Self, VectorError> {
+        let vars = [x, y, z];
+        validate_vars(&vars, pool)?;
+        let one = pool.integer(1_i32);
+        Ok(Coordinates {
+            vars,
+            scale: [one; 3],
+            label: "cartesian".to_string(),
+        })
+    }
+
+    /// Cylindrical `(ρ, φ, z)` — scale factors `(1, ρ, 1)`.
+    ///
+    /// `x = ρ cos φ`, `y = ρ sin φ`, `z = z`. Right-handed in this order.
+    ///
+    /// # Errors
+    ///
+    /// `E-VEC-002` / `E-VEC-003` if the three arguments are not distinct
+    /// symbols.
+    pub fn cylindrical(
+        rho: ExprId,
+        phi: ExprId,
+        z: ExprId,
+        pool: &ExprPool,
+    ) -> Result<Self, VectorError> {
+        let vars = [rho, phi, z];
+        validate_vars(&vars, pool)?;
+        let one = pool.integer(1_i32);
+        Ok(Coordinates {
+            vars,
+            scale: [one, rho, one],
+            label: "cylindrical".to_string(),
+        })
+    }
+
+    /// Spherical `(r, θ, φ)` — scale factors `(1, r, r sin θ)`.
+    ///
+    /// The **physics / ISO 80000-2** convention: `θ` is the polar angle
+    /// measured from the `+z` axis and `φ` the azimuth, so
+    /// `x = r sin θ cos φ`, `y = r sin θ sin φ`, `z = r cos θ`. Right-handed in
+    /// the order `(r, θ, φ)`.
+    ///
+    /// If you want the other convention swap the two angles *and* remember
+    /// that `(r, φ, θ)` is then left-handed, which flips the sign of every
+    /// `curl` component.
+    ///
+    /// # Errors
+    ///
+    /// `E-VEC-002` / `E-VEC-003` if the three arguments are not distinct
+    /// symbols.
+    pub fn spherical(
+        r: ExprId,
+        theta: ExprId,
+        phi: ExprId,
+        pool: &ExprPool,
+    ) -> Result<Self, VectorError> {
+        let vars = [r, theta, phi];
+        validate_vars(&vars, pool)?;
+        let one = pool.integer(1_i32);
+        let sin_theta = pool.func("sin", vec![theta]);
+        let r_sin_theta = pool.mul(vec![r, sin_theta]);
+        Ok(Coordinates {
+            vars,
+            scale: [one, r, r_sin_theta],
+            label: "spherical".to_string(),
+        })
+    }
+
+    /// Derive a chart from its Cartesian embedding `(x(u), y(u), z(u))`,
+    /// **verifying orthogonality** before returning it.
+    ///
+    /// `hᵢ = |∂r/∂uᵢ|`, and the pair `(i, j)` is accepted only when
+    /// `∂r/∂uᵢ · ∂r/∂u_j` is *proven* to vanish — an undecided inner product is
+    /// a refusal (`E-VEC-004`), not an assumption. Every formula in this
+    /// module is false for a skew chart, and false in a way that produces a
+    /// perfectly ordinary-looking expression.
+    ///
+    /// A scale factor that is identically zero, or whose non-vanishing could
+    /// not be established, is `E-VEC-005`: the operators all divide by it.
+    ///
+    /// # Errors
+    ///
+    /// `E-VEC-001` (a component of the embedding is not differentiable),
+    /// `E-VEC-002`/`E-VEC-003` (bad coordinates), `E-VEC-004` (not
+    /// orthogonal), `E-VEC-005` (degenerate scale factor).
+    pub fn from_embedding(
+        vars: [ExprId; 3],
+        embedding: [ExprId; 3],
+        label: impl Into<String>,
+        pool: &ExprPool,
+    ) -> Result<Self, VectorError> {
+        validate_vars(&vars, pool)?;
+
+        // Tangent vectors ∂r/∂uᵢ.
+        let mut tangent = [[embedding[0]; 3]; 3];
+        for (i, &u) in vars.iter().enumerate() {
+            for (k, &component) in embedding.iter().enumerate() {
+                let partial = diff(component, u, pool)
+                    .map_err(|e| VectorError::Differentiation(e.to_string()))?
+                    .value;
+                tangent[i][k] = simplify(partial, pool).value;
+            }
+        }
+
+        // Orthogonality: every off-diagonal inner product must be *proven* zero.
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                let inner = super::dot(&tangent[i], &tangent[j], pool);
+                let status = zero_status(pool, inner);
+                if status != ZeroStatus::Zero {
+                    return Err(VectorError::NonOrthogonal {
+                        pair: (i, j),
+                        inner_product: pool.display(inner).to_string(),
+                    });
+                }
+            }
+        }
+
+        // Scale factors, and the division-by-zero guard.
+        let mut scale = [embedding[0]; 3];
+        for i in 0..3 {
+            let h_sq = super::norm_squared(&tangent[i], pool);
+            let status = zero_status(pool, h_sq);
+            if status != ZeroStatus::NonZero {
+                let h = simplify(pool.func("sqrt", vec![h_sq]), pool).value;
+                return Err(VectorError::DegenerateScaleFactor {
+                    index: i,
+                    scale_factor: pool.display(h).to_string(),
+                    proven_zero: status == ZeroStatus::Zero,
+                });
+            }
+            scale[i] = simplify(pool.func("sqrt", vec![h_sq]), pool).value;
+        }
+
+        Ok(Coordinates {
+            vars,
+            scale,
+            label: label.into(),
+        })
+    }
+
+    /// The three coordinate symbols, in the order the constructor took them.
+    pub fn vars(&self) -> [ExprId; 3] {
+        self.vars
+    }
+
+    /// The three scale factors `(h₁, h₂, h₃)`.
+    pub fn scale_factors(&self) -> [ExprId; 3] {
+        self.scale
+    }
+
+    /// A human-readable name for the chart, for diagnostics only.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// `H = h₁h₂h₃`, the volume element's Jacobian factor, simplified.
+    pub fn jacobian_factor(&self, pool: &ExprPool) -> ExprId {
+        simplify(pool.mul(self.scale.to_vec()), pool).value
+    }
+
+    /// True when every scale factor is the literal `1`.
+    ///
+    /// An orthogonal chart with `h = (1, 1, 1)` has the constant metric `δᵢⱼ`,
+    /// so its frame is parallel-transported and the componentwise scalar
+    /// Laplacian *is* the vector Laplacian. That is the property
+    /// [`super::vector_laplacian`] branches on, so it is derived from the
+    /// scale factors rather than from a flag set at construction time.
+    pub fn is_cartesian(&self, pool: &ExprPool) -> bool {
+        self.scale
+            .iter()
+            .all(|&h| pool.with(h, |d| matches!(d, ExprData::Integer(n) if n.0 == 1)))
+    }
+}

--- a/alkahest-core/src/vector/mod.rs
+++ b/alkahest-core/src/vector/mod.rs
@@ -1,0 +1,418 @@
+//! Vector calculus over orthogonal curvilinear coordinates.
+//!
+//! `grad`, `div`, `curl` and `∇²` for a scalar or vector field written in an
+//! orthogonal coordinate system, plus the vector algebra
+//! ([`dot`], [`cross`], [`norm`]) the differential operators are usually
+//! combined with. Cartesian, cylindrical and spherical systems are built in;
+//! [`Coordinates::from_embedding`] derives a new one from its Cartesian
+//! parametrisation and **checks that it is orthogonal** before returning it.
+//!
+//! # Components are *physical* components
+//!
+//! A vector field is a `[ExprId; 3]` read in the local **orthonormal** frame
+//! `(ê₁, ê₂, ê₃)`, i.e. `F = F₁ê₁ + F₂ê₂ + F₃ê₃` with `|êᵢ| = 1`. This is the
+//! engineering convention and the one `sympy.vector` uses; it is *not* the
+//! contravariant-component convention, where the basis vectors carry the scale
+//! factors. Getting this wrong is a factor of `hᵢ` per component, so it is
+//! stated here rather than left to be inferred.
+//!
+//! # The formulas
+//!
+//! With scale factors `h = (h₁, h₂, h₃)` and `H = h₁h₂h₃`:
+//!
+//! ```text
+//! (∇f)ᵢ     = (1/hᵢ) ∂f/∂uᵢ
+//! ∇·F       = (1/H) Σᵢ ∂/∂uᵢ ( (H/hᵢ) Fᵢ )
+//! (∇×F)ᵢ    = (1/(h_j h_k)) [ ∂(h_k F_k)/∂u_j − ∂(h_j F_j)/∂u_k ],  (i,j,k) cyclic
+//! ∇²f       = (1/H) Σᵢ ∂/∂uᵢ ( (H/hᵢ²) ∂f/∂uᵢ )
+//! ```
+//!
+//! (Morse & Feshbach, *Methods of Theoretical Physics* I §1.3; Arfken & Weber,
+//! *Mathematical Methods for Physicists* 7th ed. §3.10.)
+//!
+//! The **vector** Laplacian is `∇²F ≔ ∇(∇·F) − ∇×(∇×F)`
+//! ([`vector_laplacian`]). In Cartesian coordinates that equals the
+//! componentwise scalar Laplacian and is computed that way; in every other
+//! system it does **not**, and applying the scalar Laplacian to each physical
+//! component is a classic silent error this module declines to make.
+//!
+//! # What is not checked
+//!
+//! Scale factors say nothing about where a chart is *singular*. `∇×F` in
+//! spherical coordinates divides by `r sin θ`, which vanishes on the polar
+//! axis; the returned expression is the correct one everywhere the chart is
+//! regular and is undefined (`E-EVAL-009` from `eval_expr`) on the axis, the
+//! same way `1/x` is undefined at `0`. No pointwise domain condition is
+//! attached.
+
+use crate::diff::diff;
+use crate::kernel::{ExprData, ExprId, ExprPool};
+use crate::simplify::engine::simplify;
+use std::fmt;
+
+mod coords;
+#[cfg(test)]
+mod tests;
+
+pub use coords::Coordinates;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Why a vector-calculus request could not be answered.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VectorError {
+    /// A component could not be differentiated with respect to a coordinate.
+    Differentiation(String),
+    /// Two of the three coordinates are the same expression.
+    ///
+    /// `∂/∂u₁` and `∂/∂u₂` would then be the same operator, which turns `curl`
+    /// into the zero field and `div` into a sum of the wrong partials — a
+    /// clean, plausible, wrong answer.
+    RepeatedCoordinate {
+        /// Rendered form of the coordinate that appears twice.
+        coordinate: String,
+    },
+    /// A coordinate is not a symbol, so it cannot be differentiated against.
+    NotACoordinateSymbol {
+        /// Rendered form of the offending entry.
+        got: String,
+    },
+    /// The supplied embedding is not an orthogonal coordinate system: two
+    /// tangent vectors `∂r/∂uᵢ`, `∂r/∂u_j` have a dot product that was not
+    /// shown to vanish.
+    ///
+    /// Every formula in this module assumes orthogonality. Applying them to a
+    /// skew chart returns numbers that look like a divergence and are not one.
+    NonOrthogonal {
+        /// The two coordinate indices (0-based) whose tangents are not
+        /// orthogonal.
+        pair: (usize, usize),
+        /// Rendered form of the non-vanishing inner product.
+        inner_product: String,
+    },
+    /// A scale factor `hᵢ` is identically zero, or could not be shown to be
+    /// non-zero. Every operator divides by it.
+    DegenerateScaleFactor {
+        /// Which scale factor (0-based).
+        index: usize,
+        /// Rendered form of the scale factor.
+        scale_factor: String,
+        /// `true` when `hᵢ` was *proven* zero, `false` when the vanishing
+        /// question could not be settled either way.
+        proven_zero: bool,
+    },
+}
+
+impl fmt::Display for VectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VectorError::Differentiation(msg) => {
+                write!(f, "could not differentiate a field component: {msg}")
+            }
+            VectorError::RepeatedCoordinate { coordinate } => write!(
+                f,
+                "coordinate `{coordinate}` appears twice; the three coordinates must be distinct symbols"
+            ),
+            VectorError::NotACoordinateSymbol { got } => write!(
+                f,
+                "`{got}` is not a symbol and cannot be used as a coordinate"
+            ),
+            VectorError::NonOrthogonal {
+                pair,
+                inner_product,
+            } => write!(
+                f,
+                "the embedding is not orthogonal: tangent vectors {} and {} have inner product `{inner_product}`, which was not shown to vanish",
+                pair.0, pair.1
+            ),
+            VectorError::DegenerateScaleFactor {
+                index,
+                scale_factor,
+                proven_zero,
+            } => {
+                if *proven_zero {
+                    write!(
+                        f,
+                        "scale factor h{} = `{scale_factor}` is identically zero; the chart is degenerate",
+                        index + 1
+                    )
+                } else {
+                    write!(
+                        f,
+                        "scale factor h{} = `{scale_factor}` could not be shown to be non-zero, and every operator divides by it",
+                        index + 1
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for VectorError {}
+
+impl crate::errors::AlkahestError for VectorError {
+    fn code(&self) -> &'static str {
+        match self {
+            VectorError::Differentiation(_) => "E-VEC-001",
+            VectorError::RepeatedCoordinate { .. } => "E-VEC-002",
+            VectorError::NotACoordinateSymbol { .. } => "E-VEC-003",
+            VectorError::NonOrthogonal { .. } => "E-VEC-004",
+            VectorError::DegenerateScaleFactor { .. } => "E-VEC-005",
+        }
+    }
+
+    fn remediation(&self) -> Option<&'static str> {
+        match self {
+            VectorError::Differentiation(_) => Some(
+                "the field contains a function with no differentiation rule; register it in PrimitiveRegistry or rewrite the component",
+            ),
+            VectorError::RepeatedCoordinate { .. } => Some(
+                "pass three distinct coordinate symbols, e.g. Coordinates::cylindrical(rho, phi, z)",
+            ),
+            VectorError::NotACoordinateSymbol { .. } => {
+                Some("build each coordinate with `pool.symbol(..)` before constructing Coordinates")
+            }
+            VectorError::NonOrthogonal { .. } => Some(
+                "these formulas hold only for orthogonal charts; supply an orthogonal embedding, or work in Cartesian coordinates and transform the result by hand",
+            ),
+            VectorError::DegenerateScaleFactor { .. } => Some(
+                "restrict the chart to a region where the scale factor is non-zero, or re-parametrise; a chart that collapses a direction has no unique orthonormal frame there",
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vector algebra
+// ---------------------------------------------------------------------------
+
+/// `a · b` in an orthonormal frame: `Σ aᵢ bᵢ`, simplified.
+///
+/// Valid in any orthogonal coordinate system *because* the components are
+/// physical (see the module docs): the metric is the identity in the
+/// orthonormal frame.
+pub fn dot(a: &[ExprId; 3], b: &[ExprId; 3], pool: &ExprPool) -> ExprId {
+    let terms: Vec<ExprId> = (0..3).map(|i| pool.mul(vec![a[i], b[i]])).collect();
+    simplify(pool.add(terms), pool).value
+}
+
+/// `a × b` in a **right-handed** orthonormal frame, simplified.
+///
+/// `(ê₁, ê₂, ê₃)` is assumed right-handed, which is what makes
+/// `ê₁ × ê₂ = ê₃`. All three built-in charts are right-handed in the order
+/// their constructors take: `(x, y, z)`, `(ρ, φ, z)` and `(r, θ, φ)`.
+pub fn cross(a: &[ExprId; 3], b: &[ExprId; 3], pool: &ExprPool) -> [ExprId; 3] {
+    let neg = pool.integer(-1_i32);
+    let mut out = [a[0]; 3];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let (j, k) = ((i + 1) % 3, (i + 2) % 3);
+        let plus = pool.mul(vec![a[j], b[k]]);
+        let minus = pool.mul(vec![neg, a[k], b[j]]);
+        *slot = simplify(pool.add(vec![plus, minus]), pool).value;
+    }
+    out
+}
+
+/// `|a|² = a · a`, simplified.
+pub fn norm_squared(a: &[ExprId; 3], pool: &ExprPool) -> ExprId {
+    dot(a, a, pool)
+}
+
+/// `|a| = √(a · a)`, simplified.
+///
+/// The principal (non-negative) square root, which is the length only when the
+/// components are real. For complex components this is `√(Σ aᵢ²)`, not the
+/// Hermitian norm `√(Σ |aᵢ|²)`.
+pub fn norm(a: &[ExprId; 3], pool: &ExprPool) -> ExprId {
+    let sq = norm_squared(a, pool);
+    simplify(pool.func("sqrt", vec![sq]), pool).value
+}
+
+/// `s · a`, simplified componentwise.
+pub fn scale(s: ExprId, a: &[ExprId; 3], pool: &ExprPool) -> [ExprId; 3] {
+    let mut out = [a[0]; 3];
+    for i in 0..3 {
+        out[i] = simplify(pool.mul(vec![s, a[i]]), pool).value;
+    }
+    out
+}
+
+/// `a + b`, simplified componentwise.
+pub fn add(a: &[ExprId; 3], b: &[ExprId; 3], pool: &ExprPool) -> [ExprId; 3] {
+    let mut out = [a[0]; 3];
+    for i in 0..3 {
+        out[i] = simplify(pool.add(vec![a[i], b[i]]), pool).value;
+    }
+    out
+}
+
+/// `a − b`, simplified componentwise.
+pub fn sub(a: &[ExprId; 3], b: &[ExprId; 3], pool: &ExprPool) -> [ExprId; 3] {
+    let neg = pool.integer(-1_i32);
+    let mut out = [a[0]; 3];
+    for i in 0..3 {
+        let nb = pool.mul(vec![neg, b[i]]);
+        out[i] = simplify(pool.add(vec![a[i], nb]), pool).value;
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Differential operators
+// ---------------------------------------------------------------------------
+
+fn d(expr: ExprId, var: ExprId, pool: &ExprPool) -> Result<ExprId, VectorError> {
+    diff(expr, var, pool)
+        .map(|r| r.value)
+        .map_err(|e| VectorError::Differentiation(e.to_string()))
+}
+
+/// True for the interned literal `1`, which lets the Cartesian path skip a
+/// pointless `1⁻¹ ·` wrapper on every component.
+fn is_one(id: ExprId, pool: &ExprPool) -> bool {
+    pool.with(id, |data| matches!(data, ExprData::Integer(n) if n.0 == 1))
+}
+
+fn divide(num: ExprId, den: ExprId, pool: &ExprPool) -> ExprId {
+    if is_one(den, pool) {
+        return num;
+    }
+    let inv = pool.pow(den, pool.integer(-1_i32));
+    pool.mul(vec![inv, num])
+}
+
+fn times(a: ExprId, b: ExprId, pool: &ExprPool) -> ExprId {
+    if is_one(a, pool) {
+        return b;
+    }
+    if is_one(b, pool) {
+        return a;
+    }
+    pool.mul(vec![a, b])
+}
+
+/// `num/den`, normalised before anything differentiates it.
+///
+/// The weights these operators build are ratios of scale factors, and they
+/// cancel more often than not: `H/h₂` is `ρ·ρ⁻¹ = 1` for the azimuthal index of
+/// a cylindrical chart. Differentiating the un-cancelled form is correct but
+/// fires the product rule on two factors that annihilate, and the debris
+/// survives into the returned expression even after the final `simplify`. This
+/// is a readability and cost measure only — every result is the same function
+/// either way, which is what the textbook-form tests check.
+fn weight(num: ExprId, den: ExprId, pool: &ExprPool) -> ExprId {
+    if is_one(den, pool) {
+        return num;
+    }
+    simplify(divide(num, den, pool), pool).value
+}
+
+/// `∇f` — the gradient of a scalar field, in physical components.
+///
+/// `(∇f)ᵢ = (1/hᵢ) ∂f/∂uᵢ`.
+pub fn gradient(
+    f: ExprId,
+    coords: &Coordinates,
+    pool: &ExprPool,
+) -> Result<[ExprId; 3], VectorError> {
+    let vars = coords.vars();
+    let h = coords.scale_factors();
+    let mut out = [f; 3];
+    for i in 0..3 {
+        let df = d(f, vars[i], pool)?;
+        out[i] = simplify(divide(df, h[i], pool), pool).value;
+    }
+    Ok(out)
+}
+
+/// `∇·F` — the divergence of a vector field given in physical components.
+///
+/// `∇·F = (1/H) Σᵢ ∂/∂uᵢ ( (H/hᵢ) Fᵢ )` with `H = h₁h₂h₃`.
+pub fn divergence(
+    field: &[ExprId; 3],
+    coords: &Coordinates,
+    pool: &ExprPool,
+) -> Result<ExprId, VectorError> {
+    let vars = coords.vars();
+    let h = coords.scale_factors();
+    let big_h = coords.jacobian_factor(pool);
+    let mut terms = Vec::with_capacity(3);
+    for i in 0..3 {
+        let weighted = times(weight(big_h, h[i], pool), field[i], pool);
+        terms.push(d(weighted, vars[i], pool)?);
+    }
+    let total = pool.add(terms);
+    Ok(simplify(divide(total, big_h, pool), pool).value)
+}
+
+/// `∇×F` — the curl of a vector field given in physical components.
+///
+/// `(∇×F)ᵢ = (1/(h_j h_k)) [ ∂(h_k F_k)/∂u_j − ∂(h_j F_j)/∂u_k ]` for `(i,j,k)`
+/// a cyclic permutation of `(1,2,3)`. Right-handed frame; see [`cross`].
+pub fn curl(
+    field: &[ExprId; 3],
+    coords: &Coordinates,
+    pool: &ExprPool,
+) -> Result<[ExprId; 3], VectorError> {
+    let vars = coords.vars();
+    let h = coords.scale_factors();
+    let neg = pool.integer(-1_i32);
+    let mut out = [field[0]; 3];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let (j, k) = ((i + 1) % 3, (i + 2) % 3);
+        let hk_fk = times(h[k], field[k], pool);
+        let hj_fj = times(h[j], field[j], pool);
+        let a = d(hk_fk, vars[j], pool)?;
+        let b = d(hj_fj, vars[k], pool)?;
+        let bracket = pool.add(vec![a, pool.mul(vec![neg, b])]);
+        let den = simplify(times(h[j], h[k], pool), pool).value;
+        *slot = simplify(divide(bracket, den, pool), pool).value;
+    }
+    Ok(out)
+}
+
+/// `∇²f` — the scalar (Laplace–Beltrami) Laplacian.
+///
+/// `∇²f = (1/H) Σᵢ ∂/∂uᵢ ( (H/hᵢ²) ∂f/∂uᵢ )`.
+pub fn laplacian(f: ExprId, coords: &Coordinates, pool: &ExprPool) -> Result<ExprId, VectorError> {
+    let vars = coords.vars();
+    let h = coords.scale_factors();
+    let big_h = coords.jacobian_factor(pool);
+    let mut terms = Vec::with_capacity(3);
+    for i in 0..3 {
+        let df = d(f, vars[i], pool)?;
+        let hi_sq = times(h[i], h[i], pool);
+        let weighted = times(weight(big_h, hi_sq, pool), df, pool);
+        terms.push(d(weighted, vars[i], pool)?);
+    }
+    let total = pool.add(terms);
+    Ok(simplify(divide(total, big_h, pool), pool).value)
+}
+
+/// `∇²F` — the **vector** Laplacian, `∇(∇·F) − ∇×(∇×F)`.
+///
+/// In Cartesian coordinates this is the componentwise scalar Laplacian and is
+/// computed that way (cheaper, and it leaves
+/// `∇×(∇×F) = ∇(∇·F) − ∇²F` a real check rather than a tautology). In every
+/// other chart the componentwise form is **wrong** — the basis vectors turn
+/// from point to point, contributing `−F_φ/ρ²`-style terms — so the defining
+/// identity is used instead.
+pub fn vector_laplacian(
+    field: &[ExprId; 3],
+    coords: &Coordinates,
+    pool: &ExprPool,
+) -> Result<[ExprId; 3], VectorError> {
+    if coords.is_cartesian(pool) {
+        let mut out = [field[0]; 3];
+        for i in 0..3 {
+            out[i] = laplacian(field[i], coords, pool)?;
+        }
+        return Ok(out);
+    }
+    let div = divergence(field, coords, pool)?;
+    let grad_div = gradient(div, coords, pool)?;
+    let cc = curl(&curl(field, coords, pool)?, coords, pool)?;
+    Ok(sub(&grad_div, &cc, pool))
+}

--- a/alkahest-core/src/vector/tests.rs
+++ b/alkahest-core/src/vector/tests.rs
@@ -1,0 +1,1240 @@
+//! The vector-calculus test suite is the identity suite.
+//!
+//! Three layers, each catching something the others cannot:
+//!
+//! 1. **The identities.** `∇×∇f = 0`, `∇·(∇×F) = 0`,
+//!    `∇×(∇×F) = ∇(∇·F) − ∇²F`, `∇·(fF) = f∇·F + ∇f·F`, `∇×(fF) = f∇×F + ∇f×F`.
+//!    These hold in *every* orthogonal chart, so they test the general
+//!    machinery — but they are also insensitive to a uniform scale-factor
+//!    error, because a wrong `hᵢ` used consistently on both sides can cancel.
+//! 2. **The textbook forms.** `div`, `curl` and `∇²` in cylindrical and
+//!    spherical coordinates, written out by hand from Arfken & Weber
+//!    §3.10 / Griffiths *Introduction to Electrodynamics* front cover, and
+//!    compared against what this module produces. This pins the scale factors
+//!    to published values.
+//! 3. **The Cartesian round trip.** A field is written in Cartesian
+//!    coordinates, transformed into the curvilinear chart (both the argument
+//!    substitution *and* the rotation of the components into the local
+//!    orthonormal frame), and the operator is applied in both charts. Agreement
+//!    at a random point is the independent check: it cannot be passed by a
+//!    self-consistent but wrong set of scale factors, and it is sensitive to
+//!    handedness, which the identities are not.
+//!
+//! Every numeric comparison happens at **random, ugly points**. Scale-factor
+//! errors habitually vanish at `θ = π/2`, `φ = 0`, `ρ = 1`, so those points
+//! prove nothing.
+
+use super::*;
+use crate::jit::eval_interp_checked;
+use crate::kernel::subs::subs;
+use crate::kernel::{Domain, ExprId, ExprPool};
+use crate::matrix::zero_test::{zero_status, ZeroStatus};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// xorshift64*, so the "random" points are the same on every run and a failure
+/// is reproducible from the seed alone.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed | 1)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// Uniform in `[lo, hi)`.
+    fn range(&mut self, lo: f64, hi: f64) -> f64 {
+        let u = (self.next_u64() >> 11) as f64 / (1_u64 << 53) as f64;
+        lo + (hi - lo) * u
+    }
+}
+
+fn ev(e: ExprId, env: &HashMap<ExprId, f64>, pool: &ExprPool) -> f64 {
+    eval_interp_checked(e, env, pool)
+        .unwrap_or_else(|err| panic!("could not evaluate `{}`: {err:?}", pool.display(e)))
+}
+
+#[track_caller]
+fn close(a: f64, b: f64, what: &str) {
+    let scale = 1.0_f64.max(a.abs()).max(b.abs());
+    assert!(
+        (a - b).abs() <= 1e-8 * scale,
+        "{what}: {a} vs {b} (absolute gap {:.3e}, scale {scale})",
+        (a - b).abs()
+    );
+}
+
+/// Assert a scalar field is identically zero, preferring the symbolic verdict.
+///
+/// Uses the crate's own three-valued zero test
+/// (`crate::matrix::zero_test::zero_status`): `Zero` is a proof by a sound
+/// normalisation, returned as `true`; `NonZero` is a *rigorous refutation* —
+/// a ball enclosure at some sample point that excludes `0` — and fails
+/// immediately, because it means the identity is false rather than merely
+/// unproven; `Unknown` falls back to evaluating at every supplied point, which
+/// is weaker but still catches a wrong formula.
+///
+/// The tests record which accepting path was taken, because "this identity
+/// closes symbolically" is a stronger statement than "it holds at four points"
+/// and a regression from the first to the second is worth noticing even while
+/// both pass.
+#[track_caller]
+fn assert_zero_scalar(
+    e: ExprId,
+    pool: &ExprPool,
+    env: &[&HashMap<ExprId, f64>],
+    what: &str,
+) -> bool {
+    match zero_status(pool, e) {
+        ZeroStatus::Zero => return true,
+        ZeroStatus::NonZero => panic!(
+            "{what}: `{}` is provably *not* identically zero — the identity is false",
+            pool.display(e)
+        ),
+        ZeroStatus::Unknown => {}
+    }
+    for binding in env {
+        let v = ev(e, binding, pool);
+        assert!(
+            v.abs() <= 1e-8,
+            "{what}: expected 0, got {v} for `{}`",
+            pool.display(e)
+        );
+    }
+    false
+}
+
+#[track_caller]
+fn assert_zero_field(
+    f: &[ExprId; 3],
+    pool: &ExprPool,
+    env: &[&HashMap<ExprId, f64>],
+    what: &str,
+) -> bool {
+    let mut symbolic = true;
+    for (i, &c) in f.iter().enumerate() {
+        symbolic &= assert_zero_scalar(c, pool, env, &format!("{what} component {i}"));
+    }
+    symbolic
+}
+
+#[track_caller]
+fn assert_fields_agree(
+    a: &[ExprId; 3],
+    b: &[ExprId; 3],
+    pool: &ExprPool,
+    env: &HashMap<ExprId, f64>,
+    what: &str,
+) {
+    for i in 0..3 {
+        close(
+            ev(a[i], env, pool),
+            ev(b[i], env, pool),
+            &format!("{what} component {i}"),
+        );
+    }
+}
+
+/// The three built-in charts over one pool, plus the symbols behind them.
+struct Charts {
+    pool: ExprPool,
+    cart: Coordinates,
+    cyl: Coordinates,
+    sph: Coordinates,
+    /// `(x, y, z)`
+    c: [ExprId; 3],
+    /// `(ρ, φ, z)`
+    y: [ExprId; 3],
+    /// `(r, θ, φ)`
+    s: [ExprId; 3],
+}
+
+impl Charts {
+    fn new() -> Self {
+        let pool = ExprPool::new();
+        let c = [
+            pool.symbol("x", Domain::Real),
+            pool.symbol("y", Domain::Real),
+            pool.symbol("z", Domain::Real),
+        ];
+        let y = [
+            pool.symbol("rho", Domain::Real),
+            pool.symbol("phi", Domain::Real),
+            pool.symbol("zc", Domain::Real),
+        ];
+        let s = [
+            pool.symbol("r", Domain::Real),
+            pool.symbol("theta", Domain::Real),
+            pool.symbol("phis", Domain::Real),
+        ];
+        let cart = Coordinates::cartesian(c[0], c[1], c[2], &pool).unwrap();
+        let cyl = Coordinates::cylindrical(y[0], y[1], y[2], &pool).unwrap();
+        let sph = Coordinates::spherical(s[0], s[1], s[2], &pool).unwrap();
+        Charts {
+            pool,
+            cart,
+            cyl,
+            sph,
+            c,
+            y,
+            s,
+        }
+    }
+
+    fn p(&self) -> &ExprPool {
+        &self.pool
+    }
+
+    fn sin(&self, e: ExprId) -> ExprId {
+        self.pool.func("sin", vec![e])
+    }
+
+    fn cos(&self, e: ExprId) -> ExprId {
+        self.pool.func("cos", vec![e])
+    }
+
+    fn int(&self, n: i32) -> ExprId {
+        self.pool.integer(n)
+    }
+
+    /// A random Cartesian point, bound to `(x, y, z)`.
+    fn cart_env(&self, rng: &mut Rng) -> HashMap<ExprId, f64> {
+        let mut env = HashMap::new();
+        for &v in &self.c {
+            env.insert(v, rng.range(-1.7, 1.9));
+        }
+        env
+    }
+
+    /// A random cylindrical point, well away from the axis.
+    fn cyl_env(&self, rng: &mut Rng) -> HashMap<ExprId, f64> {
+        let mut env = HashMap::new();
+        env.insert(self.y[0], rng.range(0.4, 2.3));
+        env.insert(self.y[1], rng.range(-3.0, 3.0));
+        env.insert(self.y[2], rng.range(-1.5, 1.5));
+        env
+    }
+
+    /// A random spherical point, away from both the origin and the polar axis.
+    fn sph_env(&self, rng: &mut Rng) -> HashMap<ExprId, f64> {
+        let mut env = HashMap::new();
+        env.insert(self.s[0], rng.range(0.5, 2.4));
+        env.insert(self.s[1], rng.range(0.35, std::f64::consts::PI - 0.35));
+        env.insert(self.s[2], rng.range(-3.0, 3.0));
+        env
+    }
+
+    /// The Cartesian point a cylindrical point sits at.
+    fn cyl_to_cart_env(&self, env: &HashMap<ExprId, f64>) -> HashMap<ExprId, f64> {
+        let (rho, phi, z) = (env[&self.y[0]], env[&self.y[1]], env[&self.y[2]]);
+        HashMap::from([
+            (self.c[0], rho * phi.cos()),
+            (self.c[1], rho * phi.sin()),
+            (self.c[2], z),
+        ])
+    }
+
+    /// The Cartesian point a spherical point sits at.
+    fn sph_to_cart_env(&self, env: &HashMap<ExprId, f64>) -> HashMap<ExprId, f64> {
+        let (r, th, ph) = (env[&self.s[0]], env[&self.s[1]], env[&self.s[2]]);
+        HashMap::from([
+            (self.c[0], r * th.sin() * ph.cos()),
+            (self.c[1], r * th.sin() * ph.sin()),
+            (self.c[2], r * th.cos()),
+        ])
+    }
+
+    /// Rewrite a Cartesian expression in cylindrical coordinates.
+    fn to_cyl(&self, e: ExprId) -> ExprId {
+        let (rho, phi, z) = (self.y[0], self.y[1], self.y[2]);
+        let map = HashMap::from([
+            (self.c[0], self.pool.mul(vec![rho, self.cos(phi)])),
+            (self.c[1], self.pool.mul(vec![rho, self.sin(phi)])),
+            (self.c[2], z),
+        ]);
+        simplify(subs(e, &map, &self.pool), &self.pool).value
+    }
+
+    /// Rewrite a Cartesian expression in spherical coordinates.
+    fn to_sph(&self, e: ExprId) -> ExprId {
+        let (r, th, ph) = (self.s[0], self.s[1], self.s[2]);
+        let map = HashMap::from([
+            (
+                self.c[0],
+                self.pool.mul(vec![r, self.sin(th), self.cos(ph)]),
+            ),
+            (
+                self.c[1],
+                self.pool.mul(vec![r, self.sin(th), self.sin(ph)]),
+            ),
+            (self.c[2], self.pool.mul(vec![r, self.cos(th)])),
+        ]);
+        simplify(subs(e, &map, &self.pool), &self.pool).value
+    }
+}
+
+/// Rotate Cartesian vector *values* into the cylindrical orthonormal frame.
+fn cart_values_to_cyl(v: [f64; 3], phi: f64) -> [f64; 3] {
+    [
+        v[0] * phi.cos() + v[1] * phi.sin(),
+        -v[0] * phi.sin() + v[1] * phi.cos(),
+        v[2],
+    ]
+}
+
+/// Rotate Cartesian vector *values* into the spherical orthonormal frame.
+fn cart_values_to_sph(v: [f64; 3], theta: f64, phi: f64) -> [f64; 3] {
+    let (st, ct, sp, cp) = (theta.sin(), theta.cos(), phi.sin(), phi.cos());
+    [
+        v[0] * st * cp + v[1] * st * sp + v[2] * ct,
+        v[0] * ct * cp + v[1] * ct * sp - v[2] * st,
+        -v[0] * sp + v[1] * cp,
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Vector algebra
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cross_of_the_basis_is_right_handed() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let (o, i) = (ch.int(0), ch.int(1));
+    let e1 = [i, o, o];
+    let e2 = [o, i, o];
+    let e3 = [o, o, i];
+    assert_eq!(cross(&e1, &e2, p), e3, "e1 × e2 must be e3");
+    assert_eq!(cross(&e2, &e3, p), e1, "e2 × e3 must be e1");
+    assert_eq!(cross(&e3, &e1, p), e2, "e3 × e1 must be e2");
+}
+
+#[test]
+fn cross_is_anticommutative_and_orthogonal_to_both_factors() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let a = [
+        p.symbol("a1", Domain::Real),
+        p.symbol("a2", Domain::Real),
+        p.symbol("a3", Domain::Real),
+    ];
+    let b = [
+        p.symbol("b1", Domain::Real),
+        p.symbol("b2", Domain::Real),
+        p.symbol("b3", Domain::Real),
+    ];
+    let ab = cross(&a, &b, p);
+    let ba = cross(&b, &a, p);
+    let zero = p.integer(0_i32);
+    assert_eq!(add(&ab, &ba, p), [zero; 3], "a×b + b×a must be exactly 0");
+
+    // `(a×b)·a = 0` is a cancellation of six products the default simplifier
+    // does not expand, so it is settled by the zero test rather than by
+    // structural equality.
+    let mut rng = Rng::new(0xAB0B_AB0B);
+    let envs: Vec<HashMap<ExprId, f64>> = (0..4)
+        .map(|_| {
+            a.iter()
+                .chain(b.iter())
+                .map(|&s| (s, rng.range(-2.0, 2.0)))
+                .collect()
+        })
+        .collect();
+    let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+    assert_zero_scalar(dot(&ab, &a, p), p, &refs, "(a×b)·a");
+    assert_zero_scalar(dot(&ab, &b, p), p, &refs, "(a×b)·b");
+}
+
+#[test]
+fn norm_of_a_unit_vector_is_one() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let v = [ch.int(3), ch.int(4), ch.int(0)];
+    assert_eq!(norm_squared(&v, p), p.integer(25_i32));
+    assert_eq!(norm(&v, p), p.integer(5_i32));
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1 — the identities
+// ---------------------------------------------------------------------------
+
+/// A handful of scalar fields per chart, chosen to have every partial
+/// derivative non-trivial.
+fn scalar_fields(ch: &Charts, coords: &Coordinates) -> Vec<ExprId> {
+    let p = ch.p();
+    let [u, v, w] = coords.vars();
+    let two = ch.int(2);
+    let three = ch.int(3);
+    vec![
+        p.add(vec![
+            p.mul(vec![p.pow(u, two), v]),
+            p.mul(vec![three, p.pow(w, three)]),
+        ]),
+        p.mul(vec![ch.sin(u), ch.cos(v), p.pow(w, two)]),
+        p.mul(vec![u, v, w]),
+        p.add(vec![
+            p.mul(vec![p.func("exp", vec![w]), ch.cos(v)]),
+            p.pow(u, three),
+        ]),
+    ]
+}
+
+/// A handful of vector fields per chart.
+fn vector_fields(ch: &Charts, coords: &Coordinates) -> Vec<[ExprId; 3]> {
+    let p = ch.p();
+    let [u, v, w] = coords.vars();
+    let two = ch.int(2);
+    let three = ch.int(3);
+    vec![
+        [
+            p.mul(vec![p.pow(u, two), v]),
+            p.mul(vec![v, p.pow(w, two)]),
+            p.mul(vec![three, u, w]),
+        ],
+        [
+            p.mul(vec![ch.sin(v), w]),
+            p.mul(vec![u, ch.cos(w)]),
+            p.mul(vec![p.pow(u, two), ch.sin(v)]),
+        ],
+        [
+            p.add(vec![u, p.mul(vec![two, v])]),
+            p.mul(vec![u, v, w]),
+            p.add(vec![p.pow(w, two), p.mul(vec![u, w])]),
+        ],
+    ]
+}
+
+fn envs_for(ch: &Charts, which: usize, rng: &mut Rng) -> Vec<HashMap<ExprId, f64>> {
+    (0..4)
+        .map(|_| match which {
+            0 => ch.cart_env(rng),
+            1 => ch.cyl_env(rng),
+            _ => ch.sph_env(rng),
+        })
+        .collect()
+}
+
+#[test]
+fn curl_of_a_gradient_vanishes_in_every_chart() {
+    let ch = Charts::new();
+    let mut rng = Rng::new(0x1234_5678);
+    let mut per_chart = [0_usize; 3];
+    let mut total = 0;
+    for (which, coords) in [&ch.cart, &ch.cyl, &ch.sph].into_iter().enumerate() {
+        let envs = envs_for(&ch, which, &mut rng);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        for f in scalar_fields(&ch, coords) {
+            let g = gradient(f, coords, ch.p()).unwrap();
+            let c = curl(&g, coords, ch.p()).unwrap();
+            total += 1;
+            if assert_zero_field(
+                &c,
+                ch.p(),
+                &refs,
+                &format!("curl grad in {}", coords.label()),
+            ) {
+                per_chart[which] += 1;
+            }
+        }
+    }
+    println!(
+        "curl(grad f) closed symbolically: cartesian {}/4, cylindrical {}/4, spherical {}/4 \
+         (of {total} total; the rest were checked numerically)",
+        per_chart[0], per_chart[1], per_chart[2]
+    );
+    // Cartesian and cylindrical reduce to equality of mixed partials with no
+    // surviving `1/h` factor to cancel, so those eight must close *exactly*.
+    // The spherical components carry a `1/(r sin θ)` the zero test does not
+    // clear on every field; those are checked numerically above, and this
+    // assertion pins the symbolic tier so a regression in it is visible.
+    assert_eq!(
+        (per_chart[0], per_chart[1]),
+        (4, 4),
+        "curl(grad f) must close symbolically in the Cartesian and cylindrical charts"
+    );
+}
+
+#[test]
+fn divergence_of_a_curl_vanishes_in_every_chart() {
+    let ch = Charts::new();
+    let mut rng = Rng::new(0x9ABC_DEF0);
+    let mut symbolic_closures = 0;
+    let mut total = 0;
+    for (which, coords) in [&ch.cart, &ch.cyl, &ch.sph].into_iter().enumerate() {
+        let envs = envs_for(&ch, which, &mut rng);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        for f in vector_fields(&ch, coords) {
+            let c = curl(&f, coords, ch.p()).unwrap();
+            let d = divergence(&c, coords, ch.p()).unwrap();
+            total += 1;
+            if assert_zero_scalar(d, ch.p(), &refs, &format!("div curl in {}", coords.label())) {
+                symbolic_closures += 1;
+            }
+        }
+    }
+    assert!(
+        symbolic_closures >= 3,
+        "div(curl F) closed symbolically only {symbolic_closures}/{total} times; \
+         the Cartesian cases at least must reduce to 0 exactly"
+    );
+}
+
+#[test]
+fn curl_curl_equals_grad_div_minus_vector_laplacian_in_cartesian() {
+    // Cartesian is where this identity has teeth: `vector_laplacian` is the
+    // *componentwise* scalar Laplacian there, computed independently of `curl`
+    // and `div`, so the two sides share no code. In a curvilinear chart the
+    // vector Laplacian is *defined* as `grad div − curl curl` and the identity
+    // is a tautology — see `curvilinear_vector_laplacian_matches_the_cartesian_one`
+    // for the check that has content there.
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0xFEED_BEEF);
+    let envs = envs_for(&ch, 0, &mut rng);
+    for f in vector_fields(&ch, &ch.cart) {
+        let cc = curl(&curl(&f, &ch.cart, p).unwrap(), &ch.cart, p).unwrap();
+        let gd = gradient(divergence(&f, &ch.cart, p).unwrap(), &ch.cart, p).unwrap();
+        let vl = vector_laplacian(&f, &ch.cart, p).unwrap();
+        let rhs = sub(&gd, &vl, p);
+        let residual = sub(&cc, &rhs, p);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        assert_zero_field(&residual, p, &refs, "curl curl − (grad div − lap)");
+    }
+}
+
+#[test]
+fn divergence_of_a_scaled_field_obeys_the_product_rule() {
+    // ∇·(fF) = f ∇·F + ∇f·F, in all three charts.
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0x0BAD_F00D);
+    for (which, coords) in [&ch.cart, &ch.cyl, &ch.sph].into_iter().enumerate() {
+        let envs = envs_for(&ch, which, &mut rng);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        for f in scalar_fields(&ch, coords) {
+            for field in vector_fields(&ch, coords) {
+                let scaled = scale(f, &field, p);
+                let lhs = divergence(&scaled, coords, p).unwrap();
+                let rhs = p.add(vec![
+                    p.mul(vec![f, divergence(&field, coords, p).unwrap()]),
+                    dot(&gradient(f, coords, p).unwrap(), &field, p),
+                ]);
+                let rhs = simplify(rhs, p).value;
+                let neg = p.integer(-1_i32);
+                let residual = simplify(p.add(vec![lhs, p.mul(vec![neg, rhs])]), p).value;
+                assert_zero_scalar(
+                    residual,
+                    p,
+                    &refs,
+                    &format!("div(fF) − (f div F + grad f · F) in {}", coords.label()),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn curl_of_a_scaled_field_obeys_the_product_rule() {
+    // ∇×(fF) = f ∇×F + ∇f × F.  This one is sensitive to the handedness of
+    // `cross` relative to the sign convention inside `curl`: swapping either
+    // flips the sign of the second term alone.
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0xC0FF_EE01);
+    for (which, coords) in [&ch.cart, &ch.cyl, &ch.sph].into_iter().enumerate() {
+        let envs = envs_for(&ch, which, &mut rng);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        for f in scalar_fields(&ch, coords) {
+            for field in vector_fields(&ch, coords) {
+                let lhs = curl(&scale(f, &field, p), coords, p).unwrap();
+                let term1 = scale(f, &curl(&field, coords, p).unwrap(), p);
+                let term2 = cross(&gradient(f, coords, p).unwrap(), &field, p);
+                let rhs = add(&term1, &term2, p);
+                let residual = sub(&lhs, &rhs, p);
+                assert_zero_field(
+                    &residual,
+                    p,
+                    &refs,
+                    &format!("curl(fF) − (f curl F + grad f × F) in {}", coords.label()),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn gradient_obeys_the_product_rule() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0x5EED_1234);
+    for (which, coords) in [&ch.cart, &ch.cyl, &ch.sph].into_iter().enumerate() {
+        let envs = envs_for(&ch, which, &mut rng);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        let fields = scalar_fields(&ch, coords);
+        for f in &fields {
+            for g in &fields {
+                let lhs = gradient(simplify(p.mul(vec![*f, *g]), p).value, coords, p).unwrap();
+                let rhs = add(
+                    &scale(*f, &gradient(*g, coords, p).unwrap(), p),
+                    &scale(*g, &gradient(*f, coords, p).unwrap(), p),
+                    p,
+                );
+                assert_zero_field(
+                    &sub(&lhs, &rhs, p),
+                    p,
+                    &refs,
+                    &format!("grad(fg) − (f grad g + g grad f) in {}", coords.label()),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn laplacian_is_the_divergence_of_the_gradient() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0x1111_2222);
+    for (which, coords) in [&ch.cart, &ch.cyl, &ch.sph].into_iter().enumerate() {
+        let envs = envs_for(&ch, which, &mut rng);
+        let refs: Vec<&HashMap<ExprId, f64>> = envs.iter().collect();
+        for f in scalar_fields(&ch, coords) {
+            let direct = laplacian(f, coords, p).unwrap();
+            let via = divergence(&gradient(f, coords, p).unwrap(), coords, p).unwrap();
+            let neg = p.integer(-1_i32);
+            let residual = simplify(p.add(vec![direct, p.mul(vec![neg, via])]), p).value;
+            assert_zero_scalar(
+                residual,
+                p,
+                &refs,
+                &format!("∇²f − ∇·∇f in {}", coords.label()),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — the published forms
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cylindrical_operators_match_the_textbook_forms() {
+    // Arfken & Weber, *Mathematical Methods for Physicists* 7th ed. §3.10;
+    // Griffiths, *Introduction to Electrodynamics* 4th ed., inside front cover.
+    let ch = Charts::new();
+    let p = ch.p();
+    let [rho, phi, z] = ch.cyl.vars();
+    let dd = |e: ExprId, v: ExprId| crate::diff::diff(e, v, p).unwrap().value;
+    let inv = |e: ExprId| p.pow(e, p.integer(-1_i32));
+
+    let mut rng = Rng::new(0xABCD_0001);
+    for f in scalar_fields(&ch, &ch.cyl) {
+        // ∇²f = (1/ρ)∂_ρ(ρ ∂_ρ f) + (1/ρ²)∂²_φ f + ∂²_z f
+        let expected = p.add(vec![
+            p.mul(vec![inv(rho), dd(p.mul(vec![rho, dd(f, rho)]), rho)]),
+            p.mul(vec![inv(p.pow(rho, p.integer(2_i32))), dd(dd(f, phi), phi)]),
+            dd(dd(f, z), z),
+        ]);
+        let got = laplacian(f, &ch.cyl, p).unwrap();
+        for _ in 0..6 {
+            let env = ch.cyl_env(&mut rng);
+            close(
+                ev(got, &env, p),
+                ev(expected, &env, p),
+                "cylindrical laplacian",
+            );
+        }
+    }
+
+    for field in vector_fields(&ch, &ch.cyl) {
+        let [fr, fp, fz] = field;
+        // ∇·F = (1/ρ)∂_ρ(ρ F_ρ) + (1/ρ)∂_φ F_φ + ∂_z F_z
+        let expected_div = p.add(vec![
+            p.mul(vec![inv(rho), dd(p.mul(vec![rho, fr]), rho)]),
+            p.mul(vec![inv(rho), dd(fp, phi)]),
+            dd(fz, z),
+        ]);
+        // (∇×F)_ρ = (1/ρ)∂_φ F_z − ∂_z F_φ
+        // (∇×F)_φ = ∂_z F_ρ − ∂_ρ F_z
+        // (∇×F)_z = (1/ρ)[∂_ρ(ρ F_φ) − ∂_φ F_ρ]
+        let neg = p.integer(-1_i32);
+        let expected_curl = [
+            p.add(vec![
+                p.mul(vec![inv(rho), dd(fz, phi)]),
+                p.mul(vec![neg, dd(fp, z)]),
+            ]),
+            p.add(vec![dd(fr, z), p.mul(vec![neg, dd(fz, rho)])]),
+            p.mul(vec![
+                inv(rho),
+                p.add(vec![
+                    dd(p.mul(vec![rho, fp]), rho),
+                    p.mul(vec![neg, dd(fr, phi)]),
+                ]),
+            ]),
+        ];
+        let got_div = divergence(&field, &ch.cyl, p).unwrap();
+        let got_curl = curl(&field, &ch.cyl, p).unwrap();
+        for _ in 0..6 {
+            let env = ch.cyl_env(&mut rng);
+            close(
+                ev(got_div, &env, p),
+                ev(expected_div, &env, p),
+                "cylindrical divergence",
+            );
+            assert_fields_agree(&got_curl, &expected_curl, p, &env, "cylindrical curl");
+        }
+    }
+}
+
+#[test]
+fn spherical_operators_match_the_textbook_forms() {
+    // Arfken & Weber §3.10, physics convention (θ polar, φ azimuth).
+    let ch = Charts::new();
+    let p = ch.p();
+    let [r, th, ph] = ch.sph.vars();
+    let dd = |e: ExprId, v: ExprId| crate::diff::diff(e, v, p).unwrap().value;
+    let inv = |e: ExprId| p.pow(e, p.integer(-1_i32));
+    let two = p.integer(2_i32);
+    let neg = p.integer(-1_i32);
+    let sin_th = ch.sin(th);
+    let r2 = p.pow(r, two);
+
+    let mut rng = Rng::new(0xABCD_0002);
+    for f in scalar_fields(&ch, &ch.sph) {
+        // ∇²f = (1/r²)∂_r(r²∂_r f) + (1/(r² sinθ))∂_θ(sinθ ∂_θ f)
+        //       + (1/(r² sin²θ))∂²_φ f
+        let expected = p.add(vec![
+            p.mul(vec![inv(r2), dd(p.mul(vec![r2, dd(f, r)]), r)]),
+            p.mul(vec![
+                inv(p.mul(vec![r2, sin_th])),
+                dd(p.mul(vec![sin_th, dd(f, th)]), th),
+            ]),
+            p.mul(vec![
+                inv(p.mul(vec![r2, p.pow(sin_th, two)])),
+                dd(dd(f, ph), ph),
+            ]),
+        ]);
+        let got = laplacian(f, &ch.sph, p).unwrap();
+        for _ in 0..6 {
+            let env = ch.sph_env(&mut rng);
+            close(
+                ev(got, &env, p),
+                ev(expected, &env, p),
+                "spherical laplacian",
+            );
+        }
+    }
+
+    for field in vector_fields(&ch, &ch.sph) {
+        let [fr, ft, fp] = field;
+        // ∇·F = (1/r²)∂_r(r²F_r) + (1/(r sinθ))∂_θ(sinθ F_θ)
+        //       + (1/(r sinθ))∂_φ F_φ
+        let expected_div = p.add(vec![
+            p.mul(vec![inv(r2), dd(p.mul(vec![r2, fr]), r)]),
+            p.mul(vec![
+                inv(p.mul(vec![r, sin_th])),
+                dd(p.mul(vec![sin_th, ft]), th),
+            ]),
+            p.mul(vec![inv(p.mul(vec![r, sin_th])), dd(fp, ph)]),
+        ]);
+        // (∇×F)_r = (1/(r sinθ))[∂_θ(sinθ F_φ) − ∂_φ F_θ]
+        // (∇×F)_θ = (1/r)[(1/sinθ)∂_φ F_r − ∂_r(r F_φ)]
+        // (∇×F)_φ = (1/r)[∂_r(r F_θ) − ∂_θ F_r]
+        let expected_curl = [
+            p.mul(vec![
+                inv(p.mul(vec![r, sin_th])),
+                p.add(vec![
+                    dd(p.mul(vec![sin_th, fp]), th),
+                    p.mul(vec![neg, dd(ft, ph)]),
+                ]),
+            ]),
+            p.mul(vec![
+                inv(r),
+                p.add(vec![
+                    p.mul(vec![inv(sin_th), dd(fr, ph)]),
+                    p.mul(vec![neg, dd(p.mul(vec![r, fp]), r)]),
+                ]),
+            ]),
+            p.mul(vec![
+                inv(r),
+                p.add(vec![
+                    dd(p.mul(vec![r, ft]), r),
+                    p.mul(vec![neg, dd(fr, th)]),
+                ]),
+            ]),
+        ];
+        let got_div = divergence(&field, &ch.sph, p).unwrap();
+        let got_curl = curl(&field, &ch.sph, p).unwrap();
+        for _ in 0..6 {
+            let env = ch.sph_env(&mut rng);
+            close(
+                ev(got_div, &env, p),
+                ev(expected_div, &env, p),
+                "spherical divergence",
+            );
+            assert_fields_agree(&got_curl, &expected_curl, p, &env, "spherical curl");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3 — the Cartesian round trip
+// ---------------------------------------------------------------------------
+
+/// Cartesian fields used for the round trip. Deliberately *not* symmetric
+/// about the axis: a field with no `φ` dependence passes a wrong `h₂` and
+/// tells you nothing.
+fn roundtrip_fields(ch: &Charts) -> Vec<[ExprId; 3]> {
+    let p = ch.p();
+    let [x, y, z] = ch.c;
+    let two = ch.int(2);
+    let three = ch.int(3);
+    vec![
+        [
+            p.mul(vec![p.pow(x, two), y]),
+            p.mul(vec![y, p.pow(z, two)]),
+            p.mul(vec![three, x, z]),
+        ],
+        [
+            p.add(vec![p.mul(vec![x, y, z]), p.pow(y, three)]),
+            p.mul(vec![p.func("exp", vec![z]), x]),
+            p.add(vec![p.pow(x, two), p.mul(vec![two, y, z])]),
+        ],
+        [
+            p.func("sin", vec![p.mul(vec![x, y])]),
+            p.mul(vec![z, p.func("cos", vec![x])]),
+            p.mul(vec![x, y, z]),
+        ],
+    ]
+}
+
+fn roundtrip_scalars(ch: &Charts) -> Vec<ExprId> {
+    let p = ch.p();
+    let [x, y, z] = ch.c;
+    let two = ch.int(2);
+    let three = ch.int(3);
+    vec![
+        p.add(vec![p.mul(vec![p.pow(x, two), y]), p.pow(z, three)]),
+        p.mul(vec![x, y, z]),
+        p.add(vec![
+            p.func("exp", vec![x]),
+            p.func("sin", vec![p.mul(vec![y, z])]),
+        ]),
+    ]
+}
+
+#[test]
+fn cylindrical_operators_agree_with_cartesian_under_the_change_of_chart() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0x7777_0001);
+
+    for f in roundtrip_scalars(&ch) {
+        let lap_cart = laplacian(f, &ch.cart, p).unwrap();
+        let lap_cyl = laplacian(ch.to_cyl(f), &ch.cyl, p).unwrap();
+        for _ in 0..8 {
+            let cyl = ch.cyl_env(&mut rng);
+            let cart = ch.cyl_to_cart_env(&cyl);
+            close(
+                ev(lap_cyl, &cyl, p),
+                ev(lap_cart, &cart, p),
+                "∇²f: cylindrical vs Cartesian",
+            );
+        }
+    }
+
+    for field in roundtrip_fields(&ch) {
+        let [fx, fy, fz] = field;
+        let (fxc, fyc, fzc) = (ch.to_cyl(fx), ch.to_cyl(fy), ch.to_cyl(fz));
+        let phi = ch.y[1];
+        let (c, s) = (ch.cos(phi), ch.sin(phi));
+        let neg = p.integer(-1_i32);
+        let in_cyl = [
+            simplify(p.add(vec![p.mul(vec![fxc, c]), p.mul(vec![fyc, s])]), p).value,
+            simplify(
+                p.add(vec![p.mul(vec![neg, fxc, s]), p.mul(vec![fyc, c])]),
+                p,
+            )
+            .value,
+            fzc,
+        ];
+
+        let div_cart = divergence(&field, &ch.cart, p).unwrap();
+        let div_cyl = divergence(&in_cyl, &ch.cyl, p).unwrap();
+        let curl_cart = curl(&field, &ch.cart, p).unwrap();
+        let curl_cyl = curl(&in_cyl, &ch.cyl, p).unwrap();
+        let vl_cart = vector_laplacian(&field, &ch.cart, p).unwrap();
+        let vl_cyl = vector_laplacian(&in_cyl, &ch.cyl, p).unwrap();
+
+        for _ in 0..8 {
+            let cyl = ch.cyl_env(&mut rng);
+            let cart = ch.cyl_to_cart_env(&cyl);
+            let phi_v = cyl[&ch.y[1]];
+            close(
+                ev(div_cyl, &cyl, p),
+                ev(div_cart, &cart, p),
+                "∇·F: cylindrical vs Cartesian",
+            );
+            let want_curl = cart_values_to_cyl(
+                [
+                    ev(curl_cart[0], &cart, p),
+                    ev(curl_cart[1], &cart, p),
+                    ev(curl_cart[2], &cart, p),
+                ],
+                phi_v,
+            );
+            let want_vl = cart_values_to_cyl(
+                [
+                    ev(vl_cart[0], &cart, p),
+                    ev(vl_cart[1], &cart, p),
+                    ev(vl_cart[2], &cart, p),
+                ],
+                phi_v,
+            );
+            for i in 0..3 {
+                close(
+                    ev(curl_cyl[i], &cyl, p),
+                    want_curl[i],
+                    &format!("∇×F component {i}: cylindrical vs Cartesian"),
+                );
+                close(
+                    ev(vl_cyl[i], &cyl, p),
+                    want_vl[i],
+                    &format!("∇²F component {i}: cylindrical vs Cartesian"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn spherical_operators_agree_with_cartesian_under_the_change_of_chart() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let mut rng = Rng::new(0x7777_0002);
+
+    for f in roundtrip_scalars(&ch) {
+        let lap_cart = laplacian(f, &ch.cart, p).unwrap();
+        let lap_sph = laplacian(ch.to_sph(f), &ch.sph, p).unwrap();
+        for _ in 0..8 {
+            let sph = ch.sph_env(&mut rng);
+            let cart = ch.sph_to_cart_env(&sph);
+            close(
+                ev(lap_sph, &sph, p),
+                ev(lap_cart, &cart, p),
+                "∇²f: spherical vs Cartesian",
+            );
+        }
+    }
+
+    for field in roundtrip_fields(&ch) {
+        let [fx, fy, fz] = field;
+        let (fxs, fys, fzs) = (ch.to_sph(fx), ch.to_sph(fy), ch.to_sph(fz));
+        let (th, ph) = (ch.s[1], ch.s[2]);
+        let (st, ct, sp, cp) = (ch.sin(th), ch.cos(th), ch.sin(ph), ch.cos(ph));
+        let neg = p.integer(-1_i32);
+        let in_sph = [
+            simplify(
+                p.add(vec![
+                    p.mul(vec![fxs, st, cp]),
+                    p.mul(vec![fys, st, sp]),
+                    p.mul(vec![fzs, ct]),
+                ]),
+                p,
+            )
+            .value,
+            simplify(
+                p.add(vec![
+                    p.mul(vec![fxs, ct, cp]),
+                    p.mul(vec![fys, ct, sp]),
+                    p.mul(vec![neg, fzs, st]),
+                ]),
+                p,
+            )
+            .value,
+            simplify(
+                p.add(vec![p.mul(vec![neg, fxs, sp]), p.mul(vec![fys, cp])]),
+                p,
+            )
+            .value,
+        ];
+
+        let div_cart = divergence(&field, &ch.cart, p).unwrap();
+        let div_sph = divergence(&in_sph, &ch.sph, p).unwrap();
+        let curl_cart = curl(&field, &ch.cart, p).unwrap();
+        let curl_sph = curl(&in_sph, &ch.sph, p).unwrap();
+        let vl_cart = vector_laplacian(&field, &ch.cart, p).unwrap();
+        let vl_sph = vector_laplacian(&in_sph, &ch.sph, p).unwrap();
+
+        for _ in 0..8 {
+            let sph = ch.sph_env(&mut rng);
+            let cart = ch.sph_to_cart_env(&sph);
+            let (th_v, ph_v) = (sph[&ch.s[1]], sph[&ch.s[2]]);
+            close(
+                ev(div_sph, &sph, p),
+                ev(div_cart, &cart, p),
+                "∇·F: spherical vs Cartesian",
+            );
+            let want_curl = cart_values_to_sph(
+                [
+                    ev(curl_cart[0], &cart, p),
+                    ev(curl_cart[1], &cart, p),
+                    ev(curl_cart[2], &cart, p),
+                ],
+                th_v,
+                ph_v,
+            );
+            let want_vl = cart_values_to_sph(
+                [
+                    ev(vl_cart[0], &cart, p),
+                    ev(vl_cart[1], &cart, p),
+                    ev(vl_cart[2], &cart, p),
+                ],
+                th_v,
+                ph_v,
+            );
+            for i in 0..3 {
+                close(
+                    ev(curl_sph[i], &sph, p),
+                    want_curl[i],
+                    &format!("∇×F component {i}: spherical vs Cartesian"),
+                );
+                close(
+                    ev(vl_sph[i], &sph, p),
+                    want_vl[i],
+                    &format!("∇²F component {i}: spherical vs Cartesian"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn curvilinear_vector_laplacian_is_not_the_componentwise_one() {
+    // The guard against the classic error. For `F = ê_φ` (that is, the field
+    // whose physical components are `(0, 1, 0)` in cylindrical coordinates)
+    // the componentwise Laplacian is identically zero, while the true vector
+    // Laplacian is `−ê_φ/ρ²`, because ê_φ turns as φ advances.
+    let ch = Charts::new();
+    let p = ch.p();
+    let rho = ch.cyl.vars()[0];
+    let (zero, one) = (ch.int(0), ch.int(1));
+    let field = [zero, one, zero];
+
+    let componentwise: Vec<ExprId> = field
+        .iter()
+        .map(|&c| laplacian(c, &ch.cyl, p).unwrap())
+        .collect();
+    assert_eq!(
+        componentwise,
+        vec![zero, zero, zero],
+        "the componentwise scalar Laplacian of a constant component array is 0"
+    );
+
+    let vl = vector_laplacian(&field, &ch.cyl, p).unwrap();
+    let expected = [
+        zero,
+        simplify(
+            p.mul(vec![p.integer(-1_i32), p.pow(rho, p.integer(-2_i32))]),
+            p,
+        )
+        .value,
+        zero,
+    ];
+    let mut rng = Rng::new(0x3141_5926);
+    for _ in 0..6 {
+        let env = ch.cyl_env(&mut rng);
+        assert_fields_agree(&vl, &expected, p, &env, "∇²(ê_φ) in cylindrical");
+    }
+    assert_ne!(
+        vl[1], zero,
+        "∇²F in a curvilinear chart must not be the componentwise Laplacian"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// from_embedding, and the refusals
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_embedding_rederives_the_cylindrical_scale_factors() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let [rho, phi, z] = ch.cyl.vars();
+    let derived = Coordinates::from_embedding(
+        [rho, phi, z],
+        [
+            p.mul(vec![rho, ch.cos(phi)]),
+            p.mul(vec![rho, ch.sin(phi)]),
+            z,
+        ],
+        "cylindrical (derived)",
+        p,
+    )
+    .expect("the cylindrical embedding is orthogonal");
+
+    let mut rng = Rng::new(0x2718_2818);
+    for _ in 0..6 {
+        let env = ch.cyl_env(&mut rng);
+        for i in 0..3 {
+            close(
+                ev(derived.scale_factors()[i], &env, p),
+                ev(ch.cyl.scale_factors()[i], &env, p),
+                &format!("derived h{} vs the built-in cylindrical chart", i + 1),
+            );
+        }
+    }
+    // …and the operators built on them agree too.
+    for f in scalar_fields(&ch, &ch.cyl) {
+        let a = laplacian(f, &ch.cyl, p).unwrap();
+        let b = laplacian(f, &derived, p).unwrap();
+        for _ in 0..4 {
+            let env = ch.cyl_env(&mut rng);
+            close(ev(a, &env, p), ev(b, &env, p), "∇² from derived factors");
+        }
+    }
+}
+
+#[test]
+fn from_embedding_rederives_the_spherical_scale_factors() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let [r, th, ph] = ch.sph.vars();
+    let derived = Coordinates::from_embedding(
+        [r, th, ph],
+        [
+            p.mul(vec![r, ch.sin(th), ch.cos(ph)]),
+            p.mul(vec![r, ch.sin(th), ch.sin(ph)]),
+            p.mul(vec![r, ch.cos(th)]),
+        ],
+        "spherical (derived)",
+        p,
+    )
+    .expect("the spherical embedding is orthogonal");
+
+    let mut rng = Rng::new(0x1618_0339);
+    for _ in 0..6 {
+        let env = ch.sph_env(&mut rng);
+        for i in 0..3 {
+            close(
+                ev(derived.scale_factors()[i], &env, p),
+                ev(ch.sph.scale_factors()[i], &env, p),
+                &format!("derived h{} vs the built-in spherical chart", i + 1),
+            );
+        }
+    }
+    for field in vector_fields(&ch, &ch.sph) {
+        let a = divergence(&field, &ch.sph, p).unwrap();
+        let b = divergence(&field, &derived, p).unwrap();
+        for _ in 0..4 {
+            let env = ch.sph_env(&mut rng);
+            close(ev(a, &env, p), ev(b, &env, p), "∇· from derived factors");
+        }
+    }
+}
+
+#[test]
+fn from_embedding_refuses_a_skew_chart() {
+    use crate::errors::AlkahestError;
+    let ch = Charts::new();
+    let p = ch.p();
+    let u = p.symbol("u", Domain::Real);
+    let v = p.symbol("v", Domain::Real);
+    let w = p.symbol("w", Domain::Real);
+    // x = u + v, y = v, z = w — a perfectly good chart, and not an orthogonal
+    // one: ∂r/∂u = (1,0,0), ∂r/∂v = (1,1,0), inner product 1.
+    let err = Coordinates::from_embedding([u, v, w], [p.add(vec![u, v]), v, w], "skew", p)
+        .expect_err("a skew chart must be refused, not silently treated as orthogonal");
+    assert_eq!(err.code(), "E-VEC-004");
+    assert!(matches!(
+        err,
+        VectorError::NonOrthogonal { pair: (0, 1), .. }
+    ));
+}
+
+#[test]
+fn from_embedding_refuses_a_chart_that_collapses_a_direction() {
+    use crate::errors::AlkahestError;
+    let ch = Charts::new();
+    let p = ch.p();
+    let u = p.symbol("u", Domain::Real);
+    let v = p.symbol("v", Domain::Real);
+    let w = p.symbol("w", Domain::Real);
+    // `w` does not appear in the embedding, so ∂r/∂w = 0 and h₃ = 0.
+    let err = Coordinates::from_embedding([u, v, w], [u, v, p.integer(0_i32)], "collapsed", p)
+        .expect_err("a degenerate chart must be refused");
+    assert_eq!(err.code(), "E-VEC-005");
+    assert!(matches!(
+        err,
+        VectorError::DegenerateScaleFactor {
+            index: 2,
+            proven_zero: true,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn repeated_or_non_symbol_coordinates_are_refused() {
+    use crate::errors::AlkahestError;
+    let ch = Charts::new();
+    let p = ch.p();
+    let x = p.symbol("x0", Domain::Real);
+    let y = p.symbol("y0", Domain::Real);
+    let err = Coordinates::cartesian(x, y, x, p).expect_err("x twice must be refused");
+    assert_eq!(err.code(), "E-VEC-002");
+
+    let err = Coordinates::cylindrical(x, y, p.integer(3_i32), p)
+        .expect_err("a literal is not a coordinate");
+    assert_eq!(err.code(), "E-VEC-003");
+}
+
+#[test]
+fn cartesian_gradient_is_the_plain_partial_derivatives() {
+    let ch = Charts::new();
+    let p = ch.p();
+    let [x, y, z] = ch.c;
+    let two = ch.int(2);
+    let f = p.add(vec![p.mul(vec![p.pow(x, two), y]), p.pow(z, two)]);
+    let g = gradient(f, &ch.cart, p).unwrap();
+    let expect = [
+        simplify(crate::diff::diff(f, x, p).unwrap().value, p).value,
+        simplify(crate::diff::diff(f, y, p).unwrap().value, p).value,
+        simplify(crate::diff::diff(f, z, p).unwrap().value, p).value,
+    ];
+    assert_eq!(g, expect, "Cartesian grad must be exactly (∂x, ∂y, ∂z)");
+}
+
+#[test]
+fn radial_inverse_square_field_is_divergence_free_away_from_the_origin() {
+    // ∇·(r̂/r²) = 0 for r > 0 — the textbook case where the "obvious"
+    // componentwise answer is wrong and the r² factor in the spherical
+    // divergence is doing all the work.
+    let ch = Charts::new();
+    let p = ch.p();
+    let r = ch.sph.vars()[0];
+    let zero = ch.int(0);
+    let field = [p.pow(r, p.integer(-2_i32)), zero, zero];
+    let d = divergence(&field, &ch.sph, p).unwrap();
+    assert_eq!(d, zero, "∇·(r̂/r²) must reduce to exactly 0");
+
+    // …while ∇·r̂ = 2/r, not 0.
+    let unit = [ch.int(1), zero, zero];
+    let d1 = divergence(&unit, &ch.sph, p).unwrap();
+    let mut rng = Rng::new(0x4242_4242);
+    for _ in 0..5 {
+        let env = ch.sph_env(&mut rng);
+        close(ev(d1, &env, p), 2.0 / env[&r], "∇·r̂ = 2/r");
+    }
+}

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -16998,6 +16998,760 @@ fn py_binomial_mod(a: u64, b: i128, p: u64, k: u32) -> PyResult<u64> {
     core_binomial_mod(a, b, p, k).map_err(holonomic_modular_error_to_py)
 }
 
+// ---------------------------------------------------------------------------
+// Vector calculus and quaternions (experimental surface)
+// ---------------------------------------------------------------------------
+
+pyo3::create_exception!(alkahest, PyVectorError, PyAlkahestError);
+pyo3::create_exception!(alkahest, PyQuaternionError, PyAlkahestError);
+
+fn vector_error_to_py(e: alkahest_core::vector::VectorError) -> PyErr {
+    Python::with_gil(|py| {
+        let exc_type = py.get_type_bound::<PyVectorError>();
+        make_structured_err(py, &exc_type, &e)
+    })
+}
+
+fn quaternion_error_to_py(e: alkahest_core::algebra::quaternion::QuaternionError) -> PyErr {
+    Python::with_gil(|py| {
+        let exc_type = py.get_type_bound::<PyQuaternionError>();
+        make_structured_err(py, &exc_type, &e)
+    })
+}
+
+/// The pool behind the first `Expr`/`DerivedResult` in `items`, if any.
+///
+/// Same rule `Matrix.from_rows` uses: bare numbers are coerced into the pool
+/// the symbolic entries already live in, and an all-numeric argument list has
+/// no pool to infer.
+fn pool_from_items(py: Python<'_>, items: &[Bound<'_, PyAny>]) -> Option<Py<PyExprPool>> {
+    for item in items {
+        if let Ok(e) = item.extract::<PyRef<PyExpr>>() {
+            return Some(e.pool.clone_ref(py));
+        }
+        if let Ok(dr) = item.downcast::<PyDerivedResult>() {
+            return Some(dr.borrow().value.pool.clone_ref(py));
+        }
+    }
+    None
+}
+
+fn require_three(items: &[Bound<'_, PyAny>], what: &str) -> PyResult<()> {
+    if items.len() != 3 {
+        return Err(PyTypeError::new_err(format!(
+            "{what} takes exactly 3 components, got {}",
+            items.len()
+        )));
+    }
+    Ok(())
+}
+
+fn coerce_vec3(
+    pool_py: &Py<PyExprPool>,
+    items: &[Bound<'_, PyAny>],
+    py: Python<'_>,
+    what: &str,
+) -> PyResult<[ExprId; 3]> {
+    require_three(items, what)?;
+    Ok([
+        coerce_substituent(pool_py, &items[0], py)?,
+        coerce_substituent(pool_py, &items[1], py)?,
+        coerce_substituent(pool_py, &items[2], py)?,
+    ])
+}
+
+fn vec3_to_py(v: [ExprId; 3], pool_py: &Py<PyExprPool>, py: Python<'_>) -> PyObject {
+    PyTuple::new_bound(
+        py,
+        v.iter().map(|&id| {
+            PyExpr {
+                id,
+                pool: pool_py.clone_ref(py),
+            }
+            .into_py(py)
+        }),
+    )
+    .into_py(py)
+}
+
+/// An orthogonal coordinate system — three coordinate symbols and their scale
+/// factors.
+///
+/// Build one with :meth:`cartesian`, :meth:`cylindrical`, :meth:`spherical` or
+/// :meth:`from_embedding`. There is no constructor taking scale factors
+/// directly: the three built-in charts carry textbook values, and anything
+/// else has to come from an embedding whose orthogonality was *checked*
+/// (``E-VEC-004`` when it cannot be).
+///
+/// Vector fields are given in **physical** components — the local orthonormal
+/// frame — which is the convention ``sympy.vector`` uses and the one an
+/// engineer means by "the ρ component".
+#[pyclass(name = "Coordinates", module = "alkahest.experimental")]
+#[derive(Clone)]
+struct PyCoordinates {
+    inner: alkahest_core::vector::Coordinates,
+    pool: Py<PyExprPool>,
+}
+
+#[pymethods]
+impl PyCoordinates {
+    /// Cartesian ``(x, y, z)`` — scale factors ``(1, 1, 1)``.
+    #[staticmethod]
+    fn cartesian(
+        py: Python<'_>,
+        x: PyRef<PyExpr>,
+        y: PyRef<PyExpr>,
+        z: PyRef<PyExpr>,
+    ) -> PyResult<PyCoordinates> {
+        let pool_py = x.pool.clone_ref(py);
+        if !y.pool.is(&pool_py) || !z.pool.is(&pool_py) {
+            return Err(pool_mismatch_err());
+        }
+        let inner = {
+            let pool = pool_py.borrow(py);
+            alkahest_core::vector::Coordinates::cartesian(x.id, y.id, z.id, &pool.inner)
+                .map_err(vector_error_to_py)?
+        };
+        Ok(PyCoordinates {
+            inner,
+            pool: pool_py,
+        })
+    }
+
+    /// Cylindrical ``(ρ, φ, z)`` — scale factors ``(1, ρ, 1)``, with
+    /// ``x = ρ cos φ``, ``y = ρ sin φ``. Right-handed in this order.
+    #[staticmethod]
+    fn cylindrical(
+        py: Python<'_>,
+        rho: PyRef<PyExpr>,
+        phi: PyRef<PyExpr>,
+        z: PyRef<PyExpr>,
+    ) -> PyResult<PyCoordinates> {
+        let pool_py = rho.pool.clone_ref(py);
+        if !phi.pool.is(&pool_py) || !z.pool.is(&pool_py) {
+            return Err(pool_mismatch_err());
+        }
+        let inner = {
+            let pool = pool_py.borrow(py);
+            alkahest_core::vector::Coordinates::cylindrical(rho.id, phi.id, z.id, &pool.inner)
+                .map_err(vector_error_to_py)?
+        };
+        Ok(PyCoordinates {
+            inner,
+            pool: pool_py,
+        })
+    }
+
+    /// Spherical ``(r, θ, φ)`` — scale factors ``(1, r, r sin θ)``.
+    ///
+    /// The **physics / ISO 80000-2** convention: ``θ`` is the polar angle from
+    /// ``+z``, ``φ`` the azimuth, so ``x = r sin θ cos φ``,
+    /// ``y = r sin θ sin φ``, ``z = r cos θ``. Right-handed in the order
+    /// ``(r, θ, φ)``.
+    #[staticmethod]
+    fn spherical(
+        py: Python<'_>,
+        r: PyRef<PyExpr>,
+        theta: PyRef<PyExpr>,
+        phi: PyRef<PyExpr>,
+    ) -> PyResult<PyCoordinates> {
+        let pool_py = r.pool.clone_ref(py);
+        if !theta.pool.is(&pool_py) || !phi.pool.is(&pool_py) {
+            return Err(pool_mismatch_err());
+        }
+        let inner = {
+            let pool = pool_py.borrow(py);
+            alkahest_core::vector::Coordinates::spherical(r.id, theta.id, phi.id, &pool.inner)
+                .map_err(vector_error_to_py)?
+        };
+        Ok(PyCoordinates {
+            inner,
+            pool: pool_py,
+        })
+    }
+
+    /// Derive a chart from its Cartesian embedding ``(x(u), y(u), z(u))``,
+    /// **verifying orthogonality** before returning it.
+    ///
+    /// ``hᵢ = |∂r/∂uᵢ|``, and a pair is accepted only when
+    /// ``∂r/∂uᵢ · ∂r/∂u_j`` is *proven* to vanish: an undecided inner product
+    /// raises ``E-VEC-004`` rather than being assumed away. Every formula in
+    /// this module is false on a skew chart, and false in a way that produces
+    /// an ordinary-looking expression.
+    #[staticmethod]
+    #[pyo3(signature = (coordinates, embedding, label = None))]
+    fn from_embedding(
+        py: Python<'_>,
+        coordinates: Vec<Bound<'_, PyAny>>,
+        embedding: Vec<Bound<'_, PyAny>>,
+        label: Option<String>,
+    ) -> PyResult<PyCoordinates> {
+        require_three(&coordinates, "Coordinates.from_embedding(coordinates=...)")?;
+        require_three(&embedding, "Coordinates.from_embedding(embedding=...)")?;
+        let pool_py = pool_from_items(py, &coordinates)
+            .or_else(|| pool_from_items(py, &embedding))
+            .ok_or_else(|| {
+                PyTypeError::new_err(
+                    "Coordinates.from_embedding could not determine an ExprPool: at least \
+                     one coordinate or embedding component must be an Expr",
+                )
+            })?;
+        let vars = coerce_vec3(&pool_py, &coordinates, py, "coordinates")?;
+        let emb = coerce_vec3(&pool_py, &embedding, py, "embedding")?;
+        let inner = {
+            let pool = pool_py.borrow(py);
+            alkahest_core::vector::Coordinates::from_embedding(
+                vars,
+                emb,
+                label.unwrap_or_else(|| "custom".to_string()),
+                &pool.inner,
+            )
+            .map_err(vector_error_to_py)?
+        };
+        Ok(PyCoordinates {
+            inner,
+            pool: pool_py,
+        })
+    }
+
+    /// The three coordinate symbols, in constructor order.
+    fn vars(&self, py: Python<'_>) -> PyObject {
+        vec3_to_py(self.inner.vars(), &self.pool, py)
+    }
+
+    /// The three scale factors ``(h₁, h₂, h₃)``.
+    fn scale_factors(&self, py: Python<'_>) -> PyObject {
+        vec3_to_py(self.inner.scale_factors(), &self.pool, py)
+    }
+
+    /// The chart's name, for diagnostics.
+    #[getter]
+    fn label(&self) -> String {
+        self.inner.label().to_string()
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let pool = self.pool.borrow(py);
+        let vars = self.inner.vars();
+        format!(
+            "Coordinates({}, ({}, {}, {}))",
+            self.inner.label(),
+            pool.inner.display(vars[0]),
+            pool.inner.display(vars[1]),
+            pool.inner.display(vars[2]),
+        )
+    }
+}
+
+/// ``experimental.gradient(f, coords)`` — ``∇f`` in physical components.
+#[pyfunction]
+#[pyo3(name = "gradient")]
+fn py_vector_gradient(
+    py: Python<'_>,
+    f: &Bound<'_, PyAny>,
+    coords: PyRef<PyCoordinates>,
+) -> PyResult<PyObject> {
+    let pool_py = coords.pool.clone_ref(py);
+    let fid = coerce_substituent(&pool_py, f, py)?;
+    let out = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::gradient(fid, &coords.inner, &pool.inner)
+            .map_err(vector_error_to_py)?
+    };
+    Ok(vec3_to_py(out, &pool_py, py))
+}
+
+/// ``experimental.divergence(field, coords)`` — ``∇·F``.
+#[pyfunction]
+#[pyo3(name = "divergence")]
+fn py_vector_divergence(
+    py: Python<'_>,
+    field: Vec<Bound<'_, PyAny>>,
+    coords: PyRef<PyCoordinates>,
+) -> PyResult<PyExpr> {
+    let pool_py = coords.pool.clone_ref(py);
+    let f = coerce_vec3(&pool_py, &field, py, "divergence(field=...)")?;
+    let id = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::divergence(&f, &coords.inner, &pool.inner)
+            .map_err(vector_error_to_py)?
+    };
+    Ok(PyExpr { id, pool: pool_py })
+}
+
+/// ``experimental.curl(field, coords)`` — ``∇×F`` in a right-handed frame.
+#[pyfunction]
+#[pyo3(name = "curl")]
+fn py_vector_curl(
+    py: Python<'_>,
+    field: Vec<Bound<'_, PyAny>>,
+    coords: PyRef<PyCoordinates>,
+) -> PyResult<PyObject> {
+    let pool_py = coords.pool.clone_ref(py);
+    let f = coerce_vec3(&pool_py, &field, py, "curl(field=...)")?;
+    let out = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::curl(&f, &coords.inner, &pool.inner).map_err(vector_error_to_py)?
+    };
+    Ok(vec3_to_py(out, &pool_py, py))
+}
+
+/// ``experimental.laplacian(f, coords)`` — the scalar Laplacian ``∇²f``.
+#[pyfunction]
+#[pyo3(name = "laplacian")]
+fn py_vector_laplacian_scalar(
+    py: Python<'_>,
+    f: &Bound<'_, PyAny>,
+    coords: PyRef<PyCoordinates>,
+) -> PyResult<PyExpr> {
+    let pool_py = coords.pool.clone_ref(py);
+    let fid = coerce_substituent(&pool_py, f, py)?;
+    let id = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::laplacian(fid, &coords.inner, &pool.inner)
+            .map_err(vector_error_to_py)?
+    };
+    Ok(PyExpr { id, pool: pool_py })
+}
+
+/// ``experimental.vector_laplacian(field, coords)`` — ``∇²F``, defined as
+/// ``∇(∇·F) − ∇×(∇×F)``.
+///
+/// In Cartesian coordinates that equals the componentwise scalar Laplacian and
+/// is computed that way. In every other chart it does **not**: applying
+/// :func:`laplacian` to each physical component there is a silent error, and
+/// this function exists so that nobody has to.
+#[pyfunction]
+#[pyo3(name = "vector_laplacian")]
+fn py_vector_laplacian_vector(
+    py: Python<'_>,
+    field: Vec<Bound<'_, PyAny>>,
+    coords: PyRef<PyCoordinates>,
+) -> PyResult<PyObject> {
+    let pool_py = coords.pool.clone_ref(py);
+    let f = coerce_vec3(&pool_py, &field, py, "vector_laplacian(field=...)")?;
+    let out = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::vector_laplacian(&f, &coords.inner, &pool.inner)
+            .map_err(vector_error_to_py)?
+    };
+    Ok(vec3_to_py(out, &pool_py, py))
+}
+
+fn vec3_pair(
+    py: Python<'_>,
+    a: &[Bound<'_, PyAny>],
+    b: &[Bound<'_, PyAny>],
+    what: &str,
+) -> PyResult<(Py<PyExprPool>, [ExprId; 3], [ExprId; 3])> {
+    let pool_py = pool_from_items(py, a)
+        .or_else(|| pool_from_items(py, b))
+        .ok_or_else(|| {
+            PyTypeError::new_err(format!(
+                "{what} could not determine an ExprPool: at least one component must be an Expr"
+            ))
+        })?;
+    let av = coerce_vec3(&pool_py, a, py, what)?;
+    let bv = coerce_vec3(&pool_py, b, py, what)?;
+    Ok((pool_py, av, bv))
+}
+
+/// ``experimental.dot(a, b)`` — ``Σ aᵢbᵢ`` in an orthonormal frame.
+#[pyfunction]
+#[pyo3(name = "dot")]
+fn py_vector_dot(
+    py: Python<'_>,
+    a: Vec<Bound<'_, PyAny>>,
+    b: Vec<Bound<'_, PyAny>>,
+) -> PyResult<PyExpr> {
+    let (pool_py, av, bv) = vec3_pair(py, &a, &b, "dot(a, b)")?;
+    let id = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::dot(&av, &bv, &pool.inner)
+    };
+    Ok(PyExpr { id, pool: pool_py })
+}
+
+/// ``experimental.cross(a, b)`` — ``a × b`` in a **right-handed** orthonormal
+/// frame, so ``ê₁ × ê₂ = ê₃``.
+#[pyfunction]
+#[pyo3(name = "cross")]
+fn py_vector_cross(
+    py: Python<'_>,
+    a: Vec<Bound<'_, PyAny>>,
+    b: Vec<Bound<'_, PyAny>>,
+) -> PyResult<PyObject> {
+    let (pool_py, av, bv) = vec3_pair(py, &a, &b, "cross(a, b)")?;
+    let out = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::cross(&av, &bv, &pool.inner)
+    };
+    Ok(vec3_to_py(out, &pool_py, py))
+}
+
+/// ``experimental.norm(a)`` — ``√(a·a)``, the Euclidean length of a real
+/// 3-vector.
+#[pyfunction]
+#[pyo3(name = "norm")]
+fn py_vector_norm(py: Python<'_>, a: Vec<Bound<'_, PyAny>>) -> PyResult<PyExpr> {
+    let pool_py = pool_from_items(py, &a).ok_or_else(|| {
+        PyTypeError::new_err(
+            "norm(a) could not determine an ExprPool: at least one component must be an Expr",
+        )
+    })?;
+    let av = coerce_vec3(&pool_py, &a, py, "norm(a)")?;
+    let id = {
+        let pool = pool_py.borrow(py);
+        alkahest_core::vector::norm(&av, &pool.inner)
+    };
+    Ok(PyExpr { id, pool: pool_py })
+}
+
+/// A Hamilton quaternion ``w + xi + yj + zk``.
+///
+/// ``i² = j² = k² = ijk = −1``, so ``ij = k`` and ``ji = −k``: ``*`` does not
+/// commute. :meth:`rotate` is the **active** rotation ``v ↦ q v q⁻¹`` in a
+/// right-handed frame, and composition follows from it —
+/// ``(q1 * q2)`` applies ``q2`` first, and
+/// ``(q1 * q2).to_rotation_matrix() == q1.to_rotation_matrix() @
+/// q2.to_rotation_matrix()``.
+#[pyclass(name = "Quaternion", module = "alkahest.experimental")]
+#[derive(Clone)]
+struct PyQuaternion {
+    inner: alkahest_core::algebra::quaternion::Quaternion,
+    pool: Py<PyExprPool>,
+}
+
+impl PyQuaternion {
+    fn wrap(
+        inner: alkahest_core::algebra::quaternion::Quaternion,
+        pool: &Py<PyExprPool>,
+        py: Python<'_>,
+    ) -> PyQuaternion {
+        PyQuaternion {
+            inner,
+            pool: pool.clone_ref(py),
+        }
+    }
+
+    fn expr(&self, id: ExprId, py: Python<'_>) -> PyExpr {
+        PyExpr {
+            id,
+            pool: self.pool.clone_ref(py),
+        }
+    }
+}
+
+#[pymethods]
+impl PyQuaternion {
+    /// ``Quaternion(w, x, y, z, pool=None)``.
+    ///
+    /// Each component may be an :class:`Expr`, a :class:`DerivedResult`, or a
+    /// Python number. Numbers are coerced into the pool the symbolic
+    /// components live in; if all four are numbers, pass ``pool=`` explicitly,
+    /// because there is nothing to infer it from.
+    #[new]
+    #[pyo3(signature = (w, x, y, z, pool = None))]
+    fn __new__(
+        py: Python<'_>,
+        w: Bound<'_, PyAny>,
+        x: Bound<'_, PyAny>,
+        y: Bound<'_, PyAny>,
+        z: Bound<'_, PyAny>,
+        pool: Option<Py<PyExprPool>>,
+    ) -> PyResult<PyQuaternion> {
+        let items = [w, x, y, z];
+        let pool_py = match pool {
+            Some(p) => p,
+            None => pool_from_items(py, &items).ok_or_else(|| {
+                PyTypeError::new_err(
+                    "Quaternion could not determine an ExprPool: pass at least one Expr \
+                     component, or the pool= keyword",
+                )
+            })?,
+        };
+        let mut c = Vec::with_capacity(4);
+        for item in &items {
+            c.push(coerce_substituent(&pool_py, item, py)?);
+        }
+        Ok(PyQuaternion {
+            inner: alkahest_core::algebra::quaternion::Quaternion::new(c[0], c[1], c[2], c[3]),
+            pool: pool_py,
+        })
+    }
+
+    /// The multiplicative identity ``1``.
+    #[staticmethod]
+    fn identity(py: Python<'_>, pool: Py<PyExprPool>) -> PyQuaternion {
+        let inner = {
+            let p = pool.borrow(py);
+            alkahest_core::algebra::quaternion::Quaternion::identity(&p.inner)
+        };
+        PyQuaternion { inner, pool }
+    }
+
+    /// The real part ``w``.
+    #[getter]
+    fn w(&self, py: Python<'_>) -> PyExpr {
+        self.expr(self.inner.w(), py)
+    }
+
+    /// The ``i`` component.
+    #[getter]
+    fn x(&self, py: Python<'_>) -> PyExpr {
+        self.expr(self.inner.x(), py)
+    }
+
+    /// The ``j`` component.
+    #[getter]
+    fn y(&self, py: Python<'_>) -> PyExpr {
+        self.expr(self.inner.y(), py)
+    }
+
+    /// The ``k`` component.
+    #[getter]
+    fn z(&self, py: Python<'_>) -> PyExpr {
+        self.expr(self.inner.z(), py)
+    }
+
+    /// ``(w, x, y, z)``, scalar first.
+    fn components(&self, py: Python<'_>) -> PyObject {
+        let c = self.inner.components();
+        PyTuple::new_bound(py, c.iter().map(|&id| self.expr(id, py).into_py(py))).into_py(py)
+    }
+
+    /// ``(x, y, z)`` — the vector part.
+    fn vector_part(&self, py: Python<'_>) -> PyObject {
+        vec3_to_py(self.inner.vector_part(), &self.pool, py)
+    }
+
+    /// The **Hamilton product**. Not commutative: ``i * j == k`` while
+    /// ``j * i == -k``.
+    fn __mul__(&self, py: Python<'_>, other: PyRef<PyQuaternion>) -> PyResult<PyQuaternion> {
+        if !other.pool.is(&self.pool) {
+            return Err(pool_mismatch_err());
+        }
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner.mul(&other.inner, &p.inner)
+        };
+        Ok(PyQuaternion::wrap(inner, &self.pool, py))
+    }
+
+    fn __add__(&self, py: Python<'_>, other: PyRef<PyQuaternion>) -> PyResult<PyQuaternion> {
+        if !other.pool.is(&self.pool) {
+            return Err(pool_mismatch_err());
+        }
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner.add(&other.inner, &p.inner)
+        };
+        Ok(PyQuaternion::wrap(inner, &self.pool, py))
+    }
+
+    fn __sub__(&self, py: Python<'_>, other: PyRef<PyQuaternion>) -> PyResult<PyQuaternion> {
+        if !other.pool.is(&self.pool) {
+            return Err(pool_mismatch_err());
+        }
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner.sub(&other.inner, &p.inner)
+        };
+        Ok(PyQuaternion::wrap(inner, &self.pool, py))
+    }
+
+    fn __neg__(&self, py: Python<'_>) -> PyQuaternion {
+        let inner = {
+            let p = self.pool.borrow(py);
+            let neg = p.inner.integer(-1_i32);
+            self.inner.scale(neg, &p.inner)
+        };
+        PyQuaternion::wrap(inner, &self.pool, py)
+    }
+
+    fn __eq__(&self, other: PyRef<PyQuaternion>) -> bool {
+        self.inner == other.inner && other.pool.is(&self.pool)
+    }
+
+    /// ``q̄ = w − xi − yj − zk``.
+    fn conjugate(&self, py: Python<'_>) -> PyQuaternion {
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner.conjugate(&p.inner)
+        };
+        PyQuaternion::wrap(inner, &self.pool, py)
+    }
+
+    /// ``|q|² = w² + x² + y² + z²``.
+    fn norm_squared(&self, py: Python<'_>) -> PyExpr {
+        let id = {
+            let p = self.pool.borrow(py);
+            self.inner.norm_squared(&p.inner)
+        };
+        self.expr(id, py)
+    }
+
+    /// ``|q| = √(w² + x² + y² + z²)``.
+    fn norm(&self, py: Python<'_>) -> PyExpr {
+        let id = {
+            let p = self.pool.borrow(py);
+            self.inner.norm(&p.inner)
+        };
+        self.expr(id, py)
+    }
+
+    /// ``q⁻¹ = q̄/|q|²``.
+    ///
+    /// Raises ``E-QUAT-001`` when ``|q|²`` is zero or its vanishing could not
+    /// be decided.
+    fn inverse(&self, py: Python<'_>) -> PyResult<PyQuaternion> {
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner
+                .inverse(&p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(PyQuaternion::wrap(inner, &self.pool, py))
+    }
+
+    /// ``q/|q|``. Raises ``E-QUAT-001`` for a zero or undecided norm.
+    fn normalize(&self, py: Python<'_>) -> PyResult<PyQuaternion> {
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner
+                .normalize(&p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(PyQuaternion::wrap(inner, &self.pool, py))
+    }
+
+    /// The **active** rotation ``v ↦ q v q⁻¹``, returned as a 3-tuple.
+    ///
+    /// ``q`` need not be a unit quaternion — the operator is invariant under
+    /// ``q ↦ λq``. Raises ``E-QUAT-001`` for a zero or undecided norm.
+    fn rotate(&self, py: Python<'_>, v: Vec<Bound<'_, PyAny>>) -> PyResult<PyObject> {
+        let vv = coerce_vec3(&self.pool, &v, py, "Quaternion.rotate(v)")?;
+        let out = {
+            let p = self.pool.borrow(py);
+            self.inner
+                .rotate(&vv, &p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(vec3_to_py(out, &self.pool, py))
+    }
+
+    /// The 3×3 :class:`~alkahest.Matrix` ``R`` with ``R @ v == q.rotate(v)``.
+    fn to_rotation_matrix(&self, py: Python<'_>) -> PyResult<PyMatrix> {
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner
+                .to_rotation_matrix(&p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(PyMatrix {
+            inner,
+            pool: self.pool.clone_ref(py),
+        })
+    }
+
+    /// ``(axis, angle)`` with ``angle = 2·atan2(|v|, w)`` and ``axis = v/|v|``.
+    ///
+    /// Raises ``E-QUAT-002`` when the vector part is zero: ``q`` is then a real
+    /// scalar, the rotation is the identity, and *every* unit vector is an axis
+    /// for it. There is no axis to return, and returning the conventional
+    /// ``(0, 0, 1)`` would be a stated answer to a question with no answer.
+    fn to_axis_angle(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let (axis, angle) = {
+            let p = self.pool.borrow(py);
+            self.inner
+                .to_axis_angle(&p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(PyTuple::new_bound(
+            py,
+            [
+                vec3_to_py(axis, &self.pool, py),
+                self.expr(angle, py).into_py(py),
+            ],
+        )
+        .into_py(py))
+    }
+
+    /// ``q = cos(θ/2) + sin(θ/2)·û`` for a rotation of ``angle`` about
+    /// ``axis``, right-handed.
+    ///
+    /// ``axis`` is normalised internally. Raises ``E-QUAT-001`` when it is the
+    /// zero vector — that picks out no axis.
+    #[staticmethod]
+    fn from_axis_angle(
+        py: Python<'_>,
+        axis: Vec<Bound<'_, PyAny>>,
+        angle: &Bound<'_, PyAny>,
+    ) -> PyResult<PyQuaternion> {
+        let mut items = axis.clone();
+        items.push(angle.clone());
+        let pool_py = pool_from_items(py, &items).ok_or_else(|| {
+            PyTypeError::new_err(
+                "Quaternion.from_axis_angle could not determine an ExprPool: the axis or the \
+                 angle must contain an Expr",
+            )
+        })?;
+        let ax = coerce_vec3(&pool_py, &axis, py, "Quaternion.from_axis_angle(axis)")?;
+        let ang = coerce_substituent(&pool_py, angle, py)?;
+        let inner = {
+            let p = pool_py.borrow(py);
+            alkahest_core::algebra::quaternion::Quaternion::from_axis_angle(&ax, ang, &p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(PyQuaternion {
+            inner,
+            pool: pool_py,
+        })
+    }
+
+    /// Recover a unit quaternion from a **numeric** proper rotation matrix.
+    ///
+    /// Raises ``E-QUAT-003`` unless the matrix is 3×3, every entry evaluates to
+    /// a finite number, ``RᵀR = I``, ``det R = +1``, *and* the recovered
+    /// quaternion reproduces the matrix. Symbolic entries refuse: the branch
+    /// selection is a comparison between entries, and there is none to make on
+    /// a symbol.
+    #[staticmethod]
+    fn from_rotation_matrix(py: Python<'_>, m: PyRef<PyMatrix>) -> PyResult<PyQuaternion> {
+        let pool_py = m.pool.clone_ref(py);
+        let inner = {
+            let p = pool_py.borrow(py);
+            alkahest_core::algebra::quaternion::Quaternion::from_rotation_matrix(&m.inner, &p.inner)
+                .map_err(quaternion_error_to_py)?
+        };
+        Ok(PyQuaternion {
+            inner,
+            pool: pool_py,
+        })
+    }
+
+    /// Simplify all four components.
+    fn simplify(&self, py: Python<'_>) -> PyQuaternion {
+        let inner = {
+            let p = self.pool.borrow(py);
+            self.inner.simplified(&p.inner)
+        };
+        PyQuaternion::wrap(inner, &self.pool, py)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let p = self.pool.borrow(py);
+        let c = self.inner.components();
+        format!(
+            "Quaternion({}, {}, {}, {})",
+            p.inner.display(c[0]),
+            p.inner.display(c[1]),
+            p.inner.display(c[2]),
+            p.inner.display(c[3]),
+        )
+    }
+}
+
 #[pymodule]
 fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Before anything in this module can reach GMP: install the allocation
@@ -17039,6 +17793,22 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // P1 item 10 — asymptotic expansion at scale
     m.add_class::<PyAsymptoticReport>()?;
     m.add_class::<PyPuiseuxExpansion>()?;
+    // Vector calculus and quaternions (experimental surface)
+    m.add_class::<PyCoordinates>()?;
+    m.add_class::<PyQuaternion>()?;
+    m.add("VectorError", m.py().get_type_bound::<PyVectorError>())?;
+    m.add(
+        "QuaternionError",
+        m.py().get_type_bound::<PyQuaternionError>(),
+    )?;
+    m.add_function(wrap_pyfunction!(py_vector_gradient, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_divergence, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_curl, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_laplacian_scalar, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_laplacian_vector, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_dot, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_cross, m)?)?;
+    m.add_function(wrap_pyfunction!(py_vector_norm, m)?)?;
     m.add_function(wrap_pyfunction!(py_euler_maclaurin, m)?)?;
     m.add_function(wrap_pyfunction!(py_coefficient_asymptotics, m)?)?;
     // P1 item 7 — creative telescoping / holonomic (D-finite) machinery

--- a/docs/mdbook/src/errors.md
+++ b/docs/mdbook/src/errors.md
@@ -270,6 +270,26 @@ Every error is classified on two independent axes: **subsystem** (determines the
 | `E-XCHECK-*` | `CrossCheckError` | Cross-CAS differential testing — see [Cross-CAS testing](./crosscheck.md) |
 | `E-SMT-*` | `SmtError` | SMT-LIB export, solver invocation, model lift — see [SMT bridge](./smt.md) |
 | `E-RESIDUE-*` | `AlkahestError` | `residue` — not a rational function, zero denominator, pole order out of range, or (`E-RESIDUE-005`) a point that is not an exact constant in ℚ(i) |
+| `E-VEC-*` | `VectorError` | Vector calculus over an orthogonal chart — a non-differentiable component, a repeated or non-symbol coordinate, a chart that could not be *proven* orthogonal (`E-VEC-004`), or a degenerate scale factor (`E-VEC-005`). See [Vector calculus and quaternions](#vector-calculus-and-quaternions) |
+| `E-QUAT-*` | `QuaternionError` | Quaternion algebra and rotations — a zero or undecided norm (`E-QUAT-001`), the axis of the identity rotation, which does not exist (`E-QUAT-002`), or a matrix that could not be checked to be a proper rotation (`E-QUAT-003`) |
+
+### Vector calculus and quaternions
+
+`alkahest.experimental`'s rigid-body layer refuses in three places where a clean,
+plausible number is available, and that is the point of each of them.
+
+| Code | Raised by | Why a refusal rather than an answer |
+|---|---|---|
+| `E-VEC-004` | `Coordinates.from_embedding` | Every `grad`/`div`/`curl`/`∇²` formula in the module is derived for an **orthogonal** frame. On a skew chart they still evaluate, to an expression that looks like a divergence and is not one. So the tangent inner products must be *proven* to vanish; undecided is a refusal, not an assumption |
+| `E-VEC-005` | `Coordinates.from_embedding` | A scale factor that is identically zero — or whose non-vanishing could not be established — is divided by in every operator |
+| `E-QUAT-002` | `Quaternion.to_axis_angle` | The identity rotation has no axis: *every* unit vector is one. The conventional stand-in `(0, 0, 1)` is a stated answer to a question with no answer, and nothing downstream can tell it from a real axis |
+| `E-QUAT-003` | `Quaternion.from_rotation_matrix` | Shepperd's method returns a perfectly ordinary unit quaternion for a reflection, a scaled matrix or a shear — representing some *other*, proper rotation. So `RᵀR = I` and `det R = +1` are checked, the recovered quaternion is required to reproduce the matrix, and a **symbolic** matrix refuses outright, because the branch selection is a comparison between entries and there is none to make on a symbol |
+
+The vector Laplacian is a fourth trap without an error code, because there is a right
+answer: `experimental.vector_laplacian` is `∇(∇·F) − ∇×(∇×F)`, which equals the
+componentwise scalar Laplacian in Cartesian coordinates **only**. Applying
+`experimental.laplacian` to each physical component of a cylindrical or spherical field
+silently drops the terms that come from the basis turning — `∇²(φ̂)` is `−φ̂/ρ²`, not `0`.
 
 `E-RESIDUE-005` is raised only at the Python boundary — the Rust `residue` takes an
 already-parsed point and cannot reach that state — so it is deliberately absent from

--- a/python/alkahest/exceptions.py
+++ b/python/alkahest/exceptions.py
@@ -830,3 +830,42 @@ class ParseError(AlkahestError):
         span: tuple[int, int] | None = None,
     ):
         super().__init__(message, code="E-PARSE-001", remediation=remediation, span=span)
+
+
+class VectorError(AlkahestError):
+    """Vector calculus over an orthogonal chart refused (``E-VEC-001`` … ``E-VEC-005``).
+
+    ``E-VEC-004`` is the one to read twice: the chart handed to
+    :meth:`alkahest.experimental.Coordinates.from_embedding` was not shown to be
+    orthogonal, and every ``grad``/``div``/``curl``/``∇²`` formula in that module
+    assumes it is. On a skew chart they still evaluate — to an expression that
+    looks like a divergence and is not one — so an *undecided* inner product is a
+    refusal rather than an assumption.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "E-VEC-001",
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code=code, remediation=remediation, span=span)
+
+
+class QuaternionError(AlkahestError):
+    """A quaternion operation refused (``E-QUAT-001`` … ``E-QUAT-003``).
+
+    ``E-QUAT-002`` is a refusal by design: the identity rotation has no axis,
+    because *every* unit vector is one. Returning the conventional ``(0, 0, 1)``
+    would be a stated answer to a question with no answer.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "E-QUAT-001",
+        remediation: str | None = None,
+        span: tuple[int, int] | None = None,
+    ):
+        super().__init__(message, code=code, remediation=remediation, span=span)

--- a/python/alkahest/experimental/__init__.py
+++ b/python/alkahest/experimental/__init__.py
@@ -74,6 +74,34 @@ Calculus / ODE / transform surface:
   arithmetic works over, exposed so a caller can redo the divisibility check
   by hand
 
+Vector calculus and quaternions (the rigid-body layer):
+- :class:`Coordinates` — an orthogonal chart, built by
+  :meth:`Coordinates.cartesian`, :meth:`Coordinates.cylindrical`,
+  :meth:`Coordinates.spherical`, or :meth:`Coordinates.from_embedding`, which
+  derives the scale factors from a Cartesian parametrisation and **refuses**
+  (``E-VEC-004``) a chart it cannot prove orthogonal. There is no constructor
+  taking scale factors directly
+- :func:`gradient`, :func:`divergence`, :func:`curl`, :func:`laplacian`,
+  :func:`vector_laplacian`, and the algebra they are used with —
+  :func:`dot`, :func:`cross`, :func:`norm`. Vector fields are three
+  **physical** components, read in the local orthonormal frame, which is the
+  convention ``sympy.vector`` uses and the one an engineer means by "the ρ
+  component"
+- :func:`vector_laplacian` is ``∇(∇·F) − ∇×(∇×F)``. That equals the
+  componentwise scalar Laplacian in Cartesian coordinates *only*; applying
+  :func:`laplacian` to each physical component of a cylindrical or spherical
+  field is a silent error, and this entry point exists so nobody has to
+- :class:`Quaternion` — Hamilton product (``i*j == k``, ``j*i == -k``),
+  conjugate, norm, inverse, the active rotation ``q v q⁻¹``, and conversions
+  to and from a rotation matrix and axis–angle form.
+  ``(q1 * q2)`` applies ``q2`` first, so
+  ``(q1 * q2).to_rotation_matrix()`` is ``R(q1) @ R(q2)``.
+  :meth:`Quaternion.to_axis_angle` **refuses** (``E-QUAT-002``) for the
+  identity rotation, which has no axis because every unit vector is one, and
+  :meth:`Quaternion.from_rotation_matrix` refuses (``E-QUAT-003``) anything it
+  cannot check is a proper rotation — including a symbolic matrix, where the
+  branch selection is a comparison it cannot make
+
 Risch–Norman (parallel Risch) heuristic integration:
 - :func:`integrate_parallel_risch` / :class:`ParallelRischResult` — posits
   ``F = P/Q + Σ dⱼ·log(pⱼ)`` over the monomial basis of
@@ -194,32 +222,44 @@ from alkahest._recurrence_asymptotics import (
 from alkahest.alkahest import (
     # P1 item 10 — asymptotic expansion at scale
     AsymptoticReport,
+    Coordinates,
     Fps,
     OdeTrajectory,
     ParallelRischResult,
     # Puiseux (fractional-exponent) expansion — verified before it is returned
     PuiseuxExpansion,
     QRootOfUnitySpecialization,
+    # Vector calculus over orthogonal charts, and Hamilton quaternions
+    Quaternion,
+    QuaternionError,
     QZeilbergerCertificate,
     Telescoping2dCertificate,
     TelescopingMdCertificate,
+    VectorError,
     apart_side_conditions,
     asymptotic_expand,
     # P1 item 10 — asymptotic expansion at scale
     coefficient_asymptotics,
+    cross,
+    curl,
     cyclotomic_polynomial,
     dirac_delta,
+    divergence,
+    dot,
     dsolve,
     dsolve_system,
     euler_maclaurin,
     fourier_transform,
+    gradient,
     heaviside,
     integrate_parallel_risch,
     inverse_fourier_transform,
     inverse_laplace_transform,
     inverse_z_transform,
     laplace_transform,
+    laplacian,
     multilimit,
+    norm,
     ode_integrate_rk4,
     ode_integrate_rk45,
     puiseux_series,
@@ -228,6 +268,7 @@ from alkahest.alkahest import (
     telescope2d,
     telescope_md,
     transform_side_conditions,
+    vector_laplacian,
     z_transform,
 )
 
@@ -271,6 +312,8 @@ __all__ = [
     "Assumptions",
     # P1 item 10 — asymptotic expansion at scale
     "AsymptoticReport",
+    # Vector calculus over orthogonal curvilinear charts
+    "Coordinates",
     "CudaCompiledFn",
     "EvaluationResult",
     "Fps",
@@ -298,6 +341,9 @@ __all__ = [
     "QRootOfUnitySpecialization",
     # M4(b) — q-analogue creative telescoping
     "QZeilbergerCertificate",
+    # Hamilton quaternions and the rotation operator q v q⁻¹
+    "Quaternion",
+    "QuaternionError",
     # M5 — recurrence -> asymptotics
     "RecurrenceAsymptotics",
     # M11 — novelty filtering
@@ -305,6 +351,7 @@ __all__ = [
     # M4 — double-sum (Apagodu-Zeilberger) creative telescoping
     "Telescoping2dCertificate",
     "TelescopingMdCertificate",
+    "VectorError",
     # Hypotheses the last `apart` on this thread rests on (ℚ(params) path).
     "apart_side_conditions",
     "arg",
@@ -319,15 +366,23 @@ __all__ = [
     "coefficient_asymptotics",
     "compile_cuda",
     "conjugate",
+    # Vector calculus
+    "cross",
+    "curl",
     # M4 — root-of-unity specialisation
     "cyclotomic_polynomial",
     "digamma",
     "dirac_delta",
+    # Vector calculus
+    "divergence",
+    "dot",
     "dsolve",
     "dsolve_system",
     "euler_maclaurin",
     "evaluate",
     "fourier_transform",
+    # Vector calculus
+    "gradient",
     "heaviside",
     "im",
     # Risch-Norman (parallel Risch) heuristic integrator.  Returns a result
@@ -338,7 +393,10 @@ __all__ = [
     "inverse_z_transform",
     "lambert_w",
     "laplace_transform",
+    # Vector calculus
+    "laplacian",
     "multilimit",
+    "norm",
     # M11 — novelty filtering (the module itself, for `novelty.RecordedRecurrence`
     # and the status tables)
     "novelty",
@@ -362,5 +420,7 @@ __all__ = [
     "to_stablehlo",
     # Hypotheses the last inverse Laplace / Z transform on this thread rests on.
     "transform_side_conditions",
+    # Vector calculus
+    "vector_laplacian",
     "z_transform",
 ]

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -1532,6 +1532,78 @@ def _evaluators_disagreeing_on() -> int:
     return disagreements
 
 
+# ---------------------------------------------------------------------------
+# Vector-calculus / quaternion helpers
+# ---------------------------------------------------------------------------
+#
+# The three built-in charts, over the shared pool.  A chart is three symbols
+# and three scale factors, so constructing one is cheap enough to do at import.
+#
+# Coordinate symbols get their own names rather than reusing `X`/`Y`: the whole
+# point of a chart is which symbol plays which role, and `x` standing for a
+# polar radius somewhere in a 6000-line corpus is exactly the kind of confusion
+# these cases exist to catch.
+
+#: Cartesian `(x, y, z)`.
+CX = POOL.symbol("vcx")
+CY = POOL.symbol("vcy")
+CZ = POOL.symbol("vcz")
+#: Cylindrical `(ρ, φ, z)`.
+RHO = POOL.symbol("vrho")
+PHI = POOL.symbol("vphi")
+ZCYL = POOL.symbol("vzc")
+#: Spherical `(r, θ, φ)`, physics convention: θ polar, φ azimuth.
+SR = POOL.symbol("vr")
+STH = POOL.symbol("vtheta")
+SPH = POOL.symbol("vphis")
+
+CART3 = ex.Coordinates.cartesian(CX, CY, CZ)
+CYL3 = ex.Coordinates.cylindrical(RHO, PHI, ZCYL)
+SPH3 = ex.Coordinates.spherical(SR, STH, SPH)
+
+#: Deliberately ugly sample points.  Scale-factor errors habitually vanish at
+#: `θ = π/2`, `φ = 0`, `ρ = 1`; a case evaluated there proves nothing.
+_CYL_AT = {RHO: 1.7, PHI: 0.83, ZCYL: -0.41}
+_SPH_AT = {SR: 2.3, STH: 1.12, SPH: -0.67}
+_CART_AT = {CX: 0.9, CY: 1.5, CZ: -0.7}
+
+
+def _at(expr: ak.Expr, point: dict) -> float:
+    """Reduce one component to a float at *point*."""
+    return float(ak.eval_expr(expr, point))
+
+
+def _field_at(components, point: dict) -> list[float]:
+    """Reduce a 3-component field to floats at *point*."""
+    return [_at(c, point) for c in components]
+
+
+def _quat(*components: float) -> ex.Quaternion:
+    return ex.Quaternion(*components, pool=POOL)
+
+
+def _rot(axis: tuple[float, float, float], angle: float) -> ex.Quaternion:
+    """A rotation quaternion, built from an axis and an angle."""
+    return ex.Quaternion.from_axis_angle([POOL.float(a) for a in axis], POOL.float(angle))
+
+
+#: 90° about `+z` and 90° about `+x`, the pair used by the composition-order
+#: cases.  Right-handed: `R_z(90°)` sends `x̂ → ŷ`, `R_x(90°)` sends `ŷ → ẑ`.
+_HALF_PI = math.pi / 2
+
+
+def _compose_then_rotate(first_z: bool) -> list[float]:
+    """Rotate `x̂` by the product of the two right-angle rotations.
+
+    `first_z=True` builds `q_x · q_z` — the *z* rotation applied first, because
+    the right-hand factor of a quaternion product acts first.
+    """
+    qz = _rot((0.0, 0.0, 1.0), _HALF_PI)
+    qx = _rot((1.0, 0.0, 0.0), _HALF_PI)
+    product = qx * qz if first_z else qz * qx
+    return _field_at(product.rotate([POOL.integer(1), POOL.integer(0), POOL.integer(0)]), {})
+
+
 CASES: list[Case] = [
     # ── real quantifier elimination ──────────────────────────────────────────
     #
@@ -6399,6 +6471,369 @@ CASES: list[Case] = [
             "raises E-EVAL-009. That asymmetry is documented (CompiledFn has no error "
             "channel) and is the reason this case exists rather than a Raises() one."
         ),
+    ),
+    # ── vector calculus and quaternions ──────────────────────────────────────
+    #
+    # The aerospace layer: rigid-body equations of motion need `grad`/`div`/
+    # `curl` in a non-Cartesian chart and a rotation operator whose composition
+    # order is right.  Both have a signature failure mode — a wrong scale factor
+    # and a reversed product — that produces a perfectly ordinary-looking
+    # number, never an exception.
+    Case(
+        id="vector_cyl_laplacian_of_log_rho_vanishes",
+        subsystem="vector",
+        statement="∇²(ln ρ) = 0 in cylindrical coordinates, for ρ > 0",
+        op=lambda: _at(ex.laplacian(ak.log(RHO), CYL3), _CYL_AT),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="ln ρ is the two-dimensional Green's function of the Laplacian: "
+        "∇²f = (1/ρ)∂_ρ(ρ ∂_ρ f) + (1/ρ²)∂²_φ f + ∂²_z f, and ρ·(1/ρ) = 1 is constant, "
+        "so the first term is 0 and the others vanish identically "
+        "(Griffiths, *Introduction to Electrodynamics* 4th ed., inside front cover; "
+        "Arfken & Weber 7th ed. §3.10). Dropping the ρ from the radial term — the "
+        "commonest scale-factor slip — gives ∂²_ρ ln ρ = −1/ρ², i.e. −0.346 here, "
+        "a clean wrong number.",
+    ),
+    Case(
+        id="vector_cyl_laplacian_control_rho_squared",
+        subsystem="vector",
+        statement="∇²(ρ²) = 4 in cylindrical coordinates",
+        op=lambda: _at(ex.laplacian(RHO**2, CYL3), _CYL_AT),
+        contract=Returns(4.0),
+        verified_by="(1/ρ)∂_ρ(ρ·2ρ) = (1/ρ)(4ρ) = 4. The control for the ln ρ case: the "
+        "cylindrical Laplacian is not simply returning 0 for everything, and the "
+        "answer 4 differs from the no-scale-factor answer ∂²_ρ ρ² = 2.",
+    ),
+    Case(
+        id="vector_sph_divergence_of_inverse_square_field_vanishes",
+        subsystem="vector",
+        statement="∇·(r̂/r²) = 0 in spherical coordinates, away from the origin",
+        op=lambda: _at(ex.divergence([SR**-2, POOL.integer(0), POOL.integer(0)], SPH3), _SPH_AT),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="∇·F = (1/r²)∂_r(r²F_r) + …, and r²·r⁻² = 1 is constant "
+        "(Griffiths §1.5.1 — the field whose divergence is 4πδ³(r), zero everywhere "
+        "else; Arfken & Weber §3.10). Omitting the r² weight gives ∂_r r⁻² = −2/r³ "
+        "= −0.164 here.",
+    ),
+    Case(
+        id="vector_sph_divergence_control_unit_radial_field",
+        subsystem="vector",
+        statement="∇·r̂ = 2/r in spherical coordinates",
+        op=lambda: _at(
+            ex.divergence([POOL.integer(1), POOL.integer(0), POOL.integer(0)], SPH3),
+            _SPH_AT,
+        ),
+        contract=Returns(2.0 / 2.3),
+        verified_by="(1/r²)∂_r(r²·1) = 2r/r² = 2/r (Griffiths, inside front cover); at "
+        "r = 2.3 that is 0.8695652…. The control for the inverse-square case: 0 there "
+        "is a property of that field, not of the operator.",
+    ),
+    Case(
+        id="vector_cyl_curl_of_the_wire_field_vanishes",
+        subsystem="vector",
+        statement="∇×(φ̂/ρ) = 0 in cylindrical coordinates, away from the axis",
+        op=lambda: _field_at(ex.curl([POOL.integer(0), RHO**-1, POOL.integer(0)], CYL3), _CYL_AT),
+        contract=Returns([0.0, 0.0, 0.0], tol=1e-9),
+        verified_by="The magnetostatic field of an infinite wire, B ∝ φ̂/ρ. "
+        "(∇×F)_z = (1/ρ)[∂_ρ(ρF_φ) − ∂_φ F_ρ] and ρ·ρ⁻¹ = 1, so it vanishes "
+        "(Griffiths §5.3.2: ∇×B = 0 off the wire, while ∮B·dl ≠ 0 — the standard "
+        "example that a curl-free field need not be globally conservative). A field "
+        "that visibly circulates is exactly where 'the curl must be non-zero' is the "
+        "plausible wrong answer.",
+    ),
+    Case(
+        id="vector_cyl_curl_control_rigid_rotation",
+        subsystem="vector",
+        statement="∇×(ρ φ̂) = 2 ẑ in cylindrical coordinates",
+        op=lambda: _field_at(ex.curl([POOL.integer(0), RHO, POOL.integer(0)], CYL3), _CYL_AT),
+        contract=Returns([0.0, 0.0, 2.0]),
+        verified_by="ρφ̂ is rigid rotation at unit angular velocity, whose curl is twice "
+        "the angular velocity vector: (1/ρ)∂_ρ(ρ·ρ) = 2 (Arfken & Weber §3.10). The "
+        "control for the wire field — the cylindrical curl does return a non-zero "
+        "answer for a field that really does circulate.",
+    ),
+    Case(
+        id="vector_cyl_vector_laplacian_of_the_azimuthal_unit_field",
+        subsystem="vector",
+        statement="∇²(φ̂) = −φ̂/ρ² in cylindrical coordinates — not the componentwise 0",
+        op=lambda: _field_at(
+            ex.vector_laplacian([POOL.integer(0), POOL.integer(1), POOL.integer(0)], CYL3),
+            _CYL_AT,
+        ),
+        contract=Returns([0.0, -1.0 / (1.7**2), 0.0], tol=1e-9),
+        verified_by="φ̂ has constant physical components (0,1,0) but is not a constant "
+        "field: it turns as φ advances. ∇²F ≡ ∇(∇·F) − ∇×(∇×F) gives −φ̂/ρ², = −0.3460 "
+        "at ρ = 1.7 (Arfken & Weber §3.10, the curvilinear vector Laplacian; Griffiths "
+        "inside front cover). Applying the *scalar* Laplacian to each component — the "
+        "standard mistake, and the one that costs a term in the Navier–Stokes "
+        "equations in cylindrical coordinates — returns exactly (0,0,0).",
+    ),
+    Case(
+        id="vector_cart_vector_laplacian_control_is_componentwise",
+        subsystem="vector",
+        statement="∇²(x²y x̂) = 2y x̂ in Cartesian coordinates",
+        op=lambda: _field_at(
+            ex.vector_laplacian([CX**2 * CY, POOL.integer(0), POOL.integer(0)], CART3),
+            _CART_AT,
+        ),
+        contract=Returns([2 * 1.5, 0.0, 0.0]),
+        verified_by="In Cartesian coordinates the basis is constant, so ∇²F is the "
+        "componentwise scalar Laplacian: ∇²(x²y) = 2y = 3.0 at y = 1.5. The control "
+        "for the φ̂ case — componentwise is the *right* answer here, and the two cases "
+        "together say the implementation distinguishes the charts rather than always "
+        "picking one rule.",
+    ),
+    Case(
+        id="vector_curl_of_a_gradient_vanishes_in_spherical",
+        subsystem="vector",
+        statement="∇×(∇f) = 0 for f = r² sin θ cos φ in spherical coordinates",
+        op=lambda: _field_at(
+            ex.curl(
+                ex.gradient(SR**2 * ak.sin(STH) * ak.cos(SPH), SPH3),
+                SPH3,
+            ),
+            _SPH_AT,
+        ),
+        contract=Returns([0.0, 0.0, 0.0], tol=1e-9),
+        verified_by="curl∘grad = 0 in any chart, because it reduces to the equality of "
+        "mixed second partials (Clairaut/Schwarz) once the scale factors are "
+        "arranged as (∇×F)ᵢ = (1/h_j h_k)[∂_j(h_k F_k) − ∂_k(h_j F_j)]. Arfken & "
+        "Weber §3.8. This is the identity that fails first if a scale factor is "
+        "attached to the wrong index.",
+    ),
+    Case(
+        id="vector_sph_laplacian_of_the_newtonian_potential_vanishes",
+        subsystem="vector",
+        statement="∇²(1/r) = 0 in spherical coordinates, away from the origin",
+        op=lambda: _at(ex.laplacian(SR**-1, SPH3), _SPH_AT),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="1/r is the Newtonian/Coulomb potential, harmonic off the origin: "
+        "(1/r²)∂_r(r²·(−r⁻²)) = (1/r²)∂_r(−1) = 0 (Griffiths §1.5.3). Dropping the r² "
+        "weight gives ∂²_r r⁻¹ = 2/r³ = 0.164 here.",
+    ),
+    Case(
+        id="vector_sph_laplacian_control_r_squared",
+        subsystem="vector",
+        statement="∇²(r²) = 6 in spherical coordinates",
+        op=lambda: _at(ex.laplacian(SR**2, SPH3), _SPH_AT),
+        contract=Returns(6.0),
+        verified_by="(1/r²)∂_r(r²·2r) = (1/r²)(6r²) = 6; equivalently ∇²(x²+y²+z²) = 6 "
+        "in Cartesian coordinates, which is the independent check. The control for "
+        "the 1/r case.",
+    ),
+    Case(
+        id="vector_from_embedding_refuses_a_skew_chart",
+        subsystem="vector",
+        statement="a non-orthogonal chart (x = u+v, y = v, z = w) must be refused, not used",
+        op=lambda: _at(
+            ex.Coordinates.from_embedding(
+                [POOL.symbol("vsu"), POOL.symbol("vsv"), POOL.symbol("vsw")],
+                [POOL.symbol("vsu") + POOL.symbol("vsv"), POOL.symbol("vsv"), POOL.symbol("vsw")],
+                "skew",
+            ).scale_factors()[0],
+            {},
+        ),
+        contract=Raises("E-VEC-004"),
+        verified_by="∂r/∂u = (1,0,0) and ∂r/∂v = (1,1,0) have inner product 1, so the "
+        "chart is not orthogonal. Every grad/div/curl/∇² formula in this module is "
+        "derived for an orthogonal frame (Morse & Feshbach I §1.3; Arfken & Weber "
+        "§3.10) and is simply false here — but it still evaluates, to a number that "
+        "looks like a divergence and is not one. h₁ = 1 and h₂ = √2 are computable, "
+        "which is what makes returning them tempting and wrong.",
+    ),
+    Case(
+        id="vector_from_embedding_control_accepts_the_cylindrical_chart",
+        subsystem="vector",
+        statement="the cylindrical embedding is orthogonal, and h₂ = ρ comes out of it",
+        op=lambda: _at(
+            ex.Coordinates.from_embedding(
+                [RHO, PHI, ZCYL],
+                [RHO * ak.cos(PHI), RHO * ak.sin(PHI), ZCYL],
+                "cylindrical",
+            ).scale_factors()[1],
+            _CYL_AT,
+        ),
+        contract=Returns(1.7),
+        verified_by="∂r/∂φ = (−ρ sin φ, ρ cos φ, 0), whose length is ρ = 1.7 at the "
+        "sample point (Arfken & Weber §3.10). The control for the skew-chart refusal: "
+        "`from_embedding` is not refusing every chart it is given, and the factor it "
+        "derives is the published one.",
+    ),
+    Case(
+        id="vector_repeated_coordinate_is_refused",
+        subsystem="vector",
+        statement="Coordinates.cartesian(x, y, x) must be refused",
+        op=lambda: ex.Coordinates.cartesian(CX, CY, CX).label,
+        contract=Raises("E-VEC-002"),
+        verified_by="With two coordinates equal, ∂/∂u₁ and ∂/∂u₃ are the same operator: "
+        "every curl component built from that pair cancels to 0 and the divergence "
+        "sums the wrong partials. Nothing in the returned expression records that the "
+        "chart was degenerate.",
+    ),
+    Case(
+        id="quat_product_ji_is_minus_k",
+        subsystem="vector",
+        statement="ji = −k: the k-component of j·i is −1",
+        op=lambda: _at((_quat(0, 0, 1, 0) * _quat(0, 1, 0, 0)).z, {}),
+        contract=Returns(-1.0),
+        verified_by="Hamilton's relations i² = j² = k² = ijk = −1 give ij = k and "
+        "ji = −k (Hamilton 1843; Kuipers, *Quaternions and Rotation Sequences* §5.2). "
+        "A quaternion product implemented over a *commutative* Mul returns the same "
+        "expression for both orders, so one of the two readings is necessarily wrong "
+        "and nothing says which.",
+    ),
+    Case(
+        id="quat_product_control_ij_is_plus_k",
+        subsystem="vector",
+        statement="ij = +k: the k-component of i·j is +1",
+        op=lambda: _at((_quat(0, 1, 0, 0) * _quat(0, 0, 1, 0)).z, {}),
+        contract=Returns(1.0),
+        verified_by="Hamilton's relations, same source. Paired with the ji case: the two "
+        "together are what make the non-commutativity observable — either one alone is "
+        "passed by an implementation that ignores the order.",
+    ),
+    Case(
+        id="quat_norm_is_multiplicative",
+        subsystem="vector",
+        statement="|q₁q₂| = |q₁||q₂| for q₁ = 1+2i+3j+4k, q₂ = 2−i+5k",
+        op=lambda: _at((_quat(1, 2, 3, 4) * _quat(2, -1, 0, 5)).norm(), {}),
+        contract=Returns(30.0),
+        verified_by="Euler's four-square identity: |q₁|² = 1+4+9+16 = 30 and "
+        "|q₂|² = 4+1+0+25 = 30, so |q₁q₂| = √30·√30 = 30 exactly. "
+        "(Conway & Smith, *On Quaternions and Octonions*, §2.) A sign error anywhere "
+        "in the product table breaks this, which is why it is the standard smoke test.",
+    ),
+    Case(
+        id="quat_rotation_by_120_degrees_about_the_body_diagonal_permutes_the_axes",
+        subsystem="vector",
+        statement="a 120° rotation about (1,1,1) sends x̂ to ŷ",
+        op=lambda: _field_at(
+            _rot((1.0, 1.0, 1.0), 2.0 * math.pi / 3.0).rotate(
+                [POOL.integer(1), POOL.integer(0), POOL.integer(0)]
+            ),
+            {},
+        ),
+        contract=Returns([0.0, 1.0, 0.0], tol=1e-12),
+        verified_by="The 3-fold axis of a cube through opposite vertices: rotating by "
+        "120° about (1,1,1), right-handed, cyclically permutes x̂ → ŷ → ẑ → x̂. "
+        "(Standard fact about the rotation group of the cube; also Rodrigues' formula "
+        "v cos θ + (n̂×v) sin θ + n̂(n̂·v)(1−cos θ) with n̂ = (1,1,1)/√3, θ = 2π/3.) "
+        "The *passive* convention, or a conjugation written q⁻¹ v q, gives (0,0,1) "
+        "instead — an equally clean unit vector, and wrong.",
+    ),
+    Case(
+        id="quat_composition_applies_the_right_hand_factor_first",
+        subsystem="vector",
+        statement="(q_x · q_z) rotates x̂ to ẑ — the z rotation acts first",
+        op=lambda: _compose_then_rotate(first_z=True),
+        contract=Returns([0.0, 0.0, 1.0], tol=1e-12),
+        verified_by="(q₁q₂) v (q₁q₂)⁻¹ = q₁(q₂ v q₂⁻¹)q₁⁻¹, so the **right-hand** factor "
+        "acts first and R(q₁q₂) = R(q₁)R(q₂) (Kuipers, *Quaternions and Rotation "
+        "Sequences* §5.4). In q_x·q_z the z rotation acts first: R_z(90°) sends "
+        "x̂ → ŷ, then R_x(90°) sends ŷ → ẑ. The reversed convention returns (0,1,0) — "
+        "an equally clean unit vector, and the classic silent error in attitude code. "
+        "Paired with the case below, which pins the other order to the other value, "
+        "so no single convention can satisfy both by accident.",
+    ),
+    Case(
+        id="quat_composition_control_the_reversed_product_is_the_other_rotation",
+        subsystem="vector",
+        statement="(q_z · q_x) rotates x̂ to ŷ — the x rotation acts first and fixes x̂",
+        op=lambda: _compose_then_rotate(first_z=False),
+        contract=Returns([0.0, 1.0, 0.0], tol=1e-12),
+        verified_by="In q_z·q_x the x rotation acts first and fixes x̂; R_z(90°) then "
+        "sends x̂ → ŷ (Kuipers §5.4). The control for the case above: the two products "
+        "must give *different* answers, and specifically these two, so a reversed "
+        "order convention fails both rather than merely relabelling them.",
+    ),
+    Case(
+        id="quat_identity_rotation_has_no_axis",
+        subsystem="vector",
+        statement="the axis of the identity rotation must be refused, not invented",
+        op=lambda: _field_at(ex.Quaternion.identity(POOL).to_axis_angle()[0], {}),
+        contract=Raises("E-QUAT-002"),
+        verified_by="q = 1 fixes every vector, so *every* unit vector is an axis for it "
+        "and the axis–angle decomposition is not unique (Kuipers §5.8; Shuster, "
+        "*A Survey of Attitude Representations*, JAS 41(4), on the singularity of the "
+        "Euler axis at zero rotation). Returning the conventional (0,0,1) is a stated "
+        "answer to a question with no answer, and downstream code cannot tell it from "
+        "a real axis.",
+    ),
+    Case(
+        id="quat_control_axis_angle_round_trips_for_a_real_rotation",
+        subsystem="vector",
+        statement="a 0.7-radian rotation about ẑ reports angle 0.7 and axis ẑ",
+        op=lambda: _at(_rot((0.0, 0.0, 1.0), 0.7).to_axis_angle()[1], {}),
+        contract=Returns(0.7, tol=1e-12),
+        verified_by="q = cos(θ/2) + sin(θ/2)ẑ, so 2·atan2(|v|, w) = 2·atan2(sin 0.35, "
+        "cos 0.35) = 0.7 (Kuipers §5.8). The control for the identity-rotation "
+        "refusal: axis–angle is refused because the quantity does not exist, not "
+        "because it is unimplemented.",
+    ),
+    Case(
+        id="quat_reflection_matrix_is_refused",
+        subsystem="vector",
+        statement="diag(1, 1, −1) is a reflection and has no quaternion",
+        op=lambda: _at(
+            ex.Quaternion.from_rotation_matrix(
+                ak.Matrix(
+                    [
+                        [POOL.integer(1), POOL.integer(0), POOL.integer(0)],
+                        [POOL.integer(0), POOL.integer(1), POOL.integer(0)],
+                        [POOL.integer(0), POOL.integer(0), POOL.integer(-1)],
+                    ]
+                )
+            ).w,
+            {},
+        ),
+        contract=Raises("E-QUAT-003"),
+        verified_by="diag(1,1,−1) is orthogonal with det = −1, so it lies in O(3)\\SO(3). "
+        "The quaternion rotation map covers SO(3) only — q ↦ R(q) always has "
+        "det R = +1 — so no quaternion represents it (Kuipers §5.14; Altmann, "
+        "*Rotations, Quaternions and Double Groups*, §2). Shepperd's method applied "
+        "blindly still returns a unit quaternion for it, which then represents some "
+        "*other*, proper rotation.",
+    ),
+    Case(
+        id="quat_control_from_rotation_matrix_recovers_the_rotation",
+        subsystem="vector",
+        statement="the quaternion recovered from R_z(90°) rotates x̂ to ŷ",
+        op=lambda: _field_at(
+            ex.Quaternion.from_rotation_matrix(
+                ak.Matrix(
+                    [
+                        [POOL.integer(0), POOL.integer(-1), POOL.integer(0)],
+                        [POOL.integer(1), POOL.integer(0), POOL.integer(0)],
+                        [POOL.integer(0), POOL.integer(0), POOL.integer(1)],
+                    ]
+                )
+            ).rotate([POOL.integer(1), POOL.integer(0), POOL.integer(0)]),
+            {},
+        ),
+        contract=Returns([0.0, 1.0, 0.0], tol=1e-9),
+        verified_by="R_z(90°) = [[0,−1,0],[1,0,0],[0,0,1]] sends x̂ = (1,0,0) to its "
+        "first column read as an image, (0,1,0) = ŷ (Kuipers §5.14). The control for "
+        "the reflection refusal: a proper rotation *is* recovered, and the recovered "
+        "quaternion acts the way the matrix does.",
+    ),
+    Case(
+        id="quat_zero_quaternion_has_no_inverse",
+        subsystem="vector",
+        statement="0⁻¹ must be refused",
+        op=lambda: _at(_quat(0, 0, 0, 0).inverse().w, {}),
+        contract=Raises("E-QUAT-001"),
+        verified_by="q⁻¹ = q̄/|q|², and |0|² = 0. The quaternions are a division ring "
+        "over the *non-zero* elements only (Conway & Smith §2). The conjugate q̄ = 0 "
+        "is perfectly computable, so returning it — a quaternion that satisfies no "
+        "inverse property at all — is the available wrong answer.",
+    ),
+    Case(
+        id="quat_control_inverse_of_a_unit_quaternion_is_its_conjugate",
+        subsystem="vector",
+        statement="(1+i+j+k)/2 is a unit quaternion, and its inverse has w = 1/2",
+        op=lambda: _at(_quat(1, 1, 1, 1).inverse().w, {}),
+        contract=Returns(0.25),
+        verified_by="|1+i+j+k|² = 4, so (1+i+j+k)⁻¹ = (1−i−j−k)/4 and its real part is "
+        "1/4 (Conway & Smith §2). The control for the zero-quaternion refusal.",
     ),
 ]
 


### PR DESCRIPTION
Closes the largest remaining gap for aerospace: rigid-body EOM derivation needs
vector calculus and quaternions, and Alkahest had neither.

## Surface

`alkahest_cas::vector` → `alkahest.experimental`: `gradient`, `divergence`,
`curl`, `laplacian`, `vector_laplacian`, plus `dot`, `cross`, `norm`,
`norm_squared`, `scale`, `add`, `sub`.

`Coordinates` is three coordinate symbols plus three scale factors:
`cartesian`, `cylindrical (1, ρ, 1)`, `spherical (1, r, r sin θ)` (physics/ISO,
right-handed in `(r, θ, φ)`), and `from_embedding`, which **derives** the scale
factors from a Cartesian parametrisation and checks orthogonality. There is
deliberately **no** constructor taking scale factors directly — that is the
input you cannot validate.

Fields are **physical** components in the local orthonormal frame (the
`sympy.vector` convention), stated in the module docs because getting it wrong
is a factor of `hᵢ` per component.

`alkahest_cas::algebra::quaternion`: Hamilton product, conjugate, norm,
inverse, `normalize`, `rotate` (`q v q⁻¹`, active, scale-invariant),
`to_rotation_matrix`, `from_rotation_matrix`, `from_axis_angle`,
`to_axis_angle`. A structured type rather than a rewrite-rule product table
beside `noncommutative.rs`; the reasoning is in the module header.

## Verification

Three independent layers, all evaluated at random *ugly* points — scale-factor
errors vanish at `θ = π/2`, `φ = 0`, `ρ = 1`:

1. **Identities** in every chart.
2. **Published forms** — cylindrical and spherical `div`/`curl`/`∇²` written out
   by hand from Arfken & Weber §3.10 and Griffiths, compared numerically.
3. **Cartesian round trip** — a field written in Cartesian coordinates,
   substituted into the chart *and* its components rotated into the local
   orthonormal frame, with the operator applied in both charts. This is the
   check that a self-consistent-but-wrong set of scale factors cannot pass, and
   the only one sensitive to handedness.

`from_embedding` re-derives the cylindrical and spherical scale factors, and the
operators built on them agree with the built-in charts.

| identity | result |
|---|---|
| `∇×∇f = 0` | closes **symbolically** 4/4 Cartesian, 4/4 cylindrical; spherical 0/4 symbolically (a `1/(r sin θ)` the zero test does not clear) — checked numerically instead. The counts are asserted, so a regression in the symbolic tier is visible. |
| `∇·(∇×F) = 0` | all three charts; ≥3 close symbolically |
| `∇×(∇×F) = ∇(∇·F) − ∇²F` | Cartesian, where the two sides share no code |
| `∇·(fF) = f∇·F + ∇f·F` | all three charts, 4 scalars × 3 fields |
| `∇×(fF) = f∇×F + ∇f×F` | all three charts — sensitive to `cross` handedness vs the sign convention inside `curl` |
| `\|q₁q₂\| = \|q₁\|\|q₂\|` | **proven symbolically** (Euler's four-square identity) + 24 random |
| `q q⁻¹ = q⁻¹ q = 1` | exact concrete; numeric for symbolic |

`assert_zero_scalar` uses the crate's three-valued zero test, so a `NonZero` is
a rigorous refutation that fails immediately rather than falling through to
sampling.

**Quaternion ↔ matrix, including order.** `q v q⁻¹` against **Rodrigues'
formula** — an independent derivation, not another quaternion routine — over 40
random axis/angle/vector triples; `R(q)·v` three-way against both; scale
invariance `R(λq)`; a concrete orientation check (`R_z(θ)·x̂ = (cos θ, sin θ, 0)`,
not `(cos θ, −sin θ, 0)`). Composition is checked both as matrices and as
quaternions over 25 random pairs, **and the reversed order is asserted to
disagree in ≥75% of samples**, so a test that flipped both conventions together
could not pass.

`from_rotation_matrix` round-trips through all four Shepperd branches (angles
near π about each axis) plus 25 random: quaternion recovered up to sign, matrix
reproduced exactly.

**1278 comparisons against `sympy.vector` and `sympy.algebras.Quaternion`** —
grad/div/curl/laplacian in all three charts, and product/norm/inverse/rotation/
rotation-matrix plus `(q₁q₂).to_rotation_matrix()` against `R(q₁)·R(q₂)`
entry-by-entry — **zero disagreements**. No sympy dependency ships.

## What refuses

- `E-VEC-001` non-differentiable component; `E-VEC-002/003` repeated /
  non-symbol coordinate
- **`E-VEC-004`** — `from_embedding` on a chart whose tangent inner products
  were not *proven* to vanish. Undecided is a refusal, not an assumption: every
  formula here is false on a skew chart and still evaluates.
- `E-VEC-005` — degenerate or undecided scale factor (every operator divides by
  it)
- `E-QUAT-001` — zero or undecided norm
- **`E-QUAT-002`** — `to_axis_angle` of the identity rotation: every unit vector
  is an axis, so `(0,0,1)` would be a stated answer to a question with no answer
- **`E-QUAT-003`** — `from_rotation_matrix` on a reflection, a scaled matrix, a
  shear, a wrong shape, or a **symbolic** matrix (branch selection is a
  comparison between entries)

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **3114 passed, 0
failed, 11 ignored** (main: 3072; +42). `pytest tests/` → 4185 passed, 0 failed.
Silent-error corpus **374 → 400 cases, 0 silent errors**; `vector` 26/26.
clippy `-D warnings`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`, ruff
`check` and `format --check`, `check_error_codes.py` (244 codes) and
`check_api_freeze.py` ("No API surface changes") all clean.

## Stated limits

`cargo semver-checks` with its **default all-features** set — what CI runs —
cannot build here (`jit` needs LLVM 15, `cuda` needs the CUDA toolkit), so it
was run with `--only-explicit-features --features groebner`: 223 pass, no bump
required. The changes are purely additive, but that specific invocation is
untested locally and CI is the real check. Clippy likewise ran for the
`groebner` set only.

Spherical `∇×∇f` does not close symbolically — correct, verified numerically
and against sympy, but the simplifier does not reach `0`. Recorded in the test
assertion rather than papered over. `to_axis_angle` returns an `atan2`
expression, which `eval_expr` evaluates but the separate `eval::eval_f64` facade
would reject; that asymmetry predates this work and was not widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental vector calculus for Cartesian, cylindrical, spherical, and custom orthogonal coordinates.
  - Added vector operations and differential operators, including gradient, divergence, curl, and Laplacians.
  - Added quaternion arithmetic, normalization, rotations, axis-angle conversion, and rotation-matrix conversion.
  - Exposed the new capabilities through the Python API with dedicated coordinate, quaternion, and error types.

- **Bug Fixes**
  - Added validation for invalid coordinate systems, degenerate scale factors, zero quaternions, undefined axes, and non-rotation matrices.

- **Documentation**
  - Documented new vector-calculus and quaternion error codes.

- **Tests**
  - Added extensive coverage for vector identities, coordinate systems, rotations, conversions, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->