### PR TITLE
fix(display): make every printed form re-read as the expression that was printed

### DIFF
--- a/alkahest-core/src/kernel/display.rs
+++ b/alkahest-core/src/kernel/display.rs
@@ -6,6 +6,16 @@
 use crate::kernel::expr::{ExprData, PredicateKind};
 use crate::kernel::{ExprId, ExprPool};
 
+/// Logical connectives, all *below* [`PREC_ADD`] so an arithmetic operand of a
+/// comparison is never parenthesised.  The relative order is the standard one
+/// (`∀/∃` scope widest, then `∨`, then `∧`, then a comparison, then `¬`): a
+/// printer that renders them all at one level emits `a ∨ b ∧ c` for
+/// `(a ∨ b) ∧ c`, which re-reads as `a ∨ (b ∧ c)` — a different proposition.
+const PREC_QUANT: i32 = 2;
+const PREC_OR: i32 = 4;
+const PREC_AND: i32 = 6;
+const PREC_CMP: i32 = 8;
+const PREC_NOT: i32 = 9;
 const PREC_ADD: i32 = 10;
 const PREC_MUL: i32 = 20;
 /// Unary minus: binds tighter than `*` but looser than `^`, matching `BP_UNARY`
@@ -173,6 +183,51 @@ fn literal_prec(rendered: &str) -> i32 {
     }
 }
 
