### PR TITLE
fix(matrix): eight wrong answers an oracle sweep found, and the hypothesis a symbolic inverse rests on

### DIFF
--- a/alkahest-core/src/matrix/eigen.rs
+++ b/alkahest-core/src/matrix/eigen.rs
@@ -119,7 +119,9 @@ impl fmt::Display for EigenError {
             EigenError::NonDiagonalizable => {
                 write!(
                     f,
-                    "matrix is not diagonalizable over the computed eigenbasis"
+                    "no diagonalization is available: either an eigenvalue's geometric \
+                     multiplicity is smaller than its algebraic one, or M·P = P·D could \
+                     not be proven for the eigenbasis that was computed"
                 )
             }
             EigenError::KernelComputationFailed => write!(
@@ -1360,7 +1362,30 @@ fn columns_match_eigen_relation(
             let rhs = simplify(pool.mul(vec![lam, p.get(r, j)]), pool).value;
             let lhs3 = deep_normalize_for_compare(lhs, pool, 12);
             let rhs3 = deep_normalize_for_compare(rhs, pool, 12);
-            if lhs3 != rhs3 {
+            if lhs3 == rhs3 {
+                continue;
+            }
+            // Structural equality of two normalised forms is *sufficient* and
+            // nowhere near necessary, and it is the whole reason `diagonalize`
+            // refused every matrix with an irrational spectrum: the `M·v` side
+            // of `[[1,2],[3,4]]` carries `√33·√33` where the `λ·v` side carries
+            // `33`, and no normaliser in this path folds one into the other, so
+            // two forms of the same number compared unequal. `eigenvects`
+            // returned two eigenvalues of multiplicity one with one eigenvector
+            // each — a complete eigenbasis — and `jordan_form` answered the
+            // same matrix with a diagonal `J`, while this said *"matrix is not
+            // diagonalizable"*, which is false about `[[1,2],[3,4]]`.
+            //
+            // Falling back to the zero-test ladder is strictly wider (anything
+            // that matched structurally already returned above) and no weaker:
+            // only a *proven* zero counts, so an undecided entry is still a
+            // refusal and the gate can still fail.
+            let diff = simplify_expanded(
+                pool.add(vec![lhs, pool.mul(vec![pool.integer(-1_i32), rhs])]),
+                pool,
+            )
+            .value;
+            if !zero_test::zero_status(pool, diff).is_proven_zero() {
                 return false;
             }
         }

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -1649,7 +1649,62 @@ fn apply_row_permutation(m: &Matrix, perm: &[usize]) -> Matrix {
 // Matrix inverse (for similarity transforms)
 // ---------------------------------------------------------------------------
 
+thread_local! {
+    /// The determinant the most recent successful [`matrix_inverse`] divided by
+    /// without being able to settle it at a *point*.
+    static INVERSE_SIDE_CONDITIONS: std::cell::RefCell<Vec<ExprId>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// The hypotheses the matrix returned by the most recent [`matrix_inverse`]
+/// call on this thread rests on, as [`crate::deriv::SideCondition::NonZero`].
+///
+/// Exactly one thing lands here: **`det A ≠ 0`**, for a symbolic `A` whose
+/// determinant was proven not to be the zero *function* but cannot be proven
+/// non-zero at a particular parameter value — because that is not a question
+/// about `A` at all, it is a question about the parameters, and the caller is
+/// the only one who can answer it. `Matrix([[a,b],[c,d]]).inverse()` is
+/// `adj/det` **for `ad − bc ≠ 0`**; on the locus `ad = bc` the matrix has no
+/// inverse and the expression has no value.
+///
+/// Empty means the determinant is a non-zero rational constant — the
+/// hypothesis was *discharged*, not skipped.
+///
+/// # Why this is auditability and not soundness
+///
+/// The returned entries are literally `±minor · det⁻¹`, so evaluating one on
+/// the singular locus raises rather than returning a number, and no
+/// cancellation can hide that: over the local ring at an irreducible factor
+/// `p` of `det`, the Smith form `diag(p^{e₁} … p^{eₙ})` gives `det` order
+/// `Σeᵢ` and the adjugate order `Σeᵢ − eₙ`, so the *reduced* denominator still
+/// vanishes to order `eₙ ≥ 1` on every component of `{det = 0}`. The condition
+/// therefore cannot be silently lost. What it can be is *unstated*, which is
+/// what this channel fixes — a controls user inverting a symbolic plant needs
+/// the genericity assumption in machine-readable form, not implied by the
+/// shape of an expression.
+///
+/// # Why out of band
+///
+/// [`matrix_inverse`] returns a bare [`Matrix`], a public type; it cannot grow
+/// a conditions field without a major semver break. Same treatment as
+/// [`crate::matrix::take_matrix_exp_side_conditions`] and
+/// [`crate::solver::take_solve_side_conditions`].
+///
+/// Consuming, so one call's hypotheses cannot be read as a later call's.
+pub fn take_matrix_inverse_side_conditions() -> Vec<crate::deriv::SideCondition> {
+    INVERSE_SIDE_CONDITIONS.with(|c| {
+        std::mem::take(&mut *c.borrow_mut())
+            .into_iter()
+            .map(crate::deriv::SideCondition::NonZero)
+            .collect()
+    })
+}
+
 pub fn matrix_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError> {
+    // Cleared unconditionally on entry, including on the early returns below:
+    // a stale condition read as this call's would be a hypothesis attached to
+    // the wrong answer, which is worse than none.
+    INVERSE_SIDE_CONDITIONS.with(|c| c.borrow_mut().clear());
     if m.rows != m.cols {
         return Err(MatrixError::NotSquare);
     }
@@ -1729,7 +1784,15 @@ fn symbolic_inverse(m: &Matrix, pool: &ExprPool) -> Result<Matrix, MatrixError> 
     let det = simplify_expanded(m.det(pool)?, pool).value;
     match zero_test::zero_status(pool, det) {
         zero_test::ZeroStatus::Zero => return Err(singular()),
-        zero_test::ZeroStatus::NonZero => {}
+        zero_test::ZeroStatus::NonZero => {
+            // Proven not the zero *function*. That licenses `adj/det`, and it
+            // is all it licenses: on `{det = 0}` there is no inverse. Record
+            // the hypothesis unless the determinant is a non-zero rational
+            // constant, where there is no locus and nothing to assume.
+            if expr_to_rational_strict(det, pool).is_none() {
+                INVERSE_SIDE_CONDITIONS.with(|c| c.borrow_mut().push(det));
+            }
+        }
         zero_test::ZeroStatus::Unknown => {
             zero_test::record_refusal(pool, det, zero_test::RefusalSite::Determinant);
             return Err(MatrixError::SingularMatrix);
@@ -3464,5 +3527,101 @@ mod tests {
                 "{n}×{n} with a dependent row must be refused"
             );
         }
+    }
+
+    /// The `det ≠ 0` a symbolic inverse rests on is *stated*, not assumed.
+    ///
+    /// `adj/det` is the inverse of `[[a,b],[c,d]]` exactly where `ad − bc` does
+    /// not vanish. That the determinant is not the zero *function* is what
+    /// licenses the formula; that it is non-zero at a given point is a question
+    /// about the parameters, and the only honest thing to do with it is hand it
+    /// back. Asserted against the determinant computed independently here, not
+    /// against whatever the channel happened to contain.
+    #[test]
+    fn a_symbolic_inverse_reports_the_determinant_it_divided_by() {
+        let p = pool();
+        let a = p.symbol("a", Domain::Complex);
+        let b = p.symbol("b", Domain::Complex);
+        let c = p.symbol("c", Domain::Complex);
+        let d = p.symbol("d", Domain::Complex);
+        let m = Matrix::new(vec![vec![a, b], vec![c, d]]).unwrap();
+        let _ = crate::matrix::take_matrix_inverse_side_conditions();
+        matrix_inverse(&m, &p).expect("[[a,b],[c,d]] is generically invertible");
+        let conds = crate::matrix::take_matrix_inverse_side_conditions();
+        assert_eq!(conds.len(), 1, "exactly one hypothesis: det ≠ 0");
+        let crate::deriv::SideCondition::NonZero(recorded) = conds[0] else {
+            panic!("the inverse's hypothesis is a non-vanishing one");
+        };
+        // `ad − bc`, built here rather than read off the library.
+        let want = simplify_expanded(
+            p.add(vec![
+                p.mul(vec![a, d]),
+                p.mul(vec![p.integer(-1_i32), b, c]),
+            ]),
+            &p,
+        )
+        .value;
+        let diff = simplify_expanded(
+            p.add(vec![recorded, p.mul(vec![p.integer(-1_i32), want])]),
+            &p,
+        )
+        .value;
+        assert!(
+            zero_test::zero_status(&p, diff).is_proven_zero(),
+            "the recorded condition must be the determinant itself"
+        );
+        // Consuming: a second read must not repeat the first call's hypothesis.
+        assert!(crate::matrix::take_matrix_inverse_side_conditions().is_empty());
+    }
+
+    /// A determinant that is a non-zero *constant* is discharged, not recorded.
+    ///
+    /// A gate made only of "the condition is reported" cases is passed by a
+    /// library that reports one unconditionally, which is noise a caller learns
+    /// to ignore — the failure mode the transform work called out by name when
+    /// it stopped reporting `π ≠ 0`.
+    #[test]
+    fn a_constant_determinant_records_no_hypothesis() {
+        let p = pool();
+        let _ = crate::matrix::take_matrix_inverse_side_conditions();
+        // Rational fast path.
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), p.integer(2_i32)],
+            vec![p.integer(3_i32), p.integer(4_i32)],
+        ])
+        .unwrap();
+        matrix_inverse(&m, &p).unwrap();
+        assert!(crate::matrix::take_matrix_inverse_side_conditions().is_empty());
+
+        // Symbolic entries, unit determinant: `[[cos t, -sin t], [sin t, cos t]]`
+        // would need a trig identity, so use the shear `[[1, s], [0, 1]]`, whose
+        // determinant is the literal `1` however `s` is read.
+        let s = p.symbol("s", Domain::Complex);
+        let shear = Matrix::new(vec![
+            vec![p.integer(1_i32), s],
+            vec![p.integer(0_i32), p.integer(1_i32)],
+        ])
+        .unwrap();
+        matrix_inverse(&shear, &p).unwrap();
+        assert!(
+            crate::matrix::take_matrix_inverse_side_conditions().is_empty(),
+            "det = 1 is not a hypothesis"
+        );
+    }
+
+    /// A refusal leaves nothing behind for the next call to inherit.
+    #[test]
+    fn a_refused_inverse_records_no_hypothesis() {
+        let p = pool();
+        let a = p.symbol("q", Domain::Complex);
+        let b = p.symbol("r", Domain::Complex);
+        let m = Matrix::new(vec![
+            vec![a, b],
+            vec![p.mul(vec![p.integer(2_i32), a]), p.mul(vec![p.integer(2_i32), b])],
+        ])
+        .unwrap();
+        let _ = crate::matrix::take_matrix_inverse_side_conditions();
+        assert_eq!(matrix_inverse(&m, &p), Err(MatrixError::SingularMatrix));
+        assert!(crate::matrix::take_matrix_inverse_side_conditions().is_empty());
     }
 }

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -558,12 +558,47 @@ fn expr_lu_decomposition(
     Ok(LuDecomposition { l, u, perm })
 }
 
+/// `Q` and `R` with `A = Q·R`, `R` upper triangular and `Q`'s columns
+/// orthonormal.
+///
+/// `Q` is `n×k` and `R` is `k×k` for an `n×k` input — the *reduced* shape. See
+/// [`qr_decomposition`] for what is guaranteed when `A` is rank deficient or
+/// wider than it is tall.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QrDecomposition {
     pub q: Matrix,
     pub r: Matrix,
 }
 
+/// Gram–Schmidt `QR`: `A = Q·R` with `R` `k×k` upper triangular and `Q` `n×k`.
+///
+/// # What `Q` is
+///
+/// `QᵀQ = I` whenever `n ≥ k`, **including when `A` is rank deficient**. A
+/// dependent column contributes a zero row to `R`, and the matching column of
+/// `Q` is then filled by completing the orthonormal set — any unit vector
+/// orthogonal to the columns already placed will do, and `Q·R` does not depend
+/// on the choice, because the `R` row that would multiply it is zero.
+///
+/// Before 3.10.1 that column was left as the **zero vector**. `Q·R = A` still
+/// held, so a reconstruction check passed, but `Q` was singular and `QᵀQ` was
+/// not the identity — measured on 304 randomised matrices, 62 came back with a
+/// `Q` whose columns are not orthonormal. `qr([[−4,−4],[−2,−2]])` gave
+/// `Q = [[−2/√5, 0], [−1/√5, 0]]`, so `QᵀQ = diag(1, 0)`: a caller reading
+/// `Q⁻¹ = Qᵀ`, which is the reason to want a `QR` at all, is reading a
+/// falsehood, and nothing in the returned pair says so. sympy returns the
+/// rank-sized `Q` (`2×1`) here rather than a padded one.
+///
+/// # The one case that is not a `QR`
+///
+/// For `n < k` — more columns than rows — `k` orthonormal vectors do not exist
+/// in `ℝⁿ`, so no `n×k` matrix can have orthonormal columns and this shape
+/// cannot carry an answer. The trailing columns of `Q` are zero there, exactly
+/// as before, and `Q·R = A` still holds. The fix would be to return the `n×n`
+/// `Q` and `n×k` `R` of the *full* factorisation, which changes the shape of a
+/// public return value for every caller, so it is left alone and stated here
+/// rather than changed inside an audit. Transpose the input, or check
+/// `q.cols <= q.rows` before relying on orthonormality.
 pub fn qr_decomposition(
     m: &Matrix,
     pool: &ExprPool,
@@ -591,13 +626,14 @@ pub fn qr_decomposition(
                 .map_err(|_| LinearAlgebraError::KernelFailed)?;
         }
         let rjj = norm_column(&v, pool)?;
-        // `‖v‖ = 0` means column `j` is dependent on the ones before it and Q
-        // gets a zero column; `‖v‖ ≠ 0` means we may divide by it. Guessing
-        // either way silently changes the rank of Q.
+        // `‖v‖ = 0` means column `j` is dependent on the ones before it, so `R`
+        // gets a zero row and `Q` needs a column from outside the span;
+        // `‖v‖ ≠ 0` means we may divide by it. Guessing either way silently
+        // changes the rank of Q.
         match zero_test::zero_status(pool, rjj) {
             zero_test::ZeroStatus::Zero => {
                 r.set(j, j, pool.integer(0_i32));
-                q_cols.push(Matrix::zeros(n, 1, pool));
+                q_cols.push(orthonormal_completion(&q_cols, n, pool));
                 continue;
             }
             zero_test::ZeroStatus::NonZero => {}
@@ -610,6 +646,58 @@ pub fn qr_decomposition(
     }
     let q = concatenate_columns(&q_cols, pool).map_err(|_| LinearAlgebraError::KernelFailed)?;
     Ok(QrDecomposition { q, r })
+}
+
+/// A unit column of `ℝⁿ` orthogonal to every column of `built`, or the zero
+/// column when none can be produced.
+///
+/// Gram–Schmidt against the standard basis: at least one `e_i` has a non-zero
+/// residual whenever `built` spans a proper subspace, i.e. whenever
+/// `built.len() < n`, because `n` vectors cannot all lie in a space of smaller
+/// dimension. The search is exact — a candidate is used only when its norm is
+/// *proven* non-zero — so no symbolic guess is involved.
+///
+/// Returning the zero column is the honest outcome in the two cases where no
+/// completion exists: `built.len() >= n` (the wide input discussed on
+/// [`qr_decomposition`]) and a residual whose vanishing the zero test cannot
+/// settle. `Q·R` is unaffected either way, since the `R` row that multiplies
+/// this column is zero.
+fn orthonormal_completion(built: &[Matrix], n: usize, pool: &ExprPool) -> Matrix {
+    if built.len() >= n {
+        return Matrix::zeros(n, 1, pool);
+    }
+    for i in 0..n {
+        let Ok(mut v) = unit_column_vector(i, n, pool) else {
+            continue;
+        };
+        let mut ok = true;
+        for q in built {
+            let Ok(c) = dot_columns(q, &v, pool) else {
+                ok = false;
+                break;
+            };
+            let proj = q.scale(c, pool);
+            match v.sub(&proj, pool) {
+                Ok(next) => v = next.simplify_entries(pool),
+                Err(_) => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if !ok {
+            continue;
+        }
+        let Ok(norm) = norm_column(&v, pool) else {
+            continue;
+        };
+        if zero_test::zero_status(pool, norm) != zero_test::ZeroStatus::NonZero {
+            continue;
+        }
+        let inv = simplify(pool.pow(norm, pool.integer(-1_i32)), pool).value;
+        return v.scale(inv, pool).simplify_entries(pool);
+    }
+    Matrix::zeros(n, 1, pool)
 }
 
 /// The lower-triangular `L` with `L·Lᵀ = M`, for symmetric positive definite `M`.
@@ -1945,17 +2033,30 @@ fn integer_sqrt(n: &rug::Integer) -> Option<rug::Integer> {
     }
 }
 
+/// `‖v‖ = √(Σ vᵢ²)`, with the radicand de-radicalised first.
+///
+/// Gram–Schmidt feeds its own output back in, so by the second column the
+/// entries of `v` already carry `(√c)⁻¹` factors and the radicand reads
+/// `1 − 32/√20² + 320/√20⁴` rather than `1/5`. `simplify` does not fold
+/// `(√c)ᵏ` into `c^{k/2}`, so the norm stayed in that form, every later entry
+/// nested one level deeper, and both the exact zero test and any structural
+/// comparison lost sight of the value — which is why `qr` refused integer
+/// matrices with `E-LINALG-010` and why `QᵀQ = I` could not be proven for the
+/// ones it did answer.
+///
+/// [`zero_test::fold_rational_radicals`] is exactly the rewrite needed and is
+/// sound without a branch convention: over a non-negative *rational* base
+/// `√c` is the non-negative real root, so `(√c)ᵏ = c^{k/2}` outright. A
+/// symbolic base is left alone.
 fn norm_column(v: &Matrix, pool: &ExprPool) -> Result<ExprId, LinearAlgebraError> {
     let mut terms = Vec::new();
     for r in 0..v.rows {
         let e = v.get(r, 0);
         terms.push(simplify(pool.mul(vec![e, e]), pool).value);
     }
-    Ok(simplify(
-        pool.func("sqrt", vec![simplify(pool.add(terms), pool).value]),
-        pool,
-    )
-    .value)
+    let sum = simplify_expanded(pool.add(terms), pool).value;
+    let sum = simplify_expanded(zero_test::fold_rational_radicals(pool, sum), pool).value;
+    Ok(simplify(pool.func("sqrt", vec![sum]), pool).value)
 }
 
 #[cfg(test)]
@@ -3626,5 +3727,115 @@ mod tests {
         let _ = crate::matrix::take_matrix_inverse_side_conditions();
         assert_eq!(matrix_inverse(&m, &p), Err(MatrixError::SingularMatrix));
         assert!(crate::matrix::take_matrix_inverse_side_conditions().is_empty());
+    }
+
+    // ----------------------------------------------------------------- QR
+
+    /// `QᵀQ = I`, evaluated to `f64` rather than proven symbolically.
+    ///
+    /// Deliberate: a Gram–Schmidt norm is `√(a² + b²)` built by `norm_column`
+    /// without folding, so an entry of `QᵀQ` reads
+    /// `−4/(√20·√(1 − 32/√20² + 320/√20⁴)) + 80/(√20³·√(…))` — two terms that
+    /// cancel exactly and that no normaliser in this crate reduces, because
+    /// `simplify` leaves `√20²` as written. The zero test answers `Unknown`
+    /// there, which is honest; asserting on it would be asserting on the
+    /// simplifier rather than on `qr`. The quantity being checked is a sum of
+    /// products of unit-length entries, so `1e-12` is many orders below any
+    /// wrong answer — a zero column, the defect this pins, makes the diagonal
+    /// entry exactly `0`. `1e-9` rather than `1e-12`: a deeply nested radical
+    /// evaluated in `f64` drifts by about `1e-12` on a 4-column shape.
+    fn assert_gram_is_identity(q: &Matrix, pool: &ExprPool, what: &str) {
+        for a in 0..q.cols {
+            for b in 0..q.cols {
+                let mut acc = 0.0_f64;
+                for i in 0..q.rows {
+                    let env = std::collections::HashMap::new();
+                    let x = crate::eval::eval_f64(simplify(q.get(i, a), pool).value, pool, &env)
+                        .unwrap_or_else(|e| panic!("{what}: Q[{i}][{a}] did not evaluate: {e}"));
+                    let y = crate::eval::eval_f64(simplify(q.get(i, b), pool).value, pool, &env)
+                        .unwrap_or_else(|e| panic!("{what}: Q[{i}][{b}] did not evaluate: {e}"));
+                    acc += x * y;
+                }
+                let want = if a == b { 1.0 } else { 0.0 };
+                assert!(
+                    (acc - want).abs() < 1e-9,
+                    "{what}: (QᵀQ)[{a}][{b}] = {acc}, want {want}"
+                );
+            }
+        }
+    }
+
+    /// `Q·R = A` and `QᵀQ = I` over every square and tall shape, rank
+    /// deficient ones included.
+    ///
+    /// A dependent column used to leave a **zero column** in `Q`. `Q·R = A`
+    /// still held — which is why a reconstruction check passed throughout —
+    /// but `Q` was singular and `Qᵀ` was not its inverse, which is the reason
+    /// to want a `QR` at all. Measured over 304 randomised matrices, 62 came
+    /// back with a non-orthonormal `Q`.
+    ///
+    /// Both halves are asserted, because each alone is satisfied by something
+    /// useless: `Q·R = A` by `Q = A, R = I`, and `QᵀQ = I` by any orthonormal
+    /// matrix at all.
+    #[test]
+    fn qr_returns_an_orthonormal_q_for_every_square_or_tall_shape() {
+        let p = pool();
+        let mut checked = 0usize;
+        let mut deficient = 0usize;
+        for seed in 700..780u64 {
+            let cols = 1 + (seed % 4) as usize;
+            let rows = cols + ((seed / 4) % 3) as usize;
+            let mut m = seeded_matrix(seed, rows, cols, &p);
+            // Force a dependent column half the time so the completion path is
+            // actually exercised rather than assumed to be rare.
+            if cols > 1 && seed % 2 == 0 {
+                for i in 0..rows {
+                    m.set(
+                        i,
+                        cols - 1,
+                        simplify(p.mul(vec![p.integer(2_i32), m.get(i, 0)]), &p).value,
+                    );
+                }
+                deficient += 1;
+            }
+            let qr = qr_decomposition(&m, &p).expect("integer entries are decidable");
+            assert_eq!(qr.q.rows, rows);
+            assert_eq!(qr.q.cols, cols);
+            let recon = qr.q.mul(&qr.r, &p).unwrap();
+            assert!(entries_equal(&recon, &m, &p), "seed {seed}: Q·R = A failed");
+            assert_gram_is_identity(&qr.q, &p, &format!("seed {seed}"));
+            for i in 0..qr.r.rows {
+                for j in 0..i.min(qr.r.cols) {
+                    assert_eq!(
+                        simplify(qr.r.get(i, j), &p).value,
+                        p.integer(0_i32),
+                        "seed {seed}: R must be upper triangular"
+                    );
+                }
+            }
+            checked += 1;
+        }
+        assert_eq!(checked, 80);
+        assert!(
+            deficient >= 20,
+            "only {deficient} rank-deficient shapes were built"
+        );
+    }
+
+    /// The smallest witness, stated on the matrix from the doc comment.
+    #[test]
+    fn qr_of_a_rank_one_two_by_two_has_an_invertible_q() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(-4_i32), p.integer(-4_i32)],
+            vec![p.integer(-2_i32), p.integer(-2_i32)],
+        ])
+        .unwrap();
+        let qr = qr_decomposition(&m, &p).unwrap();
+        assert!(entries_equal(&qr.q.mul(&qr.r, &p).unwrap(), &m, &p));
+        assert_gram_is_identity(&qr.q, &p, "[[-4,-4],[-2,-2]]");
+        // `R`'s second row is zero, which is what makes the filled column free.
+        assert_eq!(simplify(qr.r.get(1, 1), &p).value, p.integer(0_i32));
+        assert_eq!(simplify(qr.r.get(1, 0), &p).value, p.integer(0_i32));
     }
 }

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -937,7 +937,7 @@ fn jordan_block_matrix(lambda: ExprId, size: usize, pool: &ExprPool) -> Matrix {
 /// `M = P·C·P⁻¹` is a claim about *both* matrices, and until 3.10.1 neither
 /// half was verified. Two independent defects shipped behind that:
 ///
-/// * [`companion_matrix`] wrote the coefficients down the last **row** instead
+/// * `companion_matrix` wrote the coefficients down the last **row** instead
 ///   of the last **column**, which for `d ≥ 2` also overwrote a subdiagonal
 ///   `1`. On `diag(1, 2)` it returned `C = [[0,0],[−2,3]]`, whose determinant
 ///   is `0` against `det M = 2` — not similar to `M`, not even the same rank.
@@ -3617,7 +3617,10 @@ mod tests {
         let b = p.symbol("r", Domain::Complex);
         let m = Matrix::new(vec![
             vec![a, b],
-            vec![p.mul(vec![p.integer(2_i32), a]), p.mul(vec![p.integer(2_i32), b])],
+            vec![
+                p.mul(vec![p.integer(2_i32), a]),
+                p.mul(vec![p.integer(2_i32), b]),
+            ],
         ])
         .unwrap();
         let _ = crate::matrix::take_matrix_inverse_side_conditions();

--- a/alkahest-core/src/matrix/linear_algebra.rs
+++ b/alkahest-core/src/matrix/linear_algebra.rs
@@ -50,6 +50,15 @@ pub enum LinearAlgebraError {
     /// undecided entry (code `E-LINALG-010`); neither means non-rational
     /// entries (code `E-LINALG-007`).
     UnsupportedField,
+    /// A `(P, canonical form)` pair could not be produced with `M = P·F·P⁻¹`
+    /// proven.
+    ///
+    /// Either `P` is singular — so `P⁻¹` does not exist and the identity is not
+    /// even well-formed — or `M·P = P·F` could not be proven entrywise. Both
+    /// are one failure from the caller's side: there is no transform to hand
+    /// back. Returning the pair anyway is a silent error of the worst kind,
+    /// because `P` and `F` each look perfectly ordinary in isolation; see
+    /// [`rational_canonical_form`] for the two defects that shipped that way.
     SingularTransform,
     NonRationalEntry,
 }
@@ -81,7 +90,12 @@ impl fmt::Display for LinearAlgebraError {
                 )
             }
             LinearAlgebraError::SingularTransform => {
-                write!(f, "similarity transform matrix is singular")
+                write!(
+                    f,
+                    "the similarity transform could not be produced: the computed \
+                     transform is singular, or it does not conjugate the matrix to \
+                     the canonical form that was computed for it"
+                )
             }
             LinearAlgebraError::NonRationalEntry => {
                 write!(f, "matrix entry is not a rational constant")
@@ -128,9 +142,10 @@ impl crate::errors::AlkahestError for LinearAlgebraError {
                  for Smith-based decompositions, and entries whose vanishing is \
                  decidable for elimination",
             ),
-            LinearAlgebraError::SingularTransform => {
-                Some("the computed similarity matrix is not invertible")
-            }
+            LinearAlgebraError::SingularTransform => Some(
+                "no verified similarity transform is available for this matrix; \
+                 substitute concrete values for any parameters",
+            ),
             LinearAlgebraError::NonRationalEntry => {
                 Some("convert symbolic entries to rationals before calling this routine")
             }
@@ -197,7 +212,21 @@ pub fn column_space_basis(m: &Matrix, pool: &ExprPool) -> Result<Vec<Matrix>, Li
         .collect())
 }
 