+/// Precedence of a rendered float.
+///
+/// `rug::Float` prints `0.25` as `2.5e-1`, which is not an atom: the `-1` is
+/// exposed, so `√0.25` printed as `√2.5e-1` reads as `(√2.5e) − 1` and
+/// `0.25²` as `2.5e-1²`.  Treating it as a quotient gets it parenthesised
+/// wherever a quotient would be.
+fn float_prec(rendered: &str) -> i32 {
+    if rendered.contains(['e', 'E']) {
+        PREC_MUL.min(literal_prec(rendered))
+    } else {
+        literal_prec(rendered)
+    }
+}
+
+/// Collapse maximal runs of the *identical* factor into `(factor, count)`.
+///
+/// `Mul([x, x])` is `x²`; printing it as `x x` (LaTeX) sets two juxtaposed
+/// variables, which is how a power stops being visible in the output.  Only
+/// **consecutive** equal ids are merged, so the rewrite never reorders a
+/// product: `ExprPool::mul` sorts its arguments *only* when every factor is
+/// multiplicatively commutative, and this has to stay correct for the
+/// non-commutative generators too.
+fn collapse_runs(args: &[ExprId]) -> Vec<(ExprId, i64)> {
+    let mut out: Vec<(ExprId, i64)> = Vec::with_capacity(args.len());
+    for &id in args {
+        match out.last_mut() {
+            Some((prev, n)) if *prev == id => *n += 1,
+            _ => out.push((id, 1)),
+        }
+    }
+    out
+}
+
+/// `Some(numerator)` when a rational is really an integer (`4/2` interns as
+/// `Rational(2, 1)`, a node distinct from `Integer(2)`).  Rendering it as
+/// `\frac{2}{1}` or `2/1` is not wrong, but `x^(1/1)` reached the Unicode
+/// `ⁿ√` branch and printed `¹√x`.
+fn rational_as_integer(r: &crate::kernel::expr::BigRat) -> Option<String> {
+    if *r.0.denom() == 1 {
+        Some(r.0.numer().to_string())
+    } else {
+        None
+    }
+}
+
 fn unicode_frac(num: i64, den: i64) -> String {
     match (num, den) {
         (1, 2) => "½".into(),
@@ -203,6 +258,70 @@ fn unicode_frac(num: i64, den: i64) -> String {
 
 fn latex_frac(num: &str, den: &str) -> String {
     format!(r"\frac{{{num}}}{{{den}}}")
+}
+
+/// `base^exp`, braced unless the exponent is a single character.
+fn latex_sup(base_tex: &str, exp_tex: &str) -> String {
+    if exp_tex.chars().count() == 1 {
+        format!("{base_tex}^{exp_tex}")
+    } else {
+        format!("{base_tex}^{{{exp_tex}}}")
+    }
+}
+
+/// A float literal, with scientific notation typeset rather than copied.
+///
+/// `rug::Float` prints `0.25` as `2.5e-1`.  Emitted verbatim into math mode
+/// that reads as *e minus 1* — a subtraction against a variable called `e` —
+/// so the exponent has to become an actual power of ten.  The result is a
+/// product, hence [`PREC_MUL`] rather than an atom's precedence.
+fn latex_float(s: &str) -> (String, i32) {
+    match s.split_once(['e', 'E']) {
+        Some((mantissa, exponent)) if !exponent.is_empty() => {
+            let exponent = exponent.strip_prefix('+').unwrap_or(exponent);
+            (
+                format!(r"{mantissa} \times 10^{{{exponent}}}"),
+                PREC_MUL.min(literal_prec(mantissa)),
+            )
+        }
+        _ => (s.to_string(), literal_prec(s)),
+    }
+}
+
+/// Render one factor of a product.
+///
+/// [`latex_wrap`] at [`PREC_MUL`] is not enough on its own: a factor that
+/// renders with a leading `-` (a negative `Float`, a directly interned nested
+/// `Mul`) is juxtaposed against its left neighbour as `x -1.5`, which sets —
+/// and re-reads — as the *subtraction* `x − 1.5`.
+fn latex_factor(id: ExprId, pool: &ExprPool) -> String {
+    let (s, prec) = latex_r(id, pool);
+    if prec < PREC_MUL || s.starts_with('-') {
+        format!(r"\left({s}\right)")
+    } else {
+        s
+    }
+}
+
+/// Join the factors of a product.
+///
+/// LaTeX multiplication is juxtaposition, so a factor that *begins with a
+/// digit* fuses with whatever precedes it: `2 \cdot 3^n` written as `2 3^n`
+/// sets as `23^n`, and `1.5 \cdot 2.5` as `1.52.5`.  An explicit `\cdot` is
+/// the standard separator in exactly that position.
+fn latex_join_factors(parts: &[String]) -> String {
+    let mut out = String::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            if part.starts_with(|c: char| c.is_ascii_digit() || c == '.') {
+                out.push_str(r" \cdot ");
+            } else {
+                out.push(' ');
+            }
+        }
+        out.push_str(part);
+    }
+    out
 }
 
 fn latex_symbol(name: &str) -> String {
@@ -257,7 +376,10 @@ fn latex_signed(id: ExprId, pool: &ExprPool) -> (i32, String) {
         ExprData::Rational(r) => {
             let num = r.0.numer();
             let den = r.0.denom();
-            let s = latex_frac(num.to_string().trim_start_matches('-'), &den.to_string());
+            let s = match rational_as_integer(r) {
+                Some(n) => n.trim_start_matches('-').to_string(),
+                None => latex_frac(num.to_string().trim_start_matches('-'), &den.to_string()),
+            };
             if *num < 0 {
                 (-1, s)
             } else {
@@ -267,7 +389,12 @@ fn latex_signed(id: ExprId, pool: &ExprPool) -> (i32, String) {
         ExprData::Mul(args) => latex_signed_mul(args, pool),
         _ => {
             let (s, _) = latex_r(id, pool);
-            (1, s)
+            // A negative float is a subtraction in a sum, like every other
+            // negative literal: `x + -1.5` becomes `x - 1.5`.
+            match s.strip_prefix('-') {
+                Some(rest) if matches!(data, ExprData::Float(_)) => (-1, rest.to_string()),
+                _ => (1, s),
+            }
         }
     })
 }
@@ -306,18 +433,20 @@ fn latex_signed_mul(args: &[ExprId], pool: &ExprPool) -> (i32, String) {
     let mut num_parts: Vec<String> = Vec::new();
     let mut den_parts: Vec<String> = Vec::new();
 
-    for &child in &others {
+    for (child, mult) in collapse_runs(&others) {
         let pushed = pool.with(child, |data| {
             if let ExprData::Pow { base, exp } = data {
                 if let ExprData::Integer(n) = pool.get(*exp) {
                     let v = n.0.to_i64().unwrap_or(0);
                     if v < 0 {
-                        let exp_abs = -v;
-                        let base_tex = latex_wrap(*base, pool, PREC_POW + 1);
+                        let exp_abs = (-v).saturating_mul(mult);
                         if exp_abs == 1 {
-                            den_parts.push(base_tex);
+                            // `\frac{}{}` groups its denominator already, so the
+                            // factor only has to be safe against its siblings.
+                            den_parts.push(latex_factor(*base, pool));
                         } else {
-                            den_parts.push(format!("{{{base_tex}}}^{{{exp_abs}}}"));
+                            let base_tex = latex_wrap(*base, pool, PREC_POW + 1);
+                            den_parts.push(latex_sup(&base_tex, &exp_abs.to_string()));
                         }
                         return true;
                     }
@@ -326,7 +455,12 @@ fn latex_signed_mul(args: &[ExprId], pool: &ExprPool) -> (i32, String) {
             false
         });
         if !pushed {
-            num_parts.push(latex_wrap(child, pool, PREC_MUL));
+            if mult > 1 {
+                let base_tex = latex_wrap(child, pool, PREC_POW + 1);
+                num_parts.push(latex_sup(&base_tex, &mult.to_string()));
+            } else {
+                num_parts.push(latex_factor(child, pool));
+            }
         }
     }
 
@@ -347,13 +481,13 @@ fn latex_signed_mul(args: &[ExprId], pool: &ExprPool) -> (i32, String) {
         let num_str = if num_parts.is_empty() {
             "1".into()
         } else {
-            num_parts.join(" ")
+            latex_join_factors(&num_parts)
         };
-        let den_str = den_parts.join(" ");
+        let den_str = latex_join_factors(&den_parts);
         return (sign, latex_frac(&num_str, &den_str));
     }
 
-    (sign, num_parts.join(" "))
+    (sign, latex_join_factors(&num_parts))
 }
 
 fn latex_add(args: &[ExprId], pool: &ExprPool) -> String {
@@ -381,7 +515,9 @@ fn latex_pow(base: ExprId, exp: ExprId, pool: &ExprPool) -> String {
         let num = r.0.numer().to_i64().unwrap_or(0);
         let den = r.0.denom().to_i64().unwrap_or(1);
         if num == 1 && den >= 2 {
-            let base_tex = latex_wrap(base, pool, PREC_POW + 1);
+            // The radical is delimited by its own braces, so the radicand needs
+            // no parentheses of its own.
+            let (base_tex, _) = latex_r(base, pool);
             return if den == 2 {
                 format!(r"\sqrt{{{base_tex}}}")
             } else {
@@ -392,18 +528,13 @@ fn latex_pow(base: ExprId, exp: ExprId, pool: &ExprPool) -> String {
     // x^(-1) → 1/x
     if let ExprData::Integer(n) = pool.get(exp) {
         if n.0.to_i64() == Some(-1) {
-            let base_tex = latex_wrap(base, pool, PREC_POW + 1);
+            let base_tex = latex_factor(base, pool);
             return latex_frac("1", &base_tex);
         }
     }
     let base_tex = latex_wrap(base, pool, PREC_POW + 1);
     let (exp_tex, _) = latex_r(exp, pool);
-    let exp_braced = if exp_tex.len() == 1 {
-        exp_tex
-    } else {
-        format!("{{{exp_tex}}}")
-    };
-    format!("{base_tex}^{exp_braced}")
+    latex_sup(&base_tex, &exp_tex)
 }
 
 fn latex_func(name: &str, args: &[ExprId], pool: &ExprPool) -> String {
@@ -426,12 +557,7 @@ fn latex_func(name: &str, args: &[ExprId], pool: &ExprPool) -> String {
         }
         "exp" => {
             let (inner, _) = latex_r(args[0], pool);
-            let exp_braced = if inner.len() == 1 {
-                inner
-            } else {
-                format!("{{{inner}}}")
-            };
-            format!(r"e^{exp_braced}")
+            latex_sup("e", &inner)
         }
         // Elliptic integrals (parameter convention m = k²).  We mirror the
         // classical typeset notation: K(m), E(m), F(φ|m), E(φ|m), Π(n;φ|m).
@@ -464,6 +590,29 @@ fn latex_func(name: &str, args: &[ExprId], pool: &ExprPool) -> String {
             let rendered: Vec<String> = args.iter().map(|&a| latex_r(a, pool).0).collect();
             format!(r"{fn_latex}\!\left({}\right)", rendered.join(", "))
         }
+    }
+}
+
+/// Precedence of a rendered function application.
+///
+/// A call is an atom — `\sin\!\left(x\right)` carries its own delimiters — with
+/// one exception per renderer: a form that ends in an *open* superscript or
+/// starts with a prefix operator does not, and appending `^2` to it silently
+/// re-scopes the exponent.  In LaTeX that is `exp`, printed `e^{u}`: written as
+/// a power base it produces `e^{u}^2`, which is not only ambiguous but the hard
+/// TeX error "Double superscript".  In Unicode it is `exp` *and* `sqrt`, since
+/// `√u` has no closing delimiter and `√u²` reads as `√(u²)`.
+fn latex_func_prec(name: &str) -> i32 {
+    match name {
+        "exp" => PREC_POW,
+        _ => PREC_ATOM,
+    }
+}
+
+fn unicode_func_prec(name: &str) -> i32 {
+    match name {
+        "exp" | "sqrt" => PREC_POW,
+        _ => PREC_ATOM,
     }
 }
 
@@ -509,7 +658,24 @@ fn latex_func_name(name: &str) -> String {
         "fresnelc" => r"C".into(),
         "trigamma" => r"\psi_1".into(),
         "dilog" => r"\operatorname{Li}_2".into(),
-        other => format!(r"\operatorname{{{other}}}"),
+        // `\operatorname{}` typesets its argument in math mode, where a bare
+        // `_` is a subscript: `\operatorname{my_func}` renders as `my_func`
+        // with a subscripted `f`, and a second underscore is the hard error
+        // "Double subscript" that stops a document compiling.
+        other => format!(r"\operatorname{{{}}}", other.replace('_', r"\_")),
+    }
+}
+
+/// Precedence of a rendered predicate, and the precedence its operands have to
+/// clear.  `¬` and the quantifiers take the *whole* proposition to their right,
+/// so their operand requirement is one above everything a connective produces.
+fn predicate_prec(kind: &PredicateKind) -> i32 {
+    match kind {
+        PredicateKind::True | PredicateKind::False => PREC_ATOM,
+        PredicateKind::Not => PREC_NOT,
+        PredicateKind::And => PREC_AND,
+        PredicateKind::Or => PREC_OR,
+        _ => PREC_CMP,
     }
 }
 
@@ -518,7 +684,7 @@ fn latex_predicate(kind: &PredicateKind, args: &[ExprId], pool: &ExprPool) -> St
         PredicateKind::True => r"\top".into(),
         PredicateKind::False => r"\bot".into(),
         PredicateKind::Not => {
-            let (inner, _) = latex_r(args[0], pool);
+            let inner = latex_wrap(args[0], pool, PREC_NOT + 1);
             format!(r"\lnot {inner}")
         }
         _ => {
@@ -533,7 +699,10 @@ fn latex_predicate(kind: &PredicateKind, args: &[ExprId], pool: &ExprPool) -> St
                 PredicateKind::Or => r"\lor",
                 _ => unreachable!(),
             };
-            let rendered: Vec<String> = args.iter().map(|&a| latex_r(a, pool).0).collect();
+            // `∧`/`∨` are associative, so a same-kind operand needs no
+            // parentheses; anything that binds *looser* does.
+            let req = predicate_prec(kind);
+            let rendered: Vec<String> = args.iter().map(|&a| latex_wrap(a, pool, req)).collect();
             rendered.join(&format!(" {op} "))
         }
     }
@@ -558,6 +727,10 @@ fn latex_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
         ExprData::Rational(r) => {
             let num = r.0.numer();
             let den = r.0.denom();
+            if let Some(n) = rational_as_integer(r) {
+                let prec = literal_prec(&n);
+                return (n, prec);
+            }
             let s = latex_frac(num.to_string().trim_start_matches('-'), &den.to_string());
             // A fraction is a quotient, not an atom: it needs parentheses under
             // `^` just like any other product/quotient does.
@@ -567,11 +740,7 @@ fn latex_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
                 (s, PREC_MUL)
             }
         }
-        ExprData::Float(f) => {
-            let s = f.inner.to_string();
-            let prec = literal_prec(&s);
-            (s, prec)
-        }
+        ExprData::Float(f) => latex_float(&f.inner.to_string()),
         ExprData::Add(args) => (latex_add(args, pool), PREC_ADD),
         ExprData::Mul(args) => {
             let (sign, tex) = latex_signed_mul(args, pool);
@@ -579,20 +748,22 @@ fn latex_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
             (s, PREC_MUL)
         }
         ExprData::Pow { base, exp } => (latex_pow(*base, *exp, pool), PREC_POW),
-        ExprData::Func { name, args } => (latex_func(name, args, pool), PREC_ATOM),
+        ExprData::Func { name, args } => (latex_func(name, args, pool), latex_func_prec(name)),
         ExprData::Piecewise { branches, default } => {
             (latex_piecewise(branches, *default, pool), PREC_ATOM)
         }
-        ExprData::Predicate { kind, args } => (latex_predicate(kind, args, pool), PREC_ADD),
+        ExprData::Predicate { kind, args } => {
+            (latex_predicate(kind, args, pool), predicate_prec(kind))
+        }
         ExprData::Forall { var, body } => {
             let (v, _) = latex_r(*var, pool);
             let (b, _) = latex_r(*body, pool);
-            (format!(r"\forall {v} \, . \, {b}"), PREC_ATOM)
+            (format!(r"\forall {v} \, . \, {b}"), PREC_QUANT)
         }
         ExprData::Exists { var, body } => {
             let (v, _) = latex_r(*var, pool);
             let (b, _) = latex_r(*body, pool);
-            (format!(r"\exists {v} \, . \, {b}"), PREC_ATOM)
+            (format!(r"\exists {v} \, . \, {b}"), PREC_QUANT)
         }
         ExprData::BigO(arg) => {
             let (a, _) = latex_r(*arg, pool);
@@ -627,6 +798,26 @@ fn unicode_wrap(id: ExprId, pool: &ExprPool, req_prec: i32) -> String {
     }
 }
 
+/// `base^exp` in Unicode superscripts where the exponent allows it.
+fn unicode_sup(base_tex: &str, exp: &str) -> String {
+    match to_superscript(exp) {
+        Some(s) => format!("{base_tex}{s}"),
+        None => format!("{base_tex}^({exp})"),
+    }
+}
+
+/// One factor of a product.  See [`latex_factor`]: a factor rendering with a
+/// leading `-` reads as a subtraction when it follows the `·`-free path, and
+/// `x·-1.5` is at best unpleasant.
+fn unicode_factor(id: ExprId, pool: &ExprPool) -> String {
+    let (s, prec) = unicode_r(id, pool);
+    if prec < PREC_MUL || s.starts_with('-') {
+        format!("({s})")
+    } else {
+        s
+    }
+}
+
 fn unicode_signed(id: ExprId, pool: &ExprPool) -> (i32, String) {
     pool.with(id, |data| match data {
         ExprData::Integer(n) => {
@@ -640,16 +831,23 @@ fn unicode_signed(id: ExprId, pool: &ExprPool) -> (i32, String) {
         ExprData::Rational(r) => {
             let num = r.0.numer().to_i64().unwrap_or(0);
             let den = r.0.denom().to_i64().unwrap_or(1);
+            let render = |n: i64| match rational_as_integer(r) {
+                Some(_) => n.to_string(),
+                None => unicode_frac(n, den),
+            };
             if num < 0 {
-                (-1, unicode_frac(-num, den))
+                (-1, render(-num))
             } else {
-                (1, unicode_frac(num, den))
+                (1, render(num))
             }
         }
         ExprData::Mul(args) => unicode_signed_mul(args, pool),
         _ => {
             let (s, _) = unicode_r(id, pool);
-            (1, s)
+            match s.strip_prefix('-') {
+                Some(rest) if matches!(data, ExprData::Float(_)) => (-1, rest.to_string()),
+                _ => (1, s),
+            }
         }
     })
 }
@@ -688,18 +886,20 @@ fn unicode_signed_mul(args: &[ExprId], pool: &ExprPool) -> (i32, String) {
     let mut num_parts: Vec<String> = Vec::new();
     let mut den_parts: Vec<String> = Vec::new();
 
-    for &child in &others {
+    for (child, mult) in collapse_runs(&others) {
         let pushed = pool.with(child, |data| {
             if let ExprData::Pow { base, exp } = data {
                 if let ExprData::Integer(n) = pool.get(*exp) {
                     let v = n.0.to_i64().unwrap_or(0);
                     if v < 0 {
-                        let exp_abs = -v;
+                        let exp_abs = (-v).saturating_mul(mult);
                         let base_tex = unicode_wrap(*base, pool, PREC_POW + 1);
-                        let sup = to_superscript(&exp_abs.to_string());
-                        den_parts.push(match sup {
-                            Some(s) => format!("{base_tex}{s}"),
-                            None => format!("{base_tex}^{exp_abs}"),
+                        // `x^-1` is `1/x`, not `1/x¹`: the exponent has already
+                        // been spent by moving the factor into the denominator.
+                        den_parts.push(if exp_abs == 1 {
+                            base_tex
+                        } else {
+                            unicode_sup(&base_tex, &exp_abs.to_string())
                         });
                         return true;
                     }
@@ -708,7 +908,12 @@ fn unicode_signed_mul(args: &[ExprId], pool: &ExprPool) -> (i32, String) {
             false
         });
         if !pushed {
-            num_parts.push(unicode_wrap(child, pool, PREC_MUL));
+            if mult > 1 {
+                let base_tex = unicode_wrap(child, pool, PREC_POW + 1);
+                num_parts.push(unicode_sup(&base_tex, &mult.to_string()));
+            } else {
+                num_parts.push(unicode_factor(child, pool));
+            }
         }
     }
 
@@ -766,34 +971,41 @@ fn unicode_pow(base: ExprId, exp: ExprId, pool: &ExprPool) -> String {
     if let ExprData::Rational(r) = pool.get(exp) {
         let num = r.0.numer().to_i64().unwrap_or(0);
         let den = r.0.denom().to_i64().unwrap_or(1);
-        if num == 1 {
+        // `den >= 2` guards the radical branch: `x^(1/1)` is `x`, and the
+        // fallback below printed it as the nonsense `¹√x`.
+        if num == 1 && den >= 2 {
             let base_tex = unicode_wrap(base, pool, PREC_POW + 1);
             return match den {
                 2 => format!("√{base_tex}"),
                 3 => format!("∛{base_tex}"),
                 4 => format!("∜{base_tex}"),
-                _ => {
-                    let sup = to_superscript(&den.to_string())
-                        .map(|s| format!("{}√{base_tex}", s))
-                        .unwrap_or_else(|| format!("{base_tex}^(1/{den})"));
-                    sup
-                }
+                _ => to_superscript(&den.to_string())
+                    .map(|s| format!("{s}√{base_tex}"))
+                    .unwrap_or_else(|| format!("{base_tex}^(1/{den})")),
             };
         }
     }
     let base_tex = unicode_wrap(base, pool, PREC_POW + 1);
-    if let ExprData::Integer(n) = pool.get(exp) {
-        if let Some(v) = n.0.to_i64() {
-            if v == 1 {
-                return base_tex;
-            }
-            if let Some(sup) = to_superscript(&v.to_string()) {
-                return format!("{base_tex}{sup}");
-            }
+    if let Some(v) = integral_exponent(exp, pool) {
+        if v == 1 {
+            return base_tex;
+        }
+        if let Some(sup) = to_superscript(&v.to_string()) {
+            return format!("{base_tex}{sup}");
         }
     }
     let (exp_tex, _) = unicode_r(exp, pool);
     format!("{base_tex}^({exp_tex})")
+}
+
+/// The exponent as an `i64` when it is one — an `Integer`, or a `Rational`
+/// that reduced to one (`Rational(2, 1)` is a distinct node from `Integer(2)`).
+fn integral_exponent(exp: ExprId, pool: &ExprPool) -> Option<i64> {
+    match pool.get(exp) {
+        ExprData::Integer(n) => n.0.to_i64(),
+        ExprData::Rational(r) if *r.0.denom() == 1 => r.0.numer().to_i64(),
+        _ => None,
+    }
 }
 
 fn unicode_func(name: &str, args: &[ExprId], pool: &ExprPool) -> String {
@@ -804,7 +1016,14 @@ fn unicode_func(name: &str, args: &[ExprId], pool: &ExprPool) -> String {
         }
         "abs" => {
             let (inner, _) = unicode_r(args[0], pool);
-            format!("|{inner}|")
+            // `|` is its own mirror, so a nested absolute value gives `||2||`,
+            // which no reader can pair up.  Parenthesising the inner one makes
+            // the grouping explicit: `|(|2|)|`.
+            if inner.contains('|') {
+                format!("|({inner})|")
+            } else {
+                format!("|{inner}|")
+            }
         }
         "floor" => {
             let (inner, _) = unicode_r(args[0], pool);
@@ -863,7 +1082,7 @@ fn unicode_predicate(kind: &PredicateKind, args: &[ExprId], pool: &ExprPool) -> 
         PredicateKind::True => "⊤".into(),
         PredicateKind::False => "⊥".into(),
         PredicateKind::Not => {
-            let (inner, _) = unicode_r(args[0], pool);
+            let inner = unicode_wrap(args[0], pool, PREC_NOT + 1);
             format!("¬{inner}")
         }
         _ => {
@@ -878,7 +1097,8 @@ fn unicode_predicate(kind: &PredicateKind, args: &[ExprId], pool: &ExprPool) -> 
                 PredicateKind::Or => "∨",
                 _ => unreachable!(),
             };
-            let rendered: Vec<String> = args.iter().map(|&a| unicode_r(a, pool).0).collect();
+            let req = predicate_prec(kind);
+            let rendered: Vec<String> = args.iter().map(|&a| unicode_wrap(a, pool, req)).collect();
             rendered.join(&format!(" {op} "))
         }
     }
@@ -903,7 +1123,10 @@ fn unicode_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
         ExprData::Rational(r) => {
             let num = r.0.numer().to_i64().unwrap_or(0);
             let den = r.0.denom().to_i64().unwrap_or(1);
-            let s = unicode_frac(num.abs(), den);
+            let s = match rational_as_integer(r) {
+                Some(_) => num.abs().to_string(),
+                None => unicode_frac(num.abs(), den),
+            };
             // `unicode_frac` returns a single vulgar-fraction glyph (`½`) for a
             // handful of values and a `num/den` quotient otherwise; only the
             // former is atomic under `^`.
@@ -916,7 +1139,7 @@ fn unicode_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
         }
         ExprData::Float(f) => {
             let s = f.inner.to_string();
-            let prec = literal_prec(&s);
+            let prec = float_prec(&s);
             (s, prec)
         }
         ExprData::Add(args) => (unicode_add(args, pool), PREC_ADD),
@@ -926,20 +1149,22 @@ fn unicode_r(id: ExprId, pool: &ExprPool) -> (String, i32) {
             (s, PREC_MUL)
         }
         ExprData::Pow { base, exp } => (unicode_pow(*base, *exp, pool), PREC_POW),
-        ExprData::Func { name, args } => (unicode_func(name, args, pool), PREC_ATOM),
+        ExprData::Func { name, args } => (unicode_func(name, args, pool), unicode_func_prec(name)),
         ExprData::Piecewise { branches, default } => {
             (unicode_piecewise(branches, *default, pool), PREC_ATOM)
         }
-        ExprData::Predicate { kind, args } => (unicode_predicate(kind, args, pool), PREC_ADD),
+        ExprData::Predicate { kind, args } => {
+            (unicode_predicate(kind, args, pool), predicate_prec(kind))
+        }
         ExprData::Forall { var, body } => {
             let (v, _) = unicode_r(*var, pool);
             let (b, _) = unicode_r(*body, pool);
-            (format!("∀{v}.{b}"), PREC_ATOM)
+            (format!("∀{v}.{b}"), PREC_QUANT)
         }
         ExprData::Exists { var, body } => {
             let (v, _) = unicode_r(*var, pool);
             let (b, _) = unicode_r(*body, pool);
-            (format!("∃{v}.{b}"), PREC_ATOM)
+            (format!("∃{v}.{b}"), PREC_QUANT)
         }
         ExprData::BigO(arg) => {
             let (a, _) = unicode_r(*arg, pool);
@@ -1032,5 +1257,218 @@ mod tests {
         let prod = p.mul(vec![p.integer(-2_i32), x]);
         assert_eq!(render_latex(prod, &p), "-2 x");
         assert_eq!(render_unicode(prod, &p), "-2·x");
+    }
+
+    /// `Mul([x, x])` is `x²`.  Printed as `x x` it sets as `xx`, because LaTeX
+    /// math mode discards white space — the power stops being visible.
+    #[test]
+    fn a_repeated_factor_prints_as_a_power() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let y = p.symbol("y", Domain::Real);
+        assert_eq!(render_latex(p.mul(vec![x, x]), &p), "x^2");
+        assert_eq!(render_unicode(p.mul(vec![x, x]), &p), "x²");
+        assert_eq!(render_latex(p.mul(vec![x, x, x]), &p), "x^3");
+        assert_eq!(render_latex(p.mul(vec![x, x, y]), &p), "x^2 y");
+        // Distinct factors stay a juxtaposed product.
+        assert_eq!(render_latex(p.mul(vec![x, y]), &p), "x y");
+        // A repeated function application too.
+        let s = p.func("sin", vec![x]);
+        assert_eq!(
+            render_latex(p.mul(vec![s, s]), &p),
+            r"\sin\!\left(x\right)^2"
+        );
+    }
+
+    /// Only *consecutive* equal factors are merged, so a non-commutative
+    /// product — which `ExprPool::mul` does not sort — is never reordered.
+    #[test]
+    fn run_collapsing_does_not_reorder_a_product() {
+        assert_eq!(
+            collapse_runs(&[ExprId(1), ExprId(2), ExprId(1)]),
+            vec![(ExprId(1), 1), (ExprId(2), 1), (ExprId(1), 1)]
+        );
+        assert_eq!(
+            collapse_runs(&[ExprId(1), ExprId(1), ExprId(2)]),
+            vec![(ExprId(1), 2), (ExprId(2), 1)]
+        );
+    }
+
+    /// A factor that begins with a digit fuses with the one before it: `2 3^n`
+    /// sets as `23^n`.  `\cdot` is the standard separator in that position.
+    #[test]
+    fn a_numeral_before_a_numeral_gets_a_cdot() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let n = p.symbol("n", Domain::Real);
+        let two_three_n = p.mul(vec![p.integer(2_i32), p.pow(p.integer(3_i32), n)]);
+        assert_eq!(render_latex(two_three_n, &p), r"2 \cdot 3^n");
+        // A coefficient before a *symbol* is unambiguous and stays bare.
+        assert_eq!(render_latex(p.mul(vec![p.integer(2_i32), x]), &p), "2 x");
+    }
+
+    /// A factor whose rendering starts with `-` is read as a subtraction:
+    /// `x -1.5` is `x − 1.5`, a different expression.
+    #[test]
+    fn a_negative_float_factor_is_parenthesised() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let prod = p.mul(vec![x, p.float(-1.5_f64, 53)]);
+        assert!(
+            render_latex(prod, &p).contains(r"\left(-1.5"),
+            "{}",
+            render_latex(prod, &p)
+        );
+        assert!(render_unicode(prod, &p).contains("(-1.5"));
+    }
+
+    /// `rug::Float` prints `0.25` as `2.5e-1`; in math mode that reads as
+    /// `2.5·e − 1`.  LaTeX gets a real power of ten.
+    #[test]
+    fn a_float_in_exponent_notation_is_typeset_as_a_power_of_ten() {
+        let p = ExprPool::new();
+        let quarter = p.float(0.25_f64, 53);
+        assert_eq!(
+            render_latex(quarter, &p),
+            r"2.5000000000000000 \times 10^{-1}"
+        );
+        // It is a product, so it is parenthesised where a product would be.
+        let n = p.symbol("n", Domain::Real);
+        assert_eq!(
+            render_latex(p.pow(quarter, n), &p),
+            r"\left(2.5000000000000000 \times 10^{-1}\right)^n"
+        );
+        // Unicode keeps the machine-readable spelling, but it is not an atom:
+        // `√2.5e-1` would read as `(√2.5e) − 1`.
+        assert_eq!(
+            render_unicode(p.pow(quarter, n), &p),
+            "(2.5000000000000000e-1)^(n)"
+        );
+    }
+
+    /// `x^-1` is `1/x`, not `1/x¹`: moving the factor into the denominator is
+    /// what spends the exponent.
+    #[test]
+    fn a_reciprocal_factor_carries_no_exponent_of_one() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let one = p.integer(1_i32);
+        let denom = p.add(vec![one, x]);
+        let recip = p.mul(vec![one, p.pow(denom, p.integer(-1_i32))]);
+        assert_eq!(render_unicode(recip, &p), "1/(x + 1)");
+        assert_eq!(render_latex(recip, &p), r"\frac{1}{\left(x + 1\right)}");
+        // A genuine exponent survives.
+        let squared = p.mul(vec![one, p.pow(denom, p.integer(-2_i32))]);
+        assert_eq!(render_unicode(squared, &p), "1/(x + 1)²");
+    }
+
+    /// `∧` binds tighter than `∨`, so `(a ∨ b) ∧ c` needs the group and
+    /// `a ∨ (b ∧ c)` does not.  Printed at one level, the first re-reads as the
+    /// second — a different proposition.
+    #[test]
+    fn connective_precedence_is_parenthesised() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let a = p.predicate(PredicateKind::Lt, vec![x, p.integer(0_i32)]);
+        let b = p.predicate(PredicateKind::Gt, vec![x, p.integer(1_i32)]);
+        let c = p.predicate(PredicateKind::Eq, vec![x, p.integer(2_i32)]);
+        let or_in_and = p.predicate(
+            PredicateKind::And,
+            vec![p.predicate(PredicateKind::Or, vec![a, b]), c],
+        );
+        assert_eq!(
+            render_latex(or_in_and, &p),
+            r"\left(x < 0 \lor x > 1\right) \land x = 2"
+        );
+        assert_eq!(render_unicode(or_in_and, &p), "(x < 0 ∨ x > 1) ∧ x = 2");
+
+        let and_in_or = p.predicate(
+            PredicateKind::Or,
+            vec![a, p.predicate(PredicateKind::And, vec![b, c])],
+        );
+        assert_eq!(render_latex(and_in_or, &p), r"x < 0 \lor x > 1 \land x = 2");
+
+        // `¬` takes one operand, not the rest of the line.
+        let not_and = p.predicate(
+            PredicateKind::Not,
+            vec![p.predicate(PredicateKind::And, vec![a, b])],
+        );
+        assert_eq!(
+            render_latex(not_and, &p),
+            r"\lnot \left(x < 0 \land x > 1\right)"
+        );
+        assert_eq!(render_unicode(not_and, &p), "¬(x < 0 ∧ x > 1)");
+    }
+
+    /// A quantifier scopes over everything to its right, so it has to be
+    /// grouped when it is an operand of a connective.
+    #[test]
+    fn a_quantifier_inside_a_connective_is_parenthesised() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let a = p.predicate(PredicateKind::Lt, vec![x, p.integer(0_i32)]);
+        let b = p.predicate(PredicateKind::Gt, vec![x, p.integer(1_i32)]);
+        let quantified = p.forall(x, a);
+        let conj = p.predicate(PredicateKind::And, vec![quantified, b]);
+        assert_eq!(
+            render_latex(conj, &p),
+            r"\left(\forall x \, . \, x < 0\right) \land x > 1"
+        );
+        assert_eq!(render_unicode(conj, &p), "(∀x.x < 0) ∧ x > 1");
+    }
+
+    /// `exp` prints as `e^{u}` and `sqrt` as `√u`; neither closes, so as a
+    /// power base both have to be grouped.  `e^{x}^2` is also the hard TeX
+    /// error "Double superscript".
+    #[test]
+    fn an_open_ended_function_rendering_is_grouped_as_a_power_base() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let two = p.integer(2_i32);
+        let e = p.func("exp", vec![x]);
+        assert_eq!(render_latex(p.pow(e, two), &p), r"\left(e^x\right)^2");
+        assert_eq!(render_unicode(p.pow(e, two), &p), "(e^(x))²");
+        let r = p.func("sqrt", vec![x]);
+        assert_eq!(render_unicode(p.pow(r, two), &p), "(√x)²");
+        // A delimited rendering still needs no group.
+        let s = p.func("sin", vec![x]);
+        assert_eq!(render_latex(p.pow(s, two), &p), r"\sin\!\left(x\right)^2");
+    }
+
+    /// A bare `_` inside `\operatorname{}` is a subscript, and two of them are
+    /// the error "Double subscript".  A symbol's subscript is left alone.
+    #[test]
+    fn an_unregistered_head_escapes_its_underscores() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        assert_eq!(
+            render_latex(p.func("my_func", vec![x]), &p),
+            r"\operatorname{my\_func}\!\left(x\right)"
+        );
+        assert_eq!(render_latex(p.symbol("u_0", Domain::Real), &p), "{u}_{0}");
+    }
+
+    /// `4/2` interns as `Rational(2, 1)`, a node distinct from `Integer(2)`.
+    /// It is an integer on the page, and `x^(1/1)` reached the Unicode `ⁿ√`
+    /// branch and printed the nonsense `¹√x`.
+    #[test]
+    fn a_rational_with_denominator_one_prints_as_an_integer() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let two_over_one = p.rational(4, 2);
+        assert_eq!(render_latex(two_over_one, &p), "2");
+        assert_eq!(render_unicode(two_over_one, &p), "2");
+        assert_eq!(render_latex(p.pow(x, p.rational(1, 1)), &p), "x^1");
+        assert_eq!(render_unicode(p.pow(x, p.rational(1, 1)), &p), "x");
+    }
+
+    /// `|` is its own mirror, so `||x||` has no unique reading.
+    #[test]
+    fn a_nested_absolute_value_is_grouped() {
+        let p = ExprPool::new();
+        let x = p.symbol("x", Domain::Real);
+        let inner = p.func("abs", vec![x]);
+        assert_eq!(render_unicode(inner, &p), "|x|");
+        assert_eq!(render_unicode(p.func("abs", vec![inner]), &p), "|(|x|)|");
     }
 }

--- a/alkahest-core/src/kernel/mod.rs
+++ b/alkahest-core/src/kernel/mod.rs
@@ -7,6 +7,7 @@ pub mod expr;
 pub mod expr_props;
 pub mod pool;
 pub mod pool_persist;
+mod printer_roundtrip;
 mod proptests;
 pub mod subs;
 

--- a/alkahest-core/src/kernel/printer_roundtrip.rs
+++ b/alkahest-core/src/kernel/printer_roundtrip.rs
@@ -1,0 +1,1142 @@
+//! The round-trip property for the printers, over a generated corpus.
+//!
+//! A printer that emits something which re-parses to a *different* expression
+//! is a silent wrong answer with extra steps: the user copies the output, feeds
+//! it back, and gets different mathematics with no error raised anywhere.  So
+//! round-trip fidelity is tested as a correctness property rather than as a
+//! collection of golden strings.
+//!
+//! The property is checked in two ways, and a case passes if either holds:
+//!
+//! * **structural**, after a normalisation that only removes a difference the
+//!   parser cannot avoid — the parser builds binary `Add`/`Mul` spines
+//!   (`parse("a*b*c")` is `(a*b)*c`) while [`ExprPool::mul`] builds a flat
+//!   n-ary node, and the two are documented to be unequal (CONTRIBUTING.md,
+//!   "The parser exists twice").  [`renormalise`] rebuilds both trees bottom-up
+//!   through the pool constructors, which flatten and canonically sort exactly
+//!   those two node kinds and change nothing else;
+//! * **semantic**, by evaluating both at sample points.  This is what catches a
+//!   precedence or juxtaposition error, which renormalisation cannot repair.
+//!
+//! A case where neither side evaluates anywhere (`log` of a negative argument
+//! at every sample point, an overflowed power) is counted as *undecided* and
+//! reported; the test fails if the undecided share grows large enough to make
+//! the corpus vacuous.
+
+#![cfg(test)]
+
+use std::collections::HashMap;
+
+use crate::eval::eval_f64;
+use crate::kernel::expr::ExprData;
+use crate::kernel::{Domain, ExprId, ExprPool};
+use crate::parse::parse;
+
+// ---------------------------------------------------------------------------
+// Corpus generation
+// ---------------------------------------------------------------------------
+
+/// xorshift64*, so the corpus is identical on every machine and a failure is
+/// reproducible from the seed printed in the assertion message.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_f491_4f6c_dd1d)
+    }
+
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+
+    fn pick<T: Copy>(&mut self, xs: &[T]) -> T {
+        xs[self.below(xs.len() as u64) as usize]
+    }
+}
+
+const SYMBOL_NAMES: [&str; 3] = ["a", "b", "c"];
+const FUNCS: [&str; 8] = ["sin", "cos", "exp", "log", "sqrt", "abs", "atan", "erf"];
+
+fn atom(rng: &mut Rng, pool: &ExprPool, syms: &[ExprId]) -> ExprId {
+    match rng.below(10) {
+        0..=3 => syms[rng.below(syms.len() as u64) as usize],
+        4..=6 => pool.integer(rng.pick(&[-7_i64, -2, -1, 0, 1, 2, 3, 10])),
+        7..=8 => {
+            let (n, d) = rng.pick(&[(1_i64, 2_i64), (-1, 2), (3, 7), (-5, 3), (4, 2), (2, 1)]);
+            pool.rational(n, d)
+        }
+        _ => pool.float(rng.pick(&[-1.5_f64, 0.25, 3.5, 2.0]), 53),
+    }
+}
+
+fn build(rng: &mut Rng, pool: &ExprPool, syms: &[ExprId], depth: u32) -> ExprId {
+    if depth == 0 {
+        return atom(rng, pool, syms);
+    }
+    let lhs = build(rng, pool, syms, depth - 1);
+    let rhs = build(rng, pool, syms, depth - 1);
+    match rng.below(14) {
+        0 => pool.add(vec![lhs, rhs]),
+        1 => pool.add(vec![lhs, rhs, atom(rng, pool, syms)]),
+        // Subtraction, as `diff`/`simplify` build it.
+        2 => pool.add(vec![lhs, pool.mul(vec![pool.integer(-1_i64), rhs])]),
+        3 => pool.mul(vec![lhs, rhs]),
+        4 => pool.mul(vec![lhs, rhs, atom(rng, pool, syms)]),
+        // Division, and the repeated factor that has to print as a power.
+        5 => pool.mul(vec![lhs, pool.pow(rhs, pool.integer(-1_i64))]),
+        6 => pool.mul(vec![lhs, lhs]),
+        7 => pool.mul(vec![pool.integer(-1_i64), lhs]),
+        8 => pool.pow(lhs, pool.integer(rng.pick(&[-3_i64, -2, -1, 2, 3]))),
+        9 => pool.pow(lhs, pool.rational(1, rng.pick(&[2_i64, 3, 5]))),
+        10 => pool.pow(lhs, rhs),
+        11 => pool.pow(pool.pow(lhs, rhs), atom(rng, pool, syms)),
+        12 => pool.func(rng.pick(&FUNCS), vec![lhs]),
+        _ => pool.func("atan2", vec![lhs, rhs]),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+/// Rebuild `id` bottom-up through the pool constructors.
+///
+/// The only nodes this changes are `Add` and `Mul`, which `ExprPool::add` /
+/// `ExprPool::mul` splice flat and sort when every factor is commutative.  That
+/// is precisely the documented difference between a parsed spine and a
+/// builder-constructed n-ary node; nothing else is normalised, so a precedence
+/// or sign error survives it.
+fn renormalise(id: ExprId, pool: &ExprPool) -> ExprId {
+    match pool.get(id) {
+        ExprData::Add(args) => pool.add(
+            args.iter()
+                .map(|&a| renormalise(a, pool))
+                .collect::<Vec<_>>(),
+        ),
+        ExprData::Mul(args) => {
+            let parts: Vec<ExprId> = args.iter().map(|&a| renormalise(a, pool)).collect();
+            fold_exact_coefficient(parts, pool)
+        }
+        ExprData::Pow { base, exp } => pool.pow(renormalise(base, pool), renormalise(exp, pool)),
+        ExprData::Func { name, args } => pool.func(
+            name,
+            args.iter()
+                .map(|&a| renormalise(a, pool))
+                .collect::<Vec<_>>(),
+        ),
+        _ => id,
+    }
+}
+
+/// Multiply out the exact numeric factors of a product into one atom.
+///
+/// The second artefact the parser cannot avoid: there is no rational *literal*
+/// token, so `1/2` necessarily comes back as `1 · 2^-1` rather than as the
+/// `Rational(1, 2)` atom that was printed.  Folding exact integer/rational
+/// factors — and `q^-1` for an exact `q` — is the inverse of that and touches
+/// nothing else; a wrong coefficient still compares unequal, because both sides
+/// are folded the same way.
+fn fold_exact_coefficient(parts: Vec<ExprId>, pool: &ExprPool) -> ExprId {
+    let mut coeff = rug::Rational::from(1);
+    let mut rest: Vec<ExprId> = Vec::new();
+    for part in parts {
+        match pool.get(part) {
+            ExprData::Integer(n) => coeff *= rug::Rational::from(n.0.clone()),
+            ExprData::Rational(r) => coeff *= r.0.clone(),
+            ExprData::Pow { base, exp } => {
+                let reciprocal = matches!(pool.get(exp), ExprData::Integer(e) if e.0 == -1);
+                let value = match pool.get(base) {
+                    ExprData::Integer(n) if n.0 != 0 => Some(rug::Rational::from(n.0.clone())),
+                    ExprData::Rational(r) if *r.0.numer() != 0 => Some(r.0.clone()),
+                    _ => None,
+                };
+                match (reciprocal, value) {
+                    (true, Some(v)) => coeff /= v,
+                    _ => rest.push(part),
+                }
+            }
+            _ => rest.push(part),
+        }
+    }
+    let (num, den) = (coeff.numer().to_i64(), coeff.denom().to_i64());
+    let atom = match (num, den) {
+        (Some(n), Some(1)) => pool.integer(n),
+        (Some(n), Some(d)) => pool.rational(n, d),
+        // Out of `i64` range: leave the product alone rather than guess.
+        _ => return pool.mul(rest),
+    };
+    if rest.is_empty() {
+        return atom;
+    }
+    if coeff == 1 {
+        return pool.mul(rest);
+    }
+    rest.push(atom);
+    pool.mul(rest)
+}
+
+/// Sample points for the semantic comparison.  All strictly positive: the
+/// corpus contains `log`, `sqrt` and fractional powers, whose real branch is
+/// undefined on the negatives, and an undefined value decides nothing.
+const SAMPLES: [[f64; 3]; 5] = [
+    [0.37, 1.21, 2.03],
+    [1.7, 0.61, 0.44],
+    [2.9, 3.3, 1.05],
+    [0.11, 2.4, 0.83],
+    [1.0, 1.0, 1.0],
+];
+
+/// A sample point only decides a case when the value is inside a window where
+/// an `f64` comparison still carries information.  A power tower reaches
+/// `1e84` from inputs of order one, and there a last-bit difference is
+/// multiplied by every exponent above it.  Such a point is reported as
+/// undecided, never as a mismatch.
+///
+/// The comparison is deliberately **real only**.  Evaluating on the complex
+/// principal branch decides more cases, but it also makes two forms that are
+/// exactly equal on paper — `(-2)^-3` against `((-2)^3)^-1` — disagree by
+/// orders of magnitude, because their `f64` imaginary parts land on opposite
+/// sides of zero, `arg` flips between `+pi` and `-pi`, and a non-integer
+/// exponent above them turns that into a different branch.  A test that
+/// reports a branch cut as a printer defect is worse than a test that reports
+/// fewer cases.
+fn decides(v: f64) -> bool {
+    let m = v.abs();
+    m == 0.0 || (1e-10..=1e10).contains(&m)
+}
+
+/// Relative agreement demanded of the two evaluations.  Loose enough to
+/// survive a power tower, whose relative error is multiplied by every exponent
+/// above it; a printer that loses a precedence or a sign is out by orders of
+/// magnitude, not by parts in a million.
+const TOL: f64 = 1e-6;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Verdict {
+    Structural,
+    Numeric,
+    Undecided,
+    Mismatch,
+}
+
+fn compare(original: ExprId, reparsed: ExprId, pool: &ExprPool, syms: &[ExprId]) -> Verdict {
+    if original == reparsed || renormalise(original, pool) == renormalise(reparsed, pool) {
+        return Verdict::Structural;
+    }
+    let mut agreed = 0;
+    for point in SAMPLES.iter() {
+        let bindings: HashMap<ExprId, f64> =
+            syms.iter().copied().zip(point.iter().copied()).collect();
+        let want = match eval_f64(original, pool, &bindings) {
+            Ok(v) if decides(v) => v,
+            _ => continue,
+        };
+        // The printed form has to be usable wherever the original was.
+        let got = match eval_f64(reparsed, pool, &bindings) {
+            Err(_) => return Verdict::Mismatch,
+            Ok(v) => v,
+        };
+        let scale = want.abs().max(got.abs()).max(1.0);
+        if (want - got).abs() > TOL * scale {
+            if std::env::var("PRINTER_DEBUG").is_ok() {
+                eprintln!("DIFF want={want:?} got={got:?}");
+                eprintln!("  original: {}", pool.display(original));
+                eprintln!("  reparsed: {}", pool.display(reparsed));
+            }
+            return Verdict::Mismatch;
+        }
+        agreed += 1;
+    }
+    if agreed == 0 {
+        Verdict::Undecided
+    } else {
+        Verdict::Numeric
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reading the typeset forms back
+// ---------------------------------------------------------------------------
+
+/// Boundary between two source tokens in an expanded LaTeX string.
+const UNIT: &str = "\u{1}";
+
+/// Function names a juxtaposed `(` binds to as an *application* rather than as
+/// a product.  Everything else followed by `(` is multiplication.
+const CALLABLE: [&str; 13] = [
+    "sin", "cos", "tan", "log", "exp", "sqrt", "abs", "atan", "asin", "acos", "erf", "atan2",
+    "gamma",
+];
+
+fn take_group(s: &[char], i: &mut usize) -> Result<String, String> {
+    if s.get(*i) != Some(&'{') {
+        return Err(format!("expected '{{' at offset {i}"));
+    }
+    let start = *i + 1;
+    let mut depth = 1usize;
+    let mut j = start;
+    while j < s.len() && depth > 0 {
+        match s[j] {
+            '{' => depth += 1,
+            '}' => depth -= 1,
+            _ => {}
+        }
+        j += 1;
+    }
+    if depth != 0 {
+        return Err("unbalanced braces".into());
+    }
+    *i = j;
+    Ok(s[start..j - 1].iter().collect())
+}
+
+/// Expand the emitted LaTeX into the parser's ASCII grammar, one *unit* per
+/// source token, joined by [`UNIT`].
+///
+/// **Whitespace is dropped**, because that is what LaTeX math mode does with
+/// it: `2 3^n` sets exactly as `23^n`.  Modelling the space as a multiplication
+/// would assume away the very defect this is looking for; keeping the unit
+/// boundary is what lets [`insert_juxtaposition`] decide, for each adjacent
+/// pair, whether a reader sees a product or one fused token.
+fn expand_latex(src: &str) -> Result<String, String> {
+    let s: Vec<char> = src.chars().collect();
+    let mut units: Vec<String> = Vec::new();
+    macro_rules! emit {
+        ($e:expr) => {
+            units.push(String::from($e))
+        };
+    }
+    let mut i = 0usize;
+    while i < s.len() {
+        let c = s[i];
+        if c.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        if c == '\\' {
+            let mut j = i + 1;
+            while j < s.len() && s[j].is_ascii_alphabetic() {
+                j += 1;
+            }
+            let (name, mut k) = if j == i + 1 {
+                (s[i + 1..i + 2].iter().collect::<String>(), i + 2)
+            } else {
+                (s[i + 1..j].iter().collect::<String>(), j)
+            };
+            match name.as_str() {
+                "!" | "," | ";" | " " | "quad" => i = k,
+                "cdot" | "times" => {
+                    emit!("*");
+                    i = k;
+                }
+                "left" | "right" => {
+                    let d = *s.get(k).ok_or_else(|| format!("dangling \\{name}"))?;
+                    match (name.as_str(), d) {
+                        ("left", '(') => emit!("("),
+                        ("left", '|') => emit!("abs("),
+                        ("right", ')') | ("right", '|') => emit!(")"),
+                        _ => return Err(format!("unhandled \\{name}{d}")),
+                    }
+                    i = k + 1;
+                }
+                "frac" => {
+                    let num = take_group(&s, &mut k)?;
+                    let den = take_group(&s, &mut k)?;
+                    emit!(format!(
+                        "(({})/({}))",
+                        expand_latex(&num)?,
+                        expand_latex(&den)?
+                    ));
+                    i = k;
+                }
+                "sqrt" => {
+                    if s.get(k) == Some(&'[') {
+                        let close = s[k..]
+                            .iter()
+                            .position(|&ch| ch == ']')
+                            .ok_or("unterminated \\sqrt[")?
+                            + k;
+                        let index: String = s[k + 1..close].iter().collect();
+                        let mut kk = close + 1;
+                        let radicand = take_group(&s, &mut kk)?;
+                        emit!(format!(
+                            "(({}))^(1/({}))",
+                            expand_latex(&radicand)?,
+                            expand_latex(&index)?
+                        ));
+                        i = kk;
+                    } else {
+                        let radicand = take_group(&s, &mut k)?;
+                        emit!(format!("sqrt({})", expand_latex(&radicand)?));
+                        i = k;
+                    }
+                }
+                "operatorname" => {
+                    let body = take_group(&s, &mut k)?;
+                    emit!(body.replace("\\_", "_"));
+                    i = k;
+                }
+                other => {
+                    let ascii = match other {
+                        "sin" => "sin",
+                        "cos" => "cos",
+                        "tan" => "tan",
+                        "sinh" => "sinh",
+                        "cosh" => "cosh",
+                        "tanh" => "tanh",
+                        "arcsin" => "asin",
+                        "arccos" => "acos",
+                        "arctan" => "atan",
+                        "ln" => "log",
+                        _ => return Err(format!("unhandled macro \\{other}")),
+                    };
+                    emit!(ascii);
+                    i = k;
+                }
+            }
+            continue;
+        }
+        // `exp(u)` is emitted as `e^{u}`; no corpus symbol is called `e`.
+        if c == 'e' && s.get(i + 1) == Some(&'^') {
+            let mut k = i + 2;
+            let arg = if s.get(k) == Some(&'{') {
+                take_group(&s, &mut k)?
+            } else {
+                let ch = *s.get(k).ok_or("dangling e^")?;
+                k += 1;
+                ch.to_string()
+            };
+            emit!(format!("exp({})", expand_latex(&arg)?));
+            i = k;
+            continue;
+        }
+        if c == '^' {
+            // `^` scopes to exactly one token — `x^c y` is `(x^c)·y`, not
+            // `x^(cy)` — so a brace-less exponent is one character.
+            i += 1;
+            let mut k = i;
+            let exponent = if s.get(i) == Some(&'{') {
+                take_group(&s, &mut k)?
+            } else {
+                let ch = *s.get(i).ok_or("dangling ^")?;
+                k = i + 1;
+                ch.to_string()
+            };
+            // The exponent belongs to the same unit as the `^` that carries it.
+            emit!(format!("^({})", expand_latex(&exponent)?));
+            i = k;
+            continue;
+        }
+        if c == '{' {
+            let mut k = i;
+            let g = take_group(&s, &mut k)?;
+            emit!(format!("({})", expand_latex(&g)?));
+            i = k;
+            continue;
+        }
+        if c == '}' {
+            return Err("stray '}'".into());
+        }
+        // A numeral is one token: `23` is twenty-three, whereas `2 3` is two
+        // tokens that the page fuses into twenty-three.  Only the second is a
+        // defect, so the two must not look alike here.
+        if c.is_ascii_digit() {
+            let start = i;
+            while i < s.len() && (s[i].is_ascii_digit() || s[i] == '.') {
+                i += 1;
+            }
+            emit!(s[start..i].iter().collect::<String>());
+            continue;
+        }
+        emit!(c.to_string());
+        i += 1;
+    }
+    units.retain(|u| !u.is_empty());
+    Ok(units.join(UNIT))
+}
+
+/// Resolve each token boundary the way the page resolves it.
+///
+/// LaTeX multiplication is juxtaposition, so at a boundary a reader either sees
+/// a product or sees the two tokens *fuse into one*:
+///
+/// * digit next to digit (`2 3` → `23`) and letter followed by digit
+///   (`x 2^n` → `x2^n`) fuse — the emitter has to break these with `\cdot`;
+/// * everything else reads as a product (`2 x`, `(a+b)c`, `x \sin(y)`), except
+///   a function name followed by `(`, which is an application.
+fn insert_juxtaposition(src: &str) -> String {
+    #[derive(PartialEq, Clone, Copy)]
+    enum Class {
+        Digit,
+        Letter,
+        Open,
+        Close,
+        Other,
+    }
+    fn class(c: char) -> Class {
+        if c.is_ascii_digit() || c == '.' {
+            Class::Digit
+        } else if c.is_ascii_alphabetic() || c == '_' {
+            Class::Letter
+        } else if c == '(' {
+            Class::Open
+        } else if c == ')' {
+            Class::Close
+        } else {
+            Class::Other
+        }
+    }
+
+    let mut out = String::new();
+    for unit in src.split(UNIT) {
+        let Some(first) = unit.chars().next() else {
+            continue;
+        };
+        if let Some(last) = out.chars().last() {
+            let prev = class(last);
+            let here = class(first);
+            let juxtaposed = matches!(prev, Class::Digit | Class::Letter | Class::Close)
+                && matches!(here, Class::Digit | Class::Letter | Class::Open);
+            // A fused pair is deliberately left fused: it is what the reader
+            // gets, and the round trip is supposed to notice.
+            let fuses = matches!(
+                (prev, here),
+                (Class::Digit, Class::Digit) | (Class::Letter, Class::Digit)
+            );
+            let ident: String = out
+                .chars()
+                .rev()
+                .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            let is_call = here == Class::Open && CALLABLE.contains(&ident.as_str());
+            if juxtaposed && !fuses && !is_call {
+                out.push('*');
+            }
+        }
+        out.push_str(unit);
+    }
+    out
+}
+
+fn read_latex(src: &str) -> Result<String, String> {
+    Ok(insert_juxtaposition(&expand_latex(src)?))
+}
+
+/// Superscript digits back to an ASCII exponent.
+fn from_superscript(c: char) -> Option<char> {
+    Some(match c {
+        '⁰' => '0',
+        '¹' => '1',
+        '²' => '2',
+        '³' => '3',
+        '⁴' => '4',
+        '⁵' => '5',
+        '⁶' => '6',
+        '⁷' => '7',
+        '⁸' => '8',
+        '⁹' => '9',
+        '⁺' => '+',
+        '⁻' => '-',
+        _ => return None,
+    })
+}
+
+fn vulgar_fraction(c: char) -> Option<&'static str> {
+    Some(match c {
+        '½' => "(1/2)",
+        '⅓' => "(1/3)",
+        '⅔' => "(2/3)",
+        '¼' => "(1/4)",
+        '¾' => "(3/4)",
+        '⅕' => "(1/5)",
+        '⅖' => "(2/5)",
+        '⅗' => "(3/5)",
+        '⅘' => "(4/5)",
+        '⅙' => "(1/6)",
+        '⅚' => "(5/6)",
+        '⅐' => "(1/7)",
+        '⅛' => "(1/8)",
+        '⅜' => "(3/8)",
+        '⅝' => "(5/8)",
+        '⅞' => "(7/8)",
+        '⅑' => "(1/9)",
+        '⅒' => "(1/10)",
+        _ => return None,
+    })
+}
+
+/// Read the Unicode pretty-printed form back.  Unlike LaTeX this form writes
+/// every product with an explicit `·`, so there is no juxtaposition to recover;
+/// what has to be undone is the superscripts, the radicals, the bars and the
+/// vulgar fractions.
+fn read_unicode(src: &str) -> Result<String, String> {
+    let s: Vec<char> = src.chars().collect();
+    let mut out = String::new();
+    let mut i = 0usize;
+    while i < s.len() {
+        let c = s[i];
+        // A superscript run is an exponent — unless a radical follows, in which
+        // case it is the root *index* (`⁵√x`).
+        if from_superscript(c).is_some() {
+            let mut j = i;
+            let mut digits = String::new();
+            while j < s.len() {
+                match from_superscript(s[j]) {
+                    Some(d) => {
+                        digits.push(d);
+                        j += 1;
+                    }
+                    None => break,
+                }
+            }
+            if s.get(j) == Some(&'√') {
+                let mut k = j + 1;
+                let operand = read_unicode_atom(&s, &mut k)?;
+                out.push_str(&format!("({operand})^(1/{digits})"));
+                i = k;
+            } else {
+                out.push_str(&format!("^({digits})"));
+                i = j;
+            }
+            continue;
+        }
+        if let Some(f) = vulgar_fraction(c) {
+            out.push_str(f);
+            i += 1;
+            continue;
+        }
+        match c {
+            '·' => {
+                out.push('*');
+                i += 1;
+            }
+            '√' | '∛' | '∜' => {
+                let index = match c {
+                    '√' => 2,
+                    '∛' => 3,
+                    _ => 4,
+                };
+                let mut k = i + 1;
+                let operand = read_unicode_atom(&s, &mut k)?;
+                out.push_str(&format!("({operand})^(1/{index})"));
+                i = k;
+            }
+            '|' => {
+                let (inner, next) = read_bar_group(&s, i)?;
+                out.push_str(&format!("abs({})", read_unicode(&inner)?));
+                i = next;
+            }
+            'e' if s.get(i + 1) == Some(&'^') && s.get(i + 2) == Some(&'(') => {
+                let close = matching_paren(&s, i + 2)?;
+                let inner: String = s[i + 3..close].iter().collect();
+                out.push_str(&format!("exp({})", read_unicode(&inner)?));
+                i = close + 1;
+            }
+            'e' if s.get(i + 1).copied().and_then(from_superscript).is_some() => {
+                let mut j = i + 1;
+                let mut digits = String::new();
+                while let Some(d) = s.get(j).copied().and_then(from_superscript) {
+                    digits.push(d);
+                    j += 1;
+                }
+                out.push_str(&format!("exp({digits})"));
+                i = j;
+            }
+            _ if c.is_ascii_alphabetic() => {
+                let start = i;
+                let mut j = i;
+                while j < s.len() && (s[j].is_ascii_alphanumeric() || s[j] == '_') {
+                    j += 1;
+                }
+                let ident: String = s[start..j].iter().collect();
+                out.push_str(map_unicode_ident(&ident));
+                i = j;
+            }
+            _ => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The Unicode printer's spelling of a function back to the node name the
+/// parser knows (`arctan` is printed, `atan` is the primitive).
+fn map_unicode_ident(ident: &str) -> &str {
+    match ident {
+        "arcsin" => "asin",
+        "arccos" => "acos",
+        "arctan" => "atan",
+        "ln" => "log",
+        other => other,
+    }
+}
+
+/// The operand a radical applies to: a parenthesised group, an absolute value,
+/// a vulgar fraction, or the atom that follows it.
+fn read_unicode_atom(s: &[char], i: &mut usize) -> Result<String, String> {
+    if let Some(f) = s.get(*i).copied().and_then(vulgar_fraction) {
+        *i += 1;
+        return Ok(f.to_owned());
+    }
+    if s.get(*i) == Some(&'|') {
+        let (inner, next) = read_bar_group(s, *i)?;
+        *i = next;
+        return Ok(format!("abs({})", read_unicode(&inner)?));
+    }
+    if s.get(*i) == Some(&'(') {
+        let close = matching_paren(s, *i)?;
+        let inner: String = s[*i + 1..close].iter().collect();
+        *i = close + 1;
+        return read_unicode(&inner);
+    }
+    let start = *i;
+    let mut j = *i;
+    while j < s.len() && (s[j].is_ascii_alphanumeric() || s[j] == '.' || s[j] == '_') {
+        j += 1;
+    }
+    if j == start {
+        return Err(format!("nothing for the radical to apply to at {start}"));
+    }
+    // An identifier followed by `(` is a call, and the call is the operand.
+    if s.get(j) == Some(&'(') {
+        let close = matching_paren(s, j)?;
+        let name: String = s[start..j].iter().collect();
+        let args: String = s[j + 1..close].iter().collect();
+        *i = close + 1;
+        return Ok(format!(
+            "{}({})",
+            map_unicode_ident(&name),
+            read_unicode(&args)?
+        ));
+    }
+    *i = j;
+    Ok(s[start..j].iter().collect())
+}
+
+/// The body of a `|…|` starting at `open`, and the index just past it.
+///
+/// `|` is its own mirror, so pairing by "scan to the next bar" is wrong the
+/// moment one absolute value contains another.  The printer parenthesises the
+/// inner one (`|(|2|)|`) precisely so that this stays decidable, and that is
+/// the case handled first.
+fn read_bar_group(s: &[char], open: usize) -> Result<(String, usize), String> {
+    if s.get(open + 1) == Some(&'(') {
+        let close = matching_paren(s, open + 1)?;
+        // Only when the group *is* the whole body — `|(x)·y|` is an ordinary
+        // absolute value that happens to start with a parenthesis.
+        if s.get(close + 1) == Some(&'|') {
+            return Ok((s[open + 2..close].iter().collect(), close + 2));
+        }
+    }
+    let close = s[open + 1..]
+        .iter()
+        .position(|&ch| ch == '|')
+        .ok_or("unpaired |")?
+        + open
+        + 1;
+    let inner: String = s[open + 1..close].iter().collect();
+    if inner.contains('|') {
+        return Err(format!("ambiguous nested bars in {inner:?}"));
+    }
+    Ok((inner, close + 1))
+}
+
+fn matching_paren(s: &[char], open: usize) -> Result<usize, String> {
+    let mut depth = 0usize;
+    for (j, &ch) in s.iter().enumerate().skip(open) {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(j);
+                }
+            }
+            _ => {}
+        }
+    }
+    Err("unbalanced parentheses".into())
+}
+
+struct Harness {
+    pool: ExprPool,
+    syms: Vec<ExprId>,
+    names: HashMap<String, ExprId>,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let pool = ExprPool::new();
+        let syms: Vec<ExprId> = SYMBOL_NAMES
+            .iter()
+            .map(|n| pool.symbol(*n, Domain::Real))
+            .collect();
+        let names = SYMBOL_NAMES
+            .iter()
+            .map(|n| ((*n).to_owned(), pool.symbol(*n, Domain::Real)))
+            .collect();
+        Self { pool, syms, names }
+    }
+
+    /// `(printed, verdict)` for one expression.
+    fn check(&self, id: ExprId) -> (String, Verdict) {
+        let printed = self.pool.display(id).to_string();
+        let mut names = self.names.clone();
+        match parse(&printed, &self.pool, &mut names) {
+            // A rendering the parser rejects is a *loud* failure, not a silent
+            // one, but it still means the output is not usable as input.
+            Err(e) => panic!("printed form does not parse: {printed:?} — {e:?}"),
+            Ok(back) => (printed, compare(id, back, &self.pool, &self.syms)),
+        }
+    }
+
+    /// The same property for a typeset form, read back through `reader`.
+    fn check_typeset(
+        &self,
+        id: ExprId,
+        render: fn(ExprId, &ExprPool) -> String,
+        reader: fn(&str) -> Result<String, String>,
+    ) -> (String, Verdict) {
+        let printed = render(id, &self.pool);
+        let ascii = match reader(&printed) {
+            Ok(a) => a,
+            Err(e) => panic!("cannot read back {printed:?}: {e}"),
+        };
+        let mut names = self.names.clone();
+        if std::env::var("PRINTER_DEBUG").is_ok() {
+            eprintln!("DBG {printed}  ==>  {ascii}");
+        }
+        match parse(&ascii, &self.pool, &mut names) {
+            Err(e) => panic!("{printed:?} reads as {ascii:?}, which does not parse: {e:?}"),
+            Ok(back) => (
+                format!("{printed}   ->   {ascii}"),
+                compare(id, back, &self.pool, &self.syms),
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The property
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generated_corpus_round_trips_through_the_parser() {
+    let h = Harness::new();
+    let mut rng = Rng(0x5eed_1234_abcd_0001);
+    let mut counts = [0usize; 4];
+    let mut failures: Vec<String> = Vec::new();
+    let mut undecided: Vec<String> = Vec::new();
+
+    for _ in 0..4000 {
+        let depth = 1 + rng.below(4) as u32;
+        let id = build(&mut rng, &h.pool, &h.syms, depth);
+        let (printed, verdict) = h.check(id);
+        match verdict {
+            Verdict::Structural => counts[0] += 1,
+            Verdict::Numeric => counts[1] += 1,
+            Verdict::Undecided => {
+                counts[2] += 1;
+                if undecided.len() < 12 {
+                    undecided.push(printed.clone());
+                }
+            }
+            Verdict::Mismatch => {
+                counts[3] += 1;
+                if failures.len() < 10 {
+                    failures.push(printed);
+                }
+            }
+        }
+    }
+
+    println!(
+        "round-trip corpus: {} structural, {} numeric, {} undecided, {} mismatched",
+        counts[0], counts[1], counts[2], counts[3]
+    );
+    assert!(
+        failures.is_empty(),
+        "printed forms that re-read as a different expression \
+         (structural {}, numeric {}, undecided {}, mismatched {}):\n{}",
+        counts[0],
+        counts[1],
+        counts[2],
+        counts[3],
+        failures.join("\n")
+    );
+    // Guard against the corpus quietly becoming vacuous.
+    let decided = counts[0] + counts[1];
+    assert!(
+        decided > 3000,
+        "only {decided} of 4000 cases were decided; the corpus has gone vacuous\n{}",
+        undecided.join("\n")
+    );
+}
+
+/// The shapes where a printer classically loses the expression: non-associative
+/// operators nested on the right, stacked powers, unary minus, negative and
+/// fractional exponents, juxtaposed numeric factors, repeated factors.
+fn precedence_shapes(h: &Harness) -> Vec<ExprId> {
+    let p = &h.pool;
+    let (a, b, c) = (h.syms[0], h.syms[1], h.syms[2]);
+    let neg = |x: ExprId| p.mul(vec![p.integer(-1_i64), x]);
+    let sub = |x: ExprId, y: ExprId| p.add(vec![x, neg(y)]);
+    let div = |x: ExprId, y: ExprId| p.mul(vec![x, p.pow(y, p.integer(-1_i64))]);
+
+    vec![
+        // a - (b - c) ≠ (a - b) - c
+        sub(a, sub(b, c)),
+        sub(sub(a, b), c),
+        // a / (b / c) ≠ (a / b) / c
+        div(a, div(b, c)),
+        div(div(a, b), c),
+        // a^(b^c) ≠ (a^b)^c
+        p.pow(a, p.pow(b, c)),
+        p.pow(p.pow(a, b), c),
+        // unary minus against `^` and `*`
+        neg(p.pow(a, p.integer(2_i64))),
+        p.pow(neg(a), p.integer(2_i64)),
+        neg(p.mul(vec![a, b])),
+        p.mul(vec![neg(a), b]),
+        // negative literal bases: `-1^n` re-reads as `-(1^n)`
+        p.pow(p.integer(-1_i64), a),
+        p.pow(p.rational(-1, 2), a),
+        p.pow(p.float(-1.5, 53), a),
+        p.mul(vec![p.integer(-16_i64), p.pow(p.integer(-2_i64), a)]),
+        // negative and fractional exponents
+        p.pow(a, p.integer(-2_i64)),
+        p.pow(a, p.rational(-1, 2)),
+        p.pow(a, p.rational(1, 3)),
+        p.pow(p.rational(3, 7), a),
+        // a numeric factor next to a factor that begins with a digit
+        p.mul(vec![p.integer(2_i64), p.pow(p.integer(3_i64), a)]),
+        p.mul(vec![p.float(1.5, 53), p.float(2.5, 53)]),
+        p.mul(vec![a, p.float(-1.5, 53)]),
+        // repeated factors — the power that must not be lost
+        p.mul(vec![a, a]),
+        p.mul(vec![a, a, a, b]),
+        p.mul(vec![p.func("sin", vec![a]), p.func("sin", vec![a])]),
+        div(a, p.mul(vec![b, c])),
+        div(
+            p.func("sin", vec![a]),
+            p.add(vec![p.integer(1_i64), p.mul(vec![a, a])]),
+        ),
+        // multi-argument application
+        p.func("atan2", vec![a, b]),
+        p.func("atan2", vec![sub(a, b), div(b, c)]),
+    ]
+}
+
+#[test]
+fn associativity_and_precedence_shapes_round_trip() {
+    let h = Harness::new();
+    let mut bad: Vec<String> = Vec::new();
+    for id in precedence_shapes(&h) {
+        let (printed, verdict) = h.check(id);
+        if verdict == Verdict::Mismatch || verdict == Verdict::Undecided {
+            bad.push(format!("{verdict:?}: {printed}"));
+        }
+    }
+    assert!(bad.is_empty(), "round-trip failures:\n{}", bad.join("\n"));
+}
+
+// ---------------------------------------------------------------------------
+// The same property for the typeset forms
+// ---------------------------------------------------------------------------
+
+fn typeset_report(
+    h: &Harness,
+    ids: impl IntoIterator<Item = ExprId>,
+    render: fn(ExprId, &ExprPool) -> String,
+    reader: fn(&str) -> Result<String, String>,
+) -> ([usize; 4], Vec<String>) {
+    let mut counts = [0usize; 4];
+    let mut failures = Vec::new();
+    for id in ids {
+        let (printed, verdict) = h.check_typeset(id, render, reader);
+        match verdict {
+            Verdict::Structural => counts[0] += 1,
+            Verdict::Numeric => counts[1] += 1,
+            Verdict::Undecided => counts[2] += 1,
+            Verdict::Mismatch => {
+                counts[3] += 1;
+                if failures.len() < 10 {
+                    failures.push(printed);
+                }
+            }
+        }
+    }
+    (counts, failures)
+}
+
+fn generated_ids(n: usize, h: &Harness) -> Vec<ExprId> {
+    let mut rng = Rng(0x5eed_1234_abcd_0001);
+    (0..n)
+        .map(|_| {
+            let depth = 1 + rng.below(4) as u32;
+            build(&mut rng, &h.pool, &h.syms, depth)
+        })
+        .collect()
+}
+
+/// LaTeX, read back the way the page reads.
+///
+/// This is the check that `x x` cannot pass: math mode discards the space, so
+/// the emitted product of two `x`s has to carry a visible exponent or an
+/// explicit `\cdot`, and a numeric factor followed by a digit has to carry the
+/// `\cdot` or it fuses into one number.
+#[test]
+fn latex_round_trips_as_it_is_typeset() {
+    let h = Harness::new();
+    let mut ids = precedence_shapes(&h);
+    ids.extend(generated_ids(2000, &h));
+    let (counts, failures) = typeset_report(&h, ids, crate::kernel::render_latex, read_latex);
+    println!(
+        "latex round-trip: {} structural, {} numeric, {} undecided, {} mismatched",
+        counts[0], counts[1], counts[2], counts[3]
+    );
+    assert!(
+        failures.is_empty(),
+        "LaTeX that re-reads as a different expression:\n{}",
+        failures.join("\n")
+    );
+    assert!(
+        counts[0] + counts[1] > counts.iter().sum::<usize>() / 2,
+        "the LaTeX corpus went vacuous"
+    );
+}
+
+#[test]
+fn unicode_round_trips_as_it_is_printed() {
+    let h = Harness::new();
+    let mut ids = precedence_shapes(&h);
+    ids.extend(generated_ids(2000, &h));
+    let (counts, failures) = typeset_report(&h, ids, crate::kernel::render_unicode, read_unicode);
+    println!(
+        "unicode round-trip: {} structural, {} numeric, {} undecided, {} mismatched",
+        counts[0], counts[1], counts[2], counts[3]
+    );
+    assert!(
+        failures.is_empty(),
+        "Unicode that re-reads as a different expression:\n{}",
+        failures.join("\n")
+    );
+    assert!(
+        counts[0] + counts[1] > counts.iter().sum::<usize>() / 2,
+        "the Unicode corpus went vacuous"
+    );
+}
+
+/// Structural validity of the emitted LaTeX, independently of what it means:
+/// unbalanced braces or an unmatched `\left` stop a document compiling even
+/// when the mathematics is right.
+#[test]
+fn emitted_latex_is_structurally_valid() {
+    let h = Harness::new();
+    let mut ids = precedence_shapes(&h);
+    ids.extend(generated_ids(2000, &h));
+    let mut bad: Vec<String> = Vec::new();
+    for id in ids {
+        let tex = crate::kernel::render_latex(id, &h.pool);
+        let mut braces = 0i32;
+        let mut ok = true;
+        let chars: Vec<char> = tex.chars().collect();
+        for (i, &c) in chars.iter().enumerate() {
+            let escaped = i > 0 && chars[i - 1] == '\\';
+            match c {
+                '{' if !escaped => braces += 1,
+                '}' if !escaped => braces -= 1,
+                _ => {}
+            }
+            if braces < 0 {
+                ok = false;
+            }
+        }
+        let lefts = tex.matches(r"\left").count();
+        let rights = tex.matches(r"\right").count();
+        // A bare `_` in math mode is a subscript; `\operatorname{a_b}` renders
+        // wrong and two of them are the hard "Double subscript" error.
+        let bare_underscore = tex
+            .char_indices()
+            .any(|(i, c)| c == '_' && !tex[..i].ends_with('\\') && !tex[..i].ends_with('}'));
+        if !ok || braces != 0 || lefts != rights || bare_underscore || double_superscript(&tex) {
+            bad.push(tex);
+            if bad.len() > 5 {
+                break;
+            }
+        }
+    }
+    assert!(bad.is_empty(), "invalid LaTeX emitted:\n{}", bad.join("\n"));
+}
+
+/// `x^a^b` — ambiguous to a reader and the TeX error "Double superscript".
+fn double_superscript(tex: &str) -> bool {
+    let s: Vec<char> = tex.chars().collect();
+    let mut i = 0usize;
+    while i < s.len() {
+        if s[i] != '^' {
+            i += 1;
+            continue;
+        }
+        let mut k = i + 1;
+        if s.get(k) == Some(&'{') {
+            if take_group(&s, &mut k).is_err() {
+                return false;
+            }
+        } else {
+            k += 1;
+        }
+        while s.get(k) == Some(&' ') {
+            k += 1;
+        }
+        if s.get(k) == Some(&'^') {
+            return true;
+        }
+        i = k;
+    }
+    false
+}
+
+#[test]
+fn a_double_superscript_is_detected() {
+    assert!(double_superscript("e^{x}^2"));
+    assert!(double_superscript("x^a^b"));
+    assert!(!double_superscript("x^{a^b}"));
+    assert!(!double_superscript(r"\left(e^{x}\right)^2"));
+}
+
+/// The readers themselves have to be able to fail, or the three tests above
+/// pass by construction.
+#[test]
+fn the_typeset_readers_are_not_vacuous() {
+    // A digit next to a digit fuses, exactly as it does on the page.
+    assert_eq!(read_latex("2 3").unwrap(), "23");
+    assert_eq!(read_latex("x 2").unwrap(), "x2");
+    // Two variables read as a product; a variable next to a number does not.
+    assert_eq!(read_latex("x x").unwrap(), "x*x");
+    assert_eq!(read_latex(r"2 \cdot 3^n").unwrap(), "2*3^(n)");
+    assert_eq!(read_latex("2 x").unwrap(), "2*x");
+    assert_eq!(read_latex(r"\frac{1}{2} x").unwrap(), "((1)/(2))*x");
+    assert_eq!(read_latex(r"x^{2}").unwrap(), "x^(2)");
+    // `^` binds one token: `x^c y` is a product, not `x^(cy)`.
+    assert_eq!(read_latex(r"x^c y").unwrap(), "x^(c)*y");
+    assert_eq!(read_latex(r"2.5 \times 10^{-1}").unwrap(), "2.5*10^(-1)");
+    assert_eq!(read_latex(r"\sin\!\left(x\right)").unwrap(), "sin(x)");
+    assert_eq!(read_unicode("∛|b|").unwrap(), "(abs(b))^(1/3)");
+    // The Unicode reader undoes superscripts and radicals.
+    assert_eq!(read_unicode("x²").unwrap(), "x^(2)");
+    assert_eq!(read_unicode("x·y").unwrap(), "x*y");
+    assert_eq!(read_unicode("(x + 1)¹").unwrap(), "(x + 1)^(1)");
+    assert_eq!(read_unicode("√x").unwrap(), "(x)^(1/2)");
+    assert_eq!(read_unicode("½·x").unwrap(), "(1/2)*x");
+}

--- a/docs/mdbook/src/parsing.md
+++ b/docs/mdbook/src/parsing.md
@@ -103,6 +103,6 @@ and functions listed above:
 from alkahest import latex, unicode_str
 
 e = parse("sin(x)^2 + cos(x)^2", pool, {"x": x})
-print(latex(e))        # \sin\!\left(x\right)^{2} + \cos\!\left(x\right)^{2}
+print(latex(e))        # \sin\!\left(x\right)^2 + \cos\!\left(x\right)^2
 print(unicode_str(e))  # sin(x)² + cos(x)²
 ```

--- a/python/alkahest/_pretty.py
+++ b/python/alkahest/_pretty.py
@@ -24,7 +24,7 @@ def latex(expr) -> str:
         >>> p = alkahest.ExprPool()
         >>> x = p.symbol("x")
         >>> alkahest.latex(alkahest.sin(x)**2 + alkahest.cos(x)**2)
-        '\\\\sin\\\\!\\\\left(x\\\\right)^{2} + \\\\cos\\\\!\\\\left(x\\\\right)^{2}'
+        '\\\\sin\\\\!\\\\left(x\\\\right)^2 + \\\\cos\\\\!\\\\left(x\\\\right)^2'
     """
     return expr.display_latex()
 

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -1532,6 +1532,214 @@ def _evaluators_disagreeing_on() -> int:
     return disagreements
 
 
+# ---------------------------------------------------------------------------
+# Printer fidelity
+# ---------------------------------------------------------------------------
+#
+# A printer that emits something which re-reads as a *different* expression is a
+# silent error with extra steps: the caller copies the output, feeds it back,
+# and gets different mathematics with nothing raised anywhere.  These cases
+# score the round trip — read the emitted form back and evaluate it — rather
+# than pinning a string, so a legitimate change of rendering does not fail them
+# and a change of *meaning* does.
+
+#: Symbols the printing cases bind when re-parsing their own output.
+_PRINT_SYMS = {"x": X, "y": Y, "n": N}
+
+
+def _latex_units(tex: str) -> list[str]:
+    """Split emitted LaTeX into ASCII tokens, one per source token.
+
+    Only the subset these cases emit is handled — `\\cdot`, `\\times`,
+    `\\left(`, `\\right)`, `^`, and literals.  Anything else raises, so a case
+    whose rendering grows a new construct is reported rather than quietly
+    passing.
+    """
+    units: list[str] = []
+    i, n = 0, len(tex)
+    while i < n:
+        c = tex[i]
+        if c.isspace():
+            i += 1
+            continue
+        if c == "\\":
+            j = i + 1
+            while j < n and tex[j].isalpha():
+                j += 1
+            name, k = (tex[i + 1 : j], j) if j > i + 1 else (tex[i + 1 : i + 2], i + 2)
+            if name in {"!", ",", ";", " "}:
+                pass
+            elif name in {"cdot", "times"}:
+                units.append("*")
+            elif name == "left" and tex[k : k + 1] == "(":
+                units.append("(")
+                k += 1
+            elif name == "right" and tex[k : k + 1] == ")":
+                units.append(")")
+                k += 1
+            else:
+                raise ValueError(f"unhandled LaTeX macro {name!r} in {tex!r}")
+            i = k
+            continue
+        if c == "^":
+            # `^` scopes to exactly one token: `x^c y` is `(x^c)·y`.
+            if tex[i + 1 : i + 2] == "{":
+                depth, j = 1, i + 2
+                while j < n and depth:
+                    depth += (tex[j] == "{") - (tex[j] == "}")
+                    j += 1
+                if depth:
+                    raise ValueError(f"unbalanced braces in {tex!r}")
+                body, i = tex[i + 2 : j - 1], j
+            else:
+                body, i = tex[i + 1 : i + 2], i + 2
+            units.append("^(" + "".join(_latex_units(body)) + ")")
+            continue
+        if c.isdigit():
+            j = i
+            while j < n and (tex[j].isdigit() or tex[j] == "."):
+                j += 1
+            units.append(tex[i:j])
+            i = j
+            continue
+        units.append(c)
+        i += 1
+    return units
+
+
+def _latex_as_read(tex: str) -> str:
+    """Emitted LaTeX, as the page reads it.
+
+    Math mode discards white space (Knuth, *The TeXbook*, ch. 8), so juxtaposed
+    tokens fuse: `2 3` sets as `23`, `x 2` as `x2`.  Every other juxtaposition
+    is a product.  Modelling the space as a multiplication instead would assume
+    away exactly the defect this is looking for.
+    """
+    out = ""
+    for unit in _latex_units(tex):
+        if out:
+            prev, here = out[-1], unit[0]
+            kind = lambda ch: (  # noqa: E731 - three-line local classifier
+                "d" if ch.isdigit() or ch == "." else "l" if ch.isalpha() else ch
+            )
+            a, b = kind(prev), kind(here)
+            fuses = (a, b) in {("d", "d"), ("l", "d")}
+            juxtaposed = a in {"d", "l", ")"} and b in {"d", "l", "("}
+            if juxtaposed and not fuses:
+                out += "*"
+        out += unit
+    return out
+
+
+def latex_value(expr: ak.Expr, env: dict) -> Callable[[], float]:
+    """Answer = the value of alkahest's own LaTeX for *expr*, read back."""
+
+    def op() -> float:
+        source = _latex_as_read(ak.latex(expr))
+        return float(ak.eval_expr(ak.parse(source, POOL, dict(_PRINT_SYMS)), env))
+
+    return op
+
+
+def printed_value(expr: ak.Expr, env: dict) -> Callable[[], float]:
+    """Answer = the value of ``parse(str(expr))`` — the plain-text round trip."""
+
+    def op() -> float:
+        return float(ak.eval_expr(ak.parse(str(expr), POOL, dict(_PRINT_SYMS)), env))
+
+    return op
+
+
+def _has_double_superscript(tex: str) -> bool:
+    """`x^a^b`: ambiguous to a reader, and the TeX error "Double superscript"."""
+    i, n = 0, len(tex)
+    while i < n:
+        if tex[i] != "^":
+            i += 1
+            continue
+        if tex[i + 1 : i + 2] == "{":
+            depth, j = 1, i + 2
+            while j < n and depth:
+                depth += (tex[j] == "{") - (tex[j] == "}")
+                j += 1
+            i = j
+        else:
+            i += 2
+        while tex[i : i + 1] == " ":
+            i += 1
+        if tex[i : i + 1] == "^":
+            return True
+    return False
+
+
+def _superscript_count(rendered: str) -> int:
+    """How many Unicode superscript runs the rendering carries."""
+    runs, previous = 0, False
+    for ch in rendered:
+        here = ch in "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻"
+        runs += here and not previous
+        previous = here
+    return runs
+
+
+def _bar_nesting_depth(rendered: str) -> int:
+    """Nesting depth of ``|…|`` — or ``-1`` when the bars cannot be paired.
+
+    ``|`` is its own mirror, so ``||2||`` has no unique reading; the printer has
+    to parenthesise the inner one for the outer pair to be recoverable.
+    """
+
+    def parse(s: str) -> tuple[int, str]:
+        if not s.startswith("|"):
+            raise ValueError(f"not an absolute value: {s!r}")
+        body = s[1:]
+        if body.startswith("("):
+            depth, j = 1, 1
+            while j < len(body) and depth:
+                depth += (body[j] == "(") - (body[j] == ")")
+                j += 1
+            if depth or body[j : j + 1] != "|":
+                raise ValueError(f"unpaired bars in {s!r}")
+            return 1 + parse(body[1 : j - 1])[0], body[j + 1 :]
+        end = body.find("|")
+        if end < 0:
+            raise ValueError(f"unpaired bars in {s!r}")
+        inner = body[:end]
+        if "|" in inner:
+            raise ValueError(f"ambiguous nested bars in {s!r}")
+        return 1, body[end + 1 :]
+
+    try:
+        depth, rest = parse(rendered)
+    except ValueError:
+        return -1
+    return depth if not rest else -1
+
+
+def _operatorname_underscores_are_escaped(tex: str) -> bool:
+    """Every ``_`` inside an ``\\operatorname{…}`` must be escaped."""
+    for match in re.finditer(r"\\operatorname\{([^}]*)\}", tex):
+        body = match.group(1)
+        if any(body[k] == "_" and (k == 0 or body[k - 1] != "\\") for k in range(len(body))):
+            return False
+    return True
+
+
+def _grouping_depth(tex: str, needle: str) -> int:
+    """Parenthesis depth at which *needle* appears in *tex*."""
+    index = tex.index(needle)
+    prefix = tex[:index]
+    return prefix.count(r"\left") - prefix.count(r"\right")
+
+
+#: The two logical shapes the grouping cases compare, rendered once.
+_PRINT_A = POOL.lt(X, _int(0))
+_PRINT_B = POOL.gt(X, _int(1))
+_PRINT_C = POOL.pred_eq(X, _int(2))
+_PRINT_OR_IN_AND = ak.latex(POOL.pred_and([POOL.pred_or([_PRINT_A, _PRINT_B]), _PRINT_C]))
+_PRINT_AND_IN_OR = ak.latex(POOL.pred_or([_PRINT_A, POOL.pred_and([_PRINT_B, _PRINT_C])]))
+
+
 CASES: list[Case] = [
     # ── real quantifier elimination ──────────────────────────────────────────
     #
@@ -6399,6 +6607,213 @@ CASES: list[Case] = [
             "raises E-EVAL-009. That asymmetry is documented (CompiledFn has no error "
             "channel) and is the reason this case exists rather than a Raises() one."
         ),
+    ),
+    # ── printer fidelity ─────────────────────────────────────────────────────
+    #
+    # Printed output is *input*: an agent or a user copies it back in.  A
+    # rendering that re-reads as different mathematics is therefore a silent
+    # error with extra steps, and each case below scores the round trip — read
+    # alkahest's own output back and evaluate it — rather than pinning a
+    # string, so a legitimate change of rendering does not fail them while a
+    # change of meaning does.
+    Case(
+        id="printing_latex_repeated_factor_keeps_its_power",
+        subsystem="printing",
+        statement="latex(x·x), read back, is x² — at x = 3 it is 9",
+        op=latex_value(POOL.mul([X, X]), {X: 3.0}),
+        contract=Returns(9.0),
+        verified_by="x·x = x² by the definition of a power; at x = 3 both are 9. LaTeX math "
+        "mode discards white space (Knuth, The TeXbook, ch. 8), so a product printed "
+        "as `x x` sets as `xx` — one two-letter identifier, not a power.",
+    ),
+    Case(
+        id="printing_control_latex_distinct_factors_are_a_product",
+        subsystem="printing",
+        statement="latex(x·y), read back, is a product — at (3, 5) it is 15",
+        op=latex_value(POOL.mul([X, Y]), {X: 3.0, Y: 5.0}),
+        contract=Returns(15.0),
+        verified_by="3·5 = 15. The control for the case above: single italic letters "
+        "juxtaposed are the conventional spelling of a product (ISO 80000-2), so "
+        "collapsing repeated factors must not turn every product into a power.",
+    ),
+    Case(
+        id="printing_latex_numeral_before_a_numeral_needs_cdot",
+        subsystem="printing",
+        statement="latex(2·3ⁿ), read back at n = 3, is 54 — not 23³",
+        op=latex_value(POOL.mul([POOL.integer(2), POOL.integer(3) ** N]), {N: 3.0}),
+        contract=Returns(54.0),
+        verified_by="2·3³ = 54, while 23³ = 12167. Typeset without a separator the two "
+        "numerals fuse (The TeXbook, ch. 8); SymPy's LaTeX printer inserts `\\cdot` "
+        "between adjacent numerals for exactly this reason "
+        "(sympy/printing/latex.py, `_between_two_numbers_p`).",
+    ),
+    Case(
+        id="printing_control_latex_coefficient_before_a_symbol",
+        subsystem="printing",
+        statement="latex(2·x), read back at x = 3, is 6",
+        op=latex_value(POOL.mul([POOL.integer(2), X]), {X: 3.0}),
+        contract=Returns(6.0),
+        verified_by="2·3 = 6. The control for the case above: `2x` is the standard "
+        "spelling of a coefficient times a symbol (ISO 80000-2), and it has to go "
+        "on reading as a product — a fix that made *this* juxtaposition fuse "
+        "would be worse than the defect it was fixing.",
+    ),
+    Case(
+        id="printing_latex_negative_float_factor_is_not_a_subtraction",
+        subsystem="printing",
+        statement="latex(x·(−1.5)), read back at x = 2, is −3 — not x − 1.5",
+        op=latex_value(POOL.mul([X, POOL.float(-1.5)]), {X: 2.0}),
+        contract=Returns(-3.0),
+        verified_by="2·(−1.5) = −3, while 2 − 1.5 = 0.5. A factor emitted with its leading "
+        "minus sign exposed is read as a binary minus: juxtaposition and "
+        "subtraction are not distinguishable once the sign is bare.",
+    ),
+    Case(
+        id="printing_control_latex_positive_float_factor",
+        subsystem="printing",
+        statement="latex(x·1.5), read back at x = 2, is 3",
+        op=latex_value(POOL.mul([X, POOL.float(1.5)]), {X: 2.0}),
+        contract=Returns(3.0),
+        verified_by="2·1.5 = 3. The control for the case above: a float factor with no "
+        "sign of its own still has to read as a product.",
+    ),
+    Case(
+        id="printing_latex_float_exponent_is_a_power_of_ten",
+        subsystem="printing",
+        statement="latex(0.25·x), read back at x = 4, is 1",
+        op=latex_value(POOL.mul([POOL.float(0.25), X]), {X: 4.0}),
+        contract=Returns(1.0),
+        verified_by="0.25·4 = 1, and 0.25 = 2.5×10⁻¹. `rug::Float` prints 0.25 as `2.5e-1`; "
+        "copied verbatim into math mode that reads as 2.5·e − 1, a subtraction "
+        "against Euler's number, so the exponent has to be typeset as a power of "
+        "ten (ISO 80000-1 §7.3.2).",
+    ),
+    Case(
+        id="printing_latex_exp_base_is_not_a_double_superscript",
+        subsystem="printing",
+        statement="latex((eˣ)²) carries no `^…^` — TeX rejects a doubled superscript",
+        op=lambda: _has_double_superscript(ak.latex(ak.exp(X) ** 2)),
+        contract=Returns(False),
+        verified_by="`e^{x}^2` is the TeX error 'Double superscript' (Knuth, The TeXbook, "
+        "ch. 7: an atom may carry only one superscript), so the document does not "
+        "compile at all; and read as written it would be e^(x²), which at x = 3 is "
+        "e⁹ rather than e⁶.",
+    ),
+    Case(
+        id="printing_control_latex_nested_exponent_is_braced",
+        subsystem="printing",
+        statement="latex(x^(y^n)) is a *nested* superscript, which is legal",
+        op=lambda: _has_double_superscript(ak.latex(X ** (Y**N))),
+        contract=Returns(False),
+        verified_by="`x^{y^n}` puts the second superscript inside the first one's group, "
+        "which TeX accepts (The TeXbook, ch. 7). The control: the check above must "
+        "not fire on every expression that has two superscripts in it.",
+    ),
+    Case(
+        id="printing_unicode_reciprocal_has_no_leftover_exponent",
+        subsystem="printing",
+        statement="unicode_str(1/(x+1)) carries no superscript",
+        op=lambda: _superscript_count(ak.unicode_str(_int(1) / (X + _int(1)))),
+        contract=Returns(0),
+        verified_by="x⁻¹ is 1/x: the exponent is spent by writing the quotient, so nothing "
+        "may remain. SymPy's pretty printer renders this as `1/(x + 1)`.",
+    ),
+    Case(
+        id="printing_control_unicode_squared_denominator_keeps_its_exponent",
+        subsystem="printing",
+        statement="unicode_str(1/(x+1)²) does carry one superscript",
+        op=lambda: _superscript_count(ak.unicode_str(_int(1) / (X + _int(1)) ** 2)),
+        contract=Returns(1),
+        verified_by="1/(x+1)² has an exponent that the quotient does *not* absorb — only one "
+        "of the two powers is spent. The control for the case above: suppressing "
+        "every exponent in a denominator would be a worse error than printing a "
+        "redundant one.",
+    ),
+    Case(
+        id="printing_str_negative_base_power_round_trips",
+        subsystem="printing",
+        statement="parse(str((−1)ⁿ)) at n = 2 is +1 — `-1^n` would give −1",
+        op=printed_value(POOL.integer(-1) ** N, {N: 2.0}),
+        contract=Returns(1.0),
+        verified_by="(−1)² = +1 while −(1²) = −1. Unary minus binds looser than `^` in "
+        "Python (docs.python.org, 6.5: '-1**2 is -1'), in sympy and in every "
+        "parser that reads these strings, so only `(-1)^n` round-trips.",
+    ),
+    Case(
+        id="printing_control_str_positive_base_power_round_trips",
+        subsystem="printing",
+        statement="parse(str(2ⁿ)) at n = 3 is 8, with no parentheses added",
+        op=printed_value(POOL.integer(2) ** N, {N: 3.0}),
+        contract=Returns(8.0),
+        verified_by="2³ = 8. The control for the case above: a non-negative base has to "
+        "keep round-tripping, so the fix cannot be 'parenthesise nothing' and "
+        "cannot break the ordinary shape either.",
+    ),
+    Case(
+        id="printing_latex_disjunction_inside_conjunction_is_grouped",
+        subsystem="printing",
+        statement="latex((a ∨ b) ∧ c) puts the ∨ one group deeper than the ∧",
+        op=lambda: (
+            _grouping_depth(_PRINT_OR_IN_AND, r"\lor") - _grouping_depth(_PRINT_OR_IN_AND, r"\land")
+        ),
+        contract=Returns(1),
+        verified_by="∧ binds tighter than ∨ (Enderton, A Mathematical Introduction to Logic, "
+        "§1.2), so `a ∨ b ∧ c` *is* a ∨ (b ∧ c). Printing (a ∨ b) ∧ c without the "
+        "group states a different proposition: at a = ⊤, b = ⊥, c = ⊥ the first is "
+        "⊥ and the second is ⊤.",
+    ),
+    Case(
+        id="printing_control_latex_conjunction_inside_disjunction_is_not_grouped",
+        subsystem="printing",
+        statement="latex(a ∨ (b ∧ c)) needs no group, and gets none",
+        op=lambda: (
+            _grouping_depth(_PRINT_AND_IN_OR, r"\lor") - _grouping_depth(_PRINT_AND_IN_OR, r"\land")
+        ),
+        contract=Returns(0),
+        verified_by="a ∨ (b ∧ c) is exactly what `a ∨ b ∧ c` means under the standard "
+        "precedence (Enderton §1.2). The control: parenthesising every connective "
+        "would satisfy the case above while making the output unreadable.",
+    ),
+    Case(
+        id="printing_latex_operatorname_escapes_its_underscore",
+        subsystem="printing",
+        statement="latex of an unregistered head `my_func` escapes the underscore",
+        op=lambda: _operatorname_underscores_are_escaped(ak.latex(POOL.func("my_func", [X]))),
+        contract=Returns(True),
+        verified_by="A bare `_` in math mode is a subscript, so `\\operatorname{my_func}` sets "
+        "as my_func with a subscripted f, and a second underscore is the hard error "
+        "'Double subscript' (Knuth, The TeXbook, ch. 7).",
+    ),
+    Case(
+        id="printing_control_latex_symbol_subscript_keeps_its_underscore",
+        subsystem="printing",
+        statement="latex(u_0) still uses a real subscript, unescaped",
+        op=lambda: (
+            "_" in ak.latex(POOL.symbol("u_0")) and "\\_" not in ak.latex(POOL.symbol("u_0"))
+        ),
+        contract=Returns(True),
+        verified_by="`u_0` names a subscripted variable, and `{u}_{0}` is how that is "
+        "written (The TeXbook, ch. 7). The control for the case above: escaping "
+        "every underscore would turn subscripted symbols into literal text.",
+    ),
+    Case(
+        id="printing_unicode_nested_absolute_value_is_pairable",
+        subsystem="printing",
+        statement="unicode_str(||x||) is printed so the two bar pairs can be told apart",
+        op=lambda: _bar_nesting_depth(ak.unicode_str(ak.abs(ak.abs(X)))),
+        contract=Returns(2),
+        verified_by="U+007C is its own mirror — it is not a bracket pair (Unicode 15.0, "
+        "table 4-2, Bidi_Paired_Bracket_Type=None) — so `||x||` has no unique "
+        "reading; it is equally the norm ‖x‖. The inner pair has to be grouped.",
+    ),
+    Case(
+        id="printing_control_unicode_absolute_value_stays_plain",
+        subsystem="printing",
+        statement="unicode_str(|x|) is one bar pair, ungrouped",
+        op=lambda: _bar_nesting_depth(ak.unicode_str(ak.abs(X))),
+        contract=Returns(1),
+        verified_by="|x| is unambiguous on its own. The control for the case above: adding "
+        "the group unconditionally would print `|(x)|` for every absolute value.",
     ),
 ]
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -191,7 +191,10 @@ class TestNegativeLiteralFolding:
             ("-(-3)", "3", "3", "3"),  # (-1 * (-1 * 3)),  "--3"
             ("x^(-1)", "x^-1", r"\frac{1}{x}", "x⁻¹"),  # x^(1 * -1),  "x^(-1)"
             ("x^(-2)", "x^-2", "x^{-2}", "x⁻²"),  # x^(-1 * 2),  "x^(-2)"
-            ("-2/3", None, r"-\frac{2}{3}", "-2/3¹"),  # \frac{-2}{3}
+            # The Unicode column used to read `-2/3¹`: the reciprocal factor was
+            # moved into the denominator *and* kept its exponent.  `x^-1` is
+            # `1/x`, not `1/x¹` — the division is what spends the exponent.
+            ("-2/3", None, r"-\frac{2}{3}", "-2/3"),  # \frac{-2}{3}
             ("2 - -3", None, "2 + 3", "2 + 3"),  # "--3 + 2"
             # Unchanged, because none of these is `-<literal>`.
             ("-x", None, "-x", "-x"),


### PR DESCRIPTION
A printer that emits something which **re-reads as different mathematics** is a
silent wrong answer with extra steps: you copy the output, feed it back, and get
a different expression with no error anywhere. This treats round-trip fidelity
as a correctness property.

## The three reported defects

1. **`latex` did not collapse powers** — `Mul[x,x]` rendered as `x x`, which
   sets as a juxtaposed product. `latex_signed_mul` had no notion of a repeated
   factor. Fixed with `collapse_runs`, which merges maximal runs of
   **consecutive** equal `ExprId`s — consecutive-only, so it never reorders a
   product and stays sound for the non-commutative generators.
2. **`unicode_str` emitted a spurious exponent** — `(1 + x·x)¹`. The LaTeX
   denominator branch had an `exp_abs == 1` guard; the Unicode one did not.
3. **Negative base.** The existing `pool.rs` fix does cover every route — I
   checked the Python `**` operator, `pool.pow`, `pool.mul`-embedded bases,
   rationals `(-1/2)^n`, negative floats, negative exponents `(-2)^-3`, and
   nested powers through all three printers. Now pinned by test rather than by
   inspection.

## What the audit found beyond them

`kernel/printer_roundtrip.rs` prints, reads back, and compares — structurally
after a normalisation that undoes only what the parser *cannot* avoid (binary
`Add`/`Mul` spines, the missing rational-literal token, both documented in
CONTRIBUTING.md), or numerically at five sample points. The typeset forms are
read back **the way the page reads them**: math mode discards whitespace, so a
fused `2 3` → `23` counts as a failure rather than something the test assumes
away.

| printer | corpus | structural | numeric | undecided | **mismatched** |
|---|---|---|---|---|---|
| plain text | 4000 | 2895 | 484 | 621 | **0** |
| LaTeX | 2028 | 853 | 580 | 595 | **0** |
| Unicode | 2028 | 1042 | 488 | 498 | **0** |

Every item below was a mismatch before the fix. None was left open.

- **LaTeX juxtaposition lost the operator.** `2·3^n` → `2 3^n`, which sets as
  `23^n` — **12167 against 54**. `1.5·2.5` → `1.52.5`. Fixed with `\cdot`
  before any digit-leading factor.
- **A negative factor read as a subtraction.** `x·(−1.5)` → `x -1.5`, i.e.
  `x − 1.5` — **0.5 against −3**.
- **Floats in exponent notation.** `rug::Float` prints `0.25` as `2.5e-1`,
  which in math mode is `2.5·e − 1`. Now `2.5 \times 10^{-1}`; the literal also
  lost atom precedence, so `√0.25` can no longer print `√2.5e-1`.
- **Logical connectives all printed at one precedence.** `(a ∨ b) ∧ c` came out
  `a ∨ b ∧ c`, which re-reads as `a ∨ (b ∧ c)` — **a different proposition**.
  `¬(a ∧ b)` came out `¬a ∧ b`, and `∀`/`∃` scoped over whatever followed.
- **`e^{u}` and `√u` claimed atom precedence** — producing `e^{x}^2`, the hard
  TeX error "Double superscript", and `√x²`.
- **`\operatorname{my_func}` was invalid LaTeX** — a bare `_` in math mode is a
  subscript; two are "Double subscript".
- **`||x||` had no unique pairing** (`|` is its own mirror). Unicode now prints
  `|(|x|)|`; LaTeX uses explicitly matched `\left|…\right|`.
- **`Rational(2,1)`** — which `4/2` interns as, distinct from `Integer(2)` —
  printed `\frac{2}{1}`, and `x^(1/1)` reached the Unicode `ⁿ√` branch as
  `¹√x`.

Left as documented non-defects: `√u·v` and `√u^k` are scope-ambiguous in plain
Unicode but not value-changing for positive reals; `\frac{1}{\left(x+1\right)}`
keeps redundant parentheses (pre-existing, pinned by test).

## Out of scope, reported not fixed

- **`parse.rs` panics on a malformed float.** `tokenize` accepts a trailing `e`
  with no digits (`"1e"`), and line 517 does `s.parse::<f64>().unwrap()` — a
  panic rather than a `ParseError`. The Python parser rejects `"1e"`, so the two
  parsers also diverge here. Found because the LaTeX reader hit it.
- **`to_lean`** parenthesises every node and has none of this bug class, but an
  unregistered head emits `name (a, b)` — a Lean *tuple*. A loud type error, not
  a silent one. `to_smtlib` is s-expressions and is clean.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **3091 passed, 0
failed, 11 ignored** (main: 3072; +19). `pytest tests/` → 3145 passed, 0 failed.
Silent-error corpus → 403 passed, 0 silent errors, new `printing` subsystem at
**19 cases** — 9 round-trip/validity traps each paired with a control that fails
if the fix is applied indiscriminately. Every `verified_by` cites Knuth's
*TeXbook*, ISO 80000, Enderton, Unicode 15.0, SymPy's printer source, or
arithmetic — never Alkahest. `the_typeset_readers_are_not_vacuous` proves the
readers can fail.

clippy `-D warnings`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`, ruff
`check` and `format --check`, `check_error_codes.py`, `check_api_freeze.py` all
clean. No public enum variant or struct field added.

**Three existing expectations changed.** `tests/test_parse.py` pinned `-2/3¹` as
the Unicode rendering of `parse("-2/3")` — defect 2, enshrined as expected
output; now `-2/3` with a comment saying why. `python/alkahest/_pretty.py` and
`docs/mdbook/src/parsing.md` showed `^{2}` where the printer has emitted `^2`
since the single-character-exponent rule landed — stale before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved LaTeX and Unicode expression formatting with more accurate parentheses, operator precedence, powers, radicals, fractions, absolute values, and scientific notation.
  - Repeated factors now display compactly as powers, while negative and numeric factors are grouped unambiguously.
  - Integer-valued rational numbers now render as plain integers.
  - Improved escaping and spacing make generated LaTeX more reliable and readable.

- **Documentation**
  - Updated parsing and Python API examples to reflect current exponent formatting.

- **Tests**
  - Expanded coverage for printing, parsing, and LaTeX/Unicode round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->