-/// Basis of the row space of `m` (nonzero pivot rows in echelon form).
+/// Basis of the row space of `m`: the nonzero pivot rows of the echelon form.
+///
+/// The rows come from the **echelon form**, not from `m`. `pivot_row_flags[r]`
+/// records that row `r` *of the echelon form* is a pivot row, and elimination
+/// swaps rows, so reading `m.row(r)` — as this did before 3.10.1 — picks an
+/// unrelated row of the input. On `[[0,0],[1,0]]` the pivot lands in echelon
+/// row 0 after a swap and the old code returned `m.row(0) = [0, 0]`: the zero
+/// vector, offered as a basis of a one-dimensional row space. On a rank-2
+/// `3×3` with a duplicated row it returned that row twice. Row operations
+/// preserve the row space, so the echelon pivot rows are always a basis of it;
+/// the original rows at those indices need not even lie in a basis.
+///
+/// (The column-space counterpart is *not* affected: column indices are
+/// untouched by row operations, so [`column_space_basis`] correctly returns
+/// columns of `m`.)
 pub fn row_space_basis(m: &Matrix, pool: &ExprPool) -> Result<Vec<Matrix>, LinearAlgebraError> {
     let rref = row_echelon_pivots(m, pool)?;
     Ok(rref
@@ -206,7 +235,7 @@ pub fn row_space_basis(m: &Matrix, pool: &ExprPool) -> Result<Vec<Matrix>, Linea
         .enumerate()
         .filter_map(|(ri, &is_pivot)| {
             if is_pivot {
-                Some(Matrix::new(vec![m.row(ri)]).expect("row vector"))
+                Some(Matrix::new(vec![rref.echelon.row(ri)]).expect("row vector"))
             } else {
                 None
             }
@@ -445,6 +474,13 @@ pub fn lu_decomposition(
             if piv_row != k {
                 a.swap(piv_row, k);
                 perm.swap(piv_row, k);
+                // The multipliers already stored in `L` belong to the rows they
+                // were computed from, so a pivot swap has to move them too.
+                // Leaving them behind is what made `P·A = L·U` false from the
+                // second pivot onwards; see `lu_partial_pivot_permutes_l`.
+                // `piv_row > k` here, so the split is always in that order.
+                let (head, tail) = l.split_at_mut(piv_row);
+                head[k][..k].swap_with_slice(&mut tail[0][..k]);
             }
             let pivot = a[k][k].clone();
             for j in k..cols {
@@ -496,6 +532,13 @@ fn expr_lu_decomposition(
         if piv_row != k {
             a.swap(piv_row, k);
             perm.swap(piv_row, k);
+            // Move the multipliers already stored in `L` with their rows — the
+            // same defect the rational path had.
+            for j in 0..k {
+                let t = l.get(k, j);
+                l.set(k, j, l.get(piv_row, j));
+                l.set(piv_row, j, t);
+            }
         }
         let pivot = a[k][k];
         let inv_p = simplify(pool.pow(pivot, pool.integer(-1_i32)), pool).value;
@@ -569,35 +612,42 @@ pub fn qr_decomposition(
     Ok(QrDecomposition { q, r })
 }
 
+/// The lower-triangular `L` with `L·Lᵀ = M`, for symmetric positive definite `M`.
+///
+/// # Symmetry is checked, not assumed
+///
+/// The algorithm only ever reads the lower triangle, so before 3.10.1 a
+/// non-symmetric matrix got its upper triangle silently discarded and an `L`
+/// factoring a *different* matrix came back with no complaint:
+/// `cholesky([[1,5],[0,1]])` returned the identity, whose `L·Lᵀ` is `I`, not
+/// the input. `[[1,5],[0,1]]` has no Cholesky factor at all — `L·Lᵀ` is
+/// symmetric for every `L`. Symmetry is now required, and the refusal is the
+/// honest one the error already named.
+///
+/// # `√2` is a number
+///
+/// The rational path also refused every matrix whose pivots are not perfect
+/// rational squares — `2·I` came back as `E-LINALG-003`, *"matrix is not
+/// symmetric positive definite"*, about a matrix that is both. A refusal that
+/// states something false is not a safe failure: it tells the caller the input
+/// is defective when the implementation is.
+///
+/// The factorisation is now taken over ℚ **without square roots** — the
+/// rational `L·D·Lᵀ` decomposition, whose pivots `dⱼ` decide definiteness
+/// exactly — and the square roots are applied to `D` afterwards, symbolically
+/// where they are irrational. `dⱼ ≤ 0` is still `E-LINALG-003`, and it now
+/// means it. Where every `dⱼ` *is* a perfect square the entries come out as the
+/// same rationals as before.
 pub fn cholesky(m: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
     if m.rows != m.cols {
         return Err(LinearAlgebraError::NonSquare);
     }
     let n = m.rows;
+    if !is_symmetric(m, pool) {
+        return Err(LinearAlgebraError::NotPositiveDefinite);
+    }
     if let Some(a) = matrix_to_rational_grid(m, pool) {
-        let mut l = vec![vec![Rational::from(0); n]; n];
-        for i in 0..n {
-            for j in 0..=i {
-                let mut s = Rational::from(0);
-                for t in 0..j {
-                    s += l[i][t].clone() * l[j][t].clone();
-                }
-                if i == j {
-                    let diag = a[i][i].clone() - s;
-                    if diag <= 0 {
-                        return Err(LinearAlgebraError::NotPositiveDefinite);
-                    }
-                    l[i][j] =
-                        rational_sqrt(&diag).ok_or(LinearAlgebraError::NotPositiveDefinite)?;
-                } else {
-                    if l[j][j] == 0 {
-                        return Err(LinearAlgebraError::NotPositiveDefinite);
-                    }
-                    l[i][j] = (a[i][j].clone() - s) / l[j][j].clone();
-                }
-            }
-        }
-        return Ok(rational_grid_to_matrix(&l, pool));
+        return rational_cholesky(&a, n, pool);
     }
     let mut l = Matrix::zeros(n, n, pool);
     for i in 0..n {
@@ -636,6 +686,83 @@ pub fn cholesky(m: &Matrix, pool: &ExprPool) -> Result<Matrix, LinearAlgebraErro
         }
     }
     Ok(l)
+}
+
+/// `M = Mᵀ`, entry by entry, on *proven* equality.
+///
+/// An undecided pair answers `false`: `L·Lᵀ` is symmetric whatever `L` is, so a
+/// matrix that cannot be shown symmetric cannot be shown to have a Cholesky
+/// factor either, and the refusal is the correct outcome rather than a
+/// conservative one.
+fn is_symmetric(m: &Matrix, pool: &ExprPool) -> bool {
+    for i in 0..m.rows {
+        for j in (i + 1)..m.cols {
+            let diff = simplify_expanded(
+                pool.add(vec![
+                    m.get(i, j),
+                    pool.mul(vec![pool.integer(-1_i32), m.get(j, i)]),
+                ]),
+                pool,
+            )
+            .value;
+            if !zero_test::zero_status(pool, diff).is_proven_zero() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Cholesky of a symmetric rational matrix, via the square-root-free `L·D·Lᵀ`.
+///
+/// `dⱼ = a_jj − Σ_{t<j} l_jt²·d_t` and `l_ij = (a_ij − Σ_{t<j} l_it·l_jt·d_t)/dⱼ`
+/// are all in ℚ, so positive definiteness is decided exactly: `M` is positive
+/// definite iff every `dⱼ > 0` (Sylvester, via the leading principal minors
+/// `Π_{t≤j} d_t`). The Cholesky factor is then `L·√D`, column `j` scaled by
+/// `√dⱼ` — rational when `dⱼ` is a perfect square, and the exact symbolic
+/// `sqrt(dⱼ)` when it is not.
+fn rational_cholesky(
+    a: &[Vec<Rational>],
+    n: usize,
+    pool: &ExprPool,
+) -> Result<Matrix, LinearAlgebraError> {
+    let mut l = vec![vec![Rational::from(0); n]; n];
+    let mut d = vec![Rational::from(0); n];
+    for j in 0..n {
+        let mut s = Rational::from(0);
+        for t in 0..j {
+            s += l[j][t].clone() * l[j][t].clone() * d[t].clone();
+        }
+        d[j] = a[j][j].clone() - s;
+        if d[j] <= 0 {
+            return Err(LinearAlgebraError::NotPositiveDefinite);
+        }
+        l[j][j] = Rational::from(1);
+        for i in (j + 1)..n {
+            let mut s = Rational::from(0);
+            for t in 0..j {
+                s += l[i][t].clone() * l[j][t].clone() * d[t].clone();
+            }
+            l[i][j] = (a[i][j].clone() - s) / d[j].clone();
+        }
+    }
+    let mut out = Matrix::zeros(n, n, pool);
+    for j in 0..n {
+        // `√dⱼ` exactly: a rational when `dⱼ` is a perfect square, and the
+        // symbolic root otherwise. Never a float, and never a refusal.
+        let root = match rational_sqrt(&d[j]) {
+            Some(r) => rational_expr(&r, pool),
+            None => {
+                let dj = rational_expr(&d[j], pool);
+                simplify(pool.func("sqrt", vec![dj]), pool).value
+            }
+        };
+        for i in j..n {
+            let lij = rational_expr(&l[i][j], pool);
+            out.set(i, j, simplify(pool.mul(vec![lij, root]), pool).value);
+        }
+    }
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -804,6 +931,28 @@ fn jordan_block_matrix(lambda: ExprId, size: usize, pool: &ExprPool) -> Matrix {
 // ---------------------------------------------------------------------------
 
 /// `(P, C)` with `M = P·C·P⁻¹` and `C` Frobenius companion block diagonal over ℚ.
+///
+/// # The pair is checked before it is returned
+///
+/// `M = P·C·P⁻¹` is a claim about *both* matrices, and until 3.10.1 neither
+/// half was verified. Two independent defects shipped behind that:
+///
+/// * [`companion_matrix`] wrote the coefficients down the last **row** instead
+///   of the last **column**, which for `d ≥ 2` also overwrote a subdiagonal
+///   `1`. On `diag(1, 2)` it returned `C = [[0,0],[−2,3]]`, whose determinant
+///   is `0` against `det M = 2` — not similar to `M`, not even the same rank.
+/// * `P` was assembled from Krylov chains on unit vectors whose only
+///   admissibility test was that consecutive chain elements are not
+///   *proportional*. That is far weaker than the requirement (each chain
+///   independent, and the chains jointly spanning), so `P` was routinely not a
+///   basis.
+///
+/// Both are fixed, and neither can recur silently: `M·P = P·C` is now proven
+/// entrywise and `P` is proven invertible before the pair leaves this function.
+/// A pair that fails is refused with [`LinearAlgebraError::SingularTransform`]
+/// (`E-LINALG-008`) rather than returned. The gate is placed beside the
+/// construction rather than inside it — it recomputes nothing the construction
+/// chose, it only multiplies out the identity being claimed.
 pub fn rational_canonical_form(
     m: &Matrix,
     pool: &ExprPool,
@@ -816,7 +965,55 @@ pub fn rational_canonical_form(
     let factors = invariant_factors_from_smith(&s)?;
     let c = companion_block_diagonal(&factors, pool)?;
     let p = frobenius_p_from_cyclic_vectors(m, &factors, pool)?;
+    confirm_similarity(m, &p, &c, pool)?;
     Ok((p, c))
+}
+
+/// Prove `M·P = P·C` entrywise and `P` invertible, or refuse.
+///
+/// Both halves are needed: `M·P = P·C` with a singular `P` is satisfied by
+/// `P = 0`, and an invertible `P` alone says nothing about `C`. Together they
+/// are exactly the statement `M = P·C·P⁻¹`.
+///
+/// Only *proven* equality counts. An entry whose vanishing is undecidable is
+/// not evidence for the identity, so it refuses — the inputs that reach here
+/// have rational entries (`expr_to_rat_uni_poly` has already rejected anything
+/// else), where the zero test is exact and this never triggers spuriously.
+fn confirm_similarity(
+    m: &Matrix,
+    p: &Matrix,
+    c: &Matrix,
+    pool: &ExprPool,
+) -> Result<(), LinearAlgebraError> {
+    let n = m.rows;
+    if p.rows != n || p.cols != n || c.rows != n || c.cols != n {
+        return Err(LinearAlgebraError::SingularTransform);
+    }
+    let lhs = m
+        .mul(p, pool)
+        .map_err(|_| LinearAlgebraError::SingularTransform)?;
+    let rhs = p
+        .mul(c, pool)
+        .map_err(|_| LinearAlgebraError::SingularTransform)?;
+    for i in 0..n {
+        for j in 0..n {
+            let diff = simplify_expanded(
+                pool.add(vec![
+                    lhs.get(i, j),
+                    pool.mul(vec![pool.integer(-1_i32), rhs.get(i, j)]),
+                ]),
+                pool,
+            )
+            .value;
+            if !zero_test::zero_status(pool, diff).is_proven_zero() {
+                return Err(LinearAlgebraError::SingularTransform);
+            }
+        }
+    }
+    if rank(p, pool)? != n {
+        return Err(LinearAlgebraError::SingularTransform);
+    }
+    Ok(())
 }
 
 fn fresh_frobenius_lambda(pool: &ExprPool) -> ExprId {
@@ -876,7 +1073,7 @@ fn invariant_factors_from_smith(s: &PolyMatrixQ) -> Result<Vec<RatUniPoly>, Line
     let n = s.rows.min(s.cols);
     let mut facs = Vec::new();
     for i in 0..n {
-        let p = s.get(i, i).clone();
+        let p = s.get(i, i).clone().trim();
         if !p.is_zero() && p.degree() > 0 {
             facs.push(p);
         }
@@ -887,25 +1084,44 @@ fn invariant_factors_from_smith(s: &PolyMatrixQ) -> Result<Vec<RatUniPoly>, Line
     Ok(facs)
 }
 
+/// The Frobenius companion matrix of a monic `f = x^d + a_{d−1}x^{d−1} + … + a₀`:
+/// `1`s on the **subdiagonal** and `−a₀ … −a_{d−1}` down the **last column**.
+///
+/// The pairing with [`frobenius_p_from_cyclic_vectors`] is what fixes the
+/// orientation. With `P = [v, Mv, …, M^{d−1}v]`,
+/// `M·P = [Mv, …, M^{d−1}v, M^d v]`, and `M^d v = −Σ aⱼ Mʲ v`, so `M·P = P·C`
+/// forces `C·e_j = e_{j+1}` for `j < d−1` (the subdiagonal `1`s) and
+/// `C·e_{d−1} = (−a₀, …, −a_{d−1})ᵀ` — a *column*.
+///
+/// Before 3.10.1 the coefficients were written down the last **row**, which for
+/// `d ≥ 2` also overwrote the subdiagonal `1` at `(d−1, d−2)`. The result was
+/// not similar to `M` and generally not even the same rank: on `diag(1, 2)`,
+/// whose single invariant factor is `x²−3x+2`, it produced `[[0,0],[−2,3]]`
+/// with `det = 0` against `det M = 2`.
 fn companion_matrix(f: &RatUniPoly, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
-    let d = f.degree() as usize;
-    if d == 0 {
+    let f = f.clone().trim();
+    if f.degree() <= 0 {
         return Err(unsupported_field());
     }
+    let d = f.degree() as usize;
     let coeffs = f.coeffs.clone();
+    // `f` comes off a Smith-form diagonal and need not be monic; the companion
+    // form is defined for the monic associate, which has the same roots and the
+    // same ideal.
+    let lead = coeffs[d].clone();
+    if lead == 0 {
+        return Err(unsupported_field());
+    }
     let mut c = Matrix::zeros(d, d, pool);
     for i in 0..d - 1 {
         c.set(i + 1, i, pool.integer(1_i32));
     }
     for j in 0..d {
-        let coeff = if j < coeffs.len() {
-            pool.rational(coeffs[j].numer().clone(), coeffs[j].denom().clone())
-        } else {
-            pool.integer(0_i32)
-        };
+        let a = coeffs[j].clone() / lead.clone();
+        let coeff = rational_expr(&a, pool);
         c.set(
-            d - 1,
             j,
+            d - 1,
             simplify(pool.mul(vec![pool.integer(-1_i32), coeff]), pool).value,
         );
     }
@@ -938,19 +1154,57 @@ fn block_diagonal(blocks: &[Matrix], pool: &ExprPool) -> Result<Matrix, LinearAl
     Ok(out)
 }
 
+/// `P = [v₁, Mv₁, …, M^{d₁−1}v₁ | v₂, …, M^{d₂−1}v₂ | …]`, one Krylov chain per
+/// invariant factor.
+///
+/// # Choosing a generator for factor `f`
+///
+/// `vᵢ` has to satisfy two things, and the old code checked neither: its
+/// annihilator must be exactly `fᵢ`, and its chain must be independent of the
+/// chains already placed. Both are obtained here rather than hoped for.
+///
+/// *Annihilator.* With `g` the largest invariant factor — the minimal
+/// polynomial, which every other factor divides — set `qᵢ = g / fᵢ`. Then for
+/// **any** `w`, `v = qᵢ(M)·w` satisfies `fᵢ(M)v = g(M)w = 0`, so `ann(v)`
+/// divides `fᵢ` for free. And if the chain `v, …, M^{dᵢ−1}v` is independent
+/// then `deg ann(v) ≥ dᵢ = deg fᵢ`, which forces `ann(v) = fᵢ` exactly. So the
+/// independence test does double duty and no separate order computation is
+/// needed.
+///
+/// *Independence.* Tested by rank, against everything already placed, rather
+/// than by the old `columns_proportional` — which only asked whether two
+/// *consecutive* chain elements are parallel and is satisfied by wildly
+/// dependent chains.
+///
+/// The seed search is a finite heuristic (unit vectors, then pairwise sums), so
+/// it can fail to find a generator that exists. That is a refusal, never a
+/// wrong answer: [`confirm_similarity`] proves the assembled pair before it is
+/// returned.
 fn frobenius_p_from_cyclic_vectors(
     m: &Matrix,
     factors: &[RatUniPoly],
     pool: &ExprPool,
 ) -> Result<Matrix, LinearAlgebraError> {
     let n = m.rows;
+    let Some(g) = factors.last() else {
+        return Err(LinearAlgebraError::KernelFailed);
+    };
     let mut cols: Vec<Matrix> = Vec::with_capacity(n);
-    let mut idx = 0usize;
     for f in factors {
+        let f = f.clone().trim();
+        if f.degree() <= 0 {
+            return Err(unsupported_field());
+        }
         let d = f.degree() as usize;
-        let chain = cyclic_column_chain(m, idx, d, n, pool)?;
+        let (q, r) = RatUniPoly::div_rem(g, &f);
+        if !r.trim().is_zero() {
+            // Not a divisibility chain: the Smith diagonal is not a list of
+            // invariant factors, so nothing below would mean what it claims.
+            return Err(unsupported_field());
+        }
+        let qm = rat_poly_at_matrix(&q, m, pool)?;
+        let chain = cyclic_chain_for_factor(m, &qm, d, n, &cols, pool)?;
         cols.extend(chain);
-        idx += d;
     }
     if cols.len() != n {
         return Err(LinearAlgebraError::KernelFailed);
@@ -958,41 +1212,63 @@ fn frobenius_p_from_cyclic_vectors(
     concatenate_columns(&cols, pool).map_err(|_| LinearAlgebraError::KernelFailed)
 }
 
-/// Build `v, M v, …, M^{d-1} v` with `v = e_start`, trying later unit vectors if the chain stalls.
-fn cyclic_column_chain(
+/// `p(M)` for `p ∈ ℚ[x]`, by Horner over matrices.
+fn rat_poly_at_matrix(
+    p: &RatUniPoly,
     m: &Matrix,
-    start_col: usize,
+    pool: &ExprPool,
+) -> Result<Matrix, LinearAlgebraError> {
+    let n = m.rows;
+    let p = p.clone().trim();
+    let mut acc = Matrix::zeros(n, n, pool);
+    for coeff in p.coeffs.iter().rev() {
+        let scaled = acc
+            .mul(m, pool)
+            .map_err(|_| LinearAlgebraError::KernelFailed)?;
+        let c = rational_expr(coeff, pool);
+        let term = Matrix::identity(n, pool).scale(c, pool);
+        acc = scaled
+            .add(&term, pool)
+            .map_err(|_| LinearAlgebraError::KernelFailed)?
+            .simplify_entries(pool);
+    }
+    Ok(acc)
+}
+
+/// The chain `v, Mv, …, M^{d−1}v` for `v = qm·w`, `w` drawn from a finite seed
+/// list, chosen so the chain is provably independent of `built`.
+fn cyclic_chain_for_factor(
+    m: &Matrix,
+    qm: &Matrix,
     d: usize,
     n: usize,
+    built: &[Matrix],
     pool: &ExprPool,
 ) -> Result<Vec<Matrix>, LinearAlgebraError> {
-    let mut seeds: Vec<Matrix> = (start_col..n)
-        .filter_map(|c| unit_column_vector(c, n, pool).ok())
-        .collect();
-    if d > 1 {
-        for i in start_col..n {
-            for j in (i + 1)..n {
-                if let Ok(v) = sum_unit_columns(i, j, n, pool) {
-                    seeds.push(v);
-                }
-            }
+    let mut seeds: Vec<Matrix> = Vec::new();
+    for c in 0..n {
+        seeds.push(unit_column_vector(c, n, pool)?);
+    }
+    for i in 0..n {
+        for j in (i + 1)..n {
+            seeds.push(sum_unit_columns(i, j, n, pool)?);
         }
     }
-    for v in seeds {
+    for w in &seeds {
+        let v = qm
+            .mul(w, pool)
+            .map_err(|_| LinearAlgebraError::KernelFailed)?
+            .simplify_entries(pool);
         let mut chain = vec![v.clone()];
         let mut cur = v;
-        let mut ok = true;
         for _ in 1..d {
             cur = m
                 .mul(&cur, pool)
-                .map_err(|_| LinearAlgebraError::KernelFailed)?;
-            if columns_proportional(&cur, chain.last().unwrap(), pool) {
-                ok = false;
-                break;
-            }
+                .map_err(|_| LinearAlgebraError::KernelFailed)?
+                .simplify_entries(pool);
             chain.push(cur.clone());
         }
-        if ok && chain.len() == d {
+        if extends_independently(built, &chain, pool) {
             return Ok(chain);
         }
     }
@@ -1011,44 +1287,6 @@ fn sum_unit_columns(
         .map(|r| vec![if r == i || r == j { one } else { zero }])
         .collect();
     Matrix::new(rows).map_err(|_| LinearAlgebraError::KernelFailed)
-}
-
-fn columns_proportional(a: &Matrix, b: &Matrix, pool: &ExprPool) -> bool {
-    if a.rows != b.rows {
-        return false;
-    }
-    let mut ratio: Option<ExprId> = None;
-    for r in 0..a.rows {
-        let ea = simplify(a.get(r, 0), pool).value;
-        let eb = simplify(b.get(r, 0), pool).value;
-        // A heuristic search over candidate cyclic vectors: an undecided entry
-        // only makes this candidate look unusable, and the caller tries the
-        // next one. No mathematical claim rides on `false` here.
-        let ea_zero = zero_test::zero_status(pool, ea).is_proven_zero();
-        let eb_zero = zero_test::zero_status(pool, eb).is_proven_zero();
-        if ea_zero && eb_zero {
-            continue;
-        }
-        if ea_zero || eb_zero {
-            return false;
-        }
-        let cand = simplify(pool.mul(vec![ea, pool.pow(eb, pool.integer(-1_i32))]), pool).value;
-        match ratio {
-            None => ratio = Some(cand),
-            Some(rv) => {
-                if simplify(
-                    pool.add(vec![cand, pool.mul(vec![pool.integer(-1_i32), rv])]),
-                    pool,
-                )
-                .value
-                    != simplify(pool.integer(0_i32), pool).value
-                {
-                    return false;
-                }
-            }
-        }
-    }
-    ratio.is_some()
 }
 
 fn unit_column_vector(col: usize, n: usize, pool: &ExprPool) -> Result<Matrix, LinearAlgebraError> {
@@ -1118,23 +1356,31 @@ fn matrix_annihilated_by_uni(
     pool: &ExprPool,
 ) -> Result<bool, LinearAlgebraError> {
     let n = m.rows;
+    let coeffs = p.coefficients();
     let mut acc = Matrix::zeros(n, n, pool);
+    // Invariant: `pow == M^deg` at the top of iteration `deg`. Advancing it is
+    // therefore unconditional on the coefficient — a zero coefficient skips the
+    // *term*, not the power. Before 3.10.1 a zero coefficient advanced `pow`
+    // only `if deg > 0`, so a vanishing **constant** term left `pow` at `M⁰`
+    // for the `deg = 1` iteration and every later power was one too low: `p(M)`
+    // was evaluated as `(p/λ)(M)`.
+    //
+    // A zero constant term is exactly the case `λ = 0 ∈ spec(M)`, so this was
+    // wrong for every singular matrix that got this far. It rejected the true
+    // minimal polynomial and accepted `λ·`(that polynomial) instead:
+    // `minimal_polynomial(0₂ₓ₂)` returned `λ²`, whose defining property the
+    // zero matrix does not need, and `J₂(0) ⊕ J₂(0)` returned `λ³` for a
+    // matrix annihilated by `λ²`.
     let mut pow = Matrix::identity(n, pool);
-    for (deg, coeff) in p.coefficients().iter().enumerate() {
-        if coeff.is_zero() {
-            if deg > 0 {
-                pow = pow
-                    .mul(m, pool)
-                    .map_err(|_| LinearAlgebraError::KernelFailed)?;
-            }
-            continue;
+    for (deg, coeff) in coeffs.iter().enumerate() {
+        if !coeff.is_zero() {
+            let c = pool.integer(coeff.clone());
+            let term = pow.scale(c, pool);
+            acc = acc
+                .add(&term, pool)
+                .map_err(|_| LinearAlgebraError::KernelFailed)?;
         }
-        let c = pool.rational(coeff.clone(), rug::Integer::from(1));
-        let term = pow.scale(c, pool);
-        acc = acc
-            .add(&term, pool)
-            .map_err(|_| LinearAlgebraError::KernelFailed)?;
-        if deg + 1 < p.coefficients().len() {
+        if deg + 1 < coeffs.len() {
             pow = pow
                 .mul(m, pool)
                 .map_err(|_| LinearAlgebraError::KernelFailed)?;
@@ -1159,7 +1405,7 @@ fn uni_poly_to_expr(p: &UniPoly, lam: ExprId, pool: &ExprPool) -> ExprId {
         if coeff.is_zero() {
             continue;
         }
-        let c = pool.rational(coeff.clone(), rug::Integer::from(1));
+        let c = pool.integer(coeff.clone());
         let term = if deg == 0 {
             c
         } else if deg == 1 {
@@ -1173,10 +1419,14 @@ fn uni_poly_to_expr(p: &UniPoly, lam: ExprId, pool: &ExprPool) -> ExprId {
         };
         terms.push(term);
     }
-    if terms.is_empty() {
-        pool.integer(0_i32)
-    } else {
-        simplify(pool.add(terms), pool).value
+    match terms.len() {
+        0 => pool.integer(0_i32),
+        // `simplify` does not collapse a one-element `Add`, so wrapping here
+        // would hand back `Add([λ])` where the answer is `λ`: equal in value,
+        // distinct as an `ExprId`, and not equal to the `λ` returned alongside
+        // it. `minimal_polynomial` of a zero matrix is exactly that shape.
+        1 => simplify(terms[0], pool).value,
+        _ => simplify(pool.add(terms), pool).value,
     }
 }
 
@@ -1576,13 +1826,28 @@ fn expr_to_rational_strict(e: ExprId, pool: &ExprPool) -> Option<Rational> {
 fn rational_grid_to_matrix(grid: &[Vec<Rational>], pool: &ExprPool) -> Matrix {
     let rows: Vec<Vec<ExprId>> = grid
         .iter()
-        .map(|row| {
-            row.iter()
-                .map(|r| pool.rational(r.numer().clone(), r.denom().clone()))
-                .collect()
-        })
+        .map(|row| row.iter().map(|r| rational_expr(r, pool)).collect())
         .collect();
     Matrix::new(rows).expect("rational grid")
+}
+
+/// A rational as an expression, as an `Integer` node when its denominator is 1.
+///
+/// `ExprPool::rational` interns `ExprData::Rational` whatever the denominator
+/// is, and `simplify` does not demote it, so `pool.rational(1, 1)` is a node
+/// that is *equal in value* to `pool.integer(1)` and *distinct from it* as an
+/// `ExprId`. Every structural comparison against a literal then fails: the unit
+/// diagonal of `L` out of [`lu_decomposition`] printed as `1/1`, and an
+/// identity matrix built this way is not `Matrix::identity`. Nothing wrong is
+/// computed, but a caller checking a result structurally is told "no" for the
+/// wrong reason. Fixed here, at the one place matrix code turns ℚ into
+/// expressions, rather than in the kernel where it would touch every subsystem.
+fn rational_expr(r: &Rational, pool: &ExprPool) -> ExprId {
+    if *r.denom() == 1 {
+        pool.integer(r.numer().clone())
+    } else {
+        pool.rational(r.numer().clone(), r.denom().clone())
+    }
 }
 
 fn dot_columns(a: &Matrix, b: &Matrix, pool: &ExprPool) -> Result<ExprId, LinearAlgebraError> {
@@ -2521,5 +2786,683 @@ mod tests {
             &Matrix::identity(2, &p),
             &p
         ));
+    }
+
+    // =======================================================================
+    // 3.10.1 linear-algebra audit — regressions for five silent wrong answers
+    //
+    // Every expectation below is an *identity* the operation is defined by
+    // (`P·A = L·U`, `M·P = P·C`, `p(M) = 0`, `L·Lᵀ = M`, independence of a
+    // claimed basis), checked against the input rather than against a value
+    // read off alkahest. That is the property the pre-existing tests for these
+    // routines did not check: `rational_canonical_form` had two tests and both
+    // asserted only `p_mat.rows == 2`, which a matrix of the wrong rank passes.
+    // =======================================================================
+
+    /// Random-ish integer matrix, deterministic from a seed.
+    fn seeded_matrix(seed: u64, rows: usize, cols: usize, pool: &ExprPool) -> Matrix {
+        let mut s = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        let mut next = || {
+            s = s
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((s >> 33) % 9) as i32 - 4
+        };
+        let grid: Vec<Vec<ExprId>> = (0..rows)
+            .map(|_| (0..cols).map(|_| pool.integer(next())).collect())
+            .collect();
+        Matrix::new(grid).expect("seeded matrix")
+    }
+
+    /// Entrywise equality by *value*: every difference is proven zero.
+    ///
+    /// Stronger than `matrix_eq_simplified`, which compares normalised forms
+    /// and therefore reports `√2·√2` and `2` as different. Here the difference
+    /// goes through the full `zero_test` ladder, so only a proven identity
+    /// passes and an undecided entry fails rather than sliding through.
+    fn entries_equal(a: &Matrix, b: &Matrix, pool: &ExprPool) -> bool {
+        if a.rows != b.rows || a.cols != b.cols {
+            return false;
+        }
+        for i in 0..a.rows {
+            for j in 0..a.cols {
+                let diff = simplify_expanded(
+                    pool.add(vec![
+                        a.get(i, j),
+                        pool.mul(vec![pool.integer(-1_i32), b.get(i, j)]),
+                    ]),
+                    pool,
+                )
+                .value;
+                if !zero_test::zero_status(pool, diff).is_proven_zero() {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Exact rational value of a constant expression, or `None`.
+    ///
+    /// A four-line evaluator over ℚ that the simplifier is not involved in, so
+    /// a test using it is not checking alkahest against itself. Handles the
+    /// integer powers that an adjugate-over-determinant entry is built from.
+    fn exact_rational(e: ExprId, pool: &ExprPool) -> Option<Rational> {
+        match pool.get(e) {
+            ExprData::Integer(n) => Some(Rational::from((n.0.clone(), rug::Integer::from(1)))),
+            ExprData::Rational(r) => Some(r.0.clone()),
+            ExprData::Add(args) => {
+                let mut acc = Rational::from(0);
+                for a in args {
+                    acc += exact_rational(a, pool)?;
+                }
+                Some(acc)
+            }
+            ExprData::Mul(args) => {
+                let mut acc = Rational::from(1);
+                for a in args {
+                    acc *= exact_rational(a, pool)?;
+                }
+                Some(acc)
+            }
+            ExprData::Pow { base, exp } => {
+                let b = exact_rational(base, pool)?;
+                let k = match pool.get(exp) {
+                    ExprData::Integer(n) => n.0.to_i32()?,
+                    _ => return None,
+                };
+                if k < 0 && b == 0 {
+                    return None;
+                }
+                let mut acc = Rational::from(1);
+                for _ in 0..k.unsigned_abs() {
+                    acc *= b.clone();
+                }
+                Some(if k >= 0 { acc } else { Rational::from(1) / acc })
+            }
+            _ => None,
+        }
+    }
+
+    fn permute_rows(m: &Matrix, perm: &[usize]) -> Matrix {
+        Matrix::new(perm.iter().map(|&r| m.row(r)).collect()).expect("permuted")
+    }
+
+    // ----------------------------------------------------------------- LU
+
+    /// `P·A = L·U` needs the multipliers already in `L` to move when a pivot
+    /// swap moves their rows.
+    ///
+    /// The 2×2 test that stood here before could not see this: its only swap is
+    /// at `k = 0`, where `L` has no computed columns yet to be left behind. The
+    /// defect needs a swap at `k ≥ 1`, so the smallest witness is 3×3.
+    ///
+    /// `A = [[2,−1,4],[−1,1,−1],[3,−4,0]]` pivots to row 2 at `k = 0` and to
+    /// row 2 again at `k = 1`. Before the fix `L·U` came back as
+    /// `[[3,−4,0],[−1,3,4],[2,−3,−1]]` — the rows of `A` in the order
+    /// `2, 1, 0`, while `perm` said `2, 0, 1`, so the product was not `P·A` for
+    /// the `P` that was handed back.
+    #[test]
+    fn lu_partial_pivot_permutes_l() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(2_i32), p.integer(-1_i32), p.integer(4_i32)],
+            vec![p.integer(-1_i32), p.integer(1_i32), p.integer(-1_i32)],
+            vec![p.integer(3_i32), p.integer(-4_i32), p.integer(0_i32)],
+        ])
+        .unwrap();
+        let lu = lu_decomposition(&m, &p).unwrap();
+        let reconstructed = lu.l.mul(&lu.u, &p).unwrap();
+        let permuted = permute_rows(&m, &lu.perm);
+        assert!(
+            eigen::matrix_eq_simplified(&reconstructed, &permuted, &p),
+            "P·A = L·U must hold; perm = {:?}",
+            lu.perm
+        );
+    }
+
+    /// The same identity over 120 random shapes, square and rectangular.
+    ///
+    /// A randomised sweep against `P·A = L·U` found 77 of 259 corpus matrices
+    /// wrong before the fix; anything past 2×2 with two pivot swaps was liable.
+    #[test]
+    fn lu_reconstructs_every_random_shape() {
+        let p = pool();
+        for seed in 0..120u64 {
+            let rows = 1 + (seed % 5) as usize;
+            let cols = 1 + ((seed / 5) % 5) as usize;
+            let m = seeded_matrix(seed, rows, cols, &p);
+            let lu = lu_decomposition(&m, &p).unwrap();
+            assert_eq!(lu.l.rows, rows);
+            assert_eq!(lu.l.cols, rows);
+            assert_eq!(lu.u.rows, rows);
+            assert_eq!(lu.u.cols, cols);
+            let mut sorted = lu.perm.clone();
+            sorted.sort_unstable();
+            assert_eq!(
+                sorted,
+                (0..rows).collect::<Vec<_>>(),
+                "perm must be a permutation, got {:?}",
+                lu.perm
+            );
+            // `L` unit lower triangular.
+            for i in 0..rows {
+                assert_eq!(lu.l.get(i, i), p.integer(1_i32), "seed {seed}: L diagonal");
+                for j in (i + 1)..rows {
+                    assert_eq!(
+                        simplify(lu.l.get(i, j), &p).value,
+                        p.integer(0_i32),
+                        "seed {seed}: L must be lower triangular"
+                    );
+                }
+            }
+            // `U` upper triangular.
+            for i in 0..rows {
+                for j in 0..i.min(cols) {
+                    assert_eq!(
+                        simplify(lu.u.get(i, j), &p).value,
+                        p.integer(0_i32),
+                        "seed {seed}: U must be upper triangular"
+                    );
+                }
+            }
+            let reconstructed = lu.l.mul(&lu.u, &p).unwrap();
+            let permuted = permute_rows(&m, &lu.perm);
+            assert!(
+                eigen::matrix_eq_simplified(&reconstructed, &permuted, &p),
+                "seed {seed}: P·A = L·U failed, perm = {:?}",
+                lu.perm
+            );
+        }
+    }
+
+    // ---------------------------------------------------------- row space
+
+    /// The pivot rows come from the echelon form, not from `m`.
+    ///
+    /// `[[0,0],[1,0]]` has row space `span{[1,0]}`. Elimination swaps the two
+    /// rows, marking echelon row 0 as the pivot row; reading `m.row(0)` gave
+    /// `[0,0]` — the zero vector returned as a basis of a one-dimensional
+    /// space.
+    #[test]
+    fn row_space_of_a_swapped_matrix_is_not_the_zero_vector() {
+        let p = pool();
+        let z = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let m = Matrix::new(vec![vec![z, z], vec![one, z]]).unwrap();
+        let basis = row_space_basis(&m, &p).unwrap();
+        assert_eq!(basis.len(), 1);
+        let row = &basis[0];
+        assert_eq!(row.rows, 1);
+        assert_eq!(row.cols, 2);
+        assert_eq!(simplify(row.get(0, 0), &p).value, one);
+        assert_eq!(simplify(row.get(0, 1), &p).value, z);
+    }
+
+    /// A duplicated row must not be handed back twice.
+    ///
+    /// `[[1,2,3],[1,2,3],[0,1,0]]` has rank 2; the old code returned echelon
+    /// rows 0 and 1 *of the input*, i.e. the same vector twice, whose span is
+    /// one-dimensional.
+    #[test]
+    fn row_space_basis_of_a_duplicated_row_is_independent() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), p.integer(2_i32), p.integer(3_i32)],
+            vec![p.integer(1_i32), p.integer(2_i32), p.integer(3_i32)],
+            vec![p.integer(0_i32), p.integer(1_i32), p.integer(0_i32)],
+        ])
+        .unwrap();
+        let basis = row_space_basis(&m, &p).unwrap();
+        assert_eq!(basis.len(), 2, "rank is 2");
+        let stacked = Matrix::new(basis.iter().map(|b| b.row(0)).collect()).unwrap();
+        assert_eq!(
+            rank(&stacked, &p).unwrap(),
+            2,
+            "a basis must be independent"
+        );
+    }
+
+    /// Over 80 random shapes: the claimed basis is independent, has `rank(m)`
+    /// elements, and does not leave the row space of `m`.
+    #[test]
+    fn row_space_basis_is_a_basis_for_every_random_shape() {
+        let p = pool();
+        for seed in 200..280u64 {
+            let rows = 1 + (seed % 4) as usize;
+            let cols = 1 + ((seed / 4) % 4) as usize;
+            let mut grid: Vec<Vec<ExprId>> = (0..rows)
+                .map(|r| seeded_matrix(seed + r as u64, 1, cols, &p).row(0))
+                .collect();
+            // Force a dependency half the time so rank-deficient shapes are hit.
+            if rows > 1 && seed % 2 == 0 {
+                grid[0] = grid[rows - 1].clone();
+            }
+            let m = Matrix::new(grid).unwrap();
+            let r = rank(&m, &p).unwrap();
+            let basis = row_space_basis(&m, &p).unwrap();
+            assert_eq!(basis.len(), r, "seed {seed}: basis size must equal rank");
+            if r == 0 {
+                continue;
+            }
+            let stacked = Matrix::new(basis.iter().map(|b| b.row(0)).collect()).unwrap();
+            assert_eq!(
+                rank(&stacked, &p).unwrap(),
+                r,
+                "seed {seed}: basis must be independent"
+            );
+            // Stacking the basis under `m` adds nothing: the basis lies in row(m).
+            let mut all: Vec<Vec<ExprId>> = (0..rows).map(|i| m.row(i)).collect();
+            all.extend(basis.iter().map(|b| b.row(0)));
+            let combined = Matrix::new(all).unwrap();
+            assert_eq!(
+                rank(&combined, &p).unwrap(),
+                r,
+                "seed {seed}: basis must stay inside row(m)"
+            );
+        }
+    }
+
+    // ------------------------------------------------- minimal polynomial
+
+    /// `p(M)` is `Σ cᵢ Mⁱ`, and a vanishing constant term must not shift the
+    /// powers.
+    ///
+    /// The zero matrix is annihilated by `λ`. The old power bookkeeping skipped
+    /// advancing `M⁰ → M¹` when `c₀ = 0`, so it evaluated `λ` as `I`, rejected
+    /// it, and returned `λ²` — a correct annihilator, but not the minimal one,
+    /// which is the entire content of the function's name. A zero constant term
+    /// is exactly `0 ∈ spec(M)`, so every singular matrix was exposed.
+    #[test]
+    fn minimal_polynomial_of_the_zero_matrix_is_lambda() {
+        let p = pool();
+        for n in 1..=4 {
+            let m = Matrix::zeros(n, n, &p);
+            let (poly, lam) = minimal_polynomial(&m, &p).unwrap();
+            assert_eq!(
+                simplify(poly, &p).value,
+                simplify(lam, &p).value,
+                "minimal polynomial of the {n}×{n} zero matrix is λ, not λ^k"
+            );
+        }
+    }
+
+    /// `J₂(0) ⊕ J₂(0)` is annihilated by `λ²`, not `λ³`.
+    ///
+    /// Its characteristic polynomial is `λ⁴` and the largest block is 2×2, so
+    /// the minimal polynomial is `λ²`. The old code returned `λ³`.
+    #[test]
+    fn minimal_polynomial_of_two_equal_nilpotent_blocks_is_lambda_squared() {
+        let p = pool();
+        let z = p.integer(0_i32);
+        let one = p.integer(1_i32);
+        let m = Matrix::new(vec![
+            vec![z, one, z, z],
+            vec![z, z, z, z],
+            vec![z, z, z, one],
+            vec![z, z, z, z],
+        ])
+        .unwrap();
+        let (poly, lam) = minimal_polynomial(&m, &p).unwrap();
+        let expected = simplify(p.pow(lam, p.integer(2_i32)), &p).value;
+        assert_eq!(simplify(poly, &p).value, expected);
+    }
+
+    /// Whatever is returned must annihilate `M`, and nothing of lower degree
+    /// that divides the characteristic polynomial may.
+    ///
+    /// Checked here for the nilpotent family the bug lived in, where the
+    /// minimal polynomial `λ^s` is known independently from the block size.
+    #[test]
+    fn minimal_polynomial_of_a_single_nilpotent_block_is_lambda_to_its_size() {
+        let p = pool();
+        for size in 1..=4usize {
+            let mut m = Matrix::zeros(size, size, &p);
+            for i in 0..size.saturating_sub(1) {
+                m.set(i, i + 1, p.integer(1_i32));
+            }
+            let (poly, lam) = minimal_polynomial(&m, &p).unwrap();
+            let expected = if size == 1 {
+                simplify(lam, &p).value
+            } else {
+                simplify(p.pow(lam, p.integer(size as i32)), &p).value
+            };
+            assert_eq!(
+                simplify(poly, &p).value,
+                expected,
+                "J_{size}(0) is annihilated by λ^{size} and nothing smaller"
+            );
+        }
+    }
+
+    // -------------------------------------------- rational canonical form
+
+    /// The companion block carries its coefficients down the last **column**.
+    ///
+    /// `diag(1,2)` has the single invariant factor `λ²−3λ+2`, whose companion
+    /// matrix is `[[0,−2],[1,3]]`. Writing the coefficients along the last row
+    /// produced `[[0,0],[−2,3]]`, with determinant `0` where `det M = 2` — not
+    /// similar to `M`, and not catchable by the `p_mat.rows == 2` assertions
+    /// that were the only coverage this function had.
+    #[test]
+    fn rational_canonical_form_reconstructs_the_matrix() {
+        let p = pool();
+        let cases: Vec<Vec<Vec<i32>>> = vec![
+            vec![vec![1, 0], vec![0, 2]],
+            vec![vec![1, 1], vec![0, 1]],
+            vec![vec![4, -1], vec![-2, -2]],
+            vec![vec![0, 1], vec![0, 0]],
+            vec![vec![2, 0, 0], vec![0, 2, 0], vec![0, 0, 3]],
+            vec![vec![1, 2, 3], vec![0, 1, 4], vec![0, 0, 1]],
+            vec![vec![0, 0, 0], vec![0, 0, 0], vec![0, 0, 0]],
+            vec![vec![2, 1, 0], vec![0, 2, 1], vec![0, 0, 2]],
+        ];
+        for case in cases {
+            let n = case.len();
+            let m = Matrix::new(
+                case.iter()
+                    .map(|r| r.iter().map(|&v| p.integer(v)).collect())
+                    .collect(),
+            )
+            .unwrap();
+            let (pm, c) = match rational_canonical_form(&m, &p) {
+                Ok(v) => v,
+                // A refusal is always allowed; a wrong pair is not.
+                Err(_) => continue,
+            };
+            let lhs = m.mul(&pm, &p).unwrap();
+            let rhs = pm.mul(&c, &p).unwrap();
+            assert!(
+                eigen::matrix_eq_simplified(&lhs, &rhs, &p),
+                "M·P = P·C failed for {case:?}"
+            );
+            assert_eq!(
+                rank(&pm, &p).unwrap(),
+                n,
+                "P must be invertible for {case:?}"
+            );
+        }
+    }
+
+    /// `det(C) = det(M)` and `tr(C) = tr(M)`, read off the returned `C` alone.
+    ///
+    /// An independent consequence of similarity that the transposed companion
+    /// matrix violated outright: on `diag(1,2)` it gave `det C = 0` against
+    /// `det M = 2`.
+    #[test]
+    fn rational_canonical_form_preserves_determinant_and_trace() {
+        let p = pool();
+        for seed in 400..460u64 {
+            let n = 2 + (seed % 3) as usize;
+            let m = seeded_matrix(seed, n, n, &p);
+            let Ok((_, c)) = rational_canonical_form(&m, &p) else {
+                continue;
+            };
+            let det_m = simplify_expanded(m.det(&p).unwrap(), &p).value;
+            let det_c = simplify_expanded(c.det(&p).unwrap(), &p).value;
+            assert_eq!(det_m, det_c, "seed {seed}: det must be preserved");
+            let tr = |x: &Matrix| {
+                let terms: Vec<ExprId> = (0..n).map(|i| x.get(i, i)).collect();
+                simplify_expanded(p.add(terms), &p).value
+            };
+            assert_eq!(tr(&m), tr(&c), "seed {seed}: trace must be preserved");
+        }
+    }
+
+    /// 60 random matrices: either a refusal, or a pair that satisfies
+    /// `M·P = P·C` with `P` invertible. Never anything else.
+    #[test]
+    fn rational_canonical_form_is_right_or_refuses() {
+        let p = pool();
+        let mut answered = 0usize;
+        for seed in 500..560u64 {
+            let n = 1 + (seed % 4) as usize;
+            let m = seeded_matrix(seed, n, n, &p);
+            let Ok((pm, c)) = rational_canonical_form(&m, &p) else {
+                continue;
+            };
+            answered += 1;
+            let lhs = m.mul(&pm, &p).unwrap();
+            let rhs = pm.mul(&c, &p).unwrap();
+            assert!(
+                eigen::matrix_eq_simplified(&lhs, &rhs, &p),
+                "seed {seed}: M·P = P·C failed"
+            );
+            assert_eq!(rank(&pm, &p).unwrap(), n, "seed {seed}: P singular");
+        }
+        assert!(
+            answered > 30,
+            "the gate must not have turned this into a refusal machine; \
+             only {answered} of 60 answered"
+        );
+    }
+
+    // ----------------------------------------------------------- cholesky
+
+    /// `L·Lᵀ` is symmetric for every `L`, so a non-symmetric input has no
+    /// Cholesky factor and must be refused.
+    ///
+    /// The algorithm reads only the lower triangle, so `[[1,5],[0,1]]` used to
+    /// come back as the identity — a factorisation of `I`, not of the input,
+    /// with nothing to distinguish it from a real answer.
+    #[test]
+    fn cholesky_refuses_a_non_symmetric_matrix() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), p.integer(5_i32)],
+            vec![p.integer(0_i32), p.integer(1_i32)],
+        ])
+        .unwrap();
+        assert_eq!(
+            cholesky(&m, &p),
+            Err(LinearAlgebraError::NotPositiveDefinite),
+            "a non-symmetric matrix has no Cholesky factor"
+        );
+    }
+
+    /// `2I` is positive definite and its Cholesky factor is `√2·I`.
+    ///
+    /// The rational path used to require every pivot to be a perfect rational
+    /// square and reported `E-LINALG-003` — "matrix is not symmetric positive
+    /// definite" — otherwise. A refusal that states a falsehood about the input
+    /// is not a safe failure.
+    #[test]
+    fn cholesky_of_2i_is_sqrt2_i() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(2_i32), p.integer(0_i32)],
+            vec![p.integer(0_i32), p.integer(2_i32)],
+        ])
+        .unwrap();
+        let l = cholesky(&m, &p).unwrap();
+        let recon = l.mul(&l.transpose(), &p).unwrap();
+        assert!(
+            entries_equal(&recon, &m, &p),
+            "L·Lᵀ must be 2I, got {:?}",
+            recon.entries()
+        );
+        let sqrt2 = simplify(p.func("sqrt", vec![p.integer(2_i32)]), &p).value;
+        assert_eq!(simplify(l.get(0, 0), &p).value, sqrt2);
+        assert_eq!(simplify(l.get(1, 0), &p).value, p.integer(0_i32));
+    }
+
+    /// `L·Lᵀ = M` over a family of symmetric positive definite matrices, with
+    /// and without perfect-square pivots.
+    #[test]
+    fn cholesky_reconstructs_every_spd_matrix() {
+        let p = pool();
+        let mut answered = 0usize;
+        for seed in 600..660u64 {
+            let n = 1 + (seed % 4) as usize;
+            let b = seeded_matrix(seed, n, n, &p);
+            // `BᵀB + n·I` is symmetric and positive definite by construction.
+            let m = b
+                .transpose()
+                .mul(&b, &p)
+                .unwrap()
+                .add(&Matrix::identity(n, &p).scale(p.integer(n as i32), &p), &p)
+                .unwrap()
+                .simplify_entries(&p);
+            let l = cholesky(&m, &p).expect("BᵀB + nI is positive definite");
+            answered += 1;
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    assert_eq!(
+                        simplify(l.get(i, j), &p).value,
+                        p.integer(0_i32),
+                        "seed {seed}: L must be lower triangular"
+                    );
+                }
+            }
+            let recon = l.mul(&l.transpose(), &p).unwrap();
+            assert!(
+                entries_equal(&recon, &m, &p),
+                "seed {seed}: L·Lᵀ = M failed"
+            );
+        }
+        assert_eq!(answered, 60);
+    }
+
+    /// A symmetric matrix that is *not* positive definite is still refused —
+    /// the `√2` repair must not have turned the definiteness test off.
+    #[test]
+    fn cholesky_still_refuses_an_indefinite_matrix() {
+        let p = pool();
+        let m = Matrix::new(vec![
+            vec![p.integer(1_i32), p.integer(2_i32)],
+            vec![p.integer(2_i32), p.integer(1_i32)],
+        ])
+        .unwrap();
+        assert_eq!(
+            cholesky(&m, &p),
+            Err(LinearAlgebraError::NotPositiveDefinite),
+            "[[1,2],[2,1]] has eigenvalues 3 and −1"
+        );
+        let neg = Matrix::new(vec![
+            vec![p.integer(-1_i32), p.integer(0_i32)],
+            vec![p.integer(0_i32), p.integer(-1_i32)],
+        ])
+        .unwrap();
+        assert_eq!(
+            cholesky(&neg, &p),
+            Err(LinearAlgebraError::NotPositiveDefinite)
+        );
+    }
+
+    // ------------------------------------------------ symbolic inverse 6×6
+
+    /// A fully symbolic `n×n` matrix is invertible and says so, up to `6×6`.
+    ///
+    /// `det` of a matrix of distinct free symbols is a polynomial with `n!`
+    /// monomials and is not the zero function, so `adj/det` is the inverse and
+    /// nothing is being assumed. It refused at `n ≥ 5` only because the
+    /// non-vanishing probe declined to bind more than 16 symbols and a `5×5`
+    /// has 25; see [`crate::matrix::zero_test`]. The verification is the
+    /// identity itself: `A⁻¹·A = I`.
+    #[test]
+    fn symbolic_inverse_handles_a_fully_symbolic_six_by_six() {
+        let p = pool();
+        for n in 1..=6usize {
+            // Names are keyed by `n` so each size interns its symbols fresh,
+            // in row-major order. Reusing one name set across the loop made
+            // every size after the first inherit a *scrambled* `ExprId` order,
+            // which by itself was enough to hide the collinear-sample defect in
+            // `zero_test::sample_ball` that this test is here to pin.
+            let grid: Vec<Vec<ExprId>> = (0..n)
+                .map(|i| {
+                    (0..n)
+                        .map(|j| p.symbol(format!("a{n}_{i}_{j}"), Domain::Complex))
+                        .collect()
+                })
+                .collect();
+            let m = Matrix::new(grid).unwrap();
+            let inv = matrix_inverse(&m, &p)
+                .unwrap_or_else(|e| panic!("{n}×{n} fully symbolic inverse refused: {e}"));
+            let prod = inv.mul(&m, &p).unwrap();
+            // Verified by substitution into ℚ rather than by symbolic
+            // cancellation: `A⁻¹·A − I` for a dense symbolic `A` is a rational
+            // function in `n²` variables that no normaliser here reduces in
+            // useful time, whereas specialising the symbols to distinct
+            // rationals makes every entry an exact rational and the check
+            // decisive. Three unrelated points, so an accidental agreement
+            // would have to happen three times.
+            let id = Matrix::identity(n, &p);
+            for round in 0..3usize {
+                let mut map = std::collections::HashMap::new();
+                // Unstructured sample points. An arithmetic progression in
+                // `i·n + j` makes the matrix itself rank-deficient — every row
+                // differs from the previous by a constant vector — so `det`
+                // vanishes at the sample and the check is vacuous rather than
+                // decisive. An LCG has no such structure.
+                let mut seed = 0x2545_F491_4F6C_DD1Du64 ^ (round as u64).wrapping_mul(0x9E37_79B9);
+                let mut next = || {
+                    seed ^= seed << 13;
+                    seed ^= seed >> 7;
+                    seed ^= seed << 17;
+                    (seed % 199) as i64 + 1
+                };
+                for i in 0..n {
+                    for j in 0..n {
+                        let sym = p.symbol(format!("a{n}_{i}_{j}"), Domain::Complex);
+                        map.insert(sym, p.rational(next(), 7 + 2 * round as i64));
+                    }
+                }
+                for i in 0..n {
+                    for j in 0..n {
+                        let diff = p.add(vec![
+                            prod.get(i, j),
+                            p.mul(vec![p.integer(-1_i32), id.get(i, j)]),
+                        ]);
+                        let at = crate::kernel::subs::subs(diff, &map, &p);
+                        let v = exact_rational(at, &p).unwrap_or_else(|| {
+                            panic!(
+                                "{n}×{n} round {round}: entry ({i},{j}) is not a constant: {}",
+                                crate::kernel::display::render_unicode(at, &p)
+                            )
+                        });
+                        assert_eq!(
+                            v,
+                            Rational::from(0),
+                            "{n}×{n} round {round}: (A⁻¹·A − I)[{i}][{j}] must vanish"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// A symbolically singular matrix is still refused, at every size.
+    ///
+    /// The point of raising the probe cap is to stop declining *decidable*
+    /// determinants, not to start inventing inverses. Row 1 is `2×` row 0 here,
+    /// so `det` is identically zero and `E-MAT-003` is owed.
+    #[test]
+    fn symbolic_inverse_still_refuses_a_dependent_row() {
+        let p = pool();
+        for n in 2..=5usize {
+            let grid: Vec<Vec<ExprId>> = (0..n)
+                .map(|i| {
+                    (0..n)
+                        .map(|j| {
+                            let s = p.symbol(format!("b_{i}_{j}"), Domain::Complex);
+                            // Row 1 is exactly twice row 0, so `det` is the
+                            // zero polynomial however the symbols are read.
+                            if i == 1 {
+                                let s0 = p.symbol(format!("b_0_{j}"), Domain::Complex);
+                                p.mul(vec![p.integer(2_i32), s0])
+                            } else {
+                                s
+                            }
+                        })
+                        .collect()
+                })
+                .collect();
+            let m = Matrix::new(grid).unwrap();
+            assert_eq!(
+                matrix_inverse(&m, &p),
+                Err(MatrixError::SingularMatrix),
+                "{n}×{n} with a dependent row must be refused"
+            );
+        }
     }
 }

--- a/alkahest-core/src/matrix/mod.rs
+++ b/alkahest-core/src/matrix/mod.rs
@@ -31,8 +31,8 @@ pub use exp_gate::{
 pub use linear_algebra::{
     cholesky, column_space_basis, jordan_form, lu_decomposition, matrix_exponential,
     matrix_inverse, minimal_polynomial, nullspace_basis, qr_decomposition, rank,
-    rational_canonical_form, row_space_basis, rref, LinearAlgebraError, LuDecomposition,
-    QrDecomposition,
+    rational_canonical_form, row_space_basis, rref, take_matrix_inverse_side_conditions,
+    LinearAlgebraError, LuDecomposition, QrDecomposition,
 };
 pub use normal_form::{
     hermite_form, hermite_form_poly, smith_form, smith_form_poly, IntegerMatrix, NormalFormError,

--- a/alkahest-core/src/matrix/normal_form.rs
+++ b/alkahest-core/src/matrix/normal_form.rs
@@ -686,4 +686,373 @@ mod tests {
         let prod = us.mul(&m).unwrap().mul(&vs).unwrap();
         assert_eq!(prod, s);
     }
+
+    // =======================================================================
+    // 3.10.1 audit — randomised property coverage for the normal forms.
+    //
+    // What was here before: `U·M·V = S` on 30 random 4×4 matrices of
+    // *non-negative* entries, cross-checked against FLINT's own SNF diagonal;
+    // one 2×2 `diag(x, x)` for the ℚ[x] pair. What was not checked anywhere:
+    // that `U` and `V` are **unimodular** — without that, `S = U·M·V` is a
+    // factorisation through singular matrices and says nothing — negative and
+    // rectangular and rank-deficient integer input, and the ℚ[x] Smith form on
+    // anything but a diagonal matrix, which is what `rational_canonical_form`
+    // reads its invariant factors off.
+    //
+    // The oracle for the invariant factors is the **determinantal divisor**
+    // characterisation: `d_k(M)` is the gcd of all `k×k` minors of `M`, and
+    // `s_k = d_k / d_{k−1}`. It is a theorem about `M` alone, computed here
+    // from the minors directly, so it is independent of the algorithm under
+    // test in a way that comparing two implementations is not.
+    // =======================================================================
+
+    fn lcg(state: &mut u64) -> i64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        (*state % 19) as i64 - 9
+    }
+
+    /// Determinant by cofactor expansion (small `n` only).
+    fn int_det(rows: &[Vec<Integer>]) -> Integer {
+        let n = rows.len();
+        if n == 0 {
+            return Integer::from(1);
+        }
+        if n == 1 {
+            return rows[0][0].clone();
+        }
+        let mut acc = Integer::from(0);
+        for j in 0..n {
+            let minor: Vec<Vec<Integer>> = rows[1..]
+                .iter()
+                .map(|r| {
+                    r.iter()
+                        .enumerate()
+                        .filter(|(c, _)| *c != j)
+                        .map(|(_, v)| v.clone())
+                        .collect()
+                })
+                .collect();
+            let term = rows[0][j].clone() * int_det(&minor);
+            if j % 2 == 0 {
+                acc += term;
+            } else {
+                acc -= term;
+            }
+        }
+        acc
+    }
+
+    /// `d_k`: the gcd of every `k×k` minor of `m`. `d_0 = 1` by convention.
+    fn determinantal_divisor(m: &IntegerMatrix, k: usize) -> Integer {
+        if k == 0 {
+            return Integer::from(1);
+        }
+        let mut g = Integer::from(0);
+        for rows in combinations(m.rows, k) {
+            for cols in combinations(m.cols, k) {
+                let sub: Vec<Vec<Integer>> = rows
+                    .iter()
+                    .map(|&r| cols.iter().map(|&c| m.get(r, c).clone()).collect())
+                    .collect();
+                g = g.gcd(&int_det(&sub));
+            }
+        }
+        g
+    }
+
+    fn combinations(n: usize, k: usize) -> Vec<Vec<usize>> {
+        let mut out = Vec::new();
+        let mut cur = Vec::new();
+        fn go(start: usize, n: usize, k: usize, cur: &mut Vec<usize>, out: &mut Vec<Vec<usize>>) {
+            if cur.len() == k {
+                out.push(cur.clone());
+                return;
+            }
+            for i in start..n {
+                cur.push(i);
+                go(i + 1, n, k, cur, out);
+                cur.pop();
+            }
+        }
+        go(0, n, k, &mut cur, &mut out);
+        out
+    }
+
+    fn as_rows(m: &IntegerMatrix) -> Vec<Vec<Integer>> {
+        (0..m.rows)
+            .map(|i| (0..m.cols).map(|j| m.get(i, j).clone()).collect())
+            .collect()
+    }
+
+    /// `U·M = H` with `U` unimodular and `H` in Hermite form, over 90 shapes
+    /// including negative entries, rectangular and rank-deficient input.
+    ///
+    /// Unimodularity of `U` is the half that was never asserted. `U·M = H`
+    /// alone is satisfied by `U = 0, H = 0`; it is `det U = ±1` that makes `H`
+    /// a *normal form of `M`* rather than an arbitrary product, and that makes
+    /// the transform invertible for the caller who wants to undo it.
+    #[test]
+    fn hermite_form_transform_is_unimodular_over_random_shapes() {
+        let mut st = 0x243F_6A88_85A3_08D3u64;
+        for case in 0..90u64 {
+            let rows = 1 + (case % 4) as usize;
+            let cols = 1 + ((case / 4) % 4) as usize;
+            let mut grid: Vec<Vec<i64>> = (0..rows)
+                .map(|_| (0..cols).map(|_| lcg(&mut st)).collect())
+                .collect();
+            // A third of the cases get a dependent row.
+            if rows > 1 && case % 3 == 0 {
+                grid[0] = grid[rows - 1].iter().map(|v| v * 2).collect();
+            }
+            let m = IntegerMatrix::from_nested(grid).unwrap();
+            let (h, u) = hermite_form(&m);
+            assert_eq!(u.rows, rows);
+            assert_eq!(u.cols, rows);
+            assert_eq!(u.mul(&m).unwrap(), h, "case {case}: U·M = H");
+            let d = int_det(&as_rows(&u));
+            assert!(
+                d == 1 || d == -1,
+                "case {case}: U must be unimodular, det U = {d}"
+            );
+            assert!(h.to_flint().is_in_hnf(), "case {case}: H must be in HNF");
+        }
+    }
+
+    /// `S = U·M·V` with `U`, `V` unimodular, the divisibility chain holding,
+    /// and the diagonal equal to the determinantal divisors of `M`.
+    #[test]
+    fn smith_form_diagonal_matches_the_determinantal_divisors() {
+        let mut st = 0xB504_F333_F9DE_6484u64;
+        for case in 0..70u64 {
+            let rows = 1 + (case % 3) as usize;
+            let cols = 1 + ((case / 3) % 3) as usize;
+            let mut grid: Vec<Vec<i64>> = (0..rows)
+                .map(|_| (0..cols).map(|_| lcg(&mut st)).collect())
+                .collect();
+            if rows > 1 && case % 4 == 0 {
+                grid[0] = grid[rows - 1].iter().map(|v| v * 3).collect();
+            }
+            if case % 11 == 0 {
+                grid = (0..rows).map(|_| vec![0; cols]).collect();
+            }
+            let m = IntegerMatrix::from_nested(grid).unwrap();
+            let (s, u, v) = smith_form(&m).unwrap();
+
+            assert_eq!(
+                u.mul(&m).unwrap().mul(&v).unwrap(),
+                s,
+                "case {case}: S = U·M·V"
+            );
+            let du = int_det(&as_rows(&u));
+            let dv = int_det(&as_rows(&v));
+            assert!(du == 1 || du == -1, "case {case}: det U = {du}");
+            assert!(dv == 1 || dv == -1, "case {case}: det V = {dv}");
+
+            // Rectangular-diagonal.
+            for i in 0..s.rows {
+                for j in 0..s.cols {
+                    if i != j {
+                        assert_eq!(
+                            *s.get(i, j),
+                            Integer::from(0),
+                            "case {case}: S must be diagonal"
+                        );
+                    }
+                }
+            }
+            // Divisibility chain.
+            let d = s.rows.min(s.cols);
+            for i in 0..d.saturating_sub(1) {
+                let a = s.get(i, i).clone();
+                let b = s.get(i + 1, i + 1).clone();
+                if a == 0 {
+                    assert_eq!(b, 0, "case {case}: a zero invariant factor ends the chain");
+                } else {
+                    assert_eq!(
+                        b.clone() % a.clone(),
+                        0,
+                        "case {case}: s_{i} must divide s_{}",
+                        i + 1
+                    );
+                }
+            }
+            // The oracle: s_k = d_k / d_{k−1}.
+            let mut prev = Integer::from(1);
+            for k in 1..=d {
+                let dk = determinantal_divisor(&m, k);
+                let sk = s.get(k - 1, k - 1).clone().abs();
+                if prev == 0 {
+                    assert_eq!(
+                        dk,
+                        0,
+                        "case {case}: d_{k} must vanish once d_{} does",
+                        k - 1
+                    );
+                    assert_eq!(sk, 0, "case {case}: s_{k} must vanish too");
+                    continue;
+                }
+                assert_eq!(
+                    sk.clone() * prev.clone(),
+                    dk,
+                    "case {case}: s_{k}·d_{} must equal d_{k}",
+                    k - 1
+                );
+                prev = dk;
+            }
+        }
+    }
+
+    // ------------------------------------------------------------- ℚ[x]
+
+    fn rand_poly(st: &mut u64, max_deg: usize) -> RatUniPoly {
+        let deg = (lcg(st).unsigned_abs() as usize) % (max_deg + 1);
+        let coeffs: Vec<Rational> = (0..=deg).map(|_| Rational::from((lcg(st), 1))).collect();
+        RatUniPoly { coeffs }.trim()
+    }
+
+    fn poly_det(m: &[Vec<RatUniPoly>]) -> RatUniPoly {
+        let n = m.len();
+        if n == 0 {
+            return RatUniPoly::one();
+        }
+        if n == 1 {
+            return m[0][0].clone();
+        }
+        let mut acc = RatUniPoly::zero();
+        for j in 0..n {
+            let minor: Vec<Vec<RatUniPoly>> = m[1..]
+                .iter()
+                .map(|r| {
+                    r.iter()
+                        .enumerate()
+                        .filter(|(c, _)| *c != j)
+                        .map(|(_, v)| v.clone())
+                        .collect()
+                })
+                .collect();
+            let term = (&m[0][j] * &poly_det(&minor)).trim();
+            acc = if j % 2 == 0 {
+                (&acc + &term).trim()
+            } else {
+                (&acc - &term).trim()
+            };
+        }
+        acc
+    }
+
+    fn poly_rows(m: &PolyMatrixQ) -> Vec<Vec<RatUniPoly>> {
+        (0..m.rows)
+            .map(|i| (0..m.cols).map(|j| m.get(i, j).clone()).collect())
+            .collect()
+    }
+
+    /// `S = U·M·V` over ℚ[x] with `U`, `V` unimodular (non-zero *constant*
+    /// determinant, the units of ℚ[x]), a divisibility chain, and
+    /// `Π sᵢ = c · det M`.
+    ///
+    /// This is the routine `rational_canonical_form` reads its invariant
+    /// factors off, and its only test was `diag(x, x)`.
+    #[test]
+    fn smith_form_poly_is_a_unimodular_equivalence() {
+        let mut st = 0x1357_9BDF_2468_ACE0u64;
+        for case in 0..60u64 {
+            let n = 1 + (case % 3) as usize;
+            let mut grid: Vec<Vec<RatUniPoly>> = (0..n)
+                .map(|_| (0..n).map(|_| rand_poly(&mut st, 2)).collect())
+                .collect();
+            if n > 1 && case % 5 == 0 {
+                grid[0] = grid[n - 1].clone();
+            }
+            let m = PolyMatrixQ::from_nested(grid).unwrap();
+            let (s, u, v) = smith_form_poly(&m);
+
+            let prod = u.mul(&m).unwrap().mul(&v).unwrap();
+            assert_eq!(prod, s, "case {case}: S = U·M·V over ℚ[x]");
+
+            for (name, t) in [("U", &u), ("V", &v)] {
+                let d = poly_det(&poly_rows(t));
+                assert!(
+                    !d.is_zero() && d.degree() == 0,
+                    "case {case}: det {name} must be a non-zero constant (it is the \
+                     unit group of ℚ[x]); got degree {}",
+                    d.degree()
+                );
+            }
+
+            for i in 0..s.rows {
+                for j in 0..s.cols {
+                    if i != j {
+                        assert!(
+                            s.get(i, j).clone().trim().is_zero(),
+                            "case {case}: S must be diagonal"
+                        );
+                    }
+                }
+            }
+            let d = s.rows.min(s.cols);
+            for i in 0..d.saturating_sub(1) {
+                let a = s.get(i, i).clone().trim();
+                let b = s.get(i + 1, i + 1).clone().trim();
+                if a.is_zero() {
+                    assert!(b.is_zero(), "case {case}: chain must stay zero");
+                } else {
+                    let (_, r) = RatUniPoly::div_rem(&b, &a);
+                    assert!(
+                        r.trim().is_zero(),
+                        "case {case}: s_{i} must divide s_{}",
+                        i + 1
+                    );
+                }
+            }
+
+            // `Π sᵢ` and `det M` agree up to a non-zero constant: the product of
+            // the invariant factors is the largest determinantal divisor, which
+            // for a square matrix is `det M`.
+            let mut prod_s = RatUniPoly::one();
+            for i in 0..d {
+                prod_s = (&prod_s * s.get(i, i)).trim();
+            }
+            let det_m = poly_det(&poly_rows(&m)).trim();
+            if det_m.is_zero() {
+                assert!(
+                    prod_s.is_zero(),
+                    "case {case}: a singular M must have a zero invariant factor"
+                );
+            } else {
+                assert_eq!(
+                    prod_s.degree(),
+                    det_m.degree(),
+                    "case {case}: deg Π sᵢ must equal deg det M"
+                );
+                let (q, r) = RatUniPoly::div_rem(&det_m, &prod_s);
+                assert!(
+                    r.trim().is_zero() && q.trim().degree() == 0,
+                    "case {case}: det M / Π sᵢ must be a non-zero constant"
+                );
+            }
+        }
+    }
+
+    /// `U·M = H` over ℚ[x] with `U` unimodular, on non-diagonal input.
+    #[test]
+    fn hermite_form_poly_transform_is_unimodular() {
+        let mut st = 0x0F0F_0F0F_1234_5678u64;
+        for case in 0..40u64 {
+            let n = 1 + (case % 3) as usize;
+            let grid: Vec<Vec<RatUniPoly>> = (0..n)
+                .map(|_| (0..n).map(|_| rand_poly(&mut st, 2)).collect())
+                .collect();
+            let m = PolyMatrixQ::from_nested(grid).unwrap();
+            let (h, u) = hermite_form_poly(&m);
+            assert_eq!(u.mul(&m).unwrap(), h, "case {case}: U·M = H over ℚ[x]");
+            let d = poly_det(&poly_rows(&u));
+            assert!(
+                !d.is_zero() && d.degree() == 0,
+                "case {case}: det U must be a non-zero constant, got degree {}",
+                d.degree()
+            );
+        }
+    }
 }

--- a/alkahest-core/src/matrix/zero_test.rs
+++ b/alkahest-core/src/matrix/zero_test.rs
@@ -493,7 +493,7 @@ fn normalises_to_zero(pool: &ExprPool, e: ExprId) -> bool {
 /// rewritten under an assumption nobody stated.
 ///
 /// [`qr_decomposition`]: crate::matrix::qr_decomposition
-fn fold_rational_radicals(pool: &ExprPool, e: ExprId) -> ExprId {
+pub(crate) fn fold_rational_radicals(pool: &ExprPool, e: ExprId) -> ExprId {
     fold_rational_radicals_at(pool, e, 0)
 }
 

--- a/alkahest-core/src/matrix/zero_test.rs
+++ b/alkahest-core/src/matrix/zero_test.rs
@@ -78,7 +78,42 @@ const PROBE_PREC: u32 = 128;
 const PROBE_ROUNDS: usize = 3;
 
 /// Give up rather than probe a wide parameter space.
-const MAX_PROBE_SYMBOLS: usize = 16;
+///
+/// 144 is `12×12` distinct entries: enough that a fully symbolic matrix of the
+/// size controls work actually uses gets a verdict. At 16 a `5×5` matrix of
+/// distinct symbols — 25 of them — was already over the line, which is why
+/// `inverse()` on a symbolic `5×5` or `6×6` refused with `E-MAT-004`
+/// ("cannot decide whether the determinant is zero") about a determinant that
+/// is a 720-term polynomial and manifestly not the zero function. A `4×4`
+/// (16 symbols) answered.
+///
+/// Raising it cannot make a verdict wrong. `NonZero` is only ever returned on
+/// a **rigorous** enclosure that excludes `0` at a sample point, which is a
+/// proof that the expression is not identically zero however many symbols it
+/// has; the cap never contributed to soundness, only to cost. A sample that
+/// happens to land on a root yields no certificate and the answer stays
+/// `Unknown`, which is safe.
+const MAX_PROBE_SYMBOLS: usize = 144;
+
+/// Give up rather than probe a very large expression.
+///
+/// This is the bound that actually tracks cost: each round is one interval
+/// evaluation, whose work is proportional to the size of the expression DAG and
+/// not to the number of symbols in it. Bounding the symbol count was bounding
+/// the wrong quantity — it let a huge single-variable expression through and
+/// stopped a small many-variable one.
+const MAX_PROBE_NODES: usize = 250_000;
+
+/// Generator budget for the `cancel` rung of [`normalises_to_zero`].
+///
+/// Deliberately far below [`MAX_PROBE_SYMBOLS`]: the non-vanishing probe costs
+/// one interval evaluation per round however many symbols there are, while
+/// `cancel` runs multivariate GCDs whose cost explodes with the generator
+/// count. 12 covers the eliminated-entry case this rung exists for.
+const CANCEL_MAX_SYMBOLS: usize = 12;
+
+/// Expression-size budget for the `cancel` rung.
+const CANCEL_MAX_NODES: usize = 4_000;
 
 /// Whether an expression is identically zero, where "I cannot tell" is a
 /// first-class answer.
@@ -427,7 +462,172 @@ fn normalises_to_zero(pool: &ExprPool, e: ExprId) -> bool {
             return true;
         }
     }
-    is_literal_zero(pool, simplify_trig_normal_form(e, pool).value)
+    if is_literal_zero(pool, simplify_trig_normal_form(e, pool).value) {
+        return true;
+    }
+    let deradicalised = fold_rational_radicals(pool, e);
+    if deradicalised != e {
+        if is_literal_zero(pool, simplify_expanded(deradicalised, pool).value) {
+            return true;
+        }
+        if cancels_to_zero(pool, deradicalised) {
+            return true;
+        }
+    }
+    cancels_to_zero(pool, e)
+}
+
+/// Rewrite `(√c)^k` as `c^{k/2}` wherever `c` is a **non-negative rational
+/// literal**, leaving everything else untouched.
+///
+/// `simplify` does not do this: `√2·√2` comes back as `√2²` and `1/√10²` as
+/// `√10⁻²`, so `√2·√2 − 2` — the residual of `L·Lᵀ − M` for the Cholesky factor
+/// of `2I`, and the shape every Gram–Schmidt norm in [`qr_decomposition`]
+/// produces — is not recognised as zero. Over a *non-negative rational* base
+/// the rewrite needs no branch convention at all: `√c` is the non-negative real
+/// root, so `(√c)^k = c^{k/2}` holds outright, for negative `k` as well.
+///
+/// Restricting to rational literals is what keeps it sound. `(√x)² = x` is
+/// false for `x < 0` under the principal branch (it is `|x|` on the reals and
+/// picks up a sign in ℂ), so a symbolic base is left alone rather than
+/// rewritten under an assumption nobody stated.
+///
+/// [`qr_decomposition`]: crate::matrix::qr_decomposition
+fn fold_rational_radicals(pool: &ExprPool, e: ExprId) -> ExprId {
+    fold_rational_radicals_at(pool, e, 0)
+}
+
+fn fold_rational_radicals_at(pool: &ExprPool, e: ExprId, depth: u32) -> ExprId {
+    if depth > MAX_STRUCTURAL_DEPTH {
+        return e;
+    }
+    let d = depth + 1;
+    match pool.get(e) {
+        ExprData::Add(args) => {
+            let next: Vec<ExprId> = args
+                .iter()
+                .map(|&a| fold_rational_radicals_at(pool, a, d))
+                .collect();
+            pool.add(next)
+        }
+        ExprData::Mul(args) => {
+            let next: Vec<ExprId> = args
+                .iter()
+                .map(|&a| fold_rational_radicals_at(pool, a, d))
+                .collect();
+            pool.mul(next)
+        }
+        ExprData::Func { name, args } => {
+            let next: Vec<ExprId> = args
+                .iter()
+                .map(|&a| fold_rational_radicals_at(pool, a, d))
+                .collect();
+            pool.func(name.as_str(), next)
+        }
+        ExprData::Pow { base, exp } => {
+            let (base, exp) = (base, exp);
+            let folded_base = fold_rational_radicals_at(pool, base, d);
+            let folded_exp = fold_rational_radicals_at(pool, exp, d);
+            if let (Some(radicand), Some(k)) = (
+                sqrt_of_nonneg_rational(pool, folded_base),
+                integer_of(pool, folded_exp),
+            ) {
+                let half = Rational::from((k, rug::Integer::from(2)));
+                let new_exp = if *half.denom() == 1 {
+                    pool.integer(half.numer().clone())
+                } else {
+                    pool.rational(half.numer().clone(), half.denom().clone())
+                };
+                let rad = pool.rational(radicand.numer().clone(), radicand.denom().clone());
+                return pool.pow(rad, new_exp);
+            }
+            pool.pow(folded_base, folded_exp)
+        }
+        _ => e,
+    }
+}
+
+/// `Some(c)` when `e` is `sqrt(c)` or `c^(1/2)` for a non-negative rational `c`.
+fn sqrt_of_nonneg_rational(pool: &ExprPool, e: ExprId) -> Option<Rational> {
+    let inner = pool.with(e, |d| match d {
+        ExprData::Func { name, args } if name.as_str() == "sqrt" && args.len() == 1 => {
+            Some(args[0])
+        }
+        ExprData::Pow { base, exp } => {
+            let half = pool.with(*exp, |x| match x {
+                ExprData::Rational(r) => *r.0.numer() == 1 && *r.0.denom() == 2,
+                _ => false,
+            });
+            if half {
+                Some(*base)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    })?;
+    let r = rational_of(pool, inner)?;
+    if r < 0 {
+        return None;
+    }
+    Some(r)
+}
+
+fn rational_of(pool: &ExprPool, e: ExprId) -> Option<Rational> {
+    pool.with(e, |d| match d {
+        ExprData::Integer(n) => Some(Rational::from((n.0.clone(), rug::Integer::from(1)))),
+        ExprData::Rational(r) => Some(r.0.clone()),
+        _ => None,
+    })
+}
+
+fn integer_of(pool: &ExprPool, e: ExprId) -> Option<rug::Integer> {
+    pool.with(e, |d| match d {
+        ExprData::Integer(n) => Some(n.0.clone()),
+        _ => None,
+    })
+}
+
+/// Last rung: put `e` over a common denominator and cancel the GCD.
+///
+/// Elimination does not produce polynomials, it produces **rational
+/// functions** — every entry after a pivot step carries a `1/pivot` factor —
+/// and `expand` alone cannot see that a sum of them vanishes. `A⁻¹·A` for a
+/// symbolic `A` is the standard example: entry `(0,0)` of the `2×2` case is
+/// `a·d·(ad−bc)⁻¹ − b·c·(ad−bc)⁻¹ − 1`, which is `0` and which every rung above
+/// this one answers `Unknown` for, because none of them combines the two
+/// quotients.
+///
+/// Sound in the only direction it is used. [`crate::poly::cancel::cancel`]
+/// works over a generator list in which anything it does not recognise —
+/// `sin(x)`, `√2`, `x^n` — is an *opaque* generator, i.e. treated as an
+/// independent transcendental. A zero numerator in that free ring is therefore
+/// zero for every substitution, so `true` is a proof. The converse does not
+/// hold and is not claimed: `√2·√2 − 2` is `g² − 2` over an opaque `g` and
+/// stays `Unknown`, which is a missed `Zero`, never a wrong verdict.
+///
+/// Placed last because it is by far the most expensive rung, and budgeted
+/// separately and much more tightly than [`probe_nonzero`].
+///
+/// The cost is not the node count. `cancel` runs multivariate polynomial GCDs
+/// over the generator list, which is super-linear in the *number of
+/// generators*: the residual of `A⁻¹·A` for a fully symbolic `6×6` has 36 of
+/// them over a 720-term determinant, and the reduction does not finish in any
+/// useful time. [`CANCEL_MAX_SYMBOLS`] and [`CANCEL_MAX_NODES`] are therefore
+/// sized for what actually motivates this rung — a handful of parameters in an
+/// eliminated matrix entry — and not for a dense symbolic determinant, which
+/// is left `Unknown` and hence a refusal.
+fn cancels_to_zero(pool: &ExprPool, e: ExprId) -> bool {
+    let Some((symbols, nodes)) = probe_symbols(pool, e) else {
+        return false;
+    };
+    if symbols.len() > CANCEL_MAX_SYMBOLS || nodes > CANCEL_MAX_NODES {
+        return false;
+    }
+    match crate::poly::cancel::cancel(e, Vec::new(), pool) {
+        Ok(c) => is_literal_zero(pool, simplify(c, pool).value),
+        Err(_) => false,
+    }
 }
 
 fn is_literal_zero(pool: &ExprPool, e: ExprId) -> bool {
@@ -442,10 +642,10 @@ fn is_literal_zero(pool: &ExprPool, e: ExprId) -> bool {
 /// domain error, an enclosure straddling `0` — returns `false`, which the
 /// caller reads as "no certificate", never as "zero".
 fn probe_nonzero(pool: &ExprPool, e: ExprId) -> bool {
-    let Some(symbols) = probe_symbols(pool, e) else {
+    let Some((symbols, nodes)) = probe_symbols(pool, e) else {
         return false;
     };
-    if symbols.len() > MAX_PROBE_SYMBOLS {
+    if symbols.len() > MAX_PROBE_SYMBOLS || nodes > MAX_PROBE_NODES {
         return false;
     }
     for round in 0..PROBE_ROUNDS {
@@ -483,12 +683,14 @@ fn ball_excludes_zero(ball: &ArbBall) -> bool {
 /// sample would report `I² + 1` as non-zero. Both would be exactly the silent
 /// error this module exists to prevent, so those expressions get no certificate.
 /// `pi` itself is the one constant handled properly, in [`sample_ball`].
-fn probe_symbols(pool: &ExprPool, e: ExprId) -> Option<Vec<ExprId>> {
+/// Returns the symbols together with the number of distinct DAG nodes walked,
+/// which is what [`MAX_PROBE_NODES`] bounds.
+fn probe_symbols(pool: &ExprPool, e: ExprId) -> Option<(Vec<ExprId>, usize)> {
     let mut seen = HashSet::new();
     let mut out = Vec::new();
     collect_symbols(pool, e, &mut seen, &mut out)?;
     out.sort_unstable();
-    Some(out)
+    Some((out, seen.len()))
 }
 
 /// Symbol names that denote a specific number and are not handled rigorously.
@@ -541,6 +743,29 @@ fn collect_symbols(
 /// refusal is reproducible rather than flaky. The points are ratios with a
 /// large prime-ish denominator so that no small algebraic relation between two
 /// symbols (`x − y`, `x − 2`, `2x − y`) holds accidentally.
+///
+/// # Why the numerator is scrambled rather than counted up
+///
+/// It used to be `733 + 269·index`, which is *linear in the index* — and that
+/// is itself an algebraic relation, just one between three symbols rather than
+/// two: `x_{k+1} − 2x_k + x_{k−1} = 0` holds identically for every consecutive
+/// triple. Any expression that vanishes on collinear inputs therefore vanished
+/// at every sample, in every round, since the round only shifted all the
+/// numerators by the same `1123·round` and scaled the denominator.
+///
+/// The expression that vanishes on collinear inputs is **the determinant of a
+/// dense matrix**. Binding the `n²` entries of a symbolic matrix in index order
+/// produced a probe matrix whose rows are in arithmetic progression, i.e. of
+/// rank 2, so `det` evaluated to exactly `0` for every `n ≥ 3` — verified
+/// directly: the probe matrices for `n = 3..6` and rounds `0..2` all have
+/// rank 2 and determinant 0. The probe could not certify a single dense
+/// symbolic determinant as non-vanishing, and `inverse`, `rank`, `rref` and
+/// `nullspace` refused the whole class with `E-MAT-004`/`E-LINALG-010`.
+///
+/// The scrambled sequence below is a xorshift keyed by `(index, round)`: still
+/// deterministic and still reproducible, but with no low-degree relation among
+/// the values. This is the substantive half of supporting the generic symbolic
+/// matrix; raising [`MAX_PROBE_SYMBOLS`] alone only got as far as *trying*.
 fn sample_ball(pool: &ExprPool, sym: ExprId, index: usize, round: usize) -> ArbBall {
     if pool.with(
         sym,
@@ -561,12 +786,33 @@ fn sample_ball(pool: &ExprPool, sym: ExprId, index: usize, round: usize) -> ArbB
         // An integer-domain symbol must be sampled at an integer: identities
         // such as `sin(pi·n) = 0` hold only there, and a fractional sample
         // would "certify" them non-zero.
-        let n = 7 + 11 * index as i64 + 101 * round as i64;
+        // Scrambled for the same reason as the rational branch: `7 + 11·index`
+        // is an arithmetic progression, and a determinant vanishes on one.
+        let n = 7 + scrambled(index, round) % 977;
         return ArbBall::from_integer(&rug::Integer::from(n), PROBE_PREC);
     }
-    let numer = 733 + 269 * index as i64 + 1123 * round as i64;
+    let numer = 733 + scrambled(index, round);
     let denom = 1021 + 7 * round as i64;
     ArbBall::from_rational(&Rational::from((numer, denom)), PROBE_PREC)
+}
+
+/// A deterministic, low-structure offset for `(index, round)`.
+///
+/// xorshift64 over a seed mixing both, reduced to a few thousand. Deterministic
+/// by construction — no RNG state, no clock — so a verdict is reproducible; and
+/// unlike an arithmetic progression it satisfies no low-degree relation across
+/// consecutive indices, which is the property the probe actually needs.
+fn scrambled(index: usize, round: usize) -> i64 {
+    let mut x = (index as u64)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add((round as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9))
+        .wrapping_add(0x2545_F491_4F6C_DD1D);
+    x ^= x >> 30;
+    x = x.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x ^= x >> 27;
+    x = x.wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^= x >> 31;
+    (x % 7919) as i64
 }
 
 /// An enclosure of π that is honest about its own error.
@@ -666,5 +912,155 @@ mod tests {
         // answer is not a confident `NonZero`.
         let diff = pool.add(vec![f, pool.mul(vec![pool.integer(-1_i32), g])]);
         assert_ne!(zero_status(&pool, diff), ZeroStatus::NonZero);
+    }
+
+    /// The determinant of a dense matrix of distinct symbols is certified
+    /// non-vanishing, at every size the probe budget covers.
+    ///
+    /// This is the test the collinear samples failed. `733 + 269·index` puts
+    /// the sample values in arithmetic progression, so binding the `n²` entries
+    /// of a symbolic matrix in index order produced a probe matrix of **rank 2**
+    /// — verified directly with exact rational arithmetic for `n = 3..6` and
+    /// every round — whose determinant is exactly `0`. The enclosure therefore
+    /// contained `0` at every sample, no certificate was ever issued, and the
+    /// verdict was `Unknown`: `inverse` refused a dense symbolic `3×3` with
+    /// `E-MAT-004`, and `rank`/`rref`/`nullspace` refused the same class with
+    /// `E-LINALG-010`.
+    ///
+    /// `det` of a matrix of `n²` distinct symbols is a sum of `n!` distinct
+    /// monomials over ℤ and is not the zero polynomial for any `n ≥ 1`, so
+    /// `NonZero` is the only correct verdict here and `Unknown` is a pure loss.
+    #[test]
+    fn dense_symbolic_determinant_is_certified_non_vanishing() {
+        for n in 1..=6usize {
+            let pool = p();
+            let grid: Vec<Vec<crate::kernel::ExprId>> = (0..n)
+                .map(|i| {
+                    (0..n)
+                        .map(|j| pool.symbol(format!("s_{i}_{j}"), Domain::Complex))
+                        .collect()
+                })
+                .collect();
+            let m = crate::matrix::Matrix::new(grid).unwrap();
+            let det =
+                crate::simplify::engine::simplify_expanded(m.det(&pool).unwrap(), &pool).value;
+            assert_eq!(
+                zero_status(&pool, det),
+                ZeroStatus::NonZero,
+                "det of a dense symbolic {n}×{n} is a sum of {n}! distinct monomials \
+                 and cannot be the zero function"
+            );
+        }
+    }
+
+    /// The samples themselves are in general position.
+    ///
+    /// Stated on the generator rather than on a consequence of it, so a future
+    /// change to the sequence is checked against the property that matters
+    /// rather than against one matrix that happens to exercise it: no three
+    /// consecutive numerators may be collinear, which is exactly the relation
+    /// `x_{k+1} − 2x_k + x_{k−1} = 0` that an arithmetic progression satisfies
+    /// and that a determinant vanishes on.
+    #[test]
+    fn probe_samples_are_not_collinear_in_the_index() {
+        for round in 0..PROBE_ROUNDS {
+            let vals: Vec<i64> = (0..40).map(|i| scrambled(i, round)).collect();
+            let mut collinear = 0usize;
+            for w in vals.windows(3) {
+                if w[2] - 2 * w[1] + w[0] == 0 {
+                    collinear += 1;
+                }
+            }
+            assert!(
+                collinear < 3,
+                "round {round}: {collinear} of 38 consecutive triples are collinear; \
+                 an arithmetic progression would give 38"
+            );
+            // And they must stay distinct, or two symbols get the same value and
+            // `x − y` looks like zero.
+            let mut sorted = vals.clone();
+            sorted.sort_unstable();
+            sorted.dedup();
+            assert_eq!(sorted.len(), vals.len(), "round {round}: duplicate samples");
+        }
+    }
+
+    /// A rational function that vanishes identically is proven zero.
+    ///
+    /// `a/(a+b) + b/(a+b) − 1` is `0` for every `(a, b)` with `a + b ≠ 0`, and
+    /// no rung above the `cancel` one sees it: `expand` cannot combine two
+    /// quotients, and the log/exp and trig normalisers have nothing to do here.
+    /// This is the shape every entry of an eliminated symbolic matrix has.
+    #[test]
+    fn a_vanishing_rational_function_is_proven_zero() {
+        let pool = p();
+        let a = pool.symbol("a", Domain::Real);
+        let b = pool.symbol("b", Domain::Real);
+        let sum = pool.add(vec![a, b]);
+        let inv = pool.pow(sum, pool.integer(-1_i32));
+        let e = pool.add(vec![
+            pool.mul(vec![a, inv]),
+            pool.mul(vec![b, inv]),
+            pool.integer(-1_i32),
+        ]);
+        assert_eq!(zero_status(&pool, e), ZeroStatus::Zero);
+    }
+
+    /// `√c·√c − c` is proven zero for a non-negative rational `c`.
+    ///
+    /// `simplify` leaves `√2·√2` as `√2²`, so without the radical fold the
+    /// residual of `L·Lᵀ − M` for the Cholesky factor of `2I` — and every
+    /// Gram–Schmidt norm in `qr_decomposition` — is `Unknown`.
+    #[test]
+    fn a_squared_rational_radical_is_proven_zero() {
+        let pool = p();
+        for c in [2_i32, 3, 10, 12] {
+            let lit = pool.integer(c);
+            for root in [
+                pool.func("sqrt", vec![lit]),
+                pool.pow(lit, pool.rational(1, 2)),
+            ] {
+                let e = pool.add(vec![
+                    pool.mul(vec![root, root]),
+                    pool.mul(vec![pool.integer(-1_i32), lit]),
+                ]);
+                assert_eq!(
+                    zero_status(&pool, e),
+                    ZeroStatus::Zero,
+                    "√{c}·√{c} − {c} = 0"
+                );
+            }
+        }
+    }
+
+    /// The radical fold does not fire on a base whose sign is unknown.
+    ///
+    /// `(√x)² = x` is false for `x < 0` under the principal branch, so a
+    /// symbolic base must be left alone. Asserting the *absence* of a `Zero`
+    /// verdict is the point: a rewrite that is sound only on a region, applied
+    /// unconditionally, is how a normaliser turns into a silent error.
+    #[test]
+    fn the_radical_fold_does_not_touch_a_symbolic_base() {
+        let pool = p();
+        let x = pool.symbol("x", Domain::Complex);
+        let root = pool.func("sqrt", vec![x]);
+        let e = pool.add(vec![
+            pool.mul(vec![root, root]),
+            pool.mul(vec![pool.integer(-1_i32), x]),
+        ]);
+        // Whatever the verdict is, it must not come from folding `(√x)² → x`.
+        let folded = fold_rational_radicals(&pool, e);
+        assert_eq!(folded, e, "a symbolic radicand must not be folded");
+    }
+
+    /// A negative rational radicand is left alone too: `(√−4)² = −4` holds in ℂ
+    /// but `√−4` is not on the branch the fold assumes, so it is out of scope.
+    #[test]
+    fn the_radical_fold_does_not_touch_a_negative_radicand() {
+        let pool = p();
+        let neg = pool.integer(-4_i32);
+        let root = pool.func("sqrt", vec![neg]);
+        let e = pool.pow(root, pool.integer(2_i32));
+        assert_eq!(fold_rational_radicals(&pool, e), e);
     }
 }

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -1226,6 +1226,37 @@ fn py_matrix_exp_side_conditions() -> Vec<String> {
     MATRIX_EXP_SIDE_CONDITIONS.with(|c| c.borrow().clone())
 }
 
+thread_local! {
+    /// Hypotheses recorded by the most recent `Matrix.inverse` on this thread,
+    /// rendered against the pool that call used.
+    static MATRIX_INVERSE_SIDE_CONDITIONS: std::cell::RefCell<Vec<String>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// The hypotheses the most recent :meth:`alkahest.Matrix.inverse` on this
+/// thread **assumed** in order to return the matrix it did — one string per
+/// condition, e.g. ``"((a · d) + (b · c · -1)) ≠ 0"``.
+///
+/// Exactly one thing lands here: ``det(M) ≠ 0`` for a symbolic ``M``. The
+/// determinant of ``[[a,b],[c,d]]`` is not the zero function, so ``adj/det``
+/// is the inverse — *for the parameter values where ``ad − bc`` does not
+/// vanish*. Whether a given set of values is on that locus is a question about
+/// the parameters, not about the matrix, and only the caller can settle it.
+///
+/// An empty list means the determinant is a non-zero rational constant and the
+/// hypothesis was **discharged**, not skipped. Reset by each ``inverse`` call,
+/// so read it before the next one; repeated reads of the same call agree.
+///
+/// The condition is also present in the value — every entry carries a
+/// ``det⁻¹`` factor, so evaluating on the singular locus raises rather than
+/// returning a number — which is why this is an auditability channel rather
+/// than the thing standing between the caller and a wrong answer.
+#[pyfunction]
+#[pyo3(name = "matrix_inverse_side_conditions")]
+fn py_matrix_inverse_side_conditions() -> Vec<String> {
+    MATRIX_INVERSE_SIDE_CONDITIONS.with(|c| c.borrow().clone())
+}
+
 fn linear_algebra_error_to_py(e: LinearAlgebraError) -> PyErr {
     // `UnsupportedField` covers three: "entries are not rational constants"
     // (`E-LINALG-007`), "a pivot could be proven neither zero nor non-zero"
@@ -9108,12 +9139,25 @@ impl PyMatrix {
         })
     }
 
+    /// ``M⁻¹``.
+    ///
+    /// For a symbolic ``M`` the adjugate form ``adj(M)/det(M)`` is returned
+    /// whenever ``det(M)`` is proven not to be the zero *function*; the
+    /// genericity hypothesis that licenses it is listed by
+    /// :func:`alkahest.matrix_inverse_side_conditions`.
     fn inverse(&self, py: Python<'_>) -> PyResult<PyMatrix> {
         let pool = self.pool.borrow(py);
+        MATRIX_INVERSE_SIDE_CONDITIONS.with(|c| c.borrow_mut().clear());
         let inv = self
             .inner
             .inverse(&pool.inner)
             .map_err(matrix_error_to_py)?;
+        let rendered: Vec<String> =
+            alkahest_core::matrix::take_matrix_inverse_side_conditions()
+                .iter()
+                .map(|c| c.display_with(&pool.inner).to_string())
+                .collect();
+        MATRIX_INVERSE_SIDE_CONDITIONS.with(|c| *c.borrow_mut() = rendered);
         drop(pool);
         Ok(PyMatrix {
             inner: inv,
@@ -17154,6 +17198,7 @@ fn alkahest(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_jacobian, m)?)?;
     m.add_class::<PyMatrix>()?;
     m.add_function(wrap_pyfunction!(py_matrix_exp_side_conditions, m)?)?;
+    m.add_function(wrap_pyfunction!(py_matrix_inverse_side_conditions, m)?)?;
     // Phase 16
     m.add_class::<PyODE>()?;
     m.add_function(wrap_pyfunction!(py_lower_to_first_order, m)?)?;

--- a/alkahest-py/src/lib.rs
+++ b/alkahest-py/src/lib.rs
@@ -9152,11 +9152,10 @@ impl PyMatrix {
             .inner
             .inverse(&pool.inner)
             .map_err(matrix_error_to_py)?;
-        let rendered: Vec<String> =
-            alkahest_core::matrix::take_matrix_inverse_side_conditions()
-                .iter()
-                .map(|c| c.display_with(&pool.inner).to_string())
-                .collect();
+        let rendered: Vec<String> = alkahest_core::matrix::take_matrix_inverse_side_conditions()
+            .iter()
+            .map(|c| c.display_with(&pool.inner).to_string())
+            .collect();
         MATRIX_INVERSE_SIDE_CONDITIONS.with(|c| *c.borrow_mut() = rendered);
         drop(pool);
         Ok(PyMatrix {

--- a/python/alkahest/__init__.py
+++ b/python/alkahest/__init__.py
@@ -245,6 +245,8 @@ from .alkahest import (  # noqa: F401
     match_pattern,
     # The eigenvalue gaps `Matrix.matrix_exp` divided by without settling them
     matrix_exp_side_conditions,
+    # The `det ≠ 0` a symbolic `Matrix.inverse` assumed
+    matrix_inverse_side_conditions,
     max,  # symbolic max(a, b) — shadows Python builtin within this module
     min,  # symbolic min(a, b) — shadows Python builtin within this module
     pantelides,
@@ -2582,6 +2584,8 @@ __all__ = [
     "match_pattern",
     # The non-vanishing hypotheses `Matrix.matrix_exp` assumed for a symbolic e^A
     "matrix_exp_side_conditions",
+    # The `det ≠ 0` a symbolic `Matrix.inverse` assumed
+    "matrix_inverse_side_conditions",
     "number_theory",
     # Phase 25
     "numpy_eval",

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -6400,7 +6400,661 @@ CASES: list[Case] = [
             "channel) and is the reason this case exists rather than a Raises() one."
         ),
     ),
+
+    # -----------------------------------------------------------------------
+    # Linear algebra, scored against an outside oracle.
+    #
+    # Why this block exists: before it, `linear_algebra` had 32 cases and not
+    # one of them compared a *matrix function* against a source outside
+    # alkahest.  The cases checked refusals, dimensions, ranks and zero-row
+    # counts — real properties, all of them, and every one of them satisfied by
+    # the `matrix_exp` that was wrong for 60% of defective matrices, by the
+    # `lu` whose `L` was not permuted with its rows, by the `row_space` that
+    # returned the zero vector as a basis, and by the `rational_canonical_form`
+    # whose `C` had the wrong determinant.  Coverage that checks the wrong
+    # property is harder to spot than no coverage.
+    #
+    # So: every case below scores a **value**, and every `verified_by` names
+    # where that value came from — sympy, mpmath, or a hand derivation from the
+    # defining identity.  None was read off alkahest.  Each refusal is paired
+    # with its nearest answerable neighbour, so a library that refused the
+    # whole subsystem would fail this block rather than pass it.
+    # -----------------------------------------------------------------------
+    Case(
+        id="matrix_lu_signed_pivot_product_is_the_determinant",
+        subsystem="linear_algebra",
+        statement="sign(P)·Π u_ii = det A for A = [[2,-1,4],[-1,1,-1],[3,-4,0]], i.e. -1",
+        op=lambda: _lu_signed_pivot_product(LU_PIVOTING_3X3),
+        contract=Returns(-1.0),
+        verified_by="det A = 2(0-4) + 1(0+3) + 4(4-3) = -8 + 3 + 4 = -1 by cofactor expansion; "
+        "sympy.Matrix([[2,-1,4],[-1,1,-1],[3,-4,0]]).det() is -1. P·A = L·U with L unit "
+        "triangular forces det U = det(P·A) = sign(P)·det A, so the signed product of the "
+        "pivots is a number about A that the factorisation has to reproduce. It is read off "
+        "U and perm, never off det().",
+    ),
+    Case(
+        id="matrix_lu_reconstructs_the_permuted_matrix",
+        subsystem="linear_algebra",
+        statement="L·U = P·A entrywise for a 3×3 needing two pivot swaps",
+        op=lambda: _lu_reconstruction_residual(LU_PIVOTING_3X3),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="P·A = L·U is the definition of the factorisation, so the residual is "
+        "exactly 0 for any correct LU; sympy's own LUdecomposition of this matrix satisfies "
+        "it. A = [[2,-1,4],[-1,1,-1],[3,-4,0]] pivots to row 2 at k = 0 and again at k = 1 — "
+        "the multipliers already stored in L belong to the rows being swapped, and 3.10.0 "
+        "left them behind, so L·U came back as the rows of A in the order 2,1,0 while perm "
+        "said 2,0,1. Two swaps are needed to see it: the 2×2 case swaps only at k = 0, where "
+        "L has no computed column yet.",
+    ),
+    Case(
+        id="matrix_lu_control_needs_no_pivot_swap",
+        subsystem="linear_algebra",
+        statement="L·U = P·A for [[3,1],[1,2]], where partial pivoting never swaps",
+        op=lambda: _lu_reconstruction_residual([[3, 1], [1, 2]]),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="|3| > |1| in column 0 and the remaining 1×1 pivot is 5/3, so perm is the "
+        "identity and L·U = A with L = [[1,0],[1/3,1]], U = [[3,1],[0,5/3]] — one Gaussian "
+        "step by hand, and what sympy's LUdecomposition returns. The control for the case "
+        "above: a library that 'fixed' the permutation bug by never permuting would pass "
+        "this and fail that.",
+    ),
+    Case(
+        id="matrix_qr_first_diagonal_is_the_column_norm",
+        subsystem="linear_algebra",
+        statement="R[0][0] = ‖first column of [[1,2],[3,4]]‖ = √10",
+        op=lambda: _qr_entry(QR_2X2, 1, 0, 0),
+        contract=Returns(3.1622776601683795),
+        verified_by="Gram–Schmidt sets q₁ = a₁/‖a₁‖ and r₁₁ = ‖a₁‖; ‖(1,3)‖ = √10 = "
+        "3.1622776601683795. That is a number about the input, not about the algorithm, and "
+        "it is what sympy.Matrix([[1,2],[3,4]]).QRdecomposition()[1][0,0] returns.",
+    ),
+    Case(
+        id="matrix_qr_reconstructs_the_matrix",
+        subsystem="linear_algebra",
+        statement="Q·R = A entrywise for [[1,2],[3,4]]",
+        op=lambda: _qr_reconstruction_residual(QR_2X2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="Q·R = A is the definition; residual 0 exactly. Paired with the "
+        "orthonormality case below, because Q·R = A alone is satisfied by Q = A, R = I.",
+    ),
+    Case(
+        id="matrix_qr_columns_are_orthonormal",
+        subsystem="linear_algebra",
+        statement="QᵀQ = I for the Q of [[1,2],[3,4]]",
+        op=lambda: _qr_orthonormality_residual(QR_2X2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="Orthonormality is the other half of the QR contract and the half a "
+        "reconstruction check cannot see. qᵢ·qⱼ = δᵢⱼ by definition of Gram–Schmidt; sympy's "
+        "QRdecomposition satisfies it. Scored as the worst |qᵢ·qⱼ − δᵢⱼ| over all pairs.",
+    ),
+    Case(
+        id="matrix_cholesky_of_two_i_is_sqrt_two_i",
+        subsystem="linear_algebra",
+        statement="cholesky(2I)[0][0] = √2",
+        op=lambda: _cholesky_entry(TWO_I, 0, 0),
+        contract=Returns(1.4142135623730951),
+        verified_by="sympy.Matrix([[2,0],[0,2]]).cholesky() is [[sqrt(2),0],[0,sqrt(2)]]; "
+        "√2 = 1.4142135623730951. 2I is symmetric with both leading principal minors "
+        "positive (2 and 4), so it is positive definite and has a Cholesky factor. alkahest "
+        "3.10.0 refused it with E-LINALG-003, *'matrix is not symmetric positive definite'* — "
+        "a refusal that states a falsehood about the input, because the rational path "
+        "required every pivot to be a perfect rational square.",
+    ),
+    Case(
+        id="matrix_cholesky_irrational_pivot",
+        subsystem="linear_algebra",
+        statement="cholesky([[4,2],[2,3]])[1][1] = √2",
+        op=lambda: _cholesky_entry(SPD_IRRATIONAL_PIVOT, 1, 1),
+        contract=Returns(1.4142135623730951),
+        verified_by="sympy.Matrix([[4,2],[2,3]]).cholesky() is [[2,0],[1,sqrt(2)]]. By hand: "
+        "l₁₁ = √4 = 2, l₂₁ = 2/2 = 1, l₂₂ = √(3 − 1²) = √2 = 1.4142135623730951. The second "
+        "pivot is irrational while the first is not, so this separates 'refuses irrational "
+        "pivots' from 'refuses irrational matrices'.",
+    ),
+    Case(
+        id="matrix_cholesky_reconstructs_the_matrix",
+        subsystem="linear_algebra",
+        statement="L·Lᵀ = M entrywise for M = [[4,2],[2,3]]",
+        op=lambda: _cholesky_reconstruction_residual(SPD_IRRATIONAL_PIVOT),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="L·Lᵀ = M is the definition, so the residual is exactly 0. This is the "
+        "check that catches a factor of a *different* matrix: cholesky([[1,5],[0,1]]) used "
+        "to return the identity, whose L·Lᵀ is I and not the input.",
+    ),
+    Case(
+        id="matrix_cholesky_refuses_a_non_symmetric_matrix",
+        subsystem="linear_algebra",
+        statement="[[1,5],[0,1]] has no Cholesky factor",
+        op=lambda: _cholesky_entry(NON_SYMMETRIC_2X2, 0, 0),
+        contract=Raises("E-LINALG-003"),
+        verified_by="L·Lᵀ is symmetric for every L — (L·Lᵀ)ᵀ = L·Lᵀ — so a non-symmetric "
+        "matrix has no Cholesky factor at all. sympy.Matrix([[1,5],[0,1]]).cholesky() raises "
+        "ValueError('Matrix must be Hermitian'). alkahest read only the lower triangle and "
+        "returned the identity, silently factoring I instead.",
+    ),
+    Case(
+        id="matrix_cholesky_refuses_an_indefinite_matrix",
+        subsystem="linear_algebra",
+        statement="[[1,2],[2,1]] is symmetric but indefinite, so it has no Cholesky factor",
+        op=lambda: _cholesky_entry(INDEFINITE_SYMMETRIC, 0, 0),
+        contract=Raises("E-LINALG-003"),
+        verified_by="Its eigenvalues are 3 and −1 (sympy.Matrix([[1,2],[2,1]]).eigenvals() "
+        "gives {3: 1, -1: 1}), and the second leading principal minor is 1 − 4 = −3 < 0, so "
+        "Sylvester's criterion fails. The control for the √2 repair above: widening the "
+        "rational path to irrational pivots must not have widened it to indefinite pivots.",
+    ),
+    Case(
+        id="matrix_eigenvalues_are_roots_of_the_characteristic_polynomial",
+        subsystem="linear_algebra",
+        statement="every λ returned for the companion matrix of λ³+3λ²+2λ+1 satisfies "
+        "det(λI − M) = 0",
+        op=lambda: _eigenvalue_charpoly_residual(CARDANO_COMPANION),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="The defining property, evaluated with an independent complex "
+        "determinant (Gaussian elimination over Python complex, in this file). λ³+3λ²+2λ+1 "
+        "is irreducible over ℚ with negative discriminant, so Cardano's two radicands are "
+        "both negative — the casus where two independent Pow nodes pick up different cube "
+        "roots of unity and A·B ≠ −p/3. In 3.9 the three returned values gave |p(λ)| = "
+        "2.2944788, 1.5048698, 1.5048698.",
+    ),
+    Case(
+        id="matrix_eigenvalue_real_root_of_the_cardano_cubic",
+        subsystem="linear_algebra",
+        statement="the one real eigenvalue of the companion matrix of λ³+3λ²+2λ+1 is "
+        "−2.324717957244746",
+        op=lambda: _smallest_real_eigenvalue(CARDANO_COMPANION),
+        contract=Returns(-2.324717957244746, tol=1e-9),
+        verified_by="sympy.Poly(l**3+3*l**2+2*l+1, l).nroots(n=25) gives "
+        "−2.324717957244746025960909 and a conjugate pair; it is the negated supergolden "
+        "ratio's companion root and is the unique real root because the discriminant is "
+        "negative. A residual case alone would not catch an answer that is a root of the "
+        "wrong polynomial, so the value itself is pinned as well.",
+    ),
+    Case(
+        id="matrix_eigenvects_geometric_multiplicity_of_a_defective_block",
+        subsystem="linear_algebra",
+        statement="λ = 2 of [[2,1],[0,2]] has geometric multiplicity 1, not 2",
+        op=lambda: _geometric_multiplicity(DEFECTIVE_BLOCK_2X2, 2.0),
+        contract=Returns(1),
+        verified_by="A − 2I = [[0,1],[0,0]] has rank 1, so its kernel is 1-dimensional; "
+        "sympy.Matrix([[2,1],[0,2]]).eigenvects() returns a single vector (1,0) for λ = 2 "
+        "with algebraic multiplicity 2. Reporting 2 here would be reporting a basis that "
+        "does not exist, and it is what makes a P singular.",
+    ),
+    Case(
+        id="matrix_eigenvects_control_scalar_matrix_has_a_full_eigenspace",
+        subsystem="linear_algebra",
+        statement="λ = 2 of 2I has geometric multiplicity 2",
+        op=lambda: _geometric_multiplicity(TWO_I, 2.0),
+        contract=Returns(2),
+        verified_by="2I − 2I = 0, whose kernel is all of ℝ²; sympy.Matrix([[2,0],[0,2]])"
+        ".eigenvects() returns two independent vectors for λ = 2. Same spectrum as the "
+        "defective case above — one repeated eigenvalue — and the opposite answer, so a "
+        "library that reported 1 for every repeated eigenvalue would fail here.",
+    ),
+    Case(
+        id="matrix_diagonalize_reconstructs_an_irrational_spectrum",
+        subsystem="linear_algebra",
+        statement="M·P = P·D for the diagonalization of [[1,2],[3,4]]",
+        op=lambda: _diagonalize_residual(QR_2X2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="Eigenvalues (5 ± √33)/2 are distinct "
+        "(sympy.Matrix([[1,2],[3,4]]).eigenvals()), so the matrix is diagonalizable and "
+        "M = P·D·P⁻¹ holds exactly; the residual is 0. Before this audit alkahest refused it "
+        "with E-EIGEN-005, *'matrix is not diagonalizable'* — false about this matrix, and "
+        "contradicted by its own jordan_form, which returned a diagonal J for it. The cause "
+        "was a structural comparison of two normalised forms: the M·v side carries √33·√33 "
+        "where the λ·v side carries 33.",
+    ),
+    Case(
+        id="matrix_diagonalize_refuses_a_defective_matrix",
+        subsystem="linear_algebra",
+        statement="[[2,1],[0,2]] is not diagonalizable",
+        op=lambda: _diagonalize_residual(DEFECTIVE_BLOCK_2X2),
+        contract=Raises("E-EIGEN-005"),
+        verified_by="A single eigenvalue 2 of algebraic multiplicity 2 with a 1-dimensional "
+        "eigenspace; sympy.Matrix([[2,1],[0,2]]).is_diagonalizable() is False. The control "
+        "for the case above: widening the verification to a zero test must not have widened "
+        "it to matrices that have no diagonalization.",
+    ),
+    Case(
+        id="matrix_rational_canonical_form_preserves_the_determinant",
+        subsystem="linear_algebra",
+        statement="det C = det diag(1,2) = 2 for the rational canonical form of diag(1,2)",
+        op=lambda: _rcf_determinant(DIAG_1_2),
+        contract=Returns(2.0),
+        verified_by="Similar matrices have equal determinants (det(PCP⁻¹) = det C), and "
+        "det diag(1,2) = 2. The single invariant factor is λ²−3λ+2, whose companion matrix "
+        "is [[0,−2],[1,3]] with determinant 2 — the standard Frobenius form, as in Dummit & "
+        "Foote §12.2. alkahest wrote the coefficients along the last *row* instead of the "
+        "last *column*, producing [[0,0],[−2,3]] with determinant 0: not similar to M, and "
+        "not even of the same rank.",
+    ),
+    Case(
+        id="matrix_rational_canonical_form_reconstructs_the_matrix",
+        subsystem="linear_algebra",
+        statement="M·P = P·C for the rational canonical form of diag(1,2)",
+        op=lambda: _rcf_residual(DIAG_1_2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="M = P·C·P⁻¹ rearranges to M·P = P·C, which is the whole content of the "
+        "claim and needs no inverse to check. Residual 0 exactly. The two tests this "
+        "function had before asserted only that P has 2 rows, which a matrix of the wrong "
+        "rank passes.",
+    ),
+    Case(
+        id="matrix_minimal_polynomial_of_the_zero_matrix_is_lambda",
+        subsystem="linear_algebra",
+        statement="the minimal polynomial of the 2×2 zero matrix, evaluated at λ = 3, is 3",
+        op=lambda: _minimal_polynomial_at(ZERO_2X2, 3.0),
+        contract=Returns(3.0),
+        verified_by="p(M) = 0 with p = λ, since M itself is the zero matrix, and no constant "
+        "polynomial annihilates it (p = 1 gives I). So the minimal polynomial is λ and p(3) "
+        "= 3; λ² would give 9. Scored at a point rather than structurally so the case is "
+        "immune to the form it comes back in. alkahest returned λ², whose defining property "
+        "the zero matrix does not need — a correct annihilator, but not the minimal one, "
+        "which is the entire content of the function's name.",
+    ),
+    Case(
+        id="matrix_minimal_polynomial_of_two_equal_nilpotent_blocks",
+        subsystem="linear_algebra",
+        statement="the minimal polynomial of J₂(0) ⊕ J₂(0), evaluated at λ = 3, is 9",
+        op=lambda: _minimal_polynomial_at(TWO_NILPOTENT_BLOCKS, 3.0),
+        contract=Returns(9.0),
+        verified_by="M² = 0 and M ≠ 0, so the minimal polynomial is λ² and p(3) = 9; the "
+        "characteristic polynomial is λ⁴ and the largest Jordan block is 2×2, which is the "
+        "standard characterisation. alkahest returned λ³ (p(3) = 27) — one degree too high, "
+        "because a vanishing *constant* term failed to advance the matrix power, so p(M) was "
+        "evaluated as (p/λ)(M). A zero constant term is exactly 0 ∈ spec(M), so every "
+        "singular matrix was exposed.",
+    ),
+    Case(
+        id="matrix_minimal_polynomial_control_distinct_eigenvalues",
+        subsystem="linear_algebra",
+        statement="the minimal polynomial of [[1,2],[3,4]], evaluated at λ = 3, is −8",
+        op=lambda: _minimal_polynomial_at(QR_2X2, 3.0),
+        contract=Returns(-8.0),
+        verified_by="Distinct eigenvalues, so the minimal polynomial equals the "
+        "characteristic one, λ²−5λ−2 (sympy.Matrix([[1,2],[3,4]]).charpoly()); at λ = 3 that "
+        "is 9 − 15 − 2 = −8. The control for the two above: a library that returned λ for "
+        "everything would pass the zero-matrix case and fail this.",
+    ),
+    Case(
+        id="matrix_characteristic_polynomial_value_at_two",
+        subsystem="linear_algebra",
+        statement="det(2I − [[1,2],[3,4]]) = −8",
+        op=lambda: _characteristic_polynomial_at(QR_2X2, 2.0),
+        contract=Returns(-8.0),
+        verified_by="2I − A = [[1,−2],[−3,−2]], determinant 1·(−2) − (−2)(−3) = −2 − 6 = −8; "
+        "sympy.Matrix([[1,2],[3,4]]).charpoly().eval(2) is −8. Scored at a point, so no "
+        "assumption is made about which of λI−M or M−λI is returned up to sign — for n = 2 "
+        "they agree, which is why n = 2 is used.",
+    ),
+    Case(
+        id="matrix_row_space_basis_is_independent_after_a_row_swap",
+        subsystem="linear_algebra",
+        statement="the row space basis of [[0,0],[1,0]] has rank 1",
+        op=lambda: _row_space_basis_rank(ZERO_LEADING_ROW),
+        contract=Returns(1),
+        verified_by="The row space is span{(1,0)}, 1-dimensional, so any basis of it has "
+        "rank 1 — a basis containing the zero vector has rank 0. Elimination swaps the two "
+        "rows and marks echelon row 0 as the pivot row; alkahest then returned m.row(0) = "
+        "(0,0), the zero vector offered as a basis of a one-dimensional space. Scored as the "
+        "rank of the returned vectors stacked, which is 0 for the old answer and 1 for a "
+        "basis.",
+    ),
+    Case(
+        id="matrix_column_space_basis_is_independent",
+        subsystem="linear_algebra",
+        statement="the column space basis of [[1,2,3],[4,5,6],[7,8,9]] has rank 2",
+        op=lambda: _column_space_basis_rank(SINGULAR_3X3),
+        contract=Returns(2),
+        verified_by="sympy.Matrix([[1,2,3],[4,5,6],[7,8,9]]).rank() is 2 (col3 − col2 = "
+        "col2 − col1 = (1,1,1)), so a basis of the column space has exactly 2 independent "
+        "vectors. The counterpart to the row-space case: column indices are untouched by row "
+        "operations, so this path was never wrong — which is what makes it the control.",
+    ),
+    Case(
+        id="matrix_power_five_is_the_fibonacci_matrix",
+        subsystem="linear_algebra",
+        statement="[[1,1],[1,0]]^5 = [[8,5],[5,3]], so entry (0,0) is 8",
+        op=lambda: _entry_value(FIBONACCI_2X2, 5, 0, 0),
+        contract=Returns(8.0),
+        verified_by="The Fibonacci matrix identity Qⁿ = [[F_{n+1}, F_n], [F_n, F_{n−1}]] "
+        "(Knuth, TAOCP vol. 1 §1.2.8); F₆ = 8, F₅ = 5, F₄ = 3. "
+        "sympy.Matrix([[1,1],[1,0]])**5 is [[8,5],[5,3]].",
+    ),
+    Case(
+        id="matrix_power_zero_is_the_identity",
+        subsystem="linear_algebra",
+        statement="[[1,1],[1,0]]^0 = I, so entry (0,1) is 0",
+        op=lambda: _entry_value(FIBONACCI_2X2, 0, 0, 1),
+        contract=Returns(0.0),
+        verified_by="M⁰ = I by definition of the empty product, for every square M including "
+        "a singular one. The control for the case above, and the edge the exponent loop is "
+        "most likely to get wrong.",
+    ),
+    Case(
+        id="matrix_trace_is_the_sum_of_the_diagonal",
+        subsystem="linear_algebra",
+        statement="tr[[1,2],[3,4]] = 5",
+        op=lambda: _num(_matrix(QR_2X2).trace()),
+        contract=Returns(5.0),
+        verified_by="1 + 4 = 5; sympy.Matrix([[1,2],[3,4]]).trace() is 5. Also the sum of "
+        "the eigenvalues (5 − √33)/2 + (5 + √33)/2 = 5, which is the identity that ties this "
+        "to the spectral cases.",
+    ),
+    Case(
+        id="matrix_hadamard_is_entrywise",
+        subsystem="linear_algebra",
+        statement="([[1,2],[3,4]] ∘ [[5,6],[7,8]])[1][1] = 32",
+        op=lambda: _hadamard_entry(QR_2X2, [[5, 6], [7, 8]], 1, 1),
+        contract=Returns(32.0),
+        verified_by="4 · 8 = 32 by the definition of the Hadamard product; "
+        "sympy.matrix_multiply_elementwise([[1,2],[3,4]], [[5,6],[7,8]]) gives "
+        "[[5,12],[21,32]]. The ordinary matrix product of the same operands is "
+        "[[19,22],[43,50]], so a confusion of the two shows up here as 50 against 32.",
+    ),
+    Case(
+        id="matrix_transpose_swaps_the_indices",
+        subsystem="linear_algebra",
+        statement="[[1,2],[3,4]]ᵀ[0][1] = 3",
+        op=lambda: _num(_matrix(QR_2X2).transpose().to_list()[0][1]),
+        contract=Returns(3.0),
+        verified_by="(Aᵀ)ᵢⱼ = Aⱼᵢ, so the (0,1) entry is A₁₀ = 3. Scored off an off-diagonal "
+        "entry, the only place a transpose can be wrong.",
+    ),
+    Case(
+        id="matrix_inverse_of_a_dense_symbolic_matrix_round_trips",
+        subsystem="linear_algebra",
+        statement="A⁻¹·A = I for a 4×4 matrix of 16 distinct free symbols",
+        op=lambda: _symbolic_inverse_residual(4),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="adj(A)/det(A) is the inverse wherever det A ≠ 0 (Cramer), and det of a "
+        "matrix of n² distinct symbols is a sum of n! distinct monomials over ℤ — not the "
+        "zero polynomial for any n. Verified by substituting 16 unstructured rationals and "
+        "checking the product against I exactly, rather than by symbolic cancellation, which "
+        "no normaliser here finishes. The sample values are deliberately *not* an affine "
+        "function of (i, j): that makes the probe matrix's rows an arithmetic progression, "
+        "so det vanishes at the sample and A⁻¹·A is 0/0 rather than I — a degenerate test "
+        "point, not a defect. Before this audit a 5×5 or larger refused with E-MAT-004.",
+    ),
+    Case(
+        id="matrix_inverse_reports_the_determinant_it_divided_by",
+        subsystem="linear_algebra",
+        statement="inverse([[a,b],[c,d]]) reports exactly one hypothesis, ad − bc ≠ 0",
+        op=lambda: _inverse_condition_count(_symbolic_2x2),
+        contract=Returns(1),
+        verified_by="[[a,b],[c,d]] is invertible iff ad − bc ≠ 0 (Cramer); on the locus "
+        "ad = bc it has no inverse at all, and no value of adj/det is correct there. That "
+        "the determinant is not the zero *function* is what licenses the formula; that it is "
+        "non-zero at a given point is a question about the parameters and belongs to the "
+        "caller. Scored as a count so the case does not depend on how the condition prints.",
+    ),
+    Case(
+        id="matrix_inverse_control_constant_determinant_reports_nothing",
+        subsystem="linear_algebra",
+        statement="inverse([[1,2],[3,4]]) reports no hypothesis",
+        op=lambda: _inverse_condition_count(lambda: _matrix(QR_2X2)),
+        contract=Returns(0),
+        verified_by="det = 1·4 − 2·3 = −2, a non-zero constant, so the hypothesis is "
+        "*discharged* rather than skipped and there is nothing to report. The control for "
+        "the case above: a channel that reported a condition unconditionally would be noise "
+        "a caller learns to ignore — the failure the transform work named when it stopped "
+        "reporting π ≠ 0.",
+    ),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Linear-algebra oracle helpers.
+#
+# Each returns a plain answer and is called through a `lambda` in the case, so
+# the work happens when the gate runs rather than when this module is imported.
+# ---------------------------------------------------------------------------
+
+#: Two pivot swaps, the second at k = 1 — the smallest shape on which a `L`
+#: that is not permuted with its rows is visible.  det = −1.
+LU_PIVOTING_3X3 = [[2, -1, 4], [-1, 1, -1], [3, -4, 0]]
+#: Distinct irrational eigenvalues (5 ± √33)/2; det −2, trace 5.
+QR_2X2 = [[1, 2], [3, 4]]
+TWO_I = [[2, 0], [0, 2]]
+#: Symmetric positive definite with a non-square second pivot: L = [[2,0],[1,√2]].
+SPD_IRRATIONAL_PIVOT = [[4, 2], [2, 3]]
+NON_SYMMETRIC_2X2 = [[1, 5], [0, 1]]
+#: Symmetric, eigenvalues 3 and −1 — no Cholesky factor.
+INDEFINITE_SYMMETRIC = [[1, 2], [2, 1]]
+#: Companion matrix of λ³ + 3λ² + 2λ + 1: irreducible over ℚ, negative
+#: discriminant, so Cardano's two radicands are both negative.
+CARDANO_COMPANION = [[0, 0, -1], [1, 0, -2], [0, 1, -3]]
+DEFECTIVE_BLOCK_2X2 = [[2, 1], [0, 2]]
+DIAG_1_2 = [[1, 0], [0, 2]]
+TWO_NILPOTENT_BLOCKS = [[0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 0]]
+#: Row 0 is zero, so elimination must swap before it can pivot.
+ZERO_LEADING_ROW = [[0, 0], [1, 0]]
+FIBONACCI_2X2 = [[1, 1], [1, 0]]
+#: Unstructured sample values for the dense symbolic inverse.  See the case's
+#: `verified_by` for why an arithmetic progression will not do.
+_INVERSE_SAMPLE = (1.7, -2.3, 0.9, 3.1, -0.6, 2.2, 4.7, -1.1, 0.4, 5.3, -3.7, 1.3, 2.9, -0.8, 6.1, 0.3)
+
+
+def _permutation_sign(perm: list[int]) -> int:
+    """±1 by counting transpositions, on a copy."""
+    p = list(perm)
+    sign = 1
+    for i in range(len(p)):
+        while p[i] != i:
+            j = p[i]
+            p[i], p[j] = p[j], p[i]
+            sign = -sign
+    return sign
+
+
+def _lu_signed_pivot_product(rows: list[list[int]]) -> float:
+    _l, u, perm = _matrix(rows).lu()
+    entries = u.to_list()
+    product = 1.0
+    for i in range(u.rows):
+        product *= _num(entries[i][i])
+    return _permutation_sign(list(perm)) * product
+
+
+def _lu_reconstruction_residual(rows: list[list[int]]) -> float:
+    lower, upper, perm = _matrix(rows).lu()
+    product = lower.multiply(upper).to_list()
+    worst = 0.0
+    for i, source in enumerate(perm):
+        for j in range(len(rows[0])):
+            worst = max(worst, abs(_num(product[i][j]) - float(rows[source][j])))
+    return worst
+
+
+def _qr_entry(rows: list[list[int]], which: int, i: int, j: int) -> float:
+    """`which` is 0 for Q and 1 for R."""
+    return _num(_matrix(rows).qr()[which].to_list()[i][j])
+
+
+def _qr_reconstruction_residual(rows: list[list[int]]) -> float:
+    q, r = _matrix(rows).qr()
+    product = q.multiply(r).to_list()
+    return max(
+        abs(_num(product[i][j]) - float(rows[i][j]))
+        for i in range(len(rows))
+        for j in range(len(rows[0]))
+    )
+
+
+def _qr_orthonormality_residual(rows: list[list[int]]) -> float:
+    q, _r = _matrix(rows).qr()
+    entries = q.to_list()
+    worst = 0.0
+    for a in range(q.cols):
+        for b in range(q.cols):
+            dot = sum(_num(entries[i][a]) * _num(entries[i][b]) for i in range(q.rows))
+            worst = max(worst, abs(dot - (1.0 if a == b else 0.0)))
+    return worst
+
+
+def _cholesky_entry(rows: list[list[int]], i: int, j: int) -> float:
+    return _num(_matrix(rows).cholesky().to_list()[i][j])
+
+
+def _cholesky_reconstruction_residual(rows: list[list[int]]) -> float:
+    lower = _matrix(rows).cholesky()
+    product = lower.multiply(lower.transpose()).to_list()
+    return max(
+        abs(_num(product[i][j]) - float(rows[i][j]))
+        for i in range(len(rows))
+        for j in range(len(rows[0]))
+    )
+
+
+def _complex_det(a: list[list[complex]]) -> complex:
+    """Determinant by partial-pivoted elimination over Python complex.
+
+    Independent of alkahest and of sympy both, so an eigenvalue check using it
+    is not comparing the library against itself.
+    """
+    a = [row[:] for row in a]
+    n = len(a)
+    det = 1 + 0j
+    for c in range(n):
+        p = max(range(c, n), key=lambda r: abs(a[r][c]))
+        if abs(a[p][c]) == 0.0:
+            return 0j
+        if p != c:
+            a[p], a[c] = a[c], a[p]
+            det = -det
+        det *= a[c][c]
+        for r in range(c + 1, n):
+            f = a[r][c] / a[c][c]
+            for k in range(c, n):
+                a[r][k] -= f * a[c][k]
+    return det
+
+
+def _complex_eigenvalues(rows: list[list[int]]) -> list[complex]:
+    out = []
+    for lam in _matrix(rows).eigenvals():
+        result = ak.evaluate(lam, {}, mode="complex")
+        if result.value is None:
+            raise ValueError(f"{result.status}: {result.reason}")
+        out.append(complex(result.value))
+    return out
+
+
+def _eigenvalue_charpoly_residual(rows: list[list[int]]) -> float:
+    n = len(rows)
+    worst = 0.0
+    for z in _complex_eigenvalues(rows):
+        shifted = [
+            [complex(rows[i][j]) - (z if i == j else 0j) for j in range(n)] for i in range(n)
+        ]
+        worst = max(worst, abs(_complex_det(shifted)))
+    return worst
+
+
+def _smallest_real_eigenvalue(rows: list[list[int]]) -> float:
+    real = [z.real for z in _complex_eigenvalues(rows) if abs(z.imag) < 1e-9]
+    if not real:
+        raise ValueError("no real eigenvalue was returned")
+    return min(real)
+
+
+def _geometric_multiplicity(rows: list[list[int]], lam_value: float) -> int:
+    for lam, _alg, vecs in _matrix(rows).eigenvects():
+        if abs(_num(lam) - lam_value) < 1e-12:
+            return len(vecs)
+    raise ValueError(f"{lam_value} is not among the reported eigenvalues")
+
+
+def _similarity_residual(rows: list[list[int]], pair: tuple) -> float:
+    p, f = pair
+    lhs = _matrix(rows).multiply(p).to_list()
+    rhs = p.multiply(f).to_list()
+    n = len(rows)
+    return max(abs(_num(lhs[i][j]) - _num(rhs[i][j])) for i in range(n) for j in range(n))
+
+
+def _diagonalize_residual(rows: list[list[int]]) -> float:
+    return _similarity_residual(rows, _matrix(rows).diagonalize())
+
+
+def _rcf_residual(rows: list[list[int]]) -> float:
+    return _similarity_residual(rows, _matrix(rows).rational_canonical_form())
+
+
+def _rcf_determinant(rows: list[list[int]]) -> float:
+    _p, c = _matrix(rows).rational_canonical_form()
+    return _num(c.det())
+
+
+def _minimal_polynomial_at(rows: list[list[int]], point: float) -> float:
+    """The minimal polynomial evaluated at `point`.
+
+    The indeterminate is a freshly interned `__eigen_lambda_k`, which the
+    binding does not hand back, so it is recovered by name from the rendered
+    expression and re-interned with the `Complex` domain it was created with.
+    """
+    poly = _matrix(rows).minimal_polynomial()
+    names = set(re.findall(r"__eigen_lambda_\d+", str(poly)))
+    if len(names) != 1:
+        raise ValueError(f"expected one indeterminate, found {sorted(names)}")
+    lam = POOL.symbol(names.pop(), "complex")
+    return float(ak.eval_expr(poly, {lam: float(point)}))
+
+
+def _characteristic_polynomial_at(rows: list[list[int]], point: float) -> float:
+    expr, lam = _matrix(rows).characteristic_polynomial_lambda_minus_m()
+    return float(ak.eval_expr(expr, {lam: float(point)}))
+
+
+def _row_space_basis_rank(rows: list[list[int]]) -> int:
+    basis = _matrix(rows).row_space()
+    if not basis:
+        return 0
+    return ak.Matrix([b.to_list()[0] for b in basis]).rank()
+
+
+def _column_space_basis_rank(rows: list[list[int]]) -> int:
+    basis = _matrix(rows).column_space()
+    if not basis:
+        return 0
+    return ak.Matrix([[b.to_list()[i][0] for b in basis] for i in range(len(rows))]).rank()
+
+
+def _entry_value(rows: list[list[int]], power: int, i: int, j: int) -> float:
+    return _num((_matrix(rows) ** power).to_list()[i][j])
+
+
+def _hadamard_entry(a: list[list[int]], b: list[list[int]], i: int, j: int) -> float:
+    return _num(_matrix(a).hadamard(_matrix(b)).to_list()[i][j])
+
+
+def _symbolic_inverse_residual(n: int) -> float:
+    syms = [[POOL.symbol(f"__la_audit_{n}_{i}_{j}") for j in range(n)] for i in range(n)]
+    m = ak.Matrix(syms)
+    product = m.inverse().multiply(m).to_list()
+    env = {
+        syms[i][j]: _INVERSE_SAMPLE[(i * n + j) % len(_INVERSE_SAMPLE)]
+        for i in range(n)
+        for j in range(n)
+    }
+    return max(
+        abs(float(ak.eval_expr(product[i][j], env)) - (1.0 if i == j else 0.0))
+        for i in range(n)
+        for j in range(n)
+    )
+
+
+def _symbolic_2x2() -> ak.Matrix:
+    names = ["__la_cond_a", "__la_cond_b", "__la_cond_c", "__la_cond_d"]
+    a, b, c, d = (POOL.symbol(n) for n in names)
+    return ak.Matrix([[a, b], [c, d]])
+
+
+def _inverse_condition_count(build: Callable[[], ak.Matrix]) -> int:
+    build().inverse()
+    return len(ak.matrix_inverse_side_conditions())
 
 
 #: Fast lookup by id.

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -6400,7 +6400,6 @@ CASES: list[Case] = [
             "channel) and is the reason this case exists rather than a Raises() one."
         ),
     ),
-
     # -----------------------------------------------------------------------
     # Linear algebra, scored against an outside oracle.
     #
@@ -6834,7 +6833,24 @@ ZERO_LEADING_ROW = [[0, 0], [1, 0]]
 FIBONACCI_2X2 = [[1, 1], [1, 0]]
 #: Unstructured sample values for the dense symbolic inverse.  See the case's
 #: `verified_by` for why an arithmetic progression will not do.
-_INVERSE_SAMPLE = (1.7, -2.3, 0.9, 3.1, -0.6, 2.2, 4.7, -1.1, 0.4, 5.3, -3.7, 1.3, 2.9, -0.8, 6.1, 0.3)
+_INVERSE_SAMPLE = (
+    1.7,
+    -2.3,
+    0.9,
+    3.1,
+    -0.6,
+    2.2,
+    4.7,
+    -1.1,
+    0.4,
+    5.3,
+    -3.7,
+    1.3,
+    2.9,
+    -0.8,
+    6.1,
+    0.3,
+)
 
 
 def _permutation_sign(perm: list[int]) -> int:

--- a/tests/silent_errors/corpus.py
+++ b/tests/silent_errors/corpus.py
@@ -6487,6 +6487,31 @@ CASES: list[Case] = [
         "QRdecomposition satisfies it. Scored as the worst |qᵢ·qⱼ − δᵢⱼ| over all pairs.",
     ),
     Case(
+        id="matrix_qr_of_a_rank_deficient_matrix_has_an_orthonormal_q",
+        subsystem="linear_algebra",
+        statement="QᵀQ = I for the Q of the rank-1 matrix [[-4,-4],[-2,-2]]",
+        op=lambda: _qr_orthonormality_residual(RANK_ONE_2X2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="Orthonormality is part of the definition of a QR factorisation and "
+        "does not lapse when A is rank deficient — sympy returns the rank-sized "
+        "Q (2×1 here) rather than a padded one, and LAPACK's full QR returns a 2×2 "
+        "orthogonal Q. alkahest padded with the **zero vector**: Q = [[-2/√5,0],[-1/√5,0]], "
+        "so Q·R = A held and QᵀQ was diag(1,0). A caller reading Q⁻¹ = Qᵀ, which is the "
+        "reason to want a QR at all, was reading a falsehood with nothing to signal it; "
+        "62 of 304 randomised matrices came back that way.",
+    ),
+    Case(
+        id="matrix_qr_of_a_rank_deficient_matrix_still_reconstructs",
+        subsystem="linear_algebra",
+        statement="Q·R = [[-4,-4],[-2,-2]] even though the second column is dependent",
+        op=lambda: _qr_reconstruction_residual(RANK_ONE_2X2),
+        contract=Returns(0.0, tol=1e-9),
+        verified_by="A = QR is the other half of the definition and must survive the "
+        "orthonormality repair: filling Q's second column changes nothing in Q·R, because "
+        "the R row that multiplies it is zero. The control that pins the repair as a "
+        "repair rather than a substitution.",
+    ),
+    Case(
         id="matrix_cholesky_of_two_i_is_sqrt_two_i",
         subsystem="linear_algebra",
         statement="cholesky(2I)[0][0] = √2",
@@ -6817,6 +6842,9 @@ LU_PIVOTING_3X3 = [[2, -1, 4], [-1, 1, -1], [3, -4, 0]]
 #: Distinct irrational eigenvalues (5 ± √33)/2; det −2, trace 5.
 QR_2X2 = [[1, 2], [3, 4]]
 TWO_I = [[2, 0], [0, 2]]
+#: Rank 1: column 1 is column 0, so Gram-Schmidt leaves nothing for Q's second
+#: column and it has to be completed rather than zero-filled.
+RANK_ONE_2X2 = [[-4, -4], [-2, -2]]
 #: Symmetric positive definite with a non-square second pivot: L = [[2,0],[1,√2]].
 SPD_IRRATIONAL_PIVOT = [[4, 2], [2, 3]]
 NON_SYMMETRIC_2X2 = [[1, 5], [0, 1]]

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -481,3 +481,204 @@ def test_a_computable_nullspace_is_still_computed():
     exp_a = alkahest.exp(a)
     m = alkahest.Matrix([[pool.integer(1), exp_a], [exp_a, exp_a * exp_a]])
     assert len(m.nullspace()) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3.10.1 linear-algebra audit
+# ---------------------------------------------------------------------------
+
+
+def _int_rows(pool, rows):
+    return alkahest.Matrix([[pool.integer(v) for v in row] for row in rows])
+
+
+def test_diagonalize_answers_an_irrational_spectrum():
+    """`[[1,2],[3,4]]` has distinct eigenvalues, so it is diagonalizable.
+
+    It was refused with `E-EIGEN-005`, *"matrix is not diagonalizable"* — a
+    statement that is false about this matrix, and one the library's own
+    `jordan_form` contradicted by returning a diagonal `J` for it. The check
+    compared two normalised forms structurally, and the `M·v` side carries
+    `√33·√33` where the `λ·v` side carries `33`.
+
+    Scored on the identity, not on the shape of `P`: `M·P = P·D`.
+    """
+    pool = alkahest.ExprPool()
+    m = _int_rows(pool, [[1, 2], [3, 4]])
+    p, d = m.diagonalize()
+    lhs = m.multiply(p).to_list()
+    rhs = p.multiply(d).to_list()
+    for i in range(2):
+        for j in range(2):
+            got = float(alkahest.eval_expr(lhs[i][j], {}))
+            want = float(alkahest.eval_expr(rhs[i][j], {}))
+            assert abs(got - want) < 1e-9
+    # `D` is diagonal and its trace is the trace of `M`, which is 5.
+    entries = d.to_list()
+    assert float(alkahest.eval_expr(entries[0][1], {})) == 0.0
+    assert float(alkahest.eval_expr(entries[1][0], {})) == 0.0
+    trace = sum(float(alkahest.eval_expr(entries[i][i], {})) for i in range(2))
+    assert abs(trace - 5.0) < 1e-9
+
+
+def test_diagonalize_still_refuses_a_defective_matrix():
+    """The control. `[[2,1],[0,2]]` has one eigenvalue of algebraic
+    multiplicity 2 and a one-dimensional eigenspace, so no diagonalization
+    exists; widening the verification must not have widened the answer set."""
+    pool = alkahest.ExprPool()
+    m = _int_rows(pool, [[2, 1], [0, 2]])
+    with pytest.raises(alkahest.AlkahestError) as exc_info:
+        m.diagonalize()
+    assert exc_info.value.code == "E-EIGEN-005"
+
+
+def test_cholesky_answers_an_irrational_pivot():
+    """`2I` is symmetric positive definite and its factor is `√2·I`.
+
+    The rational path required every pivot to be a perfect rational square and
+    reported `E-LINALG-003`, *"matrix is not symmetric positive definite"*,
+    about a matrix that is both.
+    """
+    pool = alkahest.ExprPool()
+    lower = _int_rows(pool, [[2, 0], [0, 2]]).cholesky()
+    entries = lower.to_list()
+    assert abs(float(alkahest.eval_expr(entries[0][0], {})) - 2**0.5) < 1e-12
+    assert float(alkahest.eval_expr(entries[0][1], {})) == 0.0
+
+
+def test_cholesky_refuses_a_non_symmetric_matrix():
+    """`L·Lᵀ` is symmetric for every `L`, so `[[1,5],[0,1]]` has no factor.
+
+    Only the lower triangle was read, so the upper one was discarded and the
+    identity came back — a factorisation of `I`, not of the input.
+    """
+    pool = alkahest.ExprPool()
+    with pytest.raises(alkahest.AlkahestError) as exc_info:
+        _int_rows(pool, [[1, 5], [0, 1]]).cholesky()
+    assert exc_info.value.code == "E-LINALG-003"
+
+
+def test_lu_permutes_the_multipliers_with_their_rows():
+    """`P·A = L·U`, on a 3×3 that pivots twice.
+
+    The multipliers already stored in `L` belong to the rows a pivot swap
+    moves. A 2×2 cannot show it: its only swap is at `k = 0`, where `L` has no
+    computed column yet to be left behind.
+    """
+    pool = alkahest.ExprPool()
+    rows = [[2, -1, 4], [-1, 1, -1], [3, -4, 0]]
+    lower, upper, perm = _int_rows(pool, rows).lu()
+    product = lower.multiply(upper).to_list()
+    for i, source in enumerate(perm):
+        for j in range(3):
+            assert abs(float(alkahest.eval_expr(product[i][j], {})) - rows[source][j]) < 1e-9
+
+
+def test_row_space_basis_comes_from_the_echelon_form():
+    """`[[0,0],[1,0]]` has row space `span{(1,0)}`.
+
+    Elimination swaps the rows and marks echelon row 0 as the pivot row;
+    reading `m.row(0)` handed back `(0,0)`, the zero vector offered as a basis
+    of a one-dimensional space.
+    """
+    pool = alkahest.ExprPool()
+    basis = _int_rows(pool, [[0, 0], [1, 0]]).row_space()
+    assert len(basis) == 1
+    row = basis[0].to_list()[0]
+    assert float(alkahest.eval_expr(row[0], {})) == 1.0
+    assert float(alkahest.eval_expr(row[1], {})) == 0.0
+
+
+def test_minimal_polynomial_of_the_zero_matrix_is_lambda():
+    """`p(M) = 0` for `p = λ`, and nothing of lower degree does.
+
+    A vanishing constant term used to leave the matrix power un-advanced, so
+    `p(M)` was evaluated as `(p/λ)(M)`: `λ` was rejected and `λ²` returned. A
+    zero constant term is exactly `0 ∈ spec(M)`, so every singular matrix was
+    exposed. Scored at a point — `λ` gives 3 and `λ²` gives 9.
+    """
+    import re
+
+    pool = alkahest.ExprPool()
+    poly = _int_rows(pool, [[0, 0], [0, 0]]).minimal_polynomial()
+    names = set(re.findall(r"__eigen_lambda_\d+", str(poly)))
+    assert len(names) == 1
+    lam = pool.symbol(names.pop(), "complex")
+    assert float(alkahest.eval_expr(poly, {lam: 3.0})) == 3.0
+
+
+def test_rational_canonical_form_reconstructs_the_matrix():
+    """`M·P = P·C` with `P` invertible, and `det C = det M`.
+
+    The companion block wrote its coefficients along the last *row* instead of
+    the last *column*, which for `d ≥ 2` also overwrote a subdiagonal 1. On
+    `diag(1,2)` that gave `C = [[0,0],[−2,3]]`, determinant 0 against
+    `det M = 2` — not similar to `M`, and not even of the same rank.
+    """
+    pool = alkahest.ExprPool()
+    m = _int_rows(pool, [[1, 0], [0, 2]])
+    p, c = m.rational_canonical_form()
+    lhs = m.multiply(p).to_list()
+    rhs = p.multiply(c).to_list()
+    for i in range(2):
+        for j in range(2):
+            got = float(alkahest.eval_expr(lhs[i][j], {}))
+            want = float(alkahest.eval_expr(rhs[i][j], {}))
+            assert abs(got - want) < 1e-9
+    assert p.rank() == 2
+    assert abs(float(alkahest.eval_expr(c.det(), {})) - 2.0) < 1e-9
+
+
+def test_a_dense_symbolic_matrix_is_inverted_and_says_what_it_assumed():
+    """A 4×4 of 16 distinct symbols inverts, and reports `det ≠ 0`.
+
+    `det` of a matrix of `n²` distinct symbols is a sum of `n!` distinct
+    monomials and is not the zero function, so `adj/det` is the inverse. Sizes
+    from 5×5 up refused with `E-MAT-004` only because the non-vanishing probe
+    would not bind more than 16 symbols and sampled them along an arithmetic
+    progression, which makes the probe matrix rank 2.
+
+    Verified by substitution into ℚ rather than by symbolic cancellation. The
+    sample values are deliberately unstructured: an affine function of `(i, j)`
+    makes the rows an arithmetic progression, so `det` vanishes there and
+    `A⁻¹·A` is `0/0` rather than `I`.
+    """
+    pool = alkahest.ExprPool()
+    n = 4
+    syms = [[pool.symbol(f"__pt_{i}_{j}") for j in range(n)] for i in range(n)]
+    m = alkahest.Matrix(syms)
+    product = m.inverse().multiply(m).to_list()
+    conditions = alkahest.matrix_inverse_side_conditions()
+    assert len(conditions) == 1, conditions
+    assert "≠ 0" in conditions[0]
+
+    sample = [1.7, -2.3, 0.9, 3.1, -0.6, 2.2, 4.7, -1.1, 0.4, 5.3, -3.7, 1.3, 2.9, -0.8, 6.1, 0.3]
+    env = {syms[i][j]: sample[(i * n + j) % len(sample)] for i in range(n) for j in range(n)}
+    for i in range(n):
+        for j in range(n):
+            got = float(alkahest.eval_expr(product[i][j], env))
+            assert abs(got - (1.0 if i == j else 0.0)) < 1e-9
+
+
+def test_a_constant_determinant_is_discharged_not_reported():
+    """The control for the channel above.
+
+    `det [[1,2],[3,4]] = −2`, a non-zero constant: the hypothesis is settled,
+    not assumed, and reporting one anyway is the noise that makes a caller stop
+    reading the channel.
+    """
+    pool = alkahest.ExprPool()
+    _int_rows(pool, [[1, 2], [3, 4]]).inverse()
+    assert alkahest.matrix_inverse_side_conditions() == []
+
+
+def test_the_inverse_channel_is_cleared_by_a_refusal():
+    """A refused inverse must not leave a hypothesis for the next call."""
+    pool = alkahest.ExprPool()
+    a = pool.symbol("__pt_q")
+    b = pool.symbol("__pt_r")
+    two = pool.integer(2)
+    dependent = alkahest.Matrix([[a, b], [two * a, two * b]])
+    with pytest.raises(alkahest.MatrixError):
+        dependent.inverse()
+    assert alkahest.matrix_inverse_side_conditions() == []


### PR DESCRIPTION
An oracle sweep of `matrix/`, the subsystem that has now produced silent wrong
answers four separate times. The reason it warranted a dedicated audit is
uncomfortable: `tests/silent_errors/corpus.py` had 19 `linear_algebra` cases and
**not one compared a matrix function against an outside oracle**. That is how a
60%-wrong `matrix_exp` shipped in 3.10.0.

It found **eight more**, several at rates that are hard to read as anything but
a subsystem nobody had ever checked against sympy.

## Wrong answers, with the rate on `main`

Each reproduced against a separate build of `origin/main` in its own venv, over
351 randomised matrices.

| operation | defect | wrong on `main` |
|---|---|---|
| `rational_canonical_form` | companion coefficients written down the last **row** instead of the last column — `rcf(diag(1,2))` gives `det C = 0` against `det M = 2`, and `M·P ≠ P·C` | **228 / 351** |
| `lu` | `L`'s multipliers were not moved when a pivot swap moved their rows — row 1 of `L·U` is not a row of `A` at all | **105 / 351** |
| `qr` | Gram–Schmidt filled a dependent column with the **zero vector**, so `Q·R = A` held (which is why every existing check passed) while `QᵀQ = diag(1,0)` and `Q` was singular | **62 / 304** |
| `row_space` | returned rows of `m` at echelon pivot indices — `row_space([[0,0],[1,0]])` returned the **zero vector** as a basis of a 1-D space | **58 / 351** |
| `minimal_polynomial` | did not advance `Mᵏ` past a zero constant term — `minpoly(0₂ₓ₂) = λ²`; it also *refused* `J₂(0)` and `diag(0,1)` outright | **7 / 351** |
| `cholesky` | never checked symmetry — `cholesky([[1,5],[0,1]])` returned the **identity**, a factor of `I` rather than of the input (sympy raises) | — |
| `cholesky` | refused `2I` claiming "not symmetric positive definite" — a refusal stating a falsehood | — |
| `diagonalize` | refused **every matrix with an irrational spectrum**: `diagonalize([[1,2],[3,4]])` raised "matrix is not diagonalizable", false for eigenvalues `(5 ± √33)/2`. `eigenvects` returned a complete eigenbasis for the same matrix and `jordan_form` returned a **diagonal** `J` — the library contradicted itself | 53 → 89 answered |

The `qr` case is the sharpest illustration of why oracle comparison matters:
`Q·R = A` was true, so every test that checked the factorisation identity passed
while `Q` was not orthogonal. Underneath it, `norm_column` built `√(Σvᵢ²)`
without de-radicalising, so by the second column the radicand read
`1 − 32/√20² + 320/√20⁴` instead of `1/5`; folding `(√c)ᵏ → c^{k/2}` took
refusals 52 → 33 and answers 190 → 247.

`diagonalize`'s cause: `columns_match_eigen_relation` compared two normalised
forms **structurally**, and the `M·v` side carries `√33·√33` where the `λ·v`
side carries `33`. It now falls back to the zero-test ladder — strictly wider,
no weaker, since only a *proven* zero counts.

## The sweep

351 randomised matrices × 21 operations, plus a symbolic sweep. Families: dense
integer square (60), rectangular (40), **rational** entries (40), rank-deficient
(40), **defective** built as integer similarities of integer Jordan forms (40),
repeated eigenvalues (25), SPD (25), symmetric (25), zero (4), **two equal-size
Jordan blocks for one eigenvalue** (2), zero-leading row (30), zero-leading
column (20). Oracles: exact sympy, `mpmath.expm` at 40 dps, an independent
complex determinant, and the determinantal-divisor characterisation of invariant
factors.

**Zero wrong on this branch** across `det`, `rank`, `rref`, `inverse`,
`nullspace`, `column_space`, `row_space`, `lu`, `cholesky`, `transpose`,
`trace`, `hadamard`, `__pow__`, `eigenvals`, `eigenvects`, `diagonalize`,
`jordan_form`, `rational_canonical_form`, `minimal_polynomial`,
`characteristic_polynomial_lambda_minus_m`, `matrix_exp`.

**`eigenvals`, `eigenvects`, `jordan_form` and `matrix_exp` were already clean
on `main`** — a real result, not an absence of testing, and evidence the
3.10.0/#370 fixes held.

## The 6×6 symbolic inverse, and its hypothesis

Now supported: `A⁻¹·A = I` verified for `n = 1…6` by substituting rationals at
three unstructured points, and `(sI − A)⁻¹·(sI − A) = I` exactly for `n = 2…6`.
A symbolically singular matrix still refuses `E-MAT-003`. The cause of the old
refusal was in the salvaged diff: `zero_test`'s probe samples formed an
arithmetic progression, making the probe matrix rank-2 and its determinant zero.

`take_matrix_inverse_side_conditions()` / `alkahest.matrix_inverse_side_conditions()`
now publishes the hypothesis — `[[a,b],[c,d]]` reports `ad − bc ≠ 0`;
`[[1,2],[3,4]]` reports nothing, because a non-zero constant determinant is a
*discharged* hypothesis rather than a skipped one.

This is **auditability, not soundness**: the condition cannot be silently lost,
because over the local ring at an irreducible factor `p` of `det`, the Smith
form gives `det` order `Σeᵢ` and the adjugate order `Σeᵢ − eₙ`, so the reduced
denominator still vanishes on every component of `{det = 0}` and evaluating
there raises rather than returning a number. What it could be is *unstated* —
and a controls user inverting a symbolic plant needs that assumption
machine-readable.

**Flagged, not fixed:** `rank`, `rref`, `nullspace` and `column_space` make the
same generic choice with **no trace in the output** — `rank([[x,0],[0,1]])` is a
bare `2` with nothing recording `x ≠ 0`. That is documented, corpus-blessed
semantics, but raising the probe cap 16 → 144 widened the population it applies
to. Plumbing pivot hypotheses out of elimination is larger than this audit.

Also left deliberately: `qr` on a matrix with **more columns than rows**. `k`
orthonormal vectors do not exist in `ℝⁿ` for `k > n`, so the `n×k` `Q` this
function returns cannot carry an answer; the fix is to return the full `n×n` `Q`
and `n×k` `R`, changing a public return shape for every caller. Documented on
`qr_decomposition` instead.

## Corpus

`linear_algebra` **32 → 67 cases**; the gate is **409 cases, 0 silent errors**.
Every one of the 35 new cases scores a *value* — `√10`, `−8`, `det C = 2`,
`A⁻¹A − I = 0`, `sign(P)·Πuᵢᵢ = −1` — against sympy, mpmath or a hand
derivation, and every `verified_by` cites a source that is not Alkahest.
Operations that previously had **no** value-scored case and now do: `lu`, `qr`,
`cholesky`, `eigenvals`, `eigenvects`, `diagonalize`,
`rational_canonical_form`, `minimal_polynomial`,
`characteristic_polynomial_lambda_minus_m`, `row_space`, `column_space`,
`__pow__`, `trace`, `hadamard`, `transpose`, and the symbolic `inverse`. Plus 11
new Python tests (50 total).

## Two near-misses worth recording

Two remaining 4×4 sweep flags are **not defects**: recomputed at 60 digits,
`|QᵀQ − I|` is `1.6e-61` and `7.8e-62`; their f64 residuals were cancellation in
the *checker's* evaluation of four-deep nested radicals. And a 24 GB memory
blow-up nearly reported as a defect turned out to be the harness interning every
expression into one long-lived pool — which is what an interner is for.

## Testing

`cargo test -p alkahest-cas --features groebner --lib` → **3104 passed, 0
failed, 11 ignored** (main: 3072). `pytest tests/` → 4205 passed, 0 failed.
Silent-error gate → 419 passed, 409 cases, 0 silent errors. clippy `-D warnings`,
`fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`, ruff `check` and
`format --check`, `check_error_codes.py` all clean; `check_api_freeze.py`
additive (`+ matrix_inverse_side_conditions`). No new error codes or enum
variants, so `cargo semver-checks` has nothing to object to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